### PR TITLE
Identify onboarding hooks for data persistence

### DIFF
--- a/src/components/SolidPodPrompt.tsx
+++ b/src/components/SolidPodPrompt.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react'
+import { Modal } from './Modal'
+import { Button } from './Button'
+import { SolidProviderSelector } from './SolidProviderSelector'
+import { useSolidPod } from './SolidPodContext'
+
+interface SolidPodPromptProps {
+  isOpen: boolean
+  onClose: () => void
+  title: string
+  message: string
+  dismissalKey?: string
+}
+
+/**
+ * Reusable component for prompting users to set up their Solid Pod
+ * Shows benefits and integrates with the provider selector
+ */
+export function SolidPodPrompt({
+  isOpen,
+  onClose,
+  title,
+  message,
+  dismissalKey
+}: SolidPodPromptProps) {
+  const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
+  const { login } = useSolidPod()
+
+  const handleGetStarted = () => {
+    setIsProviderSelectorOpen(true)
+  }
+
+  const handleProviderSelect = (issuer: string) => {
+    // Mark as dismissed since they're taking action
+    if (dismissalKey) {
+      localStorage.setItem(dismissalKey, 'true')
+    }
+    onClose()
+    return login(issuer)
+  }
+
+  const handleMaybeLater = () => {
+    if (dismissalKey) {
+      localStorage.setItem(dismissalKey, 'true')
+    }
+    onClose()
+  }
+
+  const handleCloseProviderSelector = () => {
+    setIsProviderSelectorOpen(false)
+  }
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={handleMaybeLater} title={title}>
+        <div className="space-y-4">
+          <p className="text-gray-700 leading-relaxed">{message}</p>
+
+          <div className="bg-gradient-to-br from-primary-50 to-accent-50 border-2 border-primary-200 rounded-xl p-4 space-y-2">
+            <h4 className="font-bold text-primary-900 text-sm">Benefits of using a Solid Pod:</h4>
+            <ul className="text-sm text-gray-700 space-y-1.5 ml-4 list-disc">
+              <li>
+                <strong>Multi-device access</strong> - Access your packing lists from any device
+              </li>
+              <li>
+                <strong>You own your data</strong> - Your lists stay in your personal storage
+              </li>
+              <li>
+                <strong>Never lose your work</strong> - Safe even if you clear browser data
+              </li>
+              <li>
+                <strong>Privacy-focused</strong> - You control who can access your data
+              </li>
+            </ul>
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <Button
+              type="button"
+              onClick={handleGetStarted}
+              variant="primary"
+              className="flex-1"
+            >
+              🔒 Set Up Solid Pod
+            </Button>
+            <Button
+              type="button"
+              onClick={handleMaybeLater}
+              variant="ghost"
+              className="flex-1"
+            >
+              Maybe Later
+            </Button>
+          </div>
+
+          <p className="text-xs text-gray-500 text-center">
+            You can always set this up later from the navigation menu
+          </p>
+        </div>
+      </Modal>
+
+      <SolidProviderSelector
+        isOpen={isProviderSelectorOpen}
+        onClose={handleCloseProviderSelector}
+        onSelect={handleProviderSelect}
+      />
+    </>
+  )
+}

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -5,18 +5,33 @@ import { packingAppDb } from '../services/database'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
 import { Button } from '../components/Button'
+import { SolidPodPrompt } from '../components/SolidPodPrompt'
 import { getPrimaryPodUrl, saveMultipleFilesToPod, loadMultipleFilesFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
+
+const PACKING_LISTS_BANNER_KEY = 'packing-lists-pod-banner-dismissed'
 
 export function PackingLists() {
     const [packingLists, setPackingLists] = useState<PackingList[]>([])
     const [isLoading, setIsLoading] = useState(true)
     const [isSaving, setIsSaving] = useState(false)
     const [isLoadingFromPod, setIsLoadingFromPod] = useState(false)
+    const [showBanner, setShowBanner] = useState(false)
+    const [showPodPrompt, setShowPodPrompt] = useState(false)
     const navigate = useNavigate()
     const { isLoggedIn, session } = useSolidPod()
     const { showToast } = useToast()
     const handlePodError = usePodErrorHandler()
+
+    const handleBannerDismiss = () => {
+        localStorage.setItem(PACKING_LISTS_BANNER_KEY, 'true')
+        setShowBanner(false)
+    }
+
+    const handleBannerSetup = () => {
+        setShowBanner(false)
+        setShowPodPrompt(true)
+    }
 
     const deletePackingList = async (id: string, event: React.MouseEvent) => {
         event.stopPropagation() // Prevent navigation when clicking delete
@@ -110,6 +125,15 @@ export function PackingLists() {
             try {
                 const lists = await packingAppDb.getAllPackingLists()
                 setPackingLists(lists)
+
+                // Show banner if:
+                // 1. User is not logged in
+                // 2. User has packing lists
+                // 3. Banner hasn't been dismissed
+                const hasBannerBeenDismissed = localStorage.getItem(PACKING_LISTS_BANNER_KEY) === 'true'
+                if (!isLoggedIn && lists.length > 0 && !hasBannerBeenDismissed) {
+                    setShowBanner(true)
+                }
             } catch (err) {
                 console.error('Error fetching packing lists:', err)
             } finally {
@@ -118,7 +142,7 @@ export function PackingLists() {
         }
 
         fetchPackingLists()
-    }, [])
+    }, [isLoggedIn])
 
     if (isLoading) {
         return <div className="max-w-4xl mx-auto py-8 px-4 text-center text-gray-700 font-semibold">Loading packing lists...</div>
@@ -158,6 +182,52 @@ export function PackingLists() {
                     )}
                 </div>
             </div>
+
+            {/* Solid Pod Banner for non-logged-in users */}
+            {showBanner && (
+                <div className="mb-6 bg-gradient-to-r from-amber-50 to-orange-50 border-2 border-amber-300 rounded-2xl shadow-soft p-5 animate-fade-in">
+                    <div className="flex items-start justify-between gap-4">
+                        <div className="flex-1">
+                            <h3 className="text-lg font-bold text-amber-900 mb-2 flex items-center gap-2">
+                                <span className="text-2xl">⚠️</span>
+                                Protect Your Packing Lists
+                            </h3>
+                            <p className="text-amber-800 mb-3 leading-relaxed">
+                                You have <strong>{packingLists.length} packing list{packingLists.length !== 1 ? 's' : ''}</strong> stored locally.
+                                They could be lost if you clear your browser data or switch devices.
+                                Secure them with a Solid Pod for multi-device access and peace of mind!
+                            </p>
+                            <div className="flex gap-3">
+                                <Button
+                                    type="button"
+                                    onClick={handleBannerSetup}
+                                    variant="primary"
+                                    className="text-sm"
+                                >
+                                    🔒 Secure My Data Now
+                                </Button>
+                                <Button
+                                    type="button"
+                                    onClick={handleBannerDismiss}
+                                    variant="ghost"
+                                    className="text-sm"
+                                >
+                                    Dismiss
+                                </Button>
+                            </div>
+                        </div>
+                        <button
+                            onClick={handleBannerDismiss}
+                            className="text-amber-600 hover:text-amber-800 transition-colors"
+                            aria-label="Close banner"
+                        >
+                            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+            )}
 
             {packingLists.length === 0 ? (
                 <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
@@ -217,6 +287,15 @@ export function PackingLists() {
                     })}
                 </div>
             )}
+
+            {/* Solid Pod Setup Prompt */}
+            <SolidPodPrompt
+                isOpen={showPodPrompt}
+                onClose={() => setShowPodPrompt(false)}
+                title="🔒 Secure Your Packing Lists"
+                message="Protect your valuable packing lists from being lost! Set up a Solid Pod to store your data securely in personal storage that you control, accessible from any device."
+                dismissalKey={PACKING_LISTS_BANNER_KEY}
+            />
         </div>
     )
 } 

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -3,13 +3,19 @@ import { useForm, useFieldArray } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
+import { SolidPodPrompt } from '../components/SolidPodPrompt'
+import { useSolidPod } from '../components/SolidPodContext'
 import { packingAppDb } from '../services/database'
 import { ACTIVITIES, wizardSchema, WizardFormData } from './wizard-types'
 import { useWizardGeneration } from './useWizardGeneration'
 
+const WIZARD_POD_PROMPT_KEY = 'wizard-pod-prompt-dismissed'
+
 export const Wizard = () => {
     const [showConfirmDialog, setShowConfirmDialog] = useState(false)
+    const [showPodPrompt, setShowPodPrompt] = useState(false)
     const [hasExistingData, setHasExistingData] = useState(false)
+    const { isLoggedIn } = useSolidPod()
     const { isLoading, saveAndNavigate } = useWizardGeneration()
 
     const { register, control, handleSubmit, watch, formState: { errors } } = useForm<WizardFormData>({
@@ -62,14 +68,26 @@ export const Wizard = () => {
         if (hasExistingData) {
             setShowConfirmDialog(true)
         } else {
-            await saveAndNavigate(data)
+            await saveWizardData(data)
         }
     }
 
     const handleConfirmOverride = async () => {
         setShowConfirmDialog(false)
         const data = watch()
+        await saveWizardData(data)
+    }
+
+    const saveWizardData = async (data: WizardFormData) => {
         await saveAndNavigate(data)
+
+        // Show Solid Pod prompt if:
+        // 1. User is not already logged in
+        // 2. User hasn't dismissed this prompt before
+        const hasPromptBeenDismissed = localStorage.getItem(WIZARD_POD_PROMPT_KEY) === 'true'
+        if (!isLoggedIn && !hasPromptBeenDismissed) {
+            setShowPodPrompt(true)
+        }
     }
 
     return (
@@ -203,6 +221,15 @@ Are you sure you want to continue?"
                 confirmText="Yes, Override"
                 cancelText="Cancel"
                 confirmVariant="danger"
+            />
+
+            {/* Solid Pod Onboarding Prompt */}
+            <SolidPodPrompt
+                isOpen={showPodPrompt}
+                onClose={() => setShowPodPrompt(false)}
+                title="🎉 Great! Your Questions Are Ready"
+                message="Want to keep your personalized packing questions safe and accessible from any device? Set up a Solid Pod to store your data securely in personal storage that you control."
+                dismissalKey={WIZARD_POD_PROMPT_KEY}
             />
         </div>
     )


### PR DESCRIPTION
Implement strategic onboarding hooks to encourage users to set up Solid Pod for secure, multi-device data storage:

1. Post-wizard completion prompt - Shown after users complete the wizard and generate their personalized questions. Targets engaged users at moment of commitment.

2. View Lists banner - Persistent reminder for non-logged-in users who have packing lists. Warns about risk of data loss and encourages Pod setup.

3. Reusable SolidPodPrompt component - Modal that explains benefits and integrates with existing provider selector flow.

4. localStorage dismissal tracking - Prevents nagging users who explicitly decline, using separate keys for each hook location.

Benefits:
- Non-blocking UX with "Maybe Later" options
- Clear value proposition focusing on multi-device access and data ownership
- Seamless integration with existing authentication flow
- Separate dismissal tracking for wizard and packing lists prompts