### PR TITLE
Add Solid Pod provider selection

### DIFF
--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -12,7 +12,7 @@ interface SolidPodContextValue {
   isLoggedIn: boolean;
   webId: string | undefined;
   isLoading: boolean;
-  login: (returnTo?: string) => Promise<void>;
+  login: (oidcIssuer: string, returnTo?: string) => Promise<void>;
   logout: () => Promise<void>;
 }
 
@@ -46,13 +46,13 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
     initializeSession();
   }, []);
 
-  const login = async (returnTo?: string) => {
+  const login = async (oidcIssuer: string, returnTo?: string) => {
     const currentLocation = returnTo || window.location.hash.substring(1) || "/";
     const redirectUrl = new URL("/pod-auth-callback.html", window.location.href);
     redirectUrl.searchParams.set("returnTo", currentLocation);
 
     return solidLogin({
-      oidcIssuer: "https://login.inrupt.com",
+      oidcIssuer,
       redirectUrl: redirectUrl.toString(),
       clientName: "Pack Me Up",
     });

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { Modal } from './Modal';
+import { Button } from './Button';
+
+export interface SolidProvider {
+  name: string;
+  issuer: string;
+}
+
+export const COMMON_PROVIDERS: SolidProvider[] = [
+  {
+    name: 'Inrupt',
+    issuer: 'https://login.inrupt.com'
+  },
+  {
+    name: 'solidcommunity.net',
+    issuer: 'https://solidcommunity.net'
+  },
+  {
+    name: 'solidweb.org',
+    issuer: 'https://solidweb.org'
+  }
+];
+
+interface SolidProviderSelectorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (issuer: string) => void;
+}
+
+export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProviderSelectorProps) {
+  const [showCustomInput, setShowCustomInput] = useState(false);
+  const [customIssuer, setCustomIssuer] = useState('');
+
+  const handleProviderSelect = (issuer: string) => {
+    onSelect(issuer);
+    onClose();
+    setShowCustomInput(false);
+    setCustomIssuer('');
+  };
+
+  const handleCustomSubmit = () => {
+    if (customIssuer.trim()) {
+      handleProviderSelect(customIssuer.trim());
+    }
+  };
+
+  const handleClose = () => {
+    onClose();
+    setShowCustomInput(false);
+    setCustomIssuer('');
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="Select Solid Pod Provider">
+      <div className="space-y-4">
+        <p className="text-sm text-gray-600">
+          Choose your Solid Pod provider from the list below or enter a custom one.
+        </p>
+
+        <div className="space-y-2">
+          {COMMON_PROVIDERS.map((provider) => (
+            <button
+              key={provider.issuer}
+              onClick={() => handleProviderSelect(provider.issuer)}
+              className="w-full text-left px-4 py-3 border border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
+            >
+              <div className="font-medium text-gray-900">{provider.name}</div>
+              <div className="text-sm text-gray-500">{provider.issuer}</div>
+            </button>
+          ))}
+        </div>
+
+        {!showCustomInput ? (
+          <Button
+            type="button"
+            onClick={() => setShowCustomInput(true)}
+            variant="secondary"
+            className="w-full"
+          >
+            Use Custom Provider
+          </Button>
+        ) : (
+          <div className="space-y-3 pt-2 border-t border-gray-200">
+            <label className="block">
+              <span className="text-sm font-medium text-gray-700">Custom Provider URL</span>
+              <input
+                type="url"
+                value={customIssuer}
+                onChange={(e) => setCustomIssuer(e.target.value)}
+                placeholder="https://your-provider.com"
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                autoFocus
+              />
+            </label>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                onClick={handleCustomSubmit}
+                disabled={!customIssuer.trim()}
+                className="flex-1"
+              >
+                Connect
+              </Button>
+              <Button
+                type="button"
+                onClick={() => {
+                  setShowCustomInput(false);
+                  setCustomIssuer('');
+                }}
+                variant="secondary"
+                className="flex-1"
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -13,6 +13,7 @@ import { exampleData } from '../edit-questions/example-data'
 import { Callout } from '../components/Callout'
 import { exportFile } from '../utils/exportFile'
 import { useSolidPod } from '../components/SolidPodContext'
+import { SolidProviderSelector } from '../components/SolidProviderSelector'
 import { getPodUrlAll, saveFileInContainer, getFile, overwriteFile } from '@inrupt/solid-client'
 
 export function EditQuestionsForm() {
@@ -22,6 +23,7 @@ export function EditQuestionsForm() {
   });
   const [rev, setRev] = useState<string | undefined>(undefined)
   const [isExampleModalOpen, setIsExampleModalOpen] = useState(false)
+  const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
   const { fields: peopleFields, append: appendPeople, remove: removePeople } = useFieldArray({
     control,
     name: "people"
@@ -190,7 +192,11 @@ export function EditQuestionsForm() {
   };
 
   const handleSolidLogin = () => {
-    return login();
+    setIsProviderSelectorOpen(true);
+  };
+
+  const handleProviderSelect = (issuer: string) => {
+    return login(issuer);
   };
 
   const handleSaveToPod = async () => {
@@ -514,6 +520,12 @@ export function EditQuestionsForm() {
           ))}
         </div>
       </Modal>
+
+      <SolidProviderSelector
+        isOpen={isProviderSelectorOpen}
+        onClose={() => setIsProviderSelectorOpen(false)}
+        onSelect={handleProviderSelect}
+      />
     </div>
   )
 } 


### PR DESCRIPTION
Allow users to choose their Solid Pod provider from a list of common providers (Inrupt, solidcommunity.net, solidweb.org) or enter a custom provider URL. This replaces the previous hardcoded Inrupt provider.

Changes:
- Updated SolidPodContext to accept provider URL parameter in login function
- Created SolidProviderSelector component with modal UI for provider selection
- Updated edit-questions-form to use provider selector instead of direct login

🤖 Generated with [Claude Code](https://claude.com/claude-code)