### PR TITLE
Move Solid Pod login button to top navigation

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -21,156 +21,158 @@ export const Navigation = () => {
     }
 
     return (
-        <nav className="bg-gray-800 text-white shadow-lg">
-            <div className="max-w-7xl mx-auto px-4">
-                <div className="flex items-center justify-between h-16">
-                    <div className="flex items-center">
-                        <div className="flex-shrink-0">
-                            <Link to="/" className="text-xl font-bold hover:text-gray-300">
-                                Pack Me Up
-                            </Link>
-                        </div>
-                        <div className="hidden md:block">
-                            <div className="ml-10 flex items-baseline space-x-4">
-                                <Link
-                                    to="/manage-questions"
-                                    className="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-700 hover:text-white"
-                                >
-                                    Edit Questions
-                                </Link>
-                                <Link
-                                    to="/create-packing-list"
-                                    className="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-700 hover:text-white"
-                                >
-                                    Create List
-                                </Link>
-                                <Link
-                                    to="/view-lists"
-                                    className="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-700 hover:text-white"
-                                >
-                                    View Lists
+        <>
+            <nav className="bg-gray-800 text-white shadow-lg">
+                <div className="max-w-7xl mx-auto px-4">
+                    <div className="flex items-center justify-between h-16">
+                        <div className="flex items-center">
+                            <div className="flex-shrink-0">
+                                <Link to="/" className="text-xl font-bold hover:text-gray-300">
+                                    Pack Me Up
                                 </Link>
                             </div>
+                            <div className="hidden md:block">
+                                <div className="ml-10 flex items-baseline space-x-4">
+                                    <Link
+                                        to="/manage-questions"
+                                        className="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-700 hover:text-white"
+                                    >
+                                        Edit Questions
+                                    </Link>
+                                    <Link
+                                        to="/create-packing-list"
+                                        className="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-700 hover:text-white"
+                                    >
+                                        Create List
+                                    </Link>
+                                    <Link
+                                        to="/view-lists"
+                                        className="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-700 hover:text-white"
+                                    >
+                                        View Lists
+                                    </Link>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                    {/* Solid Login/Logout section */}
-                    <div className="hidden md:flex items-center">
-                        {isLoggedIn ? (
-                            <div className="flex items-center gap-3">
-                                <span className="text-sm text-gray-300 truncate max-w-xs" title={webId}>
-                                    {webId}
-                                </span>
+                        {/* Solid Login/Logout section */}
+                        <div className="hidden md:flex items-center">
+                            {isLoggedIn ? (
+                                <div className="flex items-center gap-3">
+                                    <span className="text-sm text-gray-300 truncate max-w-xs" title={webId}>
+                                        {webId}
+                                    </span>
+                                    <button
+                                        onClick={handleLogout}
+                                        className="px-3 py-2 rounded-md text-sm font-medium bg-gray-700 hover:bg-gray-600 transition-colors"
+                                    >
+                                        Logout
+                                    </button>
+                                </div>
+                            ) : (
                                 <button
-                                    onClick={handleLogout}
-                                    className="px-3 py-2 rounded-md text-sm font-medium bg-gray-700 hover:bg-gray-600 transition-colors"
+                                    onClick={handleSolidLogin}
+                                    className="px-3 py-2 rounded-md text-sm font-medium bg-blue-600 hover:bg-blue-700 transition-colors"
                                 >
-                                    Logout
+                                    Solid Login
                                 </button>
-                            </div>
-                        ) : (
+                            )}
+                        </div>
+                        {/* Mobile menu button */}
+                        <div className="md:hidden">
                             <button
-                                onClick={handleSolidLogin}
-                                className="px-3 py-2 rounded-md text-sm font-medium bg-blue-600 hover:bg-blue-700 transition-colors"
+                                onClick={() => setIsOpen(!isOpen)}
+                                className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none"
+                                aria-expanded="false"
                             >
-                                Solid Login
+                                <span className="sr-only">Open main menu</span>
+                                {/* Hamburger icon */}
+                                <svg
+                                    className={`${isOpen ? 'hidden' : 'block'} h-6 w-6`}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                >
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                                </svg>
+                                {/* Close icon */}
+                                <svg
+                                    className={`${isOpen ? 'block' : 'hidden'} h-6 w-6`}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                >
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                </svg>
                             </button>
-                        )}
-                    </div>
-                    {/* Mobile menu button */}
-                    <div className="md:hidden">
-                        <button
-                            onClick={() => setIsOpen(!isOpen)}
-                            className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none"
-                            aria-expanded="false"
-                        >
-                            <span className="sr-only">Open main menu</span>
-                            {/* Hamburger icon */}
-                            <svg
-                                className={`${isOpen ? 'hidden' : 'block'} h-6 w-6`}
-                                xmlns="http://www.w3.org/2000/svg"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                            >
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                            </svg>
-                            {/* Close icon */}
-                            <svg
-                                className={`${isOpen ? 'block' : 'hidden'} h-6 w-6`}
-                                xmlns="http://www.w3.org/2000/svg"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                            >
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                        </button>
+                        </div>
                     </div>
                 </div>
-            </div>
 
-            {/* Mobile menu */}
-            <div className={`${isOpen ? 'block' : 'hidden'} md:hidden`}>
-                <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-                    <Link
-                        to="/manage-questions"
-                        className="block px-3 py-2 rounded-md text-base font-medium hover:bg-gray-700 hover:text-white"
-                        onClick={() => setIsOpen(false)}
-                    >
-                        Edit Questions
-                    </Link>
-                    <Link
-                        to="/create-packing-list"
-                        className="block px-3 py-2 rounded-md text-base font-medium hover:bg-gray-700 hover:text-white"
-                        onClick={() => setIsOpen(false)}
-                    >
-                        Create List
-                    </Link>
-                    <Link
-                        to="/view-lists"
-                        className="block px-3 py-2 rounded-md text-base font-medium hover:bg-gray-700 hover:text-white"
-                        onClick={() => setIsOpen(false)}
-                    >
-                        View Lists
-                    </Link>
-                    {/* Mobile Solid Login/Logout */}
-                    <div className="border-t border-gray-700 pt-2 mt-2">
-                        {isLoggedIn ? (
-                            <>
-                                <div className="px-3 py-2 text-sm text-gray-300 truncate" title={webId}>
-                                    {webId}
-                                </div>
+                {/* Mobile menu */}
+                <div className={`${isOpen ? 'block' : 'hidden'} md:hidden`}>
+                    <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
+                        <Link
+                            to="/manage-questions"
+                            className="block px-3 py-2 rounded-md text-base font-medium hover:bg-gray-700 hover:text-white"
+                            onClick={() => setIsOpen(false)}
+                        >
+                            Edit Questions
+                        </Link>
+                        <Link
+                            to="/create-packing-list"
+                            className="block px-3 py-2 rounded-md text-base font-medium hover:bg-gray-700 hover:text-white"
+                            onClick={() => setIsOpen(false)}
+                        >
+                            Create List
+                        </Link>
+                        <Link
+                            to="/view-lists"
+                            className="block px-3 py-2 rounded-md text-base font-medium hover:bg-gray-700 hover:text-white"
+                            onClick={() => setIsOpen(false)}
+                        >
+                            View Lists
+                        </Link>
+                        {/* Mobile Solid Login/Logout */}
+                        <div className="border-t border-gray-700 pt-2 mt-2">
+                            {isLoggedIn ? (
+                                <>
+                                    <div className="px-3 py-2 text-sm text-gray-300 truncate" title={webId}>
+                                        {webId}
+                                    </div>
+                                    <button
+                                        onClick={() => {
+                                            handleLogout()
+                                            setIsOpen(false)
+                                        }}
+                                        className="w-full text-left px-3 py-2 rounded-md text-base font-medium bg-gray-700 hover:bg-gray-600"
+                                    >
+                                        Logout
+                                    </button>
+                                </>
+                            ) : (
                                 <button
                                     onClick={() => {
-                                        handleLogout()
+                                        handleSolidLogin()
                                         setIsOpen(false)
                                     }}
-                                    className="w-full text-left px-3 py-2 rounded-md text-base font-medium bg-gray-700 hover:bg-gray-600"
+                                    className="w-full text-left px-3 py-2 rounded-md text-base font-medium bg-blue-600 hover:bg-blue-700"
                                 >
-                                    Logout
+                                    Solid Login
                                 </button>
-                            </>
-                        ) : (
-                            <button
-                                onClick={() => {
-                                    handleSolidLogin()
-                                    setIsOpen(false)
-                                }}
-                                className="w-full text-left px-3 py-2 rounded-md text-base font-medium bg-blue-600 hover:bg-blue-700"
-                            >
-                                Solid Login
-                            </button>
-                        )}
+                            )}
+                        </div>
                     </div>
                 </div>
-            </div>
+            </nav>
 
-            {/* Solid Provider Selector Modal */}
+            {/* Solid Provider Selector Modal - rendered outside nav to avoid styling conflicts */}
             <SolidProviderSelector
                 isOpen={isProviderSelectorOpen}
                 onClose={() => setIsProviderSelectorOpen(false)}
                 onSelect={handleProviderSelect}
             />
-        </nav>
+        </>
     )
 } 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,8 +1,24 @@
 import { Link } from 'react-router-dom'
 import { useState } from 'react'
+import { useSolidPod } from './SolidPodContext'
+import { SolidProviderSelector } from './SolidProviderSelector'
 
 export const Navigation = () => {
     const [isOpen, setIsOpen] = useState(false)
+    const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
+    const { login, logout, isLoggedIn, webId } = useSolidPod()
+
+    const handleSolidLogin = () => {
+        setIsProviderSelectorOpen(true)
+    }
+
+    const handleProviderSelect = (issuer: string) => {
+        return login(issuer)
+    }
+
+    const handleLogout = async () => {
+        await logout()
+    }
 
     return (
         <nav className="bg-gray-800 text-white shadow-lg">
@@ -36,6 +52,29 @@ export const Navigation = () => {
                                 </Link>
                             </div>
                         </div>
+                    </div>
+                    {/* Solid Login/Logout section */}
+                    <div className="hidden md:flex items-center">
+                        {isLoggedIn ? (
+                            <div className="flex items-center gap-3">
+                                <span className="text-sm text-gray-300 truncate max-w-xs" title={webId}>
+                                    {webId}
+                                </span>
+                                <button
+                                    onClick={handleLogout}
+                                    className="px-3 py-2 rounded-md text-sm font-medium bg-gray-700 hover:bg-gray-600 transition-colors"
+                                >
+                                    Logout
+                                </button>
+                            </div>
+                        ) : (
+                            <button
+                                onClick={handleSolidLogin}
+                                className="px-3 py-2 rounded-md text-sm font-medium bg-blue-600 hover:bg-blue-700 transition-colors"
+                            >
+                                Solid Login
+                            </button>
+                        )}
                     </div>
                     {/* Mobile menu button */}
                     <div className="md:hidden">
@@ -94,8 +133,44 @@ export const Navigation = () => {
                     >
                         View Lists
                     </Link>
+                    {/* Mobile Solid Login/Logout */}
+                    <div className="border-t border-gray-700 pt-2 mt-2">
+                        {isLoggedIn ? (
+                            <>
+                                <div className="px-3 py-2 text-sm text-gray-300 truncate" title={webId}>
+                                    {webId}
+                                </div>
+                                <button
+                                    onClick={() => {
+                                        handleLogout()
+                                        setIsOpen(false)
+                                    }}
+                                    className="w-full text-left px-3 py-2 rounded-md text-base font-medium bg-gray-700 hover:bg-gray-600"
+                                >
+                                    Logout
+                                </button>
+                            </>
+                        ) : (
+                            <button
+                                onClick={() => {
+                                    handleSolidLogin()
+                                    setIsOpen(false)
+                                }}
+                                className="w-full text-left px-3 py-2 rounded-md text-base font-medium bg-blue-600 hover:bg-blue-700"
+                            >
+                                Solid Login
+                            </button>
+                        )}
+                    </div>
                 </div>
             </div>
+
+            {/* Solid Provider Selector Modal */}
+            <SolidProviderSelector
+                isOpen={isProviderSelectorOpen}
+                onClose={() => setIsProviderSelectorOpen(false)}
+                onSelect={handleProviderSelect}
+            />
         </nav>
     )
 } 

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -13,7 +13,6 @@ import { exampleData } from '../edit-questions/example-data'
 import { Callout } from '../components/Callout'
 import { exportFile } from '../utils/exportFile'
 import { useSolidPod } from '../components/SolidPodContext'
-import { SolidProviderSelector } from '../components/SolidProviderSelector'
 import { getPodUrlAll, saveFileInContainer, getFile, overwriteFile } from '@inrupt/solid-client'
 
 export function EditQuestionsForm() {
@@ -23,13 +22,12 @@ export function EditQuestionsForm() {
   });
   const [rev, setRev] = useState<string | undefined>(undefined)
   const [isExampleModalOpen, setIsExampleModalOpen] = useState(false)
-  const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
   const { fields: peopleFields, append: appendPeople, remove: removePeople } = useFieldArray({
     control,
     name: "people"
   });
   const { showToast } = useToast();
-  const { login, isLoggedIn, session } = useSolidPod();
+  const { isLoggedIn, session } = useSolidPod();
 
   console.log("EditQuestionsForm - isLoggedIn:", isLoggedIn);
 
@@ -189,14 +187,6 @@ export function EditQuestionsForm() {
       setIsExampleModalOpen(false);
       showToast('Example loaded successfully!', 'success');
     }
-  };
-
-  const handleSolidLogin = () => {
-    setIsProviderSelectorOpen(true);
-  };
-
-  const handleProviderSelect = (issuer: string) => {
-    return login(issuer);
   };
 
   const handleSaveToPod = async () => {
@@ -370,7 +360,7 @@ export function EditQuestionsForm() {
         {/* Sticky sidebar for large screens */}
         <div className="hidden lg:block lg:w-64 lg:sticky lg:top-24 flex-shrink-0">
           <div className="backdrop-blur-md bg-white/80 border border-gray-200 shadow-xl rounded-xl flex flex-col items-stretch gap-4 py-6 px-4">
-            {isLoggedIn ? (
+            {isLoggedIn && (
               <>
                 <Button
                   type="button"
@@ -387,14 +377,6 @@ export function EditQuestionsForm() {
                   Load from Pod
                 </Button>
               </>
-            ) : (
-              <Button
-                type="button"
-                onClick={handleSolidLogin}
-                variant="secondary"
-              >
-                Solid Pod Login
-              </Button>
             )}
             <Button
               type="button"
@@ -438,7 +420,7 @@ export function EditQuestionsForm() {
       <div className="fixed bottom-0 left-0 w-full z-50 flex justify-center pointer-events-none lg:hidden">
         <div className="max-w-4xl w-full px-4 pb-4">
           <div className="backdrop-blur-md bg-white/80 border border-gray-200 shadow-xl rounded-xl flex flex-wrap items-center gap-4 justify-center py-4 pointer-events-auto">
-            {isLoggedIn ? (
+            {isLoggedIn && (
               <>
                 <Button
                   type="button"
@@ -455,14 +437,6 @@ export function EditQuestionsForm() {
                   Load from Pod
                 </Button>
               </>
-            ) : (
-              <Button
-                type="button"
-                onClick={handleSolidLogin}
-                variant="secondary"
-              >
-                Solid Pod Login
-              </Button>
             )}
             <Button
               type="button"
@@ -520,12 +494,6 @@ export function EditQuestionsForm() {
           ))}
         </div>
       </Modal>
-
-      <SolidProviderSelector
-        isOpen={isProviderSelectorOpen}
-        onClose={() => setIsProviderSelectorOpen(false)}
-        onSelect={handleProviderSelect}
-      />
     </div>
   )
 } 


### PR DESCRIPTION
Relocate the Solid Pod authentication to the global navigation bar for better accessibility and user experience. The login button is now available on every page, not just the Edit Questions page.

Changes:
- Add Solid login/logout functionality to Navigation component
- Display user's webId when logged in
- Support both desktop and mobile layouts
- Remove login button from Edit Questions form
- Keep Save/Load from Pod buttons in form (feature-specific actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)