### PR TITLE
Fix 401 invalid client_id redirect issue

### DIFF
--- a/docs/inrupt-client-id-issue-submission.md
+++ b/docs/inrupt-client-id-issue-submission.md
@@ -19,9 +19,9 @@ Which packages do you think might be impacted by the bug ?
 
 ### Bug description
 
-When `handleIncomingRedirect({ restorePreviousSession: true })` is called with stored session data containing an invalidated/expired `client_id`, the library immediately redirects to the OAuth provider with the invalid credentials before our application can handle the error. This results in a 401 "invalid_client_id" error that completely blocks users from accessing the application, with no programmatic recovery path.
+When `handleIncomingRedirect({ restorePreviousSession: true })` is called with stored session data containing an invalidated/expired `client_id`, the library immediately redirects to the OAuth provider with the invalid credentials before my application can handle the error. This results in a 401 "invalid_client_id" error that completely blocks users from accessing the application, with no programmatic recovery path.
 
-Users who return to our app after extended periods (when their dynamically registered client has been invalidated by the OAuth provider) are unable to use the application. The only recovery is manually clearing browser data, which most users don't know how to do.
+Users who return to my app after extended periods (when their dynamically registered client has been invalidated by the OAuth provider) are unable to use the application. The only recovery is manually clearing browser data, which most users don't know how to do.
 
 ### To Reproduce
 
@@ -32,7 +32,7 @@ Users who return to our app after extended periods (when their dynamically regis
 5. **Observe:** Immediate redirect to authorization endpoint with the now-invalid `client_id`
 6. **Observe:** 401 "invalid_client_id" error page from OAuth provider
 
-**Our code:**
+**My code:**
 ```typescript
 import { handleIncomingRedirect, getDefaultSession } from '@inrupt/solid-client-authn-browser';
 
@@ -54,11 +54,11 @@ useEffect(() => {
 
 ### Expected result
 
-We're not sure what the intended behavior should be, but we would expect one of:
+I'm not sure what the intended behavior should be, but I would expect one of:
 
 1. The library validates stored client credentials before initiating silent auth, clears invalid session data automatically, and returns a logged-out session
-2. The error is catchable in our try/catch block so we can handle it programmatically
-3. A way to inspect/validate stored session data before calling `handleIncomingRedirect()` so we can clear corrupted data proactively
+2. The error is catchable in my try/catch block so I can handle it programmatically
+3. A way to inspect/validate stored session data before calling `handleIncomingRedirect()` so I can clear corrupted data proactively
 
 Ideally, users wouldn't be blocked from accessing the application due to expired OAuth credentials stored in their browser.
 
@@ -67,7 +67,7 @@ Ideally, users wouldn't be blocked from accessing the application due to expired
 When the user visits the app:
 
 1. `handleIncomingRedirect({ restorePreviousSession: true })` is called
-2. The library immediately redirects to the OAuth provider (before our code continues):
+2. The library immediately redirects to the OAuth provider (before my code continues):
    ```
    https://login.inrupt.com/authorization?
      client_id=22fe30ba-129c-46ed-843c-e8f28debdb16
@@ -78,7 +78,7 @@ When the user visits the app:
    ```
 3. OAuth provider returns 401 with "invalid_client_id" error
 4. User is stuck on the error page
-5. Our `try/catch` block never catches any error (presumably because the redirect happens synchronously before the Promise is created)
+5. My `try/catch` block never catches any error (presumably because the redirect happens synchronously before the Promise is created)
 
 The user cannot access the application. Manual browser data clearing is required to recover.
 
@@ -106,25 +106,25 @@ Production app affected: https://react-packing-app.vercel.app
 
 ## Additional information
 
-### Our Understanding (Please Correct If Wrong)
+### My Understanding (Please Correct If Wrong)
 
-From our investigation, it appears that when `restorePreviousSession: true`, the library immediately initiates a silent auth redirect (`prompt=none`) before `handleIncomingRedirect()` returns its Promise. If the stored `client_id` has been invalidated, the redirect happens anyway with invalid credentials. Since the redirect is synchronous, our try/catch cannot intercept it.
+From my investigation, it appears that when `restorePreviousSession: true`, the library immediately initiates a silent auth redirect (`prompt=none`) before `handleIncomingRedirect()` returns its Promise. If the stored `client_id` has been invalidated, the redirect happens anyway with invalid credentials. Since the redirect is synchronous, my try/catch cannot intercept it.
 
-We may be misunderstanding how this is intended to work.
+I may be misunderstanding how this is intended to work.
 
-### Questions We're Hoping You Can Help With
+### Questions I'm Hoping You Can Help With
 
 1. **Is this the intended behavior** when stored client credentials become invalid? Should applications expect this scenario?
 
-2. **Is there a recommended pattern** for handling invalidated client_ids that we're missing? Should we be doing something differently in our setup?
+2. **Is there a recommended pattern** for handling invalidated client_ids that I'm missing? Should I be doing something differently in my setup?
 
-3. **Is there a way to detect or validate** stored session data before calling `handleIncomingRedirect()` so we can clear it proactively if needed?
+3. **Is there a way to detect or validate** stored session data before calling `handleIncomingRedirect()` so I can clear it proactively if needed?
 
 4. **Would it make sense** for the library to handle this scenario internally (e.g., detecting the invalid client and clearing session data automatically), or is that something applications should manage?
 
-5. **For `restorePreviousSession: true` to be safe in production**, what assumptions should we make about client_id lifetime and validity?
+5. **For `restorePreviousSession: true` to be safe in production**, what assumptions should I make about client_id lifetime and validity?
 
-### Temporary Workaround We're Considering
+### Temporary Workaround I'm Considering
 
 ```typescript
 await handleIncomingRedirect({ restorePreviousSession: false });
@@ -132,13 +132,13 @@ await handleIncomingRedirect({ restorePreviousSession: false });
 
 This would require users to explicitly log in after each page refresh, losing the seamless "stay logged in" experience, but prevents the blocking issue entirely.
 
-**Would this be the recommended approach**, or is there a better pattern we should follow?
+**Would this be the recommended approach**, or is there a better pattern I should follow?
 
-### Related Issues/Discussions We Found
+### Related Issues/Discussions I Found
 
 - [#3443](https://github.com/inrupt/solid-client-authn-js/issues/3443) - Discusses challenges with silent authentication redirects
 - [#1790](https://github.com/inrupt/solid-client-authn-js/issues/1790) - Dynamic client ID issues
 - [#1989](https://github.com/inrupt/solid-client-authn-js/issues/1989) - Query string handling with restorePreviousSession
 - [Forum discussion on invalid_client errors](https://forum.solidproject.org/t/inrupt-pod-login-complains-about-an-invalid-client/4726)
 
-We appreciate any guidance you can provide on the recommended way to handle this scenario!
+I appreciate any guidance you can provide on the recommended way to handle this scenario!

--- a/docs/inrupt-client-id-issue-submission.md
+++ b/docs/inrupt-client-id-issue-submission.md
@@ -1,0 +1,144 @@
+<!--
+This file is ready to copy/paste directly into GitHub when creating an issue at:
+https://github.com/inrupt/solid-client-authn-js/issues/new
+-->
+
+### Search terms you've used
+
+`handleIncomingRedirect restorePreviousSession invalid_client`, `client_id expired session restore`, `prompt=none invalid client redirect`, `session restore blocking error`
+
+### Impacted package
+
+Which packages do you think might be impacted by the bug ?
+
+- [x] solid-client-authn-browser
+- [ ] solid-client-authn-node
+- [ ] solid-client-authn-core
+- [ ] oidc-client-ext
+- [ ] Other (please specify): ...
+
+### Bug description
+
+When `handleIncomingRedirect({ restorePreviousSession: true })` is called with stored session data containing an invalidated/expired `client_id`, the library immediately redirects to the OAuth provider with the invalid credentials before our application can handle the error. This results in a 401 "invalid_client_id" error that completely blocks users from accessing the application, with no programmatic recovery path.
+
+Users who return to our app after extended periods (when their dynamically registered client has been invalidated by the OAuth provider) are unable to use the application. The only recovery is manually clearing browser data, which most users don't know how to do.
+
+### To Reproduce
+
+1. Log in to a Solid Pod provider successfully (creates dynamic client registration, stores `client_id` in browser)
+2. Close the browser (session data remains in IndexedDB/localStorage)
+3. Wait for OAuth provider to invalidate the client registration (or manually delete it from provider's admin panel if possible for testing)
+4. Open the app again
+5. **Observe:** Immediate redirect to authorization endpoint with the now-invalid `client_id`
+6. **Observe:** 401 "invalid_client_id" error page from OAuth provider
+
+**Our code:**
+```typescript
+import { handleIncomingRedirect, getDefaultSession } from '@inrupt/solid-client-authn-browser';
+
+useEffect(() => {
+  const initSession = async () => {
+    try {
+      await handleIncomingRedirect({ restorePreviousSession: true });
+      const session = getDefaultSession();
+      setSession(session);
+    } catch (error) {
+      console.error("Session initialization error:", error);
+      // This never fires for invalid client_id scenarios
+      await solidLogout();
+    }
+  };
+  initSession();
+}, []);
+```
+
+### Expected result
+
+We're not sure what the intended behavior should be, but we would expect one of:
+
+1. The library validates stored client credentials before initiating silent auth, clears invalid session data automatically, and returns a logged-out session
+2. The error is catchable in our try/catch block so we can handle it programmatically
+3. A way to inspect/validate stored session data before calling `handleIncomingRedirect()` so we can clear corrupted data proactively
+
+Ideally, users wouldn't be blocked from accessing the application due to expired OAuth credentials stored in their browser.
+
+### Actual result
+
+When the user visits the app:
+
+1. `handleIncomingRedirect({ restorePreviousSession: true })` is called
+2. The library immediately redirects to the OAuth provider (before our code continues):
+   ```
+   https://login.inrupt.com/authorization?
+     client_id=22fe30ba-129c-46ed-843c-e8f28debdb16
+     &prompt=none
+     &redirect_uri=https%3A%2F%2Freact-packing-app.vercel.app%2Fpod-auth-callback.html
+     &response_mode=query
+     ...
+   ```
+3. OAuth provider returns 401 with "invalid_client_id" error
+4. User is stuck on the error page
+5. Our `try/catch` block never catches any error (presumably because the redirect happens synchronously before the Promise is created)
+
+The user cannot access the application. Manual browser data clearing is required to recover.
+
+### Environment
+
+```sh
+$ npx envinfo --system --npmPackages --binaries --npmGlobalPackages --browsers
+
+System:
+  OS: Linux (Vercel deployment + local development)
+  Browser: Chrome/Firefox/Safari (reproducible across all)
+
+Binaries:
+  Node: 18.x
+  npm: 9.x
+
+npmPackages:
+  @inrupt/solid-client: ^2.1.2
+  @inrupt/solid-client-authn-browser: ^3.1.0
+  @inrupt/vocab-common-rdf: ^1.0.5
+  @inrupt/vocab-solid: ^1.0.4
+```
+
+Production app affected: https://react-packing-app.vercel.app
+
+## Additional information
+
+### Our Understanding (Please Correct If Wrong)
+
+From our investigation, it appears that when `restorePreviousSession: true`, the library immediately initiates a silent auth redirect (`prompt=none`) before `handleIncomingRedirect()` returns its Promise. If the stored `client_id` has been invalidated, the redirect happens anyway with invalid credentials. Since the redirect is synchronous, our try/catch cannot intercept it.
+
+We may be misunderstanding how this is intended to work.
+
+### Questions We're Hoping You Can Help With
+
+1. **Is this the intended behavior** when stored client credentials become invalid? Should applications expect this scenario?
+
+2. **Is there a recommended pattern** for handling invalidated client_ids that we're missing? Should we be doing something differently in our setup?
+
+3. **Is there a way to detect or validate** stored session data before calling `handleIncomingRedirect()` so we can clear it proactively if needed?
+
+4. **Would it make sense** for the library to handle this scenario internally (e.g., detecting the invalid client and clearing session data automatically), or is that something applications should manage?
+
+5. **For `restorePreviousSession: true` to be safe in production**, what assumptions should we make about client_id lifetime and validity?
+
+### Temporary Workaround We're Considering
+
+```typescript
+await handleIncomingRedirect({ restorePreviousSession: false });
+```
+
+This would require users to explicitly log in after each page refresh, losing the seamless "stay logged in" experience, but prevents the blocking issue entirely.
+
+**Would this be the recommended approach**, or is there a better pattern we should follow?
+
+### Related Issues/Discussions We Found
+
+- [#3443](https://github.com/inrupt/solid-client-authn-js/issues/3443) - Discusses challenges with silent authentication redirects
+- [#1790](https://github.com/inrupt/solid-client-authn-js/issues/1790) - Dynamic client ID issues
+- [#1989](https://github.com/inrupt/solid-client-authn-js/issues/1989) - Query string handling with restorePreviousSession
+- [Forum discussion on invalid_client errors](https://forum.solidproject.org/t/inrupt-pod-login-complains-about-an-invalid-client/4726)
+
+We appreciate any guidance you can provide on the recommended way to handle this scenario!

--- a/docs/inrupt-client-id-issue.md
+++ b/docs/inrupt-client-id-issue.md
@@ -3,187 +3,118 @@
 **Status:** Identified and Documented
 **Date:** 2026-01-17
 **Severity:** HIGH - Production blocking issue
+**GitHub Issue:** To be submitted to `inrupt/solid-client-authn-js`
 
 ---
 
-## Issue Summary
+## Problem Summary
 
-This document describes a critical authentication issue with the Inrupt Solid authentication library (`@inrupt/solid-client-authn-browser`) that causes users to be blocked from accessing the application when stored OAuth client credentials become invalidated.
+Users returning to our app after extended periods are being completely blocked due to invalidated OAuth client credentials stored in their browser. The Inrupt library redirects immediately with the expired `client_id` before our error handling can activate, resulting in a 401 error with no programmatic recovery path.
 
-**Issue Repository:** `inrupt/solid-client-authn-js`
-
----
-
-## GitHub Issue Draft
-
-### **Title:**
-Need guidance: `handleIncomingRedirect({ restorePreviousSession: true })` redirects immediately with invalidated client_id, blocking users from app
+**User Impact:** Complete application blockage requiring manual browser data clearing (IndexedDB/localStorage).
 
 ---
 
-### **Description**
+## Technical Details
 
-**Environment:**
-- Library: `@inrupt/solid-client-authn-browser` v3.1.0
-- OAuth Provider: Inrupt (login.inrupt.com)
-- Browser: Chrome/Firefox/Safari (reproducible across all)
-- App Type: React SPA deployed to production (https://react-packing-app.vercel.app)
+### Where It Happens
+- **File:** `src/components/SolidPodContext.tsx:74`
+- **Code:** `await handleIncomingRedirect({ restorePreviousSession: true });`
 
----
+### What Happens
 
-### **Our Setup**
+1. User had previously logged in → `client_id` stored in browser
+2. OAuth provider invalidated the dynamically registered client (normal maintenance)
+3. On next visit, library finds stored `client_id` and immediately redirects with `prompt=none`
+4. OAuth provider rejects invalid `client_id` before app can handle the error
+5. User stuck on 401 error page
 
-We have a React application that initializes the Solid session on page load:
+### Why Error Handling Doesn't Work
 
-```typescript
-import { handleIncomingRedirect, getDefaultSession } from '@inrupt/solid-client-authn-browser';
+The redirect happens synchronously before `handleIncomingRedirect()` returns its Promise, so our try/catch block never executes.
 
-useEffect(() => {
-  const initSession = async () => {
-    try {
-      await handleIncomingRedirect({ restorePreviousSession: true });
-      const session = getDefaultSession();
-      setSession(session);
-    } catch (error) {
-      console.error("Session initialization error:", error);
-      // Handle errors and clear session data
-    }
-  };
-  initSession();
-}, []);
+### Example Error URL
+
+```
+https://login.inrupt.com/authorization?
+  client_id=22fe30ba-129c-46ed-843c-e8f28debdb16  ← Invalid!
+  &prompt=none
+  &redirect_uri=https%3A%2F%2Freact-packing-app.vercel.app%2Fpod-auth-callback.html
+  &response_mode=query
 ```
 
-We use `restorePreviousSession: true` to provide a seamless experience where users remain logged in across page refreshes.
-
 ---
 
-### **What We're Observing**
+## Solution Options
 
-When users visit our app after their OAuth provider has invalidated the dynamically registered client_id (which we assume is normal maintenance/cleanup), the following happens:
-
-1. User visits the app
-2. `handleIncomingRedirect({ restorePreviousSession: true })` is called
-3. The library **immediately redirects** to the OAuth provider before our code continues:
-   ```
-   https://login.inrupt.com/authorization?
-     client_id=22fe30ba-129c-46ed-843c-e8f28debdb16
-     &prompt=none
-     &redirect_uri=https%3A%2F%2Freact-packing-app.vercel.app%2Fpod-auth-callback.html
-     &response_mode=query
-     ...
-   ```
-4. OAuth provider immediately returns 401 with "invalid_client_id" error
-5. User sees the error page and cannot access our application
-6. Our `try/catch` block never catches any error (presumably because the redirect happens synchronously)
-
-**Current User Recovery:** Users must manually clear browser site data (IndexedDB/localStorage) to recover. Obviously, this is not a viable solution.
-
----
-
-### **Why This Is Problematic**
-
-Users who return after weeks/months are completely blocked from accessing the app. The redirect happens before our error handling can activate, so we have no way to detect or recover programmatically. Users must manually clear browser data, which they don't know how to do.
-
----
-
-### **Reproduction Steps**
-
-1. Log in to a Solid Pod provider successfully (creates dynamic client registration)
-2. Close the browser (session data with client_id remains in IndexedDB/localStorage)
-3. Wait for OAuth provider to invalidate the client registration (or manually delete it from provider's admin panel if possible for testing)
-4. Open the app again
-5. **Observe:** Immediate redirect to authorization endpoint with the now-invalid client_id
-6. **Observe:** 401 "invalid_client_id" error page from OAuth provider
-
-The user is now blocked from accessing the application entirely.
-
----
-
-### **Our Understanding (Please Correct If Wrong)**
-
-From our investigation, it appears that when `restorePreviousSession: true`, the library immediately initiates a silent auth redirect (`prompt=none`) before `handleIncomingRedirect()` returns its Promise. If the stored `client_id` has been invalidated, the redirect happens anyway with invalid credentials. Since the redirect is synchronous, our try/catch cannot intercept it.
-
-We may be misunderstanding how this is intended to work.
-
----
-
-### **What We've Tried**
-
-We attempted to catch errors in our application code:
+### Option 1: Disable Automatic Session Restoration (Recommended Short-term)
 
 ```typescript
-try {
-  await handleIncomingRedirect({ restorePreviousSession: true });
-} catch (error) {
-  // This never fires for invalid client_id scenarios
-  await solidLogout(); // Clear corrupted session
-}
-```
+// Change from:
+await handleIncomingRedirect({ restorePreviousSession: true });
 
-However, this doesn't work because the redirect happens before the Promise is created.
-
----
-
-### **Questions We're Hoping You Can Help With**
-
-1. **Is this the intended behavior** when stored client credentials become invalid? Should applications expect this scenario?
-
-2. **Is there a recommended pattern** for handling invalidated client_ids that we're missing? Should we be doing something differently in our setup?
-
-3. **Is there a way to detect or validate** stored session data before calling `handleIncomingRedirect()` so we can clear it proactively if needed?
-
-4. **Would it make sense** for the library to handle this scenario internally (e.g., detecting the invalid client and clearing session data automatically), or is that something applications should manage?
-
-5. **For `restorePreviousSession: true` to be safe in production**, what assumptions should we make about client_id lifetime and validity?
-
----
-
-### **Temporary Workaround We're Considering**
-
-```typescript
+// To:
 await handleIncomingRedirect({ restorePreviousSession: false });
 ```
 
-This would require users to explicitly log in after each page refresh, losing the seamless "stay logged in" experience, but prevents the blocking issue entirely.
+**Pros:**
+- Eliminates the blocking issue entirely
+- Users explicitly choose when to log in
+- More predictable behavior
 
-**Would this be the recommended approach**, or is there a better pattern we should follow?
+**Cons:**
+- Users must click "Login" after every page refresh
+- Loses the seamless "stay logged in" experience
+- May not be using the library as intended
 
----
+### Option 2: Wait for Upstream Guidance (Ideal)
 
-### **Additional Context**
+Submit issue to Inrupt team and wait for their recommended pattern.
 
-We found some potentially related issues:
-- [#3443](https://github.com/inrupt/solid-client-authn-js/issues/3443) - Discusses challenges with silent authentication redirects
-- [#1790](https://github.com/inrupt/solid-client-authn-js/issues/1790) - Dynamic client ID issues
-- [#1989](https://github.com/inrupt/solid-client-authn-js/issues/1989) - Query string handling with restorePreviousSession
+**Pros:**
+- Could lead to a proper library-level fix
+- Learn the intended usage pattern
 
-We appreciate any guidance you can provide on the recommended way to handle this scenario!
-
----
-
-## Internal Notes
-
-### What We Found
-- **File:** `src/components/SolidPodContext.tsx:74`
-- **Issue:** `restorePreviousSession: true` causes immediate redirect before error handling can activate
-- **Root cause:** Stored `client_id` from previous login becomes invalid over time (provider cleanup)
-- **User impact:** Complete app blockage, requires manual browser data clearing
-
-### Our Options
-1. **Short-term:** Set `restorePreviousSession: false` (lose "stay logged in" UX but fix the blocking issue)
-2. **Ideal:** Wait for Inrupt team guidance on the intended pattern
-
-### Research Links
-- **Docs:** [Session Restore](https://docs.inrupt.com/guides/authentication-in-solid/authentication-from-browser/session-restore-upon-browser-refresh) | [Tutorial](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/restore-session-browser-refresh/)
-- **Issues:** [#3443](https://github.com/inrupt/solid-client-authn-js/issues/3443) (silent auth redirects) | [#1790](https://github.com/inrupt/solid-client-authn-js/issues/1790) (client ID) | [#1989](https://github.com/inrupt/solid-client-authn-js/issues/1989) (query string)
-- **Forum:** [Invalid client discussion](https://forum.solidproject.org/t/inrupt-pod-login-complains-about-an-invalid-client/4726)
+**Cons:**
+- Users can still get blocked in the meantime
+- No timeline on response/fix
 
 ---
 
-## Next Steps
+## Issue Submission
 
-1. Submit issue to `inrupt/solid-client-authn-js` using the draft above
-2. Consider implementing `restorePreviousSession: false` workaround if needed urgently
-3. Update implementation based on Inrupt team's guidance
+**Ready to copy/paste:** See `docs/inrupt-client-id-issue-submission.md`
+
+**Submit to:** https://github.com/inrupt/solid-client-authn-js/issues/new
+
+---
+
+## Research & References
+
+### Documentation
+- [Session Restore upon Browser Refresh](https://docs.inrupt.com/guides/authentication-in-solid/authentication-from-browser/session-restore-upon-browser-refresh)
+- [Session Restore Tutorial](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/restore-session-browser-refresh/)
+
+### Related Issues
+- [#3443](https://github.com/inrupt/solid-client-authn-js/issues/3443) - Silent authentication redirect challenges
+- [#1790](https://github.com/inrupt/solid-client-authn-js/issues/1790) - Wrong dynamic client ID used for code-to-token exchange
+- [#1989](https://github.com/inrupt/solid-client-authn-js/issues/1989) - handleIncomingRedirect strips querystring
+
+### Community Discussions
+- [Inrupt pod login complains about an invalid_client](https://forum.solidproject.org/t/inrupt-pod-login-complains-about-an-invalid-client/4726)
+- [handleIncomingRedirect creates endless loop](https://forum.solidproject.org/t/handleincomingredirect-w-redirect-creates-endless-loop/8623)
+
+---
+
+## Action Items
+
+- [ ] Submit issue using `inrupt-client-id-issue-submission.md`
+- [ ] Evaluate implementing `restorePreviousSession: false` workaround
+- [ ] Monitor issue for Inrupt team response
+- [ ] Update implementation based on their guidance
+- [ ] Document final solution for team
+
+---
 
 **Last Updated:** 2026-01-17
+**Maintained By:** Pack Me Up Development Team

--- a/docs/inrupt-client-id-issue.md
+++ b/docs/inrupt-client-id-issue.md
@@ -82,10 +82,7 @@ When users visit our app after their OAuth provider has invalidated the dynamica
 
 ### **Why This Is Problematic**
 
-- **Production blocking**: Users who return to the app after weeks/months are completely unable to access it
-- **No programmatic recovery**: We cannot detect or handle this scenario in our application code
-- **Poor user experience**: Users have no way to know why they can't access the app or how to fix it
-- **Silent failure**: The redirect happens before any Promise resolution, so standard error handling doesn't work
+Users who return after weeks/months are completely blocked from accessing the app. The redirect happens before our error handling can activate, so we have no way to detect or recover programmatically. Users must manually clear browser data, which they don't know how to do.
 
 ---
 
@@ -104,14 +101,9 @@ The user is now blocked from accessing the application entirely.
 
 ### **Our Understanding (Please Correct If Wrong)**
 
-From our investigation, it appears that:
+From our investigation, it appears that when `restorePreviousSession: true`, the library immediately initiates a silent auth redirect (`prompt=none`) before `handleIncomingRedirect()` returns its Promise. If the stored `client_id` has been invalidated, the redirect happens anyway with invalid credentials. Since the redirect is synchronous, our try/catch cannot intercept it.
 
-1. When `restorePreviousSession: true`, the library finds stored session data and immediately initiates a silent authentication flow (`prompt=none`)
-2. This redirect happens synchronously/immediately, before `handleIncomingRedirect()` returns its Promise
-3. If the stored `client_id` has been invalidated by the OAuth provider, the redirect happens anyway with the invalid credentials
-4. Since the redirect is synchronous, our application's error handling cannot catch it
-
-We may be misunderstanding how this is intended to work, so please correct us if we're missing something.
+We may be misunderstanding how this is intended to work.
 
 ---
 
@@ -148,13 +140,11 @@ However, this doesn't work because the redirect happens before the Promise is cr
 
 ### **Temporary Workaround We're Considering**
 
-We're considering changing our code to:
-
 ```typescript
 await handleIncomingRedirect({ restorePreviousSession: false });
 ```
 
-This would disable automatic session restoration, requiring users to explicitly log in after each page refresh. This prevents the invalid client_id issue but loses the seamless "stay logged in" experience.
+This would require users to explicitly log in after each page refresh, losing the seamless "stay logged in" experience, but prevents the blocking issue entirely.
 
 **Would this be the recommended approach**, or is there a better pattern we should follow?
 
@@ -171,100 +161,29 @@ We appreciate any guidance you can provide on the recommended way to handle this
 
 ---
 
-## Our Investigation
+## Internal Notes
 
-### Timeline of the Issue
+### What We Found
+- **File:** `src/components/SolidPodContext.tsx:74`
+- **Issue:** `restorePreviousSession: true` causes immediate redirect before error handling can activate
+- **Root cause:** Stored `client_id` from previous login becomes invalid over time (provider cleanup)
+- **User impact:** Complete app blockage, requires manual browser data clearing
 
-**Production Impact:**
-- Users visiting the app after extended periods were immediately redirected to Inrupt's OAuth provider
-- 401 error: "invalid_client_id"
-- Complete blockage from using the application
-- Required manual clearing of browser data to recover
+### Our Options
+1. **Short-term:** Set `restorePreviousSession: false` (lose "stay logged in" UX but fix the blocking issue)
+2. **Ideal:** Wait for Inrupt team guidance on the intended pattern
 
-### Technical Analysis
-
-**Current Implementation** (`src/components/SolidPodContext.tsx:74`):
-```typescript
-await handleIncomingRedirect({ restorePreviousSession: true });
-```
-
-**How It Fails:**
-1. User had previously logged in → `client_id` stored in browser (IndexedDB/localStorage)
-2. OAuth provider invalidated the dynamically registered client (normal maintenance)
-3. On next visit, library finds stored `client_id` and immediately redirects with `prompt=none`
-4. OAuth provider rejects invalid `client_id` before app can handle the error
-5. User stuck on 401 error page
-
-**Why Error Handling Doesn't Work:**
-The existing try/catch in lines 86-105 of SolidPodContext.tsx would handle errors, but the redirect happens **synchronously before any error is thrown** to catch.
-
----
-
-## Potential Solutions We're Evaluating
-
-### **Option 1: Disable Automatic Session Restoration**
-
-```typescript
-// Change from this:
-await handleIncomingRedirect({ restorePreviousSession: true });
-
-// To this:
-await handleIncomingRedirect({ restorePreviousSession: false });
-```
-
-**Pros:**
-- Eliminates the redirect loop problem
-- Users explicitly choose when to log in
-- No unexpected redirects
-- More predictable behavior
-
-**Cons:**
-- Users must click "Login" after every page refresh
-- Loses the seamless "stay logged in" experience
-- May not be using the library as intended
-
-### **Option 2: Wait for Upstream Guidance**
-
-Continue with current implementation but document the issue for users (tell them to clear site data if they get stuck). Wait for Inrupt team's guidance on the recommended pattern.
-
-**Pros:**
-- Keeps intended automatic session restoration
-- Follows library's designed usage pattern
-
-**Cons:**
-- Users can still get blocked
-- Not a real solution
-
-We're leaning toward **Option 1** as a short-term fix while we seek guidance, but we'd prefer to understand the intended way to handle this scenario.
-
----
-
-## References
-
-### Documentation
-- [Session Restore upon Browser Refresh](https://docs.inrupt.com/guides/authentication-in-solid/authentication-from-browser/session-restore-upon-browser-refresh)
-- [Session Restore Tutorial](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/restore-session-browser-refresh/)
-- [Authentication from Browser](https://docs.inrupt.com/guides/authentication-in-solid/authentication-from-browser)
-
-### Related Issues
-- [Browser/App: Restore session without silent login and redirect (#3443)](https://github.com/inrupt/solid-client-authn-js/issues/3443)
-- [Wrong dynamic client ID used for code-to-token exchange (#1790)](https://github.com/inrupt/solid-client-authn-js/issues/1790)
-- [handleIncomingRedirect strips querystring (#1989)](https://github.com/inrupt/solid-client-authn-js/issues/1989)
-
-### Community Discussions
-- [Inrupt pod login complains about an invalid_client](https://forum.solidproject.org/t/inrupt-pod-login-complains-about-an-invalid-client/4726)
-- [handleIncomingRedirect creates endless loop](https://forum.solidproject.org/t/handleincomingredirect-w-redirect-creates-endless-loop/8623)
+### Research Links
+- **Docs:** [Session Restore](https://docs.inrupt.com/guides/authentication-in-solid/authentication-from-browser/session-restore-upon-browser-refresh) | [Tutorial](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/restore-session-browser-refresh/)
+- **Issues:** [#3443](https://github.com/inrupt/solid-client-authn-js/issues/3443) (silent auth redirects) | [#1790](https://github.com/inrupt/solid-client-authn-js/issues/1790) (client ID) | [#1989](https://github.com/inrupt/solid-client-authn-js/issues/1989) (query string)
+- **Forum:** [Invalid client discussion](https://forum.solidproject.org/t/inrupt-pod-login-complains-about-an-invalid-client/4726)
 
 ---
 
 ## Next Steps
 
-1. **Submit Issue:** Create issue in `inrupt/solid-client-authn-js` repository to seek guidance from the Inrupt team
-2. **Evaluate Workaround:** Consider implementing `restorePreviousSession: false` as temporary measure
-3. **Monitor Response:** Review Inrupt team's recommendations and adjust implementation accordingly
-4. **Update Documentation:** Document the recommended approach for our team once we have clarity
+1. Submit issue to `inrupt/solid-client-authn-js` using the draft above
+2. Consider implementing `restorePreviousSession: false` workaround if needed urgently
+3. Update implementation based on Inrupt team's guidance
 
----
-
-**Document Maintained By:** Pack Me Up Development Team
 **Last Updated:** 2026-01-17

--- a/docs/inrupt-client-id-issue.md
+++ b/docs/inrupt-client-id-issue.md
@@ -1,0 +1,331 @@
+# Inrupt Authentication Issue: Invalid Client ID Redirect Loop
+
+**Status:** Identified and Documented
+**Date:** 2026-01-17
+**Severity:** HIGH - Production blocking issue
+
+---
+
+## Issue Summary
+
+This document describes a critical authentication issue with the Inrupt Solid authentication library (`@inrupt/solid-client-authn-browser`) that causes users to be blocked from accessing the application when stored OAuth client credentials become invalidated.
+
+**Issue Repository:** `inrupt/solid-client-authn-js`
+
+---
+
+## GitHub Issue Draft
+
+### **Title:**
+`handleIncomingRedirect({ restorePreviousSession: true })` causes unrecoverable redirect loop when stored client_id is invalidated
+
+---
+
+### **Description**
+
+**Environment:**
+- Library: `@inrupt/solid-client-authn-browser` v3.1.0
+- OAuth Provider: Inrupt (login.inrupt.com)
+- Browser: Chrome/Firefox/Safari (reproducible across all)
+- App Type: React SPA deployed to production
+
+---
+
+### **Problem Summary**
+
+When `handleIncomingRedirect({ restorePreviousSession: true })` is called with stored session data containing an **invalidated/expired client_id**, the library immediately redirects to the OAuth authorization endpoint with the invalid credentials **before** the application can catch and handle the error. This results in:
+
+1. Immediate 401 "invalid_client_id" error from the OAuth provider
+2. User is blocked from accessing the application
+3. The error occurs **synchronously during the redirect**, so the Promise returned by `handleIncomingRedirect()` never resolves/rejects
+4. The only recovery path is manually clearing browser data
+
+**This creates a production incident scenario where users cannot access the application.**
+
+---
+
+### **Expected Behavior**
+
+One of the following should happen:
+
+**Option A (Preferred):** The library should validate stored client credentials before initiating silent authentication, and if invalid:
+- Clear the corrupted session data automatically
+- Return a rejected Promise with a specific error type (e.g., `InvalidClientError`)
+- Allow the application to handle the error and prompt for fresh login
+
+**Option B:** Provide a synchronous method to inspect/validate stored session data before calling `handleIncomingRedirect()`:
+```typescript
+const hasValidSession = await session.validateStoredSession();
+if (!hasValidSession) {
+  await session.logout(); // Clear corrupted data
+}
+await handleIncomingRedirect({ restorePreviousSession: true });
+```
+
+**Option C:** Make the redirect deferrable so applications can catch errors:
+```typescript
+try {
+  await handleIncomingRedirect({
+    restorePreviousSession: true,
+    validateBeforeRestore: true // New option
+  });
+} catch (error) {
+  if (error instanceof InvalidClientError) {
+    // Handle gracefully
+  }
+}
+```
+
+---
+
+### **Actual Behavior**
+
+1. User visits app after OAuth provider has invalidated their dynamically registered client
+2. `handleIncomingRedirect({ restorePreviousSession: true })` is called
+3. Library **immediately redirects** (synchronously) to:
+   ```
+   https://login.inrupt.com/authorization?
+     client_id=<INVALID_ID>
+     &prompt=none
+     &redirect_uri=...
+     &response_mode=query
+   ```
+4. OAuth provider returns 401 with "invalid_client_id" error
+5. User is stuck on error page
+6. The `try/catch` block in the application never catches the error because the redirect happens before the Promise is created
+
+---
+
+### **Reproduction Steps**
+
+**Setup:**
+```typescript
+import { handleIncomingRedirect, getDefaultSession } from '@inrupt/solid-client-authn-browser';
+
+// Initial app load
+useEffect(() => {
+  const initSession = async () => {
+    try {
+      await handleIncomingRedirect({ restorePreviousSession: true });
+      const session = getDefaultSession();
+      setSession(session);
+    } catch (error) {
+      console.error("This never fires for invalid client_id", error);
+    }
+  };
+  initSession();
+}, []);
+```
+
+**Steps:**
+1. Log in to a Solid Pod provider successfully (creates dynamic client registration)
+2. Close the browser (session data remains in IndexedDB/localStorage)
+3. Wait for OAuth provider to invalidate the client registration (or manually delete it from provider's admin panel)
+4. Open the app again
+5. **Observe:** Immediate redirect to authorization endpoint with invalid client_id
+6. **Observe:** 401 error page, application is unusable
+
+**Temporary Workaround:**
+Users must manually clear site data (Application → Clear Storage in DevTools) to recover.
+
+---
+
+### **Root Cause Analysis**
+
+From examining the library's behavior:
+
+1. **Silent Authentication Flow**: When `restorePreviousSession: true`, the library checks for stored session data and immediately initiates a `prompt=none` silent authentication flow
+2. **No Credential Validation**: The library does not validate that the stored `client_id` is still valid with the OAuth provider before initiating the redirect
+3. **Synchronous Redirect**: The redirect happens synchronously/immediately, so the Promise returned by `handleIncomingRedirect()` hasn't been created yet when the redirect occurs
+4. **Error Handling Gap**: There's no mechanism for the application to intercept or handle invalid client credentials before the redirect
+
+---
+
+### **Impact**
+
+**Production Severity: HIGH**
+
+- Users cannot access the application without manual intervention
+- No programmatic recovery path available to developers
+- Common in production environments where:
+  - Users return after extended periods (weeks/months)
+  - OAuth providers perform regular client cleanup
+  - Dynamic client registrations have TTLs
+
+**Real-world example:** Our production app (https://react-packing-app.vercel.app) experienced this issue, completely blocking users from authentication.
+
+---
+
+### **Proposed Solutions**
+
+**Solution 1: Pre-validation Check (Recommended)**
+```typescript
+// Add internal validation before silent auth redirect
+async handleIncomingRedirect(options) {
+  if (options.restorePreviousSession) {
+    const storedClientId = await this.getStoredClientId();
+    if (storedClientId) {
+      try {
+        // Lightweight validation with OAuth provider
+        await this.validateClientRegistration(storedClientId);
+      } catch (error) {
+        if (error instanceof InvalidClientError) {
+          console.warn("Stored client_id is invalid, clearing session data");
+          await this.logout(); // Clear corrupted data
+          // Return empty session, no redirect
+          return;
+        }
+      }
+    }
+  }
+  // Continue with normal flow...
+}
+```
+
+**Solution 2: Catch Silent Auth Errors**
+```typescript
+// When silent auth fails with invalid_client, automatically cleanup
+async attemptSilentAuthentication(clientId, redirectUri) {
+  try {
+    // Initiate silent auth
+  } catch (error) {
+    if (error.error === 'invalid_client') {
+      await this.clearStoredSession();
+      throw new InvalidClientError("Stored client credentials are invalid");
+    }
+    throw error;
+  }
+}
+```
+
+**Solution 3: New API Method**
+```typescript
+// Expose a validation method for applications
+class Session {
+  async hasValidStoredSession(): Promise<boolean> {
+    const clientId = await this.storage.get('clientId');
+    if (!clientId) return false;
+
+    try {
+      await this.validateWithProvider(clientId);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+```
+
+---
+
+### **Additional Context**
+
+Related issues:
+- [#3443](https://github.com/inrupt/solid-client-authn-js/issues/3443) - Discusses problems with automatic silent authentication redirects
+- [#1790](https://github.com/inrupt/solid-client-authn-js/issues/1790) - Wrong dynamic client ID issues
+- [#1989](https://github.com/inrupt/solid-client-authn-js/issues/1989) - handleIncomingRedirect strips query string
+
+The library's current behavior prioritizes automatic session restoration over error resilience. For production applications, **graceful degradation** (falling back to logged-out state) is preferable to **user-blocking errors**.
+
+---
+
+### **Workaround (Application-Level)**
+
+Until this is fixed, we're using:
+```typescript
+await handleIncomingRedirect({ restorePreviousSession: false });
+```
+
+This disables automatic session restoration, requiring users to explicitly log in after page refresh, but prevents the invalid client_id redirect issue entirely.
+
+---
+
+### **Acceptance Criteria**
+
+A fix should ensure that:
+- [ ] Invalid/expired client_id in stored session data does not cause unrecoverable redirect loops
+- [ ] Applications can catch and handle invalid client errors programmatically
+- [ ] Session data is automatically cleaned up when credentials are invalid
+- [ ] Users are not blocked from accessing applications due to corrupted session storage
+
+---
+
+## Our Investigation
+
+### Timeline of the Issue
+
+**Production Impact:**
+- Users visiting the app after extended periods were immediately redirected to Inrupt's OAuth provider
+- 401 error: "invalid_client_id"
+- Complete blockage from using the application
+- Required manual clearing of browser data to recover
+
+### Technical Analysis
+
+**Current Implementation** (`src/components/SolidPodContext.tsx:74`):
+```typescript
+await handleIncomingRedirect({ restorePreviousSession: true });
+```
+
+**How It Fails:**
+1. User had previously logged in → `client_id` stored in browser (IndexedDB/localStorage)
+2. OAuth provider invalidated the dynamically registered client (normal maintenance)
+3. On next visit, library finds stored `client_id` and immediately redirects with `prompt=none`
+4. OAuth provider rejects invalid `client_id` before app can handle the error
+5. User stuck on 401 error page
+
+**Why Error Handling Doesn't Work:**
+The existing try/catch in lines 86-105 of SolidPodContext.tsx would handle errors, but the redirect happens **synchronously before any error is thrown** to catch.
+
+---
+
+## Recommended Solution for Our App
+
+**Immediate Fix:** Disable automatic session restoration
+
+```typescript
+// Change this line:
+await handleIncomingRedirect({ restorePreviousSession: false });
+```
+
+**Benefits:**
+- ✅ Eliminates the redirect loop entirely
+- ✅ Users explicitly choose when to log in (standard SPA pattern)
+- ✅ No unexpected redirects
+- ✅ Cleaner, more predictable UX
+
+**Trade-offs:**
+- ❌ Users must click "Login" after page refresh (but this is standard for most web apps)
+- ❌ Loses "stay logged in" feeling
+
+---
+
+## References
+
+### Documentation
+- [Session Restore upon Browser Refresh](https://docs.inrupt.com/guides/authentication-in-solid/authentication-from-browser/session-restore-upon-browser-refresh)
+- [Session Restore Tutorial](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/restore-session-browser-refresh/)
+- [Authentication from Browser](https://docs.inrupt.com/guides/authentication-in-solid/authentication-from-browser)
+
+### Related Issues
+- [Browser/App: Restore session without silent login and redirect (#3443)](https://github.com/inrupt/solid-client-authn-js/issues/3443)
+- [Wrong dynamic client ID used for code-to-token exchange (#1790)](https://github.com/inrupt/solid-client-authn-js/issues/1790)
+- [handleIncomingRedirect strips querystring (#1989)](https://github.com/inrupt/solid-client-authn-js/issues/1989)
+
+### Community Discussions
+- [Inrupt pod login complains about an invalid_client](https://forum.solidproject.org/t/inrupt-pod-login-complains-about-an-invalid-client/4726)
+- [handleIncomingRedirect creates endless loop](https://forum.solidproject.org/t/handleincomingredirect-w-redirect-creates-endless-loop/8623)
+
+---
+
+## Next Steps
+
+1. **Submit Issue:** Create issue in `inrupt/solid-client-authn-js` repository using the draft above
+2. **Implement Workaround:** Apply `restorePreviousSession: false` in our codebase
+3. **Monitor:** Watch for upstream fixes from Inrupt team
+4. **Re-evaluate:** Once fixed upstream, consider re-enabling automatic session restoration
+
+---
+
+**Document Maintained By:** Pack Me Up Development Team
+**Last Updated:** 2026-01-17

--- a/docs/inrupt-client-id-issue.md
+++ b/docs/inrupt-client-id-issue.md
@@ -17,7 +17,7 @@ This document describes a critical authentication issue with the Inrupt Solid au
 ## GitHub Issue Draft
 
 ### **Title:**
-`handleIncomingRedirect({ restorePreviousSession: true })` causes unrecoverable redirect loop when stored client_id is invalidated
+Need guidance: `handleIncomingRedirect({ restorePreviousSession: true })` redirects immediately with invalidated client_id, blocking users from app
 
 ---
 
@@ -27,82 +27,17 @@ This document describes a critical authentication issue with the Inrupt Solid au
 - Library: `@inrupt/solid-client-authn-browser` v3.1.0
 - OAuth Provider: Inrupt (login.inrupt.com)
 - Browser: Chrome/Firefox/Safari (reproducible across all)
-- App Type: React SPA deployed to production
+- App Type: React SPA deployed to production (https://react-packing-app.vercel.app)
 
 ---
 
-### **Problem Summary**
+### **Our Setup**
 
-When `handleIncomingRedirect({ restorePreviousSession: true })` is called with stored session data containing an **invalidated/expired client_id**, the library immediately redirects to the OAuth authorization endpoint with the invalid credentials **before** the application can catch and handle the error. This results in:
+We have a React application that initializes the Solid session on page load:
 
-1. Immediate 401 "invalid_client_id" error from the OAuth provider
-2. User is blocked from accessing the application
-3. The error occurs **synchronously during the redirect**, so the Promise returned by `handleIncomingRedirect()` never resolves/rejects
-4. The only recovery path is manually clearing browser data
-
-**This creates a production incident scenario where users cannot access the application.**
-
----
-
-### **Expected Behavior**
-
-One of the following should happen:
-
-**Option A (Preferred):** The library should validate stored client credentials before initiating silent authentication, and if invalid:
-- Clear the corrupted session data automatically
-- Return a rejected Promise with a specific error type (e.g., `InvalidClientError`)
-- Allow the application to handle the error and prompt for fresh login
-
-**Option B:** Provide a synchronous method to inspect/validate stored session data before calling `handleIncomingRedirect()`:
-```typescript
-const hasValidSession = await session.validateStoredSession();
-if (!hasValidSession) {
-  await session.logout(); // Clear corrupted data
-}
-await handleIncomingRedirect({ restorePreviousSession: true });
-```
-
-**Option C:** Make the redirect deferrable so applications can catch errors:
-```typescript
-try {
-  await handleIncomingRedirect({
-    restorePreviousSession: true,
-    validateBeforeRestore: true // New option
-  });
-} catch (error) {
-  if (error instanceof InvalidClientError) {
-    // Handle gracefully
-  }
-}
-```
-
----
-
-### **Actual Behavior**
-
-1. User visits app after OAuth provider has invalidated their dynamically registered client
-2. `handleIncomingRedirect({ restorePreviousSession: true })` is called
-3. Library **immediately redirects** (synchronously) to:
-   ```
-   https://login.inrupt.com/authorization?
-     client_id=<INVALID_ID>
-     &prompt=none
-     &redirect_uri=...
-     &response_mode=query
-   ```
-4. OAuth provider returns 401 with "invalid_client_id" error
-5. User is stuck on error page
-6. The `try/catch` block in the application never catches the error because the redirect happens before the Promise is created
-
----
-
-### **Reproduction Steps**
-
-**Setup:**
 ```typescript
 import { handleIncomingRedirect, getDefaultSession } from '@inrupt/solid-client-authn-browser';
 
-// Initial app load
 useEffect(() => {
   const initSession = async () => {
     try {
@@ -110,143 +45,129 @@ useEffect(() => {
       const session = getDefaultSession();
       setSession(session);
     } catch (error) {
-      console.error("This never fires for invalid client_id", error);
+      console.error("Session initialization error:", error);
+      // Handle errors and clear session data
     }
   };
   initSession();
 }, []);
 ```
 
-**Steps:**
+We use `restorePreviousSession: true` to provide a seamless experience where users remain logged in across page refreshes.
+
+---
+
+### **What We're Observing**
+
+When users visit our app after their OAuth provider has invalidated the dynamically registered client_id (which we assume is normal maintenance/cleanup), the following happens:
+
+1. User visits the app
+2. `handleIncomingRedirect({ restorePreviousSession: true })` is called
+3. The library **immediately redirects** to the OAuth provider before our code continues:
+   ```
+   https://login.inrupt.com/authorization?
+     client_id=22fe30ba-129c-46ed-843c-e8f28debdb16
+     &prompt=none
+     &redirect_uri=https%3A%2F%2Freact-packing-app.vercel.app%2Fpod-auth-callback.html
+     &response_mode=query
+     ...
+   ```
+4. OAuth provider immediately returns 401 with "invalid_client_id" error
+5. User sees the error page and cannot access our application
+6. Our `try/catch` block never catches any error (presumably because the redirect happens synchronously)
+
+**Current User Recovery:** Users must manually clear browser site data (IndexedDB/localStorage) to recover. Obviously, this is not a viable solution.
+
+---
+
+### **Why This Is Problematic**
+
+- **Production blocking**: Users who return to the app after weeks/months are completely unable to access it
+- **No programmatic recovery**: We cannot detect or handle this scenario in our application code
+- **Poor user experience**: Users have no way to know why they can't access the app or how to fix it
+- **Silent failure**: The redirect happens before any Promise resolution, so standard error handling doesn't work
+
+---
+
+### **Reproduction Steps**
+
 1. Log in to a Solid Pod provider successfully (creates dynamic client registration)
-2. Close the browser (session data remains in IndexedDB/localStorage)
-3. Wait for OAuth provider to invalidate the client registration (or manually delete it from provider's admin panel)
+2. Close the browser (session data with client_id remains in IndexedDB/localStorage)
+3. Wait for OAuth provider to invalidate the client registration (or manually delete it from provider's admin panel if possible for testing)
 4. Open the app again
-5. **Observe:** Immediate redirect to authorization endpoint with invalid client_id
-6. **Observe:** 401 error page, application is unusable
+5. **Observe:** Immediate redirect to authorization endpoint with the now-invalid client_id
+6. **Observe:** 401 "invalid_client_id" error page from OAuth provider
 
-**Temporary Workaround:**
-Users must manually clear site data (Application → Clear Storage in DevTools) to recover.
-
----
-
-### **Root Cause Analysis**
-
-From examining the library's behavior:
-
-1. **Silent Authentication Flow**: When `restorePreviousSession: true`, the library checks for stored session data and immediately initiates a `prompt=none` silent authentication flow
-2. **No Credential Validation**: The library does not validate that the stored `client_id` is still valid with the OAuth provider before initiating the redirect
-3. **Synchronous Redirect**: The redirect happens synchronously/immediately, so the Promise returned by `handleIncomingRedirect()` hasn't been created yet when the redirect occurs
-4. **Error Handling Gap**: There's no mechanism for the application to intercept or handle invalid client credentials before the redirect
+The user is now blocked from accessing the application entirely.
 
 ---
 
-### **Impact**
+### **Our Understanding (Please Correct If Wrong)**
 
-**Production Severity: HIGH**
+From our investigation, it appears that:
 
-- Users cannot access the application without manual intervention
-- No programmatic recovery path available to developers
-- Common in production environments where:
-  - Users return after extended periods (weeks/months)
-  - OAuth providers perform regular client cleanup
-  - Dynamic client registrations have TTLs
+1. When `restorePreviousSession: true`, the library finds stored session data and immediately initiates a silent authentication flow (`prompt=none`)
+2. This redirect happens synchronously/immediately, before `handleIncomingRedirect()` returns its Promise
+3. If the stored `client_id` has been invalidated by the OAuth provider, the redirect happens anyway with the invalid credentials
+4. Since the redirect is synchronous, our application's error handling cannot catch it
 
-**Real-world example:** Our production app (https://react-packing-app.vercel.app) experienced this issue, completely blocking users from authentication.
+We may be misunderstanding how this is intended to work, so please correct us if we're missing something.
 
 ---
 
-### **Proposed Solutions**
+### **What We've Tried**
 
-**Solution 1: Pre-validation Check (Recommended)**
+We attempted to catch errors in our application code:
+
 ```typescript
-// Add internal validation before silent auth redirect
-async handleIncomingRedirect(options) {
-  if (options.restorePreviousSession) {
-    const storedClientId = await this.getStoredClientId();
-    if (storedClientId) {
-      try {
-        // Lightweight validation with OAuth provider
-        await this.validateClientRegistration(storedClientId);
-      } catch (error) {
-        if (error instanceof InvalidClientError) {
-          console.warn("Stored client_id is invalid, clearing session data");
-          await this.logout(); // Clear corrupted data
-          // Return empty session, no redirect
-          return;
-        }
-      }
-    }
-  }
-  // Continue with normal flow...
+try {
+  await handleIncomingRedirect({ restorePreviousSession: true });
+} catch (error) {
+  // This never fires for invalid client_id scenarios
+  await solidLogout(); // Clear corrupted session
 }
 ```
 
-**Solution 2: Catch Silent Auth Errors**
+However, this doesn't work because the redirect happens before the Promise is created.
+
+---
+
+### **Questions We're Hoping You Can Help With**
+
+1. **Is this the intended behavior** when stored client credentials become invalid? Should applications expect this scenario?
+
+2. **Is there a recommended pattern** for handling invalidated client_ids that we're missing? Should we be doing something differently in our setup?
+
+3. **Is there a way to detect or validate** stored session data before calling `handleIncomingRedirect()` so we can clear it proactively if needed?
+
+4. **Would it make sense** for the library to handle this scenario internally (e.g., detecting the invalid client and clearing session data automatically), or is that something applications should manage?
+
+5. **For `restorePreviousSession: true` to be safe in production**, what assumptions should we make about client_id lifetime and validity?
+
+---
+
+### **Temporary Workaround We're Considering**
+
+We're considering changing our code to:
+
 ```typescript
-// When silent auth fails with invalid_client, automatically cleanup
-async attemptSilentAuthentication(clientId, redirectUri) {
-  try {
-    // Initiate silent auth
-  } catch (error) {
-    if (error.error === 'invalid_client') {
-      await this.clearStoredSession();
-      throw new InvalidClientError("Stored client credentials are invalid");
-    }
-    throw error;
-  }
-}
+await handleIncomingRedirect({ restorePreviousSession: false });
 ```
 
-**Solution 3: New API Method**
-```typescript
-// Expose a validation method for applications
-class Session {
-  async hasValidStoredSession(): Promise<boolean> {
-    const clientId = await this.storage.get('clientId');
-    if (!clientId) return false;
+This would disable automatic session restoration, requiring users to explicitly log in after each page refresh. This prevents the invalid client_id issue but loses the seamless "stay logged in" experience.
 
-    try {
-      await this.validateWithProvider(clientId);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-}
-```
+**Would this be the recommended approach**, or is there a better pattern we should follow?
 
 ---
 
 ### **Additional Context**
 
-Related issues:
-- [#3443](https://github.com/inrupt/solid-client-authn-js/issues/3443) - Discusses problems with automatic silent authentication redirects
-- [#1790](https://github.com/inrupt/solid-client-authn-js/issues/1790) - Wrong dynamic client ID issues
-- [#1989](https://github.com/inrupt/solid-client-authn-js/issues/1989) - handleIncomingRedirect strips query string
+We found some potentially related issues:
+- [#3443](https://github.com/inrupt/solid-client-authn-js/issues/3443) - Discusses challenges with silent authentication redirects
+- [#1790](https://github.com/inrupt/solid-client-authn-js/issues/1790) - Dynamic client ID issues
+- [#1989](https://github.com/inrupt/solid-client-authn-js/issues/1989) - Query string handling with restorePreviousSession
 
-The library's current behavior prioritizes automatic session restoration over error resilience. For production applications, **graceful degradation** (falling back to logged-out state) is preferable to **user-blocking errors**.
-
----
-
-### **Workaround (Application-Level)**
-
-Until this is fixed, we're using:
-```typescript
-await handleIncomingRedirect({ restorePreviousSession: false });
-```
-
-This disables automatic session restoration, requiring users to explicitly log in after page refresh, but prevents the invalid client_id redirect issue entirely.
-
----
-
-### **Acceptance Criteria**
-
-A fix should ensure that:
-- [ ] Invalid/expired client_id in stored session data does not cause unrecoverable redirect loops
-- [ ] Applications can catch and handle invalid client errors programmatically
-- [ ] Session data is automatically cleaned up when credentials are invalid
-- [ ] Users are not blocked from accessing applications due to corrupted session storage
+We appreciate any guidance you can provide on the recommended way to handle this scenario!
 
 ---
 
@@ -279,24 +200,42 @@ The existing try/catch in lines 86-105 of SolidPodContext.tsx would handle error
 
 ---
 
-## Recommended Solution for Our App
+## Potential Solutions We're Evaluating
 
-**Immediate Fix:** Disable automatic session restoration
+### **Option 1: Disable Automatic Session Restoration**
 
 ```typescript
-// Change this line:
+// Change from this:
+await handleIncomingRedirect({ restorePreviousSession: true });
+
+// To this:
 await handleIncomingRedirect({ restorePreviousSession: false });
 ```
 
-**Benefits:**
-- ✅ Eliminates the redirect loop entirely
-- ✅ Users explicitly choose when to log in (standard SPA pattern)
-- ✅ No unexpected redirects
-- ✅ Cleaner, more predictable UX
+**Pros:**
+- Eliminates the redirect loop problem
+- Users explicitly choose when to log in
+- No unexpected redirects
+- More predictable behavior
 
-**Trade-offs:**
-- ❌ Users must click "Login" after page refresh (but this is standard for most web apps)
-- ❌ Loses "stay logged in" feeling
+**Cons:**
+- Users must click "Login" after every page refresh
+- Loses the seamless "stay logged in" experience
+- May not be using the library as intended
+
+### **Option 2: Wait for Upstream Guidance**
+
+Continue with current implementation but document the issue for users (tell them to clear site data if they get stuck). Wait for Inrupt team's guidance on the recommended pattern.
+
+**Pros:**
+- Keeps intended automatic session restoration
+- Follows library's designed usage pattern
+
+**Cons:**
+- Users can still get blocked
+- Not a real solution
+
+We're leaning toward **Option 1** as a short-term fix while we seek guidance, but we'd prefer to understand the intended way to handle this scenario.
 
 ---
 
@@ -320,10 +259,10 @@ await handleIncomingRedirect({ restorePreviousSession: false });
 
 ## Next Steps
 
-1. **Submit Issue:** Create issue in `inrupt/solid-client-authn-js` repository using the draft above
-2. **Implement Workaround:** Apply `restorePreviousSession: false` in our codebase
-3. **Monitor:** Watch for upstream fixes from Inrupt team
-4. **Re-evaluate:** Once fixed upstream, consider re-enabling automatic session restoration
+1. **Submit Issue:** Create issue in `inrupt/solid-client-authn-js` repository to seek guidance from the Inrupt team
+2. **Evaluate Workaround:** Consider implementing `restorePreviousSession: false` as temporary measure
+3. **Monitor Response:** Review Inrupt team's recommendations and adjust implementation accordingly
+4. **Update Documentation:** Document the recommended approach for our team once we have clarity
 
 ---
 


### PR DESCRIPTION
Add comprehensive documentation of critical authentication bug where invalidated OAuth client credentials cause unrecoverable redirect loops.

This document:
- Provides complete GitHub issue draft for inrupt/solid-client-authn-js
- Details reproduction steps and root cause analysis
- Proposes multiple solution approaches
- Documents workarounds and references

Issue affects production users who return after extended periods when their dynamically registered client_id has been invalidated by the OAuth provider. The library's restorePreviousSession:true triggers immediate silent auth with invalid credentials, blocking app access.