### PR TITLE
Fix unexpected redirects after creating packing list

### DIFF
--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList, PackingListFormData, PackingListItem } from '../create-packing-list/types'
 import { packingAppDb } from '../services/database'
@@ -16,6 +16,7 @@ export function CreatePackingList() {
     const [selectedPeopleIds, setSelectedPeopleIds] = useState<string[]>([])
     const { showToast } = useToast()
     const { isLoggedIn } = useSolidPod()
+    const navigate = useNavigate()
 
     const { register, handleSubmit, setValue, watch } = useForm<PackingListFormData>({
         defaultValues: {
@@ -109,8 +110,8 @@ export function CreatePackingList() {
         try {
             await packingAppDb.savePackingList(packingList)
             showToast('Packing list created successfully!', 'success')
-            // Reset the form after successful creation
-            window.location.href = '/#/view-lists'
+            // Navigate to the newly created packing list
+            navigate(`/view-lists/${packingList.id}`)
         } catch (err) {
             console.error('Error saving packing list:', err)
             showToast('Failed to create packing list. Please try again.', 'error')


### PR DESCRIPTION
Root causes fixed:
1. Replaced window.location.href with React Router's navigate()
   - Eliminates full page reload
   - Uses idiomatic React Router navigation
   - Prevents race conditions with database operations

2. Changed redirect destination from /view-lists to /view-lists/{id}
   - Improved UX: users now see their newly created list immediately
   - Avoids double redirect issue
   - Direct navigation to the detail page

This resolves both the initial redirect to the list page and the subsequent redirect back to home that was caused by the page reload.