### PR TITLE
Improve Solid Pod login clarity with better explanations

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -55,7 +55,7 @@ export const Navigation = () => {
                             </div>
                         </div>
                         {/* Solid Login/Logout section */}
-                        <div className="hidden md:flex items-center">
+                        <div className="hidden md:flex items-center gap-2">
                             {isLoggedIn ? (
                                 <div className="flex items-center gap-3">
                                     <span className="text-sm text-gray-300 truncate max-w-xs" title={webId}>
@@ -69,12 +69,16 @@ export const Navigation = () => {
                                     </button>
                                 </div>
                             ) : (
-                                <button
-                                    onClick={handleSolidLogin}
-                                    className="px-3 py-2 rounded-md text-sm font-medium bg-blue-600 hover:bg-blue-700 transition-colors"
-                                >
-                                    Solid Login
-                                </button>
+                                <div className="flex flex-col items-end">
+                                    <button
+                                        onClick={handleSolidLogin}
+                                        className="px-4 py-2 rounded-md text-sm font-medium bg-blue-600 hover:bg-blue-700 transition-colors"
+                                        title="Store your packing lists in your own personal Pod - you own your data"
+                                    >
+                                        Login with Solid Pod
+                                    </button>
+                                    <span className="text-xs text-gray-400 mt-1">Own your data</span>
+                                </div>
                             )}
                         </div>
                         {/* Mobile menu button */}
@@ -152,15 +156,19 @@ export const Navigation = () => {
                                     </button>
                                 </>
                             ) : (
-                                <button
-                                    onClick={() => {
-                                        handleSolidLogin()
-                                        setIsOpen(false)
-                                    }}
-                                    className="w-full text-left px-3 py-2 rounded-md text-base font-medium bg-blue-600 hover:bg-blue-700"
-                                >
-                                    Solid Login
-                                </button>
+                                <div>
+                                    <button
+                                        onClick={() => {
+                                            handleSolidLogin()
+                                            setIsOpen(false)
+                                        }}
+                                        className="w-full text-left px-3 py-2 rounded-md text-base font-medium bg-blue-600 hover:bg-blue-700"
+                                        title="Store your packing lists in your own personal Pod - you own your data"
+                                    >
+                                        Login with Solid Pod
+                                    </button>
+                                    <p className="px-3 py-1 text-xs text-gray-400">Own your data</p>
+                                </div>
                             )}
                         </div>
                     </div>

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -52,11 +52,36 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} title="Select Solid Pod Provider">
+    <Modal isOpen={isOpen} onClose={handleClose} title="Login with Your Solid Pod">
       <div className="space-y-4">
-        <p className="text-sm text-gray-600">
-          Choose your Solid Pod provider from the list below or enter a custom one.
-        </p>
+        {/* Explanation section */}
+        <div className="bg-blue-50 border border-blue-200 rounded-md p-4 space-y-2">
+          <h3 className="font-semibold text-gray-900 text-sm">What is a Solid Pod?</h3>
+          <p className="text-sm text-gray-700">
+            A Solid Pod is your personal data storage that <strong>you control</strong>. Instead of storing your packing lists on our servers, they're stored in your own secure space.
+          </p>
+          <ul className="text-sm text-gray-700 space-y-1 ml-4 list-disc">
+            <li><strong>You own your data</strong> - it stays in your Pod</li>
+            <li><strong>Privacy-focused</strong> - you choose who can access it</li>
+            <li><strong>Portable</strong> - use your Pod with any Solid app</li>
+          </ul>
+          <p className="text-xs text-gray-600 mt-2">
+            <a
+              href="https://solidproject.org/users/get-a-pod"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:text-blue-800 underline"
+            >
+              Learn more about Solid
+            </a>
+          </p>
+        </div>
+
+        <div className="border-t border-gray-200 pt-4">
+          <p className="text-sm text-gray-600 mb-3">
+            Choose your Solid Pod provider to get started:
+          </p>
+        </div>
 
         <div className="space-y-2">
           {COMMON_PROVIDERS.map((provider) => (

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -311,10 +311,6 @@ export function EditQuestionsForm() {
           <div className="backdrop-blur-md bg-white/80 border border-gray-200 shadow-xl rounded-xl flex flex-col items-stretch gap-4 py-6 px-4">
             {isLoggedIn ? (
               <>
-                <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
-                  <p className="text-xs text-gray-700 font-medium mb-1">Solid Pod Storage</p>
-                  <p className="text-xs text-gray-600">Your questions are stored in your personal Pod</p>
-                </div>
                 <Button
                   type="button"
                   onClick={handleSaveToPod}

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -309,8 +309,12 @@ export function EditQuestionsForm() {
         {/* Sticky sidebar for large screens */}
         <div className="hidden lg:block lg:w-64 lg:sticky lg:top-24 flex-shrink-0">
           <div className="backdrop-blur-md bg-white/80 border border-gray-200 shadow-xl rounded-xl flex flex-col items-stretch gap-4 py-6 px-4">
-            {isLoggedIn && (
+            {isLoggedIn ? (
               <>
+                <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
+                  <p className="text-xs text-gray-700 font-medium mb-1">Solid Pod Storage</p>
+                  <p className="text-xs text-gray-600">Your questions are stored in your personal Pod</p>
+                </div>
                 <Button
                   type="button"
                   onClick={handleSaveToPod}
@@ -326,6 +330,12 @@ export function EditQuestionsForm() {
                   Load from Pod
                 </Button>
               </>
+            ) : (
+              <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
+                <p className="text-xs text-gray-700 font-semibold mb-1">💡 Store in Your Pod</p>
+                <p className="text-xs text-gray-600 mb-2">Login with Solid Pod to save your questions privately in storage you control.</p>
+                <p className="text-xs text-blue-600">→ Click "Login with Solid Pod" above</p>
+              </div>
             )}
             <Button
               type="button"
@@ -354,7 +364,13 @@ export function EditQuestionsForm() {
       {/* Sticky bottom bar for small/medium screens */}
       <div className="fixed bottom-0 left-0 w-full z-50 flex justify-center pointer-events-none lg:hidden">
         <div className="max-w-4xl w-full px-4 pb-4">
-          <div className="backdrop-blur-md bg-white/80 border border-gray-200 shadow-xl rounded-xl flex flex-wrap items-center gap-4 justify-center py-4 pointer-events-auto">
+          <div className="backdrop-blur-md bg-white/80 border border-gray-200 shadow-xl rounded-xl flex flex-col gap-3 py-4 px-3 pointer-events-auto">
+            {!isLoggedIn && (
+              <div className="bg-blue-50 border border-blue-200 rounded-md p-2 mx-2">
+                <p className="text-xs text-gray-700 font-semibold">💡 Login with Solid Pod to save privately</p>
+              </div>
+            )}
+            <div className="flex flex-wrap items-center gap-3 justify-center">
             {isLoggedIn && (
               <>
                 <Button
@@ -394,6 +410,7 @@ export function EditQuestionsForm() {
             >
               Load Example
             </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -48,6 +48,18 @@ export const LandingPage = () => {
                             Simple and intuitive interface that makes packing preparation a breeze.
                         </p>
                     </div>
+
+                    <div className="bg-blue-50 p-6 rounded-lg shadow-md border-2 border-blue-200">
+                        <h2 className="text-2xl font-semibold mb-3">Own Your Data</h2>
+                        <p className="text-gray-600 mb-4">
+                            Login with your Solid Pod to store your questions and lists in personal storage that you control. Your data stays private and portable.
+                        </p>
+                        {!isLoggedIn && (
+                            <p className="text-sm text-blue-600 font-medium">
+                                → Click "Login with Solid Pod" above to get started
+                            </p>
+                        )}
+                    </div>
                 </div>
 
                 <div className="text-center">


### PR DESCRIPTION
Enhanced the user experience around Solid Pod login to make it clearer what Solid is and why users should use it:

1. **Navigation updates:**
   - Changed button text from "Solid Login" to "Login with Solid Pod"
   - Added "Own your data" subtitle for quick benefit communication
   - Added tooltip explaining data ownership

2. **Provider selector modal improvements:**
   - Added prominent explanation box describing what Solid Pods are
   - Listed key benefits: data ownership, privacy, and portability
   - Included "Learn more" link to Solid documentation
   - Improved modal title to be more descriptive

3. **Edit questions page enhancements:**
   - Added contextual info box when logged in showing Pod storage status
   - Added helpful prompt when NOT logged in to encourage Pod usage
   - Applied to both desktop sidebar and mobile bottom bar

These changes address user confusion about what "Solid" means and clearly communicate the value proposition of using Solid Pods for data storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)