### PR TITLE
Collapse/expand all and re-order questions

### DIFF
--- a/src/edit-questions/question-section.tsx
+++ b/src/edit-questions/question-section.tsx
@@ -4,7 +4,7 @@ import { Input } from '../components/Input'
 import { Button } from '../components/Button'
 import { CloseButton } from '../components/CloseButton'
 import { OptionSection } from './option-section'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 interface QuestionSectionProps {
     questionIndex: number;
@@ -14,10 +14,20 @@ interface QuestionSectionProps {
     setValue: any;
     removeQuestion: () => void;
     people: Person[];
+    moveUp?: () => void;
+    moveDown?: () => void;
+    forceCollapsed?: boolean | null;
 }
 
-export function QuestionSection({ questionIndex, control, register, watch, setValue, removeQuestion, people }: QuestionSectionProps) {
+export function QuestionSection({ questionIndex, control, register, watch, setValue, removeQuestion, people, moveUp, moveDown, forceCollapsed }: QuestionSectionProps) {
     const [isExpanded, setIsExpanded] = useState(true);
+
+    // Sync with forceCollapsed when it changes
+    useEffect(() => {
+        if (forceCollapsed !== null && forceCollapsed !== undefined) {
+            setIsExpanded(!forceCollapsed);
+        }
+    }, [forceCollapsed]);
     const { fields: optionFields, append: appendOption, remove: removeOption } = useFieldArray({
         control,
         name: `questions.${questionIndex}.options` as const
@@ -31,6 +41,7 @@ export function QuestionSection({ questionIndex, control, register, watch, setVa
                         type="button"
                         onClick={() => setIsExpanded(!isExpanded)}
                         className="text-gray-400 hover:text-gray-600 transition-colors duration-200"
+                        title={isExpanded ? 'Collapse' : 'Expand'}
                     >
                         <svg
                             className={`w-5 h-5 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
@@ -41,6 +52,40 @@ export function QuestionSection({ questionIndex, control, register, watch, setVa
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                         </svg>
                     </button>
+                    <div className="flex flex-col gap-1">
+                        <button
+                            type="button"
+                            onClick={moveUp}
+                            disabled={!moveUp}
+                            className={`text-gray-400 transition-colors duration-200 ${moveUp ? 'hover:text-gray-600 cursor-pointer' : 'opacity-30 cursor-not-allowed'}`}
+                            title="Move up"
+                        >
+                            <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                            >
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                            </svg>
+                        </button>
+                        <button
+                            type="button"
+                            onClick={moveDown}
+                            disabled={!moveDown}
+                            className={`text-gray-400 transition-colors duration-200 ${moveDown ? 'hover:text-gray-600 cursor-pointer' : 'opacity-30 cursor-not-allowed'}`}
+                            title="Move down"
+                        >
+                            <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                            >
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                            </svg>
+                        </button>
+                    </div>
                     <div className="flex-1">
                         <Input
                             label={`Question ${questionIndex + 1}`}

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -42,6 +42,7 @@ export function EditQuestionsForm() {
   const watchedFormValues = useWatch({ control });
 
   const [currentQuestionSet, setCurrentQuestionSet] = useState<PackingListQuestionSet | null>(null);
+  const [allQuestionsCollapsed, setAllQuestionsCollapsed] = useState<boolean | null>(null);
 
   console.log("EditQuestionsForm - isLoggedIn:", isLoggedIn);
 
@@ -283,7 +284,7 @@ export function EditQuestionsForm() {
     loadQuestionSet()
   }, [])
 
-  const { fields: questionFields, append: appendQuestion, remove: removeQuestion } = useFieldArray({
+  const { fields: questionFields, append: appendQuestion, remove: removeQuestion, move: moveQuestion } = useFieldArray({
     control,
     name: "questions"
   });
@@ -528,6 +529,17 @@ export function EditQuestionsForm() {
             setValue={setValue}
             people={people}
           />
+          {questionFields.length > 0 && (
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                onClick={() => setAllQuestionsCollapsed(!allQuestionsCollapsed)}
+                variant="secondary"
+              >
+                {allQuestionsCollapsed ? 'Expand All' : 'Collapse All'}
+              </Button>
+            </div>
+          )}
           {questionFields.map((question, questionIndex) => (
             <QuestionSection
               key={question.id}
@@ -538,6 +550,9 @@ export function EditQuestionsForm() {
               setValue={setValue}
               removeQuestion={() => removeQuestion(questionIndex)}
               people={people}
+              moveUp={questionIndex > 0 ? () => moveQuestion(questionIndex, questionIndex - 1) : undefined}
+              moveDown={questionIndex < questionFields.length - 1 ? () => moveQuestion(questionIndex, questionIndex + 1) : undefined}
+              forceCollapsed={allQuestionsCollapsed}
             />
           ))}
           {/* Add Question button at bottom of form - only visible on large screens */}


### PR DESCRIPTION
- Add 'Collapse All' / 'Expand All' button to minimize/expand all question sections at once
- Add up/down arrow buttons to each question section to reorder questions
- Update QuestionSection to sync with global collapse state
- Disable up arrow on first question and down arrow on last question

🤖 Generated with [Claude Code](https://claude.com/claude-code)