### PR TITLE
Debug Login Functionality After App Interruption

### DIFF
--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -38,6 +38,24 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
         setSessionVersion(v => v + 1);
       } catch (error) {
         console.error("Error initializing session:", error);
+        console.log("Session restoration failed, clearing any corrupted session data...");
+
+        // Clear any corrupted session data by logging out
+        // This handles cases where an invalid client_id or expired session data
+        // is stored in the browser, causing authentication failures
+        try {
+          await solidLogout();
+          const clearedSession = getDefaultSession();
+          setSession(clearedSession);
+          setSessionVersion(v => v + 1);
+          console.log("Session data cleared successfully");
+        } catch (logoutError) {
+          console.error("Error clearing session data:", logoutError);
+          // Even if logout fails, try to set a fresh session
+          const currentSession = getDefaultSession();
+          setSession(currentSession);
+          setSessionVersion(v => v + 1);
+        }
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
When users return to the app after being away, they were encountering "Invalid client_id" errors. This occurred because the Solid Pod authentication library stores session data (including a dynamically registered client_id) in browser storage. When this client registration expires on the OAuth provider, session restoration fails but the corrupted data remains in storage, preventing fresh login attempts.

The fix automatically detects session restoration failures and calls logout to clear all corrupted session data, allowing users to proceed with a fresh login flow. This ensures the app never gets stuck in a broken authentication state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)