### PR TITLE
Fix build failure and errors

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,5 +22,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"]
 }


### PR DESCRIPTION
Test files (*.test.ts, *.test.tsx, *.spec.ts, *.spec.tsx) were being included in the production TypeScript compilation, causing build failures due to unused variables and type mismatches in test code.

Updated tsconfig.app.json to exclude test files from the build.