### PR TITLE
Add age-based filtering to wizard output

### DIFF
--- a/src/edit-questions/age-specific-items.ts
+++ b/src/edit-questions/age-specific-items.ts
@@ -1,0 +1,253 @@
+import { Person, Item, PersonSelection, AgeRange } from './types'
+
+/**
+ * Helper function to create person selections for specific people
+ */
+function createPersonSelections(people: Person[], selectedPeople: Person[]): PersonSelection[] {
+    return people.map(p => ({
+        personId: p.id,
+        selected: selectedPeople.some(sp => sp.id === p.id)
+    }))
+}
+
+/**
+ * Helper function to filter people by age range
+ */
+function filterByAgeRange(people: Person[], ageRange: AgeRange): Person[] {
+    return people.filter(p => p.ageRange === ageRange)
+}
+
+/**
+ * Generate age-specific items for "Always Needed Items" section
+ */
+export function generateAlwaysNeededAgeSpecificItems(people: Person[]): Item[] {
+    const items: Item[] = []
+
+    // Baby (0-1 years) items
+    const babies = filterByAgeRange(people, 'Baby')
+    if (babies.length > 0) {
+        items.push(
+            { text: 'Nappies (pack/supply)', personSelections: createPersonSelections(people, babies) },
+            { text: 'Baby wipes', personSelections: createPersonSelections(people, babies) },
+            { text: 'Nappy bags', personSelections: createPersonSelections(people, babies) },
+            { text: 'Change mat', personSelections: createPersonSelections(people, babies) },
+            { text: 'Bibs', personSelections: createPersonSelections(people, babies) },
+            { text: 'Muslins/Burp cloths', personSelections: createPersonSelections(people, babies) },
+            { text: 'Bottles (if bottle feeding)', personSelections: createPersonSelections(people, babies) },
+            { text: 'Formula/Baby food', personSelections: createPersonSelections(people, babies) },
+            { text: 'Dummy/Pacifier (if used)', personSelections: createPersonSelections(people, babies) },
+            { text: 'Spare clothes (×3-4 sets)', personSelections: createPersonSelections(people, babies) }
+        )
+    }
+
+    // Toddler (1-3 years) items
+    const toddlers = filterByAgeRange(people, 'Toddler')
+    if (toddlers.length > 0) {
+        items.push(
+            { text: 'Pull-ups/Toddler nappies', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Potty (travel potty)', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Wipes', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Spare clothes (×2-3 sets)', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Sippy cup/Toddler cup', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Toddler snacks', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Comfort item (teddy/blanket)', personSelections: createPersonSelections(people, toddlers) }
+        )
+    }
+
+    // Child (3-12 years) items
+    const children = filterByAgeRange(people, 'Child')
+    if (children.length > 0) {
+        items.push(
+            { text: 'Entertainment (books/small toys)', personSelections: createPersonSelections(people, children) },
+            { text: 'Playing cards/Travel games', personSelections: createPersonSelections(people, children) }
+        )
+    }
+
+    // Teenager (12-17 years) items
+    const teenagers = filterByAgeRange(people, 'Teenager')
+    if (teenagers.length > 0) {
+        items.push(
+            { text: 'Headphones', personSelections: createPersonSelections(people, teenagers) },
+            { text: 'Phone charger', personSelections: createPersonSelections(people, teenagers) }
+        )
+    }
+
+    return items
+}
+
+/**
+ * Generate age-specific items for overnight stays
+ */
+export function generateOvernightAgeSpecificItems(people: Person[]): Item[] {
+    const items: Item[] = []
+
+    // Baby (0-1 years) items
+    const babies = filterByAgeRange(people, 'Baby')
+    if (babies.length > 0) {
+        items.push(
+            { text: 'Baby monitor', personSelections: createPersonSelections(people, babies) },
+            { text: 'Nightlight', personSelections: createPersonSelections(people, babies) },
+            { text: 'Baby sleeping bag/Swaddle', personSelections: createPersonSelections(people, babies) },
+            { text: 'Extra bedding/sheets', personSelections: createPersonSelections(people, babies) },
+            { text: 'Bedtime bottle', personSelections: createPersonSelections(people, babies) }
+        )
+    }
+
+    // Toddler (1-3 years) items
+    const toddlers = filterByAgeRange(people, 'Toddler')
+    if (toddlers.length > 0) {
+        items.push(
+            { text: 'Bedtime books', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Night nappy/Pull-up', personSelections: createPersonSelections(people, toddlers) }
+        )
+    }
+
+    // Child (3-12 years) items
+    const children = filterByAgeRange(people, 'Child')
+    if (children.length > 0) {
+        items.push(
+            { text: 'Favorite toy/Stuffed animal', personSelections: createPersonSelections(people, children) },
+            { text: 'Flashlight', personSelections: createPersonSelections(people, children) }
+        )
+    }
+
+    // Teenager (12-17 years) items
+    const teenagers = filterByAgeRange(people, 'Teenager')
+    if (teenagers.length > 0) {
+        items.push(
+            { text: 'Personal care items (face wash, etc.)', personSelections: createPersonSelections(people, teenagers) }
+        )
+    }
+
+    return items
+}
+
+/**
+ * Generate age-specific items for swimming activities
+ */
+export function generateSwimmingAgeSpecificItems(people: Person[]): Item[] {
+    const items: Item[] = []
+
+    // Baby (0-1 years) items
+    const babies = filterByAgeRange(people, 'Baby')
+    if (babies.length > 0) {
+        items.push(
+            { text: 'Baby swim nappy', personSelections: createPersonSelections(people, babies) },
+            { text: 'Baby float/Swim seat', personSelections: createPersonSelections(people, babies) },
+            { text: 'Baby sun hat with neck protection', personSelections: createPersonSelections(people, babies) },
+            { text: 'Baby rash guard/Sun suit', personSelections: createPersonSelections(people, babies) }
+        )
+    }
+
+    // Toddler (1-3 years) items
+    const toddlers = filterByAgeRange(people, 'Toddler')
+    if (toddlers.length > 0) {
+        items.push(
+            { text: 'Swim nappy (if not potty trained)', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Armbands/Floaties', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Toddler sun hat', personSelections: createPersonSelections(people, toddlers) }
+        )
+    }
+
+    // Child (3-12 years) items
+    const children = filterByAgeRange(people, 'Child')
+    if (children.length > 0) {
+        items.push(
+            { text: 'Swim aids (noodles, kickboard)', personSelections: createPersonSelections(people, children) }
+        )
+    }
+
+    return items
+}
+
+/**
+ * Generate age-specific items for hot weather
+ */
+export function generateHotWeatherAgeSpecificItems(people: Person[]): Item[] {
+    const items: Item[] = []
+
+    // Baby (0-1 years) items
+    const babies = filterByAgeRange(people, 'Baby')
+    if (babies.length > 0) {
+        items.push(
+            { text: 'Baby sunscreen (SPF 50+)', personSelections: createPersonSelections(people, babies) },
+            { text: 'Sun protective baby clothing', personSelections: createPersonSelections(people, babies) },
+            { text: 'Shade cover/Parasol for pram', personSelections: createPersonSelections(people, babies) }
+        )
+    }
+
+    // Toddler (1-3 years) items
+    const toddlers = filterByAgeRange(people, 'Toddler')
+    if (toddlers.length > 0) {
+        items.push(
+            { text: 'Toddler sunscreen', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Sun protective clothing', personSelections: createPersonSelections(people, toddlers) }
+        )
+    }
+
+    // Child (3-12 years) items
+    const children = filterByAgeRange(people, 'Child')
+    if (children.length > 0) {
+        items.push(
+            { text: 'Kids sunscreen', personSelections: createPersonSelections(people, children) }
+        )
+    }
+
+    return items
+}
+
+/**
+ * Generate age-specific items for cold weather
+ */
+export function generateColdWeatherAgeSpecificItems(people: Person[]): Item[] {
+    const items: Item[] = []
+
+    // Baby (0-1 years) items
+    const babies = filterByAgeRange(people, 'Baby')
+    if (babies.length > 0) {
+        items.push(
+            { text: 'Baby snowsuit/Pramsuit', personSelections: createPersonSelections(people, babies) },
+            { text: 'Baby mittens', personSelections: createPersonSelections(people, babies) },
+            { text: 'Baby warm hat with ear coverage', personSelections: createPersonSelections(people, babies) },
+            { text: 'Blanket for carrier/pram', personSelections: createPersonSelections(people, babies) }
+        )
+    }
+
+    // Toddler (1-3 years) items
+    const toddlers = filterByAgeRange(people, 'Toddler')
+    if (toddlers.length > 0) {
+        items.push(
+            { text: 'Toddler snowsuit/Winter coat', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Toddler mittens (not gloves - easier)', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Toddler warm hat', personSelections: createPersonSelections(people, toddlers) }
+        )
+    }
+
+    return items
+}
+
+/**
+ * Generate age-specific items for hiking
+ */
+export function generateHikingAgeSpecificItems(people: Person[]): Item[] {
+    const items: Item[] = []
+
+    // Baby (0-1 years) items
+    const babies = filterByAgeRange(people, 'Baby')
+    if (babies.length > 0) {
+        items.push(
+            { text: 'Baby carrier/Sling', personSelections: createPersonSelections(people, babies) }
+        )
+    }
+
+    // Toddler (1-3 years) items
+    const toddlers = filterByAgeRange(people, 'Toddler')
+    if (toddlers.length > 0) {
+        items.push(
+            { text: 'Toddler reins/Backpack harness', personSelections: createPersonSelections(people, toddlers) },
+            { text: 'Lightweight buggy/Stroller', personSelections: createPersonSelections(people, toddlers) }
+        )
+    }
+
+    return items
+}

--- a/src/edit-questions/age-specific-items.ts
+++ b/src/edit-questions/age-specific-items.ts
@@ -1,14 +1,4 @@
-import { Person, Item, PersonSelection, AgeRange } from './types'
-
-/**
- * Helper function to create person selections for specific people
- */
-function createPersonSelections(people: Person[], selectedPeople: Person[]): PersonSelection[] {
-    return people.map(p => ({
-        personId: p.id,
-        selected: selectedPeople.some(sp => sp.id === p.id)
-    }))
-}
+import { Person, AgeRange } from './types'
 
 /**
  * Helper function to filter people by age range
@@ -32,6 +22,34 @@ export function getAdults(people: Person[]): Person[] {
 }
 
 /**
+ * Get teenagers only
+ */
+export function getTeenagers(people: Person[]): Person[] {
+    return filterByAgeRange(people, 'Teenager')
+}
+
+/**
+ * Get children only
+ */
+export function getChildren(people: Person[]): Person[] {
+    return filterByAgeRange(people, 'Child')
+}
+
+/**
+ * Get toddlers only
+ */
+export function getToddlers(people: Person[]): Person[] {
+    return filterByAgeRange(people, 'Toddler')
+}
+
+/**
+ * Get babies only
+ */
+export function getBabies(people: Person[]): Person[] {
+    return filterByAgeRange(people, 'Baby')
+}
+
+/**
  * Get teenagers and adults
  */
 export function getTeenagersAndAdults(people: Person[]): Person[] {
@@ -50,246 +68,4 @@ export function getChildrenAndOlder(people: Person[]): Person[] {
  */
 export function getToddlersAndOlder(people: Person[]): Person[] {
     return filterByAgeRanges(people, ['Toddler', 'Child', 'Teenager', 'Adult'])
-}
-
-/**
- * Get everyone (all people regardless of age range)
- */
-export function getEveryone(people: Person[]): Person[] {
-    return people
-}
-
-/**
- * Generate age-specific items for "Always Needed Items" section
- */
-export function generateAlwaysNeededAgeSpecificItems(people: Person[]): Item[] {
-    const items: Item[] = []
-
-    // Baby (0-1 years) items
-    const babies = filterByAgeRange(people, 'Baby')
-    if (babies.length > 0) {
-        items.push(
-            { text: 'Nappies (pack/supply)', personSelections: createPersonSelections(people, babies) },
-            { text: 'Baby wipes', personSelections: createPersonSelections(people, babies) },
-            { text: 'Nappy bags', personSelections: createPersonSelections(people, babies) },
-            { text: 'Change mat', personSelections: createPersonSelections(people, babies) },
-            { text: 'Bibs', personSelections: createPersonSelections(people, babies) },
-            { text: 'Muslins/Burp cloths', personSelections: createPersonSelections(people, babies) },
-            { text: 'Bottles (if bottle feeding)', personSelections: createPersonSelections(people, babies) },
-            { text: 'Formula/Baby food', personSelections: createPersonSelections(people, babies) },
-            { text: 'Dummy/Pacifier (if used)', personSelections: createPersonSelections(people, babies) },
-            { text: 'Spare clothes (×3-4 sets)', personSelections: createPersonSelections(people, babies) }
-        )
-    }
-
-    // Toddler (1-3 years) items
-    const toddlers = filterByAgeRange(people, 'Toddler')
-    if (toddlers.length > 0) {
-        items.push(
-            { text: 'Pull-ups/Toddler nappies', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Potty (travel potty)', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Wipes', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Spare clothes (×2-3 sets)', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Sippy cup/Toddler cup', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Toddler snacks', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Comfort item (teddy/blanket)', personSelections: createPersonSelections(people, toddlers) }
-        )
-    }
-
-    // Child (3-12 years) items
-    const children = filterByAgeRange(people, 'Child')
-    if (children.length > 0) {
-        items.push(
-            { text: 'Entertainment (books/small toys)', personSelections: createPersonSelections(people, children) },
-            { text: 'Playing cards/Travel games', personSelections: createPersonSelections(people, children) }
-        )
-    }
-
-    // Teenager (12-17 years) items
-    const teenagers = filterByAgeRange(people, 'Teenager')
-    if (teenagers.length > 0) {
-        items.push(
-            { text: 'Headphones', personSelections: createPersonSelections(people, teenagers) },
-            { text: 'Phone charger', personSelections: createPersonSelections(people, teenagers) }
-        )
-    }
-
-    return items
-}
-
-/**
- * Generate age-specific items for overnight stays
- */
-export function generateOvernightAgeSpecificItems(people: Person[]): Item[] {
-    const items: Item[] = []
-
-    // Baby (0-1 years) items
-    const babies = filterByAgeRange(people, 'Baby')
-    if (babies.length > 0) {
-        items.push(
-            { text: 'Baby monitor', personSelections: createPersonSelections(people, babies) },
-            { text: 'Nightlight', personSelections: createPersonSelections(people, babies) },
-            { text: 'Baby sleeping bag/Swaddle', personSelections: createPersonSelections(people, babies) },
-            { text: 'Extra bedding/sheets', personSelections: createPersonSelections(people, babies) },
-            { text: 'Bedtime bottle', personSelections: createPersonSelections(people, babies) }
-        )
-    }
-
-    // Toddler (1-3 years) items
-    const toddlers = filterByAgeRange(people, 'Toddler')
-    if (toddlers.length > 0) {
-        items.push(
-            { text: 'Bedtime books', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Night nappy/Pull-up', personSelections: createPersonSelections(people, toddlers) }
-        )
-    }
-
-    // Child (3-12 years) items
-    const children = filterByAgeRange(people, 'Child')
-    if (children.length > 0) {
-        items.push(
-            { text: 'Favorite toy/Stuffed animal', personSelections: createPersonSelections(people, children) },
-            { text: 'Flashlight', personSelections: createPersonSelections(people, children) }
-        )
-    }
-
-    // Teenager (12-17 years) items
-    const teenagers = filterByAgeRange(people, 'Teenager')
-    if (teenagers.length > 0) {
-        items.push(
-            { text: 'Personal care items (face wash, etc.)', personSelections: createPersonSelections(people, teenagers) }
-        )
-    }
-
-    return items
-}
-
-/**
- * Generate age-specific items for swimming activities
- */
-export function generateSwimmingAgeSpecificItems(people: Person[]): Item[] {
-    const items: Item[] = []
-
-    // Baby (0-1 years) items
-    const babies = filterByAgeRange(people, 'Baby')
-    if (babies.length > 0) {
-        items.push(
-            { text: 'Baby swim nappy', personSelections: createPersonSelections(people, babies) },
-            { text: 'Baby float/Swim seat', personSelections: createPersonSelections(people, babies) },
-            { text: 'Baby sun hat with neck protection', personSelections: createPersonSelections(people, babies) },
-            { text: 'Baby rash guard/Sun suit', personSelections: createPersonSelections(people, babies) }
-        )
-    }
-
-    // Toddler (1-3 years) items
-    const toddlers = filterByAgeRange(people, 'Toddler')
-    if (toddlers.length > 0) {
-        items.push(
-            { text: 'Swim nappy (if not potty trained)', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Armbands/Floaties', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Toddler sun hat', personSelections: createPersonSelections(people, toddlers) }
-        )
-    }
-
-    // Child (3-12 years) items
-    const children = filterByAgeRange(people, 'Child')
-    if (children.length > 0) {
-        items.push(
-            { text: 'Swim aids (noodles, kickboard)', personSelections: createPersonSelections(people, children) }
-        )
-    }
-
-    return items
-}
-
-/**
- * Generate age-specific items for hot weather
- */
-export function generateHotWeatherAgeSpecificItems(people: Person[]): Item[] {
-    const items: Item[] = []
-
-    // Baby (0-1 years) items
-    const babies = filterByAgeRange(people, 'Baby')
-    if (babies.length > 0) {
-        items.push(
-            { text: 'Baby sunscreen (SPF 50+)', personSelections: createPersonSelections(people, babies) },
-            { text: 'Sun protective baby clothing', personSelections: createPersonSelections(people, babies) },
-            { text: 'Shade cover/Parasol for pram', personSelections: createPersonSelections(people, babies) }
-        )
-    }
-
-    // Toddler (1-3 years) items
-    const toddlers = filterByAgeRange(people, 'Toddler')
-    if (toddlers.length > 0) {
-        items.push(
-            { text: 'Toddler sunscreen', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Sun protective clothing', personSelections: createPersonSelections(people, toddlers) }
-        )
-    }
-
-    // Child (3-12 years) items
-    const children = filterByAgeRange(people, 'Child')
-    if (children.length > 0) {
-        items.push(
-            { text: 'Kids sunscreen', personSelections: createPersonSelections(people, children) }
-        )
-    }
-
-    return items
-}
-
-/**
- * Generate age-specific items for cold weather
- */
-export function generateColdWeatherAgeSpecificItems(people: Person[]): Item[] {
-    const items: Item[] = []
-
-    // Baby (0-1 years) items
-    const babies = filterByAgeRange(people, 'Baby')
-    if (babies.length > 0) {
-        items.push(
-            { text: 'Baby snowsuit/Pramsuit', personSelections: createPersonSelections(people, babies) },
-            { text: 'Baby mittens', personSelections: createPersonSelections(people, babies) },
-            { text: 'Baby warm hat with ear coverage', personSelections: createPersonSelections(people, babies) },
-            { text: 'Blanket for carrier/pram', personSelections: createPersonSelections(people, babies) }
-        )
-    }
-
-    // Toddler (1-3 years) items
-    const toddlers = filterByAgeRange(people, 'Toddler')
-    if (toddlers.length > 0) {
-        items.push(
-            { text: 'Toddler snowsuit/Winter coat', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Toddler mittens (not gloves - easier)', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Toddler warm hat', personSelections: createPersonSelections(people, toddlers) }
-        )
-    }
-
-    return items
-}
-
-/**
- * Generate age-specific items for hiking
- */
-export function generateHikingAgeSpecificItems(people: Person[]): Item[] {
-    const items: Item[] = []
-
-    // Baby (0-1 years) items
-    const babies = filterByAgeRange(people, 'Baby')
-    if (babies.length > 0) {
-        items.push(
-            { text: 'Baby carrier/Sling', personSelections: createPersonSelections(people, babies) }
-        )
-    }
-
-    // Toddler (1-3 years) items
-    const toddlers = filterByAgeRange(people, 'Toddler')
-    if (toddlers.length > 0) {
-        items.push(
-            { text: 'Toddler reins/Backpack harness', personSelections: createPersonSelections(people, toddlers) },
-            { text: 'Lightweight buggy/Stroller', personSelections: createPersonSelections(people, toddlers) }
-        )
-    }
-
-    return items
 }

--- a/src/edit-questions/age-specific-items.ts
+++ b/src/edit-questions/age-specific-items.ts
@@ -18,6 +18,48 @@ function filterByAgeRange(people: Person[], ageRange: AgeRange): Person[] {
 }
 
 /**
+ * Helper function to filter people by multiple age ranges
+ */
+function filterByAgeRanges(people: Person[], ageRanges: AgeRange[]): Person[] {
+    return people.filter(p => p.ageRange && ageRanges.includes(p.ageRange))
+}
+
+/**
+ * Get adults only
+ */
+export function getAdults(people: Person[]): Person[] {
+    return filterByAgeRange(people, 'Adult')
+}
+
+/**
+ * Get teenagers and adults
+ */
+export function getTeenagersAndAdults(people: Person[]): Person[] {
+    return filterByAgeRanges(people, ['Teenager', 'Adult'])
+}
+
+/**
+ * Get children and older (Child, Teenager, Adult)
+ */
+export function getChildrenAndOlder(people: Person[]): Person[] {
+    return filterByAgeRanges(people, ['Child', 'Teenager', 'Adult'])
+}
+
+/**
+ * Get toddlers and older (Toddler, Child, Teenager, Adult)
+ */
+export function getToddlersAndOlder(people: Person[]): Person[] {
+    return filterByAgeRanges(people, ['Toddler', 'Child', 'Teenager', 'Adult'])
+}
+
+/**
+ * Get everyone (all people regardless of age range)
+ */
+export function getEveryone(people: Person[]): Person[] {
+    return people
+}
+
+/**
  * Generate age-specific items for "Always Needed Items" section
  */
 export function generateAlwaysNeededAgeSpecificItems(people: Person[]): Item[] {

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -6,7 +6,11 @@ import {
     generateSwimmingAgeSpecificItems,
     generateHotWeatherAgeSpecificItems,
     generateColdWeatherAgeSpecificItems,
-    generateHikingAgeSpecificItems
+    generateHikingAgeSpecificItems,
+    getAdults,
+    getTeenagersAndAdults,
+    getChildrenAndOlder,
+    getToddlersAndOlder
 } from './age-specific-items';
 
 export function createExampleData(people: Person[]): PackingListQuestionSet {
@@ -17,7 +21,7 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
         alwaysNeededItems: [
             {
                 text: "Day bag / Backpack",
-                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                personSelections: people.map(p => ({ personId: p.id, selected: getChildrenAndOlder(people).some(person => person.id === p.id) }))
             },
             {
                 text: "Snacks",
@@ -25,7 +29,7 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
             },
             {
                 text: "Water bottle",
-                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
             },
             ...generateAlwaysNeededAgeSpecificItems(people)
         ],
@@ -44,23 +48,23 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         items: [
                             {
                                 text: "Toothbrush",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Toothpaste",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Deodorant",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Phone Charger",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Passport/ID",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Pajamas",
@@ -68,11 +72,11 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                             },
                             {
                                 text: "Toiletries bag",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Underwear",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Socks",
@@ -111,19 +115,19 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         items: [
                             {
                                 text: "Dish soap and sponge",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Dishwasher tablets",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Tea towels",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Shopping bags",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
                             }
                         ]
                     },
@@ -149,7 +153,7 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         items: [
                             {
                                 text: "Swimsuit",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Swim towel",
@@ -157,11 +161,11 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                             },
                             {
                                 text: "Goggles",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getChildrenAndOlder(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Swim cap",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getChildrenAndOlder(people).some(person => person.id === p.id) }))
                             },
                             ...generateSwimmingAgeSpecificItems(people)
                         ]
@@ -173,19 +177,19 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         items: [
                             {
                                 text: "Wetsuit",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Water shoes",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Waterproof bag",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Rash guard",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             }
                         ]
                     },
@@ -196,23 +200,23 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         items: [
                             {
                                 text: "Cycling shorts",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Helmet",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Water bottle",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Bike repair kit",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Cycling gloves",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             }
                         ]
                     },
@@ -223,19 +227,19 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         items: [
                             {
                                 text: "Running shoes",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Running clothes",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Sports watch",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Running socks",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             }
                         ]
                     },
@@ -246,23 +250,23 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         items: [
                             {
                                 text: "Climbing shoes",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Chalk bag",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Harness",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Climbing gloves",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Belay device",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             }
                         ]
                     },
@@ -273,23 +277,23 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         items: [
                             {
                                 text: "Hiking boots",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getChildrenAndOlder(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Daypack/Backpack",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Walking poles",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Trail map",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "First aid kit",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
                             },
                             ...generateHikingAgeSpecificItems(people)
                         ]
@@ -305,15 +309,15 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                             },
                             {
                                 text: "Dress shoes",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Accessories (watch, jewelry, etc.)",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Evening bag/Clutch",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
                             }
                         ]
                     }
@@ -341,7 +345,7 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                             },
                             {
                                 text: "Sunglasses",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getChildrenAndOlder(people).some(person => person.id === p.id) }))
                             },
                             {
                                 text: "Light, breathable clothing",
@@ -349,7 +353,7 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                             },
                             {
                                 text: "Sandals",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
+                                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
                             },
                             ...generateHotWeatherAgeSpecificItems(people)
                         ]

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -1,4 +1,4 @@
-import { PackingListQuestionSet, Person } from './types';
+import { PackingListQuestionSet, Person, Item } from './types';
 import { generateUUID } from '../utils/uuid';
 import {
     generateAlwaysNeededAgeSpecificItems,
@@ -13,24 +13,32 @@ import {
     getToddlersAndOlder
 } from './age-specific-items';
 
+/**
+ * Helper function to create an item with age-appropriate person selections
+ * @param text - The item text/name
+ * @param people - All people in the group
+ * @param ageFilter - Optional function to filter people by age range (defaults to everyone)
+ */
+function item(text: string, people: Person[], ageFilter?: (p: Person[]) => Person[]): Item {
+    const selectedPeople = ageFilter ? ageFilter(people) : people;
+    return {
+        text,
+        personSelections: people.map(p => ({
+            personId: p.id,
+            selected: selectedPeople.some(sp => sp.id === p.id)
+        }))
+    };
+}
+
 export function createExampleData(people: Person[]): PackingListQuestionSet {
 
     return {
         _id: "1",
         people,
         alwaysNeededItems: [
-            {
-                text: "Day bag / Backpack",
-                personSelections: people.map(p => ({ personId: p.id, selected: getChildrenAndOlder(people).some(person => person.id === p.id) }))
-            },
-            {
-                text: "Snacks",
-                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-            },
-            {
-                text: "Water bottle",
-                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
-            },
+            item("Day bag / Backpack", people, getChildrenAndOlder),
+            item("Snacks", people),
+            item("Water bottle", people, getToddlersAndOlder),
             ...generateAlwaysNeededAgeSpecificItems(people)
         ],
         questions: [
@@ -46,50 +54,17 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Yes",
                         order: 0,
                         items: [
-                            {
-                                text: "Toothbrush",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Toothpaste",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Deodorant",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Phone Charger",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Passport/ID",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Pajamas",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Toiletries bag",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Underwear",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Socks",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "T-shirt/Top",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Trousers/Shorts",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
+                            item("Toothbrush", people, getToddlersAndOlder),
+                            item("Toothpaste", people, getAdults),
+                            item("Deodorant", people, getTeenagersAndAdults),
+                            item("Phone Charger", people, getTeenagersAndAdults),
+                            item("Passport/ID", people, getAdults),
+                            item("Pajamas", people),
+                            item("Toiletries bag", people, getTeenagersAndAdults),
+                            item("Underwear", people, getToddlersAndOlder),
+                            item("Socks", people),
+                            item("T-shirt/Top", people),
+                            item("Trousers/Shorts", people),
                             ...generateOvernightAgeSpecificItems(people)
                         ]
                     },
@@ -113,22 +88,10 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Yes",
                         order: 0,
                         items: [
-                            {
-                                text: "Dish soap and sponge",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Dishwasher tablets",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Tea towels",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Shopping bags",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
-                            }
+                            item("Dish soap and sponge", people, getAdults),
+                            item("Dishwasher tablets", people, getAdults),
+                            item("Tea towels", people, getAdults),
+                            item("Shopping bags", people, getAdults)
                         ]
                     },
                     {
@@ -151,22 +114,10 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Swimming",
                         order: 0,
                         items: [
-                            {
-                                text: "Swimsuit",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Swim towel",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Goggles",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getChildrenAndOlder(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Swim cap",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getChildrenAndOlder(people).some(person => person.id === p.id) }))
-                            },
+                            item("Swimsuit", people, getToddlersAndOlder),
+                            item("Swim towel", people),
+                            item("Goggles", people, getChildrenAndOlder),
+                            item("Swim cap", people, getChildrenAndOlder),
                             ...generateSwimmingAgeSpecificItems(people)
                         ]
                     },
@@ -175,22 +126,10 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Watersports",
                         order: 1,
                         items: [
-                            {
-                                text: "Wetsuit",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Water shoes",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Waterproof bag",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Rash guard",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            }
+                            item("Wetsuit", people, getTeenagersAndAdults),
+                            item("Water shoes", people, getTeenagersAndAdults),
+                            item("Waterproof bag", people, getTeenagersAndAdults),
+                            item("Rash guard", people, getTeenagersAndAdults)
                         ]
                     },
                     {
@@ -198,26 +137,11 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Cycling",
                         order: 2,
                         items: [
-                            {
-                                text: "Cycling shorts",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Helmet",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Water bottle",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Bike repair kit",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Cycling gloves",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            }
+                            item("Cycling shorts", people, getTeenagersAndAdults),
+                            item("Helmet", people, getTeenagersAndAdults),
+                            item("Water bottle", people, getTeenagersAndAdults),
+                            item("Bike repair kit", people, getTeenagersAndAdults),
+                            item("Cycling gloves", people, getTeenagersAndAdults)
                         ]
                     },
                     {
@@ -225,22 +149,10 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Running",
                         order: 3,
                         items: [
-                            {
-                                text: "Running shoes",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Running clothes",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Sports watch",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Running socks",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            }
+                            item("Running shoes", people, getTeenagersAndAdults),
+                            item("Running clothes", people, getTeenagersAndAdults),
+                            item("Sports watch", people, getTeenagersAndAdults),
+                            item("Running socks", people, getTeenagersAndAdults)
                         ]
                     },
                     {
@@ -248,26 +160,11 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Climbing",
                         order: 4,
                         items: [
-                            {
-                                text: "Climbing shoes",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Chalk bag",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Harness",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Climbing gloves",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Belay device",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            }
+                            item("Climbing shoes", people, getTeenagersAndAdults),
+                            item("Chalk bag", people, getTeenagersAndAdults),
+                            item("Harness", people, getTeenagersAndAdults),
+                            item("Climbing gloves", people, getTeenagersAndAdults),
+                            item("Belay device", people, getTeenagersAndAdults)
                         ]
                     },
                     {
@@ -275,26 +172,11 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Hiking",
                         order: 5,
                         items: [
-                            {
-                                text: "Hiking boots",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getChildrenAndOlder(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Daypack/Backpack",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Walking poles",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Trail map",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "First aid kit",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getAdults(people).some(person => person.id === p.id) }))
-                            },
+                            item("Hiking boots", people, getChildrenAndOlder),
+                            item("Daypack/Backpack", people, getTeenagersAndAdults),
+                            item("Walking poles", people, getAdults),
+                            item("Trail map", people, getAdults),
+                            item("First aid kit", people, getAdults),
                             ...generateHikingAgeSpecificItems(people)
                         ]
                     },
@@ -303,22 +185,10 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Formal occasions",
                         order: 6,
                         items: [
-                            {
-                                text: "Formal outfit",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Dress shoes",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Accessories (watch, jewelry, etc.)",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Evening bag/Clutch",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getTeenagersAndAdults(people).some(person => person.id === p.id) }))
-                            }
+                            item("Formal outfit", people),
+                            item("Dress shoes", people, getToddlersAndOlder),
+                            item("Accessories (watch, jewelry, etc.)", people, getTeenagersAndAdults),
+                            item("Evening bag/Clutch", people, getTeenagersAndAdults)
                         ]
                     }
                 ]
@@ -335,26 +205,11 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Hot",
                         order: 0,
                         items: [
-                            {
-                                text: "Sunscreen",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Sun hat",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Sunglasses",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getChildrenAndOlder(people).some(person => person.id === p.id) }))
-                            },
-                            {
-                                text: "Light, breathable clothing",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Sandals",
-                                personSelections: people.map(p => ({ personId: p.id, selected: getToddlersAndOlder(people).some(person => person.id === p.id) }))
-                            },
+                            item("Sunscreen", people),
+                            item("Sun hat", people),
+                            item("Sunglasses", people, getChildrenAndOlder),
+                            item("Light, breathable clothing", people),
+                            item("Sandals", people, getToddlersAndOlder),
                             ...generateHotWeatherAgeSpecificItems(people)
                         ]
                     },
@@ -363,22 +218,10 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Rain",
                         order: 1,
                         items: [
-                            {
-                                text: "Raincoat",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Umbrella",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Waterproof shoes/boots",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Waterproof bag cover",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            }
+                            item("Raincoat", people),
+                            item("Umbrella", people),
+                            item("Waterproof shoes/boots", people),
+                            item("Waterproof bag cover", people)
                         ]
                     },
                     {
@@ -386,22 +229,10 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Warm",
                         order: 2,
                         items: [
-                            {
-                                text: "Light jacket",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Comfortable layers",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Long-sleeved shirts",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Comfortable walking shoes",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            }
+                            item("Light jacket", people),
+                            item("Comfortable layers", people),
+                            item("Long-sleeved shirts", people),
+                            item("Comfortable walking shoes", people)
                         ]
                     },
                     {
@@ -409,30 +240,12 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                         text: "Cold",
                         order: 3,
                         items: [
-                            {
-                                text: "Winter coat",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Gloves",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Scarf",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Warm hat/Beanie",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Thermal underwear",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
-                            {
-                                text: "Warm boots",
-                                personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            },
+                            item("Winter coat", people),
+                            item("Gloves", people),
+                            item("Scarf", people),
+                            item("Warm hat/Beanie", people),
+                            item("Thermal underwear", people),
+                            item("Warm boots", people),
                             ...generateColdWeatherAgeSpecificItems(people)
                         ]
                     }

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -1,11 +1,15 @@
-import { PackingListQuestionSet } from './types';
+import { PackingListQuestionSet, Person } from './types';
 import { generateUUID } from '../utils/uuid';
+import {
+    generateAlwaysNeededAgeSpecificItems,
+    generateOvernightAgeSpecificItems,
+    generateSwimmingAgeSpecificItems,
+    generateHotWeatherAgeSpecificItems,
+    generateColdWeatherAgeSpecificItems,
+    generateHikingAgeSpecificItems
+} from './age-specific-items';
 
-export function createExampleData(numPeople: number, names?: string[]): PackingListQuestionSet {
-    const people = Array.from({ length: numPeople }, (_, i) => ({
-        id: generateUUID(),
-        name: names?.[i] || (i === 0 ? "Me" : `Person ${i + 1}`)
-    }));
+export function createExampleData(people: Person[]): PackingListQuestionSet {
 
     return {
         _id: "1",
@@ -22,7 +26,8 @@ export function createExampleData(numPeople: number, names?: string[]): PackingL
             {
                 text: "Water bottle",
                 personSelections: people.map(p => ({ personId: p.id, selected: true }))
-            }
+            },
+            ...generateAlwaysNeededAgeSpecificItems(people)
         ],
         questions: [
             {
@@ -80,7 +85,8 @@ export function createExampleData(numPeople: number, names?: string[]): PackingL
                             {
                                 text: "Trousers/Shorts",
                                 personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            }
+                            },
+                            ...generateOvernightAgeSpecificItems(people)
                         ]
                     },
                     {
@@ -156,7 +162,8 @@ export function createExampleData(numPeople: number, names?: string[]): PackingL
                             {
                                 text: "Swim cap",
                                 personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            }
+                            },
+                            ...generateSwimmingAgeSpecificItems(people)
                         ]
                     },
                     {
@@ -283,7 +290,8 @@ export function createExampleData(numPeople: number, names?: string[]): PackingL
                             {
                                 text: "First aid kit",
                                 personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            }
+                            },
+                            ...generateHikingAgeSpecificItems(people)
                         ]
                     },
                     {
@@ -342,7 +350,8 @@ export function createExampleData(numPeople: number, names?: string[]): PackingL
                             {
                                 text: "Sandals",
                                 personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            }
+                            },
+                            ...generateHotWeatherAgeSpecificItems(people)
                         ]
                     },
                     {
@@ -419,7 +428,8 @@ export function createExampleData(numPeople: number, names?: string[]): PackingL
                             {
                                 text: "Warm boots",
                                 personSelections: people.map(p => ({ personId: p.id, selected: true }))
-                            }
+                            },
+                            ...generateColdWeatherAgeSpecificItems(people)
                         ]
                     }
                 ]
@@ -428,10 +438,19 @@ export function createExampleData(numPeople: number, names?: string[]): PackingL
     };
 }
 
+// Helper function to create people for examples
+function createExamplePeople(count: number): Person[] {
+    return Array.from({ length: count }, (_, i) => ({
+        id: generateUUID(),
+        name: i === 0 ? "Me" : `Person ${i + 1}`,
+        ageRange: undefined
+    }));
+}
+
 export const exampleData = {
-    "Basic packing list for 1": createExampleData(1),
-    "Basic packing list for 2": createExampleData(2),
-    "Basic packing list for 3": createExampleData(3),
-    "Basic packing list for 4": createExampleData(4),
-    "Basic packing list for 5": createExampleData(5),
+    "Basic packing list for 1": createExampleData(createExamplePeople(1)),
+    "Basic packing list for 2": createExampleData(createExamplePeople(2)),
+    "Basic packing list for 3": createExampleData(createExamplePeople(3)),
+    "Basic packing list for 4": createExampleData(createExamplePeople(4)),
+    "Basic packing list for 5": createExampleData(createExamplePeople(5)),
 }; 

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -1,12 +1,10 @@
 import { PackingListQuestionSet, Person, Item } from './types';
 import { generateUUID } from '../utils/uuid';
 import {
-    generateAlwaysNeededAgeSpecificItems,
-    generateOvernightAgeSpecificItems,
-    generateSwimmingAgeSpecificItems,
-    generateHotWeatherAgeSpecificItems,
-    generateColdWeatherAgeSpecificItems,
-    generateHikingAgeSpecificItems,
+    getBabies,
+    getToddlers,
+    getChildren,
+    getTeenagers,
     getAdults,
     getTeenagersAndAdults,
     getChildrenAndOlder,
@@ -39,7 +37,31 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
             item("Day bag / Backpack", people, getChildrenAndOlder),
             item("Snacks", people),
             item("Water bottle", people, getToddlersAndOlder),
-            ...generateAlwaysNeededAgeSpecificItems(people)
+            // Baby items
+            item("Nappies (pack/supply)", people, getBabies),
+            item("Baby wipes", people, getBabies),
+            item("Nappy bags", people, getBabies),
+            item("Change mat", people, getBabies),
+            item("Bibs", people, getBabies),
+            item("Muslins/Burp cloths", people, getBabies),
+            item("Bottles (if bottle feeding)", people, getBabies),
+            item("Formula/Baby food", people, getBabies),
+            item("Dummy/Pacifier (if used)", people, getBabies),
+            item("Spare clothes (×3-4 sets)", people, getBabies),
+            // Toddler items
+            item("Pull-ups/Toddler nappies", people, getToddlers),
+            item("Potty (travel potty)", people, getToddlers),
+            item("Wipes", people, getToddlers),
+            item("Spare clothes (×2-3 sets)", people, getToddlers),
+            item("Sippy cup/Toddler cup", people, getToddlers),
+            item("Toddler snacks", people, getToddlers),
+            item("Comfort item (teddy/blanket)", people, getToddlers),
+            // Child items
+            item("Entertainment (books/small toys)", people, getChildren),
+            item("Playing cards/Travel games", people, getChildren),
+            // Teenager items
+            item("Headphones", people, getTeenagers),
+            item("Phone charger", people, getTeenagers)
         ],
         questions: [
             {
@@ -65,7 +87,20 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                             item("Socks", people),
                             item("T-shirt/Top", people),
                             item("Trousers/Shorts", people),
-                            ...generateOvernightAgeSpecificItems(people)
+                            // Baby items
+                            item("Baby monitor", people, getBabies),
+                            item("Nightlight", people, getBabies),
+                            item("Baby sleeping bag/Swaddle", people, getBabies),
+                            item("Extra bedding/sheets", people, getBabies),
+                            item("Bedtime bottle", people, getBabies),
+                            // Toddler items
+                            item("Bedtime books", people, getToddlers),
+                            item("Night nappy/Pull-up", people, getToddlers),
+                            // Child items
+                            item("Favorite toy/Stuffed animal", people, getChildren),
+                            item("Flashlight", people, getChildren),
+                            // Teenager items
+                            item("Personal care items (face wash, etc.)", people, getTeenagers)
                         ]
                     },
                     {
@@ -118,7 +153,17 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                             item("Swim towel", people),
                             item("Goggles", people, getChildrenAndOlder),
                             item("Swim cap", people, getChildrenAndOlder),
-                            ...generateSwimmingAgeSpecificItems(people)
+                            // Baby items
+                            item("Baby swim nappy", people, getBabies),
+                            item("Baby float/Swim seat", people, getBabies),
+                            item("Baby sun hat with neck protection", people, getBabies),
+                            item("Baby rash guard/Sun suit", people, getBabies),
+                            // Toddler items
+                            item("Swim nappy (if not potty trained)", people, getToddlers),
+                            item("Armbands/Floaties", people, getToddlers),
+                            item("Toddler sun hat", people, getToddlers),
+                            // Child items
+                            item("Swim aids (noodles, kickboard)", people, getChildren)
                         ]
                     },
                     {
@@ -177,7 +222,11 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                             item("Walking poles", people, getAdults),
                             item("Trail map", people, getAdults),
                             item("First aid kit", people, getAdults),
-                            ...generateHikingAgeSpecificItems(people)
+                            // Baby items
+                            item("Baby carrier/Sling", people, getBabies),
+                            // Toddler items
+                            item("Toddler reins/Backpack harness", people, getToddlers),
+                            item("Lightweight buggy/Stroller", people, getToddlers)
                         ]
                     },
                     {
@@ -210,7 +259,15 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                             item("Sunglasses", people, getChildrenAndOlder),
                             item("Light, breathable clothing", people),
                             item("Sandals", people, getToddlersAndOlder),
-                            ...generateHotWeatherAgeSpecificItems(people)
+                            // Baby items
+                            item("Baby sunscreen (SPF 50+)", people, getBabies),
+                            item("Sun protective baby clothing", people, getBabies),
+                            item("Shade cover/Parasol for pram", people, getBabies),
+                            // Toddler items
+                            item("Toddler sunscreen", people, getToddlers),
+                            item("Sun protective clothing", people, getToddlers),
+                            // Child items
+                            item("Kids sunscreen", people, getChildren)
                         ]
                     },
                     {
@@ -246,7 +303,15 @@ export function createExampleData(people: Person[]): PackingListQuestionSet {
                             item("Warm hat/Beanie", people),
                             item("Thermal underwear", people),
                             item("Warm boots", people),
-                            ...generateColdWeatherAgeSpecificItems(people)
+                            // Baby items
+                            item("Baby snowsuit/Pramsuit", people, getBabies),
+                            item("Baby mittens", people, getBabies),
+                            item("Baby warm hat with ear coverage", people, getBabies),
+                            item("Blanket for carrier/pram", people, getBabies),
+                            // Toddler items
+                            item("Toddler snowsuit/Winter coat", people, getToddlers),
+                            item("Toddler mittens (not gloves - easier)", people, getToddlers),
+                            item("Toddler warm hat", people, getToddlers)
                         ]
                     }
                 ]

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -1,9 +1,23 @@
 import { z } from 'zod'
 
+// Age Range Type
+export const AgeRangeSchema = z.enum(['Baby', 'Toddler', 'Child', 'Teenager', 'Adult'])
+export type AgeRange = z.infer<typeof AgeRangeSchema>
+
+// Age range options for dropdowns with descriptions
+export const AGE_RANGE_OPTIONS = [
+  { value: 'Baby' as const, label: '👶 Baby (0-1) - nappies, wipes, change mat' },
+  { value: 'Toddler' as const, label: '🧒 Toddler (1-3) - potty, pull-ups, extra clothes' },
+  { value: 'Child' as const, label: '👧 Child (3-12)' },
+  { value: 'Teenager' as const, label: '👦 Teenager (12-17)' },
+  { value: 'Adult' as const, label: '🧑 Adult (18+)' }
+] as const
+
 // Zod Schemas
 export const PersonSchema = z.object({
   id: z.string(),
-  name: z.string()
+  name: z.string(),
+  ageRange: AgeRangeSchema.optional()
 })
 
 export const PersonSelectionSchema = z.object({

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -4,6 +4,8 @@ import { packingAppDb } from '../services/database'
 import { createExampleData } from '../edit-questions/example-data'
 import { QUESTION_SET_ID } from '../constants'
 import { WizardFormData } from './wizard-types'
+import { generateUUID } from '../utils/uuid'
+import { Person } from '../edit-questions/types'
 
 export function useWizardGeneration() {
     const { showToast } = useToast()
@@ -11,8 +13,12 @@ export function useWizardGeneration() {
     const [isSuccess, setIsSuccess] = useState(false)
 
     const generateQuestionSet = (data: WizardFormData) => {
-        const names = data.people.map(p => p.name)
-        return createExampleData(data.people.length, names)
+        const people: Person[] = data.people.map(p => ({
+            id: generateUUID(),
+            name: p.name,
+            ageRange: p.ageRange
+        }))
+        return createExampleData(people)
     }
 
     const generateAndSave = async (data: WizardFormData) => {

--- a/src/pages/wizard-types.ts
+++ b/src/pages/wizard-types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { AgeRangeSchema } from '../edit-questions/types'
 
 export const ACTIVITIES = [
     { id: 'swimming', label: 'Swimming (pool)', icon: '🏊' },
@@ -13,7 +14,7 @@ export type ActivityId = typeof ACTIVITIES[number]['id']
 export const wizardSchema = z.object({
     people: z.array(z.object({
         name: z.string().min(1, 'Name is required'),
-        age: z.string().optional()
+        ageRange: AgeRangeSchema.optional()
     })).min(1, 'At least 1 person required').max(10, 'Maximum 10 people allowed'),
     activities: z.array(z.string())
 })

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -10,6 +10,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { packingAppDb } from '../services/database'
 import { ACTIVITIES, wizardSchema, WizardFormData } from './wizard-types'
 import { useWizardGeneration } from './useWizardGeneration'
+import { AGE_RANGE_OPTIONS } from '../edit-questions/types'
 
 const WIZARD_POD_PROMPT_KEY = 'wizard-pod-prompt-dismissed'
 
@@ -24,7 +25,7 @@ export const Wizard = () => {
     const { register, control, handleSubmit, watch, formState: { errors } } = useForm<WizardFormData>({
         resolver: zodResolver(wizardSchema),
         defaultValues: {
-            people: [{ name: 'Me', age: '' }],
+            people: [{ name: 'Me', ageRange: undefined }],
             activities: []
         }
     })
@@ -75,7 +76,7 @@ export const Wizard = () => {
     }
 
     const handleAddPerson = () => {
-        append({ name: `Person ${fields.length + 1}`, age: '' })
+        append({ name: `Person ${fields.length + 1}`, ageRange: undefined })
     }
 
     const handleRemovePerson = (index: number) => {
@@ -125,18 +126,25 @@ export const Wizard = () => {
                                         </div>
                                         <div>
                                             <label className="block text-sm font-semibold text-gray-700 mb-2">
-                                                Age{' '}
+                                                Age Range{' '}
                                                 <span className="text-xs text-gray-500 font-normal">
-                                                    (Coming in future version)
+                                                    (optional)
                                                 </span>
                                             </label>
-                                            <input
-                                                type="text"
-                                                placeholder="e.g., 5, 12, Adult"
-                                                {...register(`people.${index}.age`)}
-                                                className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all opacity-60"
-                                                disabled
-                                            />
+                                            <select
+                                                {...register(`people.${index}.ageRange`)}
+                                                className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                            >
+                                                <option value="">Select age range...</option>
+                                                {AGE_RANGE_OPTIONS.map(option => (
+                                                    <option key={option.value} value={option.value}>
+                                                        {option.label}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                            {errors.people?.[index]?.ageRange && (
+                                                <p className="text-danger-500 text-sm mt-1">{errors.people[index]?.ageRange?.message}</p>
+                                            )}
                                         </div>
                                     </div>
                                     {fields.length > 1 && (


### PR DESCRIPTION
This update enables the wizard to generate age-specific packing items based on selected age ranges. Users can now select from Baby (0-1), Toddler (1-3), Child (3-12), Teenager (12-17), or Adult (18+) categories.

Changes:
- Add AgeRange type and age range dropdown options with descriptions
- Update Person type to include optional ageRange field
- Replace disabled age text input with functional age range dropdown in wizard
- Create comprehensive age-specific item generation helpers for all question categories
- Integrate age-specific items into:
  - Always needed items (nappies, wipes, potty, etc. for babies/toddlers)
  - Overnight items (baby monitor, bedtime books, etc.)
  - Swimming activities (swim nappies, floaties, etc.)
  - Hot/cold weather items (baby sunscreen, snowsuits, etc.)
  - Hiking activities (baby carriers, toddler reins, etc.)
- Update wizard generation flow to pass age range data through to item creation

Items are automatically added with appropriate person selections based on age range, allowing users to easily customize for their needs.