### PR TITLE
Fix Packing List Loading Issue

### DIFF
--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -75,7 +75,13 @@ export function PackingLists() {
                 return
             }
 
-            // Save each loaded list to local database
+            // First, delete all existing local packing lists
+            const existingLists = await packingAppDb.getAllPackingLists()
+            for (const existingList of existingLists) {
+                await packingAppDb.deletePackingList(existingList.id)
+            }
+
+            // Then save each loaded list to local database
             for (const list of loadedLists) {
                 // Remove _rev to avoid conflicts with local database version
                 delete list._rev


### PR DESCRIPTION
When loading packing lists from pod storage, the app now correctly deletes all existing local packing lists before saving the ones from the pod. This ensures the local data is completely replaced with the pod data, rather than merging them.

Previously, local packing lists that didn't exist in the pod would remain after loading, causing data inconsistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)