### PR TITLE
Add Solid Pod sync buttons to Packing Lists page

### DIFF
--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -12,7 +12,7 @@ import { Modal } from '../components/Modal'
 import { exampleData } from '../edit-questions/example-data'
 import { Callout } from '../components/Callout'
 import { useSolidPod } from '../components/SolidPodContext'
-import { getPodUrlAll, saveFileInContainer, getFile, overwriteFile } from '@inrupt/solid-client'
+import { getPrimaryPodUrl, saveFileToPod, loadFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
 
 export function EditQuestionsForm() {
 
@@ -147,92 +147,46 @@ export function EditQuestionsForm() {
   };
 
   const handleSaveToPod = async () => {
-    if (!session || !session.info.isLoggedIn || !session.info.webId) {
-      showToast('You must be logged in to save to Pod', 'error');
+    const podUrl = await getPrimaryPodUrl(session);
+
+    if (!podUrl) {
+      showToast(POD_ERROR_MESSAGES.NOT_LOGGED_IN, 'error');
       return;
     }
 
     try {
-      // Get the user's pod URLs
-      const podUrls = await getPodUrlAll(session.info.webId, { fetch: session.fetch });
-
-      if (!podUrls || podUrls.length === 0) {
-        showToast('No pod found for your account', 'error');
-        return;
-      }
-
-      // Use the first pod
-      const podUrl = podUrls[0];
-      const containerUrl = `${podUrl}pack-me-up/`;
-
-      // Get current form data
       const data = getValues();
-      const json = JSON.stringify(data, null, 2);
-      const blob = new Blob([json], { type: 'application/json' });
-      const file = new File([blob], 'packing-list-questions.json', { type: 'application/json' });
+      const containerUrl = `${podUrl}${POD_CONTAINERS.ROOT}`;
 
-      console.log(`Saving file to container: ${containerUrl}`);
-
-      // Try saveFileInContainer first
-      try {
-        const savedFile = await saveFileInContainer(
-          containerUrl,
-          file,
-          {
-            fetch: session.fetch,
-            slug: 'packing-list-questions.json'
-          }
-        );
-        console.log('File saved at:', savedFile.internal_resourceInfo.sourceIri);
-      } catch (saveError: any) {
-        // If we get 404 or 409, use overwriteFile instead
-        if (saveError.statusCode === 404 || saveError.statusCode === 409) {
-          console.log(`Container issue (${saveError.statusCode}), using overwriteFile...`);
-          const fileUrl = `${containerUrl}packing-list-questions.json`;
-          await overwriteFile(fileUrl, blob, {
-            fetch: session.fetch,
-            contentType: 'application/json'
-          });
-          console.log('File saved at:', fileUrl);
-        } else {
-          throw saveError;
-        }
-      }
+      await saveFileToPod({
+        session: session!,
+        containerPath: containerUrl,
+        filename: 'packing-list-questions.json',
+        data
+      });
 
       showToast('Successfully saved to Solid Pod!', 'success');
     } catch (error) {
       console.error('Error saving to pod:', error);
-      showToast('Failed to save to Pod. Please try again.', 'error');
+      showToast(POD_ERROR_MESSAGES.SAVE_FAILED, 'error');
     }
   };
 
   const handleLoadFromPod = async () => {
-    if (!session || !session.info.isLoggedIn || !session.info.webId) {
-      showToast('You must be logged in to load from Pod', 'error');
+    const podUrl = await getPrimaryPodUrl(session);
+
+    if (!podUrl) {
+      showToast(POD_ERROR_MESSAGES.NOT_LOGGED_IN_LOAD, 'error');
       return;
     }
 
     try {
-      // Get the user's pod URLs
-      const podUrls = await getPodUrlAll(session.info.webId, { fetch: session.fetch });
+      const fileUrl = `${podUrl}${POD_CONTAINERS.QUESTIONS}`;
 
-      if (!podUrls || podUrls.length === 0) {
-        showToast('No pod found for your account', 'error');
-        return;
-      }
-
-      // Use the first pod
-      const podUrl = podUrls[0];
-      const fileUrl = `${podUrl}pack-me-up/packing-list-questions.json`;
-
-      console.log(`Loading from pod: ${fileUrl}`);
-
-      // Get the file from the pod
-      const file = await getFile(fileUrl, { fetch: session.fetch });
-
-      // Read the file content
-      const text = await file.text();
-      const data = JSON.parse(text) as PackingListQuestionSet;
+      const data = await loadFileFromPod<PackingListQuestionSet>({
+        session: session!,
+        fileUrl
+      });
 
       // Preserve the current revision
       data._rev = rev;
@@ -242,7 +196,7 @@ export function EditQuestionsForm() {
       showToast('Questions loaded from Pod successfully!', 'success');
     } catch (error) {
       console.error('Error loading from pod:', error);
-      showToast('Failed to load from Pod. Please try again.', 'error');
+      showToast(POD_ERROR_MESSAGES.LOAD_FAILED, 'error');
     }
   };
 

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -150,6 +150,9 @@ export function PackingLists() {
                     const text = await file.text()
                     const list = JSON.parse(text) as PackingList
 
+                    // Remove _rev to avoid conflicts with local database version
+                    delete list._rev
+
                     // Save to local database
                     await packingAppDb.savePackingList(list)
                     loadedLists.push(list)

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -2,11 +2,19 @@ import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { PackingList } from '../create-packing-list/types'
 import { packingAppDb } from '../services/database'
+import { useSolidPod } from '../components/SolidPodContext'
+import { useToast } from '../components/ToastContext'
+import { Button } from '../components/Button'
+import { getPodUrlAll, saveFileInContainer, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile } from '@inrupt/solid-client'
 
 export function PackingLists() {
     const [packingLists, setPackingLists] = useState<PackingList[]>([])
     const [isLoading, setIsLoading] = useState(true)
+    const [isSaving, setIsSaving] = useState(false)
+    const [isLoadingFromPod, setIsLoadingFromPod] = useState(false)
     const navigate = useNavigate()
+    const { isLoggedIn, session } = useSolidPod()
+    const { showToast } = useToast()
 
     const deletePackingList = async (id: string, event: React.MouseEvent) => {
         event.stopPropagation() // Prevent navigation when clicking delete
@@ -15,6 +23,157 @@ export function PackingLists() {
             setPackingLists(packingLists.filter(list => list.id !== id))
         } catch (err) {
             console.error('Error deleting packing list:', err)
+        }
+    }
+
+    const handleSaveToPod = async () => {
+        if (!session || !session.info.isLoggedIn || !session.info.webId) {
+            showToast('You must be logged in to save to Pod', 'error')
+            return
+        }
+
+        setIsSaving(true)
+        try {
+            // Get the user's pod URLs
+            const podUrls = await getPodUrlAll(session.info.webId, { fetch: session.fetch })
+
+            if (!podUrls || podUrls.length === 0) {
+                showToast('No pod found for your account', 'error')
+                return
+            }
+
+            // Use the first pod
+            const podUrl = podUrls[0]
+            const containerUrl = `${podUrl}pack-me-up/packing-lists/`
+
+            let successCount = 0
+            let failCount = 0
+
+            // Save each packing list as a separate file
+            for (const list of packingLists) {
+                try {
+                    const json = JSON.stringify(list, null, 2)
+                    const blob = new Blob([json], { type: 'application/json' })
+                    const file = new File([blob], `${list.id}.json`, { type: 'application/json' })
+
+                    // Try saveFileInContainer first
+                    try {
+                        await saveFileInContainer(
+                            containerUrl,
+                            file,
+                            {
+                                fetch: session.fetch,
+                                slug: `${list.id}.json`
+                            }
+                        )
+                        successCount++
+                    } catch (saveError: any) {
+                        // If we get 404 or 409, use overwriteFile instead
+                        if (saveError.statusCode === 404 || saveError.statusCode === 409) {
+                            const fileUrl = `${containerUrl}${list.id}.json`
+                            await overwriteFile(fileUrl, blob, {
+                                fetch: session.fetch,
+                                contentType: 'application/json'
+                            })
+                            successCount++
+                        } else {
+                            throw saveError
+                        }
+                    }
+                } catch (error) {
+                    console.error(`Error saving packing list ${list.id}:`, error)
+                    failCount++
+                }
+            }
+
+            if (failCount === 0) {
+                showToast(`Successfully saved ${successCount} packing list(s) to Solid Pod!`, 'success')
+            } else {
+                showToast(`Saved ${successCount}/${packingLists.length} packing list(s). ${failCount} failed.`, 'error')
+            }
+        } catch (error) {
+            console.error('Error saving to pod:', error)
+            showToast('Failed to save to Pod. Please try again.', 'error')
+        } finally {
+            setIsSaving(false)
+        }
+    }
+
+    const handleLoadFromPod = async () => {
+        if (!session || !session.info.isLoggedIn || !session.info.webId) {
+            showToast('You must be logged in to load from Pod', 'error')
+            return
+        }
+
+        setIsLoadingFromPod(true)
+        try {
+            // Get the user's pod URLs
+            const podUrls = await getPodUrlAll(session.info.webId, { fetch: session.fetch })
+
+            if (!podUrls || podUrls.length === 0) {
+                showToast('No pod found for your account', 'error')
+                return
+            }
+
+            // Use the first pod
+            const podUrl = podUrls[0]
+            const containerUrl = `${podUrl}pack-me-up/packing-lists/`
+
+            // Get the container dataset to list all files
+            let dataset
+            try {
+                dataset = await getSolidDataset(containerUrl, { fetch: session.fetch })
+            } catch (error: any) {
+                if (error.statusCode === 404) {
+                    showToast('No packing lists found in Pod', 'error')
+                    return
+                }
+                throw error
+            }
+
+            const fileUrls = getContainedResourceUrlAll(dataset)
+            const jsonFileUrls = fileUrls.filter(url => url.endsWith('.json'))
+
+            if (jsonFileUrls.length === 0) {
+                showToast('No packing lists found in Pod', 'error')
+                return
+            }
+
+            let successCount = 0
+            let failCount = 0
+            const loadedLists: PackingList[] = []
+
+            // Load each file
+            for (const fileUrl of jsonFileUrls) {
+                try {
+                    const file = await getFile(fileUrl, { fetch: session.fetch })
+                    const text = await file.text()
+                    const list = JSON.parse(text) as PackingList
+
+                    // Save to local database
+                    await packingAppDb.savePackingList(list)
+                    loadedLists.push(list)
+                    successCount++
+                } catch (error) {
+                    console.error(`Error loading file ${fileUrl}:`, error)
+                    failCount++
+                }
+            }
+
+            // Refresh the local list
+            const allLists = await packingAppDb.getAllPackingLists()
+            setPackingLists(allLists)
+
+            if (failCount === 0) {
+                showToast(`Successfully loaded ${successCount} packing list(s) from Solid Pod!`, 'success')
+            } else {
+                showToast(`Loaded ${successCount}/${jsonFileUrls.length} packing list(s). ${failCount} failed.`, 'error')
+            }
+        } catch (error) {
+            console.error('Error loading from pod:', error)
+            showToast('Failed to load from Pod. Please try again.', 'error')
+        } finally {
+            setIsLoadingFromPod(false)
         }
     }
 
@@ -40,8 +199,32 @@ export function PackingLists() {
     return (
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8">
-                <h1 className="text-2xl font-bold text-gray-900">Packing Lists</h1>
-                <p className="mt-2 text-gray-600">View all your created packing lists.</p>
+                <div className="flex justify-between items-start mb-2">
+                    <div>
+                        <h1 className="text-2xl font-bold text-gray-900">Packing Lists</h1>
+                        <p className="mt-2 text-gray-600">View all your created packing lists.</p>
+                    </div>
+                    {isLoggedIn && (
+                        <div className="flex gap-2">
+                            <Button
+                                type="button"
+                                onClick={handleSaveToPod}
+                                disabled={isSaving || packingLists.length === 0}
+                                variant="secondary"
+                            >
+                                {isSaving ? 'Saving...' : 'Save to Pod'}
+                            </Button>
+                            <Button
+                                type="button"
+                                onClick={handleLoadFromPod}
+                                disabled={isLoadingFromPod}
+                                variant="secondary"
+                            >
+                                {isLoadingFromPod ? 'Loading...' : 'Load from Pod'}
+                            </Button>
+                        </div>
+                    )}
+                </div>
             </div>
 
             {packingLists.length === 0 ? (

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -5,7 +5,7 @@ import { packingAppDb } from '../services/database'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
 import { Button } from '../components/Button'
-import { getPodUrlAll, saveFileInContainer, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile } from '@inrupt/solid-client'
+import { getPrimaryPodUrl, saveMultipleFilesToPod, loadMultipleFilesFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
 
 export function PackingLists() {
     const [packingLists, setPackingLists] = useState<PackingList[]>([])
@@ -27,154 +27,73 @@ export function PackingLists() {
     }
 
     const handleSaveToPod = async () => {
-        if (!session || !session.info.isLoggedIn || !session.info.webId) {
-            showToast('You must be logged in to save to Pod', 'error')
+        const podUrl = await getPrimaryPodUrl(session)
+
+        if (!podUrl) {
+            showToast(POD_ERROR_MESSAGES.NOT_LOGGED_IN, 'error')
             return
         }
 
         setIsSaving(true)
         try {
-            // Get the user's pod URLs
-            const podUrls = await getPodUrlAll(session.info.webId, { fetch: session.fetch })
+            const containerUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`
 
-            if (!podUrls || podUrls.length === 0) {
-                showToast('No pod found for your account', 'error')
-                return
-            }
+            const result = await saveMultipleFilesToPod(session!, containerUrl, packingLists)
 
-            // Use the first pod
-            const podUrl = podUrls[0]
-            const containerUrl = `${podUrl}pack-me-up/packing-lists/`
-
-            let successCount = 0
-            let failCount = 0
-
-            // Save each packing list as a separate file
-            for (const list of packingLists) {
-                try {
-                    const json = JSON.stringify(list, null, 2)
-                    const blob = new Blob([json], { type: 'application/json' })
-                    const file = new File([blob], `${list.id}.json`, { type: 'application/json' })
-
-                    // Try saveFileInContainer first
-                    try {
-                        await saveFileInContainer(
-                            containerUrl,
-                            file,
-                            {
-                                fetch: session.fetch,
-                                slug: `${list.id}.json`
-                            }
-                        )
-                        successCount++
-                    } catch (saveError: any) {
-                        // If we get 404 or 409, use overwriteFile instead
-                        if (saveError.statusCode === 404 || saveError.statusCode === 409) {
-                            const fileUrl = `${containerUrl}${list.id}.json`
-                            await overwriteFile(fileUrl, blob, {
-                                fetch: session.fetch,
-                                contentType: 'application/json'
-                            })
-                            successCount++
-                        } else {
-                            throw saveError
-                        }
-                    }
-                } catch (error) {
-                    console.error(`Error saving packing list ${list.id}:`, error)
-                    failCount++
-                }
-            }
-
-            if (failCount === 0) {
-                showToast(`Successfully saved ${successCount} packing list(s) to Solid Pod!`, 'success')
+            if (result.success) {
+                showToast(`Successfully saved ${result.successCount} packing list(s) to Solid Pod!`, 'success')
             } else {
-                showToast(`Saved ${successCount}/${packingLists.length} packing list(s). ${failCount} failed.`, 'error')
+                showToast(`Saved ${result.successCount}/${result.totalCount} packing list(s). ${result.failCount} failed.`, 'error')
             }
         } catch (error) {
             console.error('Error saving to pod:', error)
-            showToast('Failed to save to Pod. Please try again.', 'error')
+            showToast(POD_ERROR_MESSAGES.SAVE_FAILED, 'error')
         } finally {
             setIsSaving(false)
         }
     }
 
     const handleLoadFromPod = async () => {
-        if (!session || !session.info.isLoggedIn || !session.info.webId) {
-            showToast('You must be logged in to load from Pod', 'error')
+        const podUrl = await getPrimaryPodUrl(session)
+
+        if (!podUrl) {
+            showToast(POD_ERROR_MESSAGES.NOT_LOGGED_IN_LOAD, 'error')
             return
         }
 
         setIsLoadingFromPod(true)
         try {
-            // Get the user's pod URLs
-            const podUrls = await getPodUrlAll(session.info.webId, { fetch: session.fetch })
+            const containerUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`
 
-            if (!podUrls || podUrls.length === 0) {
-                showToast('No pod found for your account', 'error')
+            const { data: loadedLists, result } = await loadMultipleFilesFromPod<PackingList>({
+                session: session!,
+                containerPath: containerUrl
+            })
+
+            if (result.totalCount === 0) {
+                showToast(POD_ERROR_MESSAGES.NO_DATA_FOUND('packing lists'), 'error')
                 return
             }
 
-            // Use the first pod
-            const podUrl = podUrls[0]
-            const containerUrl = `${podUrl}pack-me-up/packing-lists/`
-
-            // Get the container dataset to list all files
-            let dataset
-            try {
-                dataset = await getSolidDataset(containerUrl, { fetch: session.fetch })
-            } catch (error: any) {
-                if (error.statusCode === 404) {
-                    showToast('No packing lists found in Pod', 'error')
-                    return
-                }
-                throw error
-            }
-
-            const fileUrls = getContainedResourceUrlAll(dataset)
-            const jsonFileUrls = fileUrls.filter(url => url.endsWith('.json'))
-
-            if (jsonFileUrls.length === 0) {
-                showToast('No packing lists found in Pod', 'error')
-                return
-            }
-
-            let successCount = 0
-            let failCount = 0
-            const loadedLists: PackingList[] = []
-
-            // Load each file
-            for (const fileUrl of jsonFileUrls) {
-                try {
-                    const file = await getFile(fileUrl, { fetch: session.fetch })
-                    const text = await file.text()
-                    const list = JSON.parse(text) as PackingList
-
-                    // Remove _rev to avoid conflicts with local database version
-                    delete list._rev
-
-                    // Save to local database
-                    await packingAppDb.savePackingList(list)
-                    loadedLists.push(list)
-                    successCount++
-                } catch (error) {
-                    console.error(`Error loading file ${fileUrl}:`, error)
-                    failCount++
-                }
+            // Save each loaded list to local database
+            for (const list of loadedLists) {
+                // Remove _rev to avoid conflicts with local database version
+                delete list._rev
+                await packingAppDb.savePackingList(list)
             }
 
             // Refresh the local list
             const allLists = await packingAppDb.getAllPackingLists()
             setPackingLists(allLists)
 
-            if (failCount === 0) {
-                showToast(`Successfully loaded ${successCount} packing list(s) from Solid Pod!`, 'success')
+            if (result.success) {
+                showToast(`Successfully loaded ${result.successCount} packing list(s) from Solid Pod!`, 'success')
             } else {
-                showToast(`Loaded ${successCount}/${jsonFileUrls.length} packing list(s). ${failCount} failed.`, 'error')
+                showToast(`Loaded ${result.successCount}/${result.totalCount} packing list(s). ${result.failCount} failed.`, 'error')
             }
         } catch (error) {
             console.error('Error loading from pod:', error)
-            showToast('Failed to load from Pod. Please try again.', 'error')
+            showToast(POD_ERROR_MESSAGES.LOAD_FAILED, 'error')
         } finally {
             setIsLoadingFromPod(false)
         }

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -1,0 +1,244 @@
+import { Session } from '@inrupt/solid-client-authn-browser'
+import { getPodUrlAll, saveFileInContainer, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile } from '@inrupt/solid-client'
+
+/**
+ * Pod container paths under the user's Pod root
+ */
+export const POD_CONTAINERS = {
+    ROOT: 'pack-me-up/',
+    QUESTIONS: 'pack-me-up/packing-list-questions.json',
+    PACKING_LISTS: 'pack-me-up/packing-lists/',
+} as const
+
+/**
+ * User-facing error messages for Pod operations
+ */
+export const POD_ERROR_MESSAGES = {
+    NOT_LOGGED_IN: 'You must be logged in to save to Pod',
+    NOT_LOGGED_IN_LOAD: 'You must be logged in to load from Pod',
+    NO_POD_FOUND: 'No pod found for your account',
+    SAVE_FAILED: 'Failed to save to Pod. Please try again.',
+    LOAD_FAILED: 'Failed to load from Pod. Please try again.',
+    NO_DATA_FOUND: (resourceType: string) => `No ${resourceType} found in Pod`,
+} as const
+
+/**
+ * Result of a Pod sync operation
+ */
+export interface PodSyncResult {
+    success: boolean
+    successCount: number
+    failCount: number
+    totalCount: number
+}
+
+/**
+ * Options for saving data to Pod
+ */
+export interface SaveToPodOptions {
+    session: Session
+    containerPath: string
+    filename: string
+    data: any
+    onError?: (error: Error) => void
+}
+
+/**
+ * Options for loading data from Pod
+ */
+export interface LoadFromPodOptions {
+    session: Session
+    fileUrl: string
+    onError?: (error: Error) => void
+}
+
+/**
+ * Options for batch loading files from a Pod container
+ */
+export interface LoadMultipleFromPodOptions<T> {
+    session: Session
+    containerPath: string
+    onFileLoaded?: (data: T) => void
+    onError?: (fileUrl: string, error: Error) => void
+}
+
+/**
+ * Validates session and retrieves the user's primary Pod URL
+ * @returns Pod URL if valid, null otherwise
+ */
+export async function getPrimaryPodUrl(session: Session | null): Promise<string | null> {
+    if (!session || !session.info.isLoggedIn || !session.info.webId) {
+        return null
+    }
+
+    const podUrls = await getPodUrlAll(session.info.webId, { fetch: session.fetch })
+
+    if (!podUrls || podUrls.length === 0) {
+        return null
+    }
+
+    return podUrls[0]
+}
+
+/**
+ * Saves a file to a Pod container with automatic fallback to overwrite
+ * Handles both saveFileInContainer (creates) and overwriteFile (updates) strategies
+ */
+export async function saveFileToPod(options: SaveToPodOptions): Promise<void> {
+    const { session, containerPath, filename, data } = options
+
+    const json = JSON.stringify(data, null, 2)
+    const blob = new Blob([json], { type: 'application/json' })
+    const file = new File([blob], filename, { type: 'application/json' })
+
+    // Try saveFileInContainer first (creates new file in container)
+    try {
+        await saveFileInContainer(
+            containerPath,
+            file,
+            {
+                fetch: session.fetch,
+                slug: filename
+            }
+        )
+    } catch (saveError: any) {
+        // If container doesn't exist (404) or file already exists (409),
+        // use overwriteFile instead
+        if (saveError.statusCode === 404 || saveError.statusCode === 409) {
+            const fileUrl = `${containerPath}${filename}`
+            await overwriteFile(fileUrl, blob, {
+                fetch: session.fetch,
+                contentType: 'application/json'
+            })
+        } else {
+            throw saveError
+        }
+    }
+}
+
+/**
+ * Loads a single file from a Pod
+ */
+export async function loadFileFromPod<T>(options: LoadFromPodOptions): Promise<T> {
+    const { session, fileUrl } = options
+
+    const file = await getFile(fileUrl, { fetch: session.fetch })
+    const text = await file.text()
+    return JSON.parse(text) as T
+}
+
+/**
+ * Saves multiple items as separate files in a Pod container
+ * Returns a sync result with success/failure counts
+ */
+export async function saveMultipleFilesToPod<T extends { id: string }>(
+    session: Session,
+    containerUrl: string,
+    items: T[]
+): Promise<PodSyncResult> {
+    let successCount = 0
+    let failCount = 0
+
+    for (const item of items) {
+        try {
+            await saveFileToPod({
+                session,
+                containerPath: containerUrl,
+                filename: `${item.id}.json`,
+                data: item
+            })
+            successCount++
+        } catch (error) {
+            console.error(`Error saving item ${item.id}:`, error)
+            failCount++
+        }
+    }
+
+    return {
+        success: failCount === 0,
+        successCount,
+        failCount,
+        totalCount: items.length
+    }
+}
+
+/**
+ * Loads all JSON files from a Pod container
+ * Returns an array of parsed data and sync stats
+ */
+export async function loadMultipleFilesFromPod<T>(
+    options: LoadMultipleFromPodOptions<T>
+): Promise<{ data: T[], result: PodSyncResult }> {
+    const { session, containerPath, onFileLoaded, onError } = options
+
+    // Get the container dataset to list all files
+    let dataset
+    try {
+        dataset = await getSolidDataset(containerPath, { fetch: session.fetch })
+    } catch (error: any) {
+        if (error.statusCode === 404) {
+            return {
+                data: [],
+                result: {
+                    success: false,
+                    successCount: 0,
+                    failCount: 0,
+                    totalCount: 0
+                }
+            }
+        }
+        throw error
+    }
+
+    const fileUrls = getContainedResourceUrlAll(dataset)
+    const jsonFileUrls = fileUrls.filter(url => url.endsWith('.json'))
+
+    if (jsonFileUrls.length === 0) {
+        return {
+            data: [],
+            result: {
+                success: true,
+                successCount: 0,
+                failCount: 0,
+                totalCount: 0
+            }
+        }
+    }
+
+    const loadedData: T[] = []
+    let successCount = 0
+    let failCount = 0
+
+    // Load each file
+    for (const fileUrl of jsonFileUrls) {
+        try {
+            const file = await getFile(fileUrl, { fetch: session.fetch })
+            const text = await file.text()
+            const item = JSON.parse(text) as T
+
+            loadedData.push(item)
+            successCount++
+
+            if (onFileLoaded) {
+                onFileLoaded(item)
+            }
+        } catch (error) {
+            console.error(`Error loading file ${fileUrl}:`, error)
+            failCount++
+
+            if (onError) {
+                onError(fileUrl, error as Error)
+            }
+        }
+    }
+
+    return {
+        data: loadedData,
+        result: {
+            success: failCount === 0,
+            successCount,
+            failCount,
+            totalCount: jsonFileUrls.length
+        }
+    }
+}


### PR DESCRIPTION
Implement Save to Pod and Load from Pod functionality for packing lists, allowing users to sync their packing lists with their Solid Pod storage. Each packing list is stored as a separate JSON file in the pack-me-up/packing-lists/ container.

Features:
- Save to Pod button: uploads all local packing lists to Solid Pod
- Load from Pod button: downloads all packing lists from Solid Pod to local storage
- Both buttons only visible when logged in to a Solid Pod
- Loading states and disabled states for better UX
- Aggregated success/error reporting with count of synced lists
- Graceful error handling with detailed toast notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)