### PR TITLE
Namespace PouchDB databases by Solid Pod identity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
@@ -46,6 +48,13 @@
         "vite": "^6.3.1",
         "vitest": "^4.0.8"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1950,6 +1959,90 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2854,6 +2947,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2876,6 +2980,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -3199,6 +3313,13 @@
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -3243,6 +3364,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3251,6 +3382,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4007,6 +4146,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -4853,6 +5002,17 @@
       "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
       "license": "MIT"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4930,6 +5090,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -5458,6 +5628,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -5700,6 +5908,20 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/relative-to-absolute-iri": {
@@ -5967,6 +6189,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { CreatePackingList } from './pages/create-packing-list'
 import { PackingLists } from './pages/packing-lists'
 import { ViewPackingList } from './pages/view-packing-list'
 import { SolidPodProvider } from './components/SolidPodContext'
+import { DatabaseProvider } from './components/DatabaseContext'
 import { SolidPodHandleRedirectPage } from './pages/solid-pod-handle-redirect-page'
 import { Wizard } from './pages/wizard'
 
@@ -17,6 +18,7 @@ function App() {
   return (
     <ToastProvider>
       <SolidPodProvider>
+        <DatabaseProvider>
         <HashRouter>
           <div className="min-h-screen bg-gradient-to-br from-primary-50 via-white to-accent-50">
             <Navigation />
@@ -33,6 +35,7 @@ function App() {
             </div>
           </div>
         </HashRouter>
+        </DatabaseProvider>
       </SolidPodProvider>
     </ToastProvider>
   )

--- a/src/components/DatabaseContext.test.tsx
+++ b/src/components/DatabaseContext.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { DatabaseProvider, useDatabase } from './DatabaseContext'
+
+// --- Mocks ---
+
+vi.mock('./SolidPodContext', () => ({
+  useSolidPod: vi.fn(),
+}))
+
+vi.mock('../services/solidPod', () => ({
+  getPrimaryPodUrl: vi.fn(),
+}))
+
+// Mock PackingAppDatabase so tests don't create real filesystem databases
+vi.mock('../services/database', () => {
+  const instanceCache = new Map<string, object>()
+  return {
+    LOCAL_NAMESPACE: 'local',
+    PackingAppDatabase: {
+      getInstance: vi.fn((namespace: string) => {
+        if (!instanceCache.has(namespace)) {
+          instanceCache.set(namespace, {
+            getInfo: vi.fn().mockResolvedValue({ db_name: `packing-app-data--${namespace}`, doc_count: 0 }),
+          })
+        }
+        return instanceCache.get(namespace)
+      }),
+      sanitizePodUrl: vi.fn((url: string) =>
+        url.replace(/^https?:\/\//, '').replace(/\/+$/, '').replace(/\//g, '_')
+      ),
+    },
+  }
+})
+
+import { useSolidPod } from './SolidPodContext'
+import { getPrimaryPodUrl } from '../services/solidPod'
+import { PackingAppDatabase } from '../services/database'
+
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
+const mockGetInstance = vi.mocked(PackingAppDatabase.getInstance)
+
+function NamespaceDisplay() {
+  const { db } = useDatabase()
+  return <div data-testid="db-name">{(db as any).getInfo ? 'has-db' : 'no-db'}</div>
+}
+
+function OutsideProvider() {
+  useDatabase()
+  return null
+}
+
+describe('DatabaseContext', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockGetInstance.mockClear()
+    mockGetPrimaryPodUrl.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders children when not logged in and not loading', async () => {
+    mockUseSolidPod.mockReturnValue({
+      session: null,
+      isLoggedIn: false,
+      webId: undefined,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+    })
+
+    render(
+      <DatabaseProvider>
+        <NamespaceDisplay />
+      </DatabaseProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('db-name')).toBeTruthy()
+    })
+  })
+
+  it('does not render children while session is loading', () => {
+    mockUseSolidPod.mockReturnValue({
+      session: null,
+      isLoggedIn: false,
+      webId: undefined,
+      isLoading: true,
+      login: vi.fn(),
+      logout: vi.fn(),
+    })
+
+    render(
+      <DatabaseProvider>
+        <div data-testid="child">hello</div>
+      </DatabaseProvider>
+    )
+
+    expect(screen.queryByTestId('child')).toBeNull()
+  })
+
+  it('provides a local-namespaced db when not logged in', async () => {
+    mockUseSolidPod.mockReturnValue({
+      session: null,
+      isLoggedIn: false,
+      webId: undefined,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+    })
+
+    render(
+      <DatabaseProvider>
+        <div data-testid="child" />
+      </DatabaseProvider>
+    )
+
+    await waitFor(() => screen.getByTestId('child'))
+    expect(mockGetInstance).toHaveBeenCalledWith('local')
+  })
+
+  it('provides a pod-namespaced db when logged in with a pod URL', async () => {
+    const mockSession = { info: { isLoggedIn: true, webId: 'https://example.com/profile#me' } }
+    mockUseSolidPod.mockReturnValue({
+      session: mockSession as any,
+      isLoggedIn: true,
+      webId: 'https://example.com/profile#me',
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+    })
+    mockGetPrimaryPodUrl.mockResolvedValue('https://example.com/')
+
+    render(
+      <DatabaseProvider>
+        <div data-testid="child" />
+      </DatabaseProvider>
+    )
+
+    await waitFor(() => screen.getByTestId('child'))
+    expect(mockGetInstance).toHaveBeenCalledWith('example.com')
+  })
+
+  it('falls back to sanitized webId when getPrimaryPodUrl returns null', async () => {
+    const mockSession = { info: { isLoggedIn: true, webId: 'https://example.com/profile#me' } }
+    mockUseSolidPod.mockReturnValue({
+      session: mockSession as any,
+      isLoggedIn: true,
+      webId: 'https://example.com/profile#me',
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+    })
+    mockGetPrimaryPodUrl.mockResolvedValue(null)
+
+    render(
+      <DatabaseProvider>
+        <div data-testid="child" />
+      </DatabaseProvider>
+    )
+
+    await waitFor(() => screen.getByTestId('child'))
+    // Should fall back to sanitized webId: 'https://example.com/profile#me' -> 'example.com_profile#me'
+    expect(mockGetInstance).toHaveBeenCalled()
+    const namespace = mockGetInstance.mock.calls[mockGetInstance.mock.calls.length - 1][0]
+    expect(namespace).not.toBe('local')
+    expect(namespace).toContain('example.com')
+  })
+
+  it('throws when useDatabase is called outside DatabaseProvider', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<OutsideProvider />)).toThrow('useDatabase must be used within a DatabaseProvider')
+  })
+})

--- a/src/components/DatabaseContext.tsx
+++ b/src/components/DatabaseContext.tsx
@@ -1,0 +1,81 @@
+import { createContext, ReactNode, useContext, useState, useEffect } from 'react'
+import { PackingAppDatabase, LOCAL_NAMESPACE } from '../services/database'
+import { useSolidPod } from './SolidPodContext'
+import { getPrimaryPodUrl } from '../services/solidPod'
+
+interface DatabaseContextValue {
+    db: PackingAppDatabase
+}
+
+const DatabaseContext = createContext<DatabaseContextValue | undefined>(undefined)
+
+/**
+ * Provides a PouchDB instance namespaced to the current pod identity.
+ *
+ * - Not logged in → uses the 'local' namespace (packing-app-data--local)
+ * - Logged into a pod → uses the pod URL as namespace (e.g. packing-app-data--timgent.solidcommunity.net)
+ *
+ * This ensures that local data and pod data are always kept in separate databases,
+ * preventing accidental overwrites between identities.
+ *
+ * Children are not rendered until the database is ready.
+ */
+export function DatabaseProvider({ children }: { children: ReactNode }) {
+    const { isLoggedIn, webId, session, isLoading } = useSolidPod()
+    const [db, setDb] = useState<PackingAppDatabase | null>(null)
+    const [isResolvingPod, setIsResolvingPod] = useState(false)
+
+    useEffect(() => {
+        // While session is still initialising, wait
+        if (isLoading) {
+            return
+        }
+
+        if (!isLoggedIn || !webId) {
+            // Not logged in — use the local namespace immediately
+            setDb(PackingAppDatabase.getInstance(LOCAL_NAMESPACE))
+            return
+        }
+
+        // Logged in — resolve the pod URL to use as namespace
+        let cancelled = false
+        setIsResolvingPod(true)
+
+        getPrimaryPodUrl(session).then(podUrl => {
+            if (cancelled) return
+
+            const namespace = podUrl
+                ? PackingAppDatabase.sanitizePodUrl(podUrl)
+                : PackingAppDatabase.sanitizePodUrl(webId)
+
+            setDb(PackingAppDatabase.getInstance(namespace))
+            setIsResolvingPod(false)
+        })
+
+        return () => {
+            cancelled = true
+        }
+    }, [isLoggedIn, webId, session, isLoading])
+
+    if (isLoading || isResolvingPod || !db) {
+        return null
+    }
+
+    return (
+        <DatabaseContext.Provider value={{ db }}>
+            {children}
+        </DatabaseContext.Provider>
+    )
+}
+
+/**
+ * Returns the PouchDB instance for the current pod identity.
+ * Must be used within a DatabaseProvider.
+ */
+export function useDatabase(): DatabaseContextValue {
+    const context = useContext(DatabaseContext)
+    if (context === undefined) {
+        throw new Error('useDatabase must be used within a DatabaseProvider')
+    }
+    return context
+}

--- a/src/components/DatabaseContext.tsx
+++ b/src/components/DatabaseContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useContext, useState, useEffect } from 'react'
+import { createContext, ReactNode, useContext, useState, useEffect, Fragment } from 'react'
 import { PackingAppDatabase, LOCAL_NAMESPACE } from '../services/database'
 import { useSolidPod } from './SolidPodContext'
 import { getPrimaryPodUrl } from '../services/solidPod'
@@ -23,6 +23,7 @@ const DatabaseContext = createContext<DatabaseContextValue | undefined>(undefine
 export function DatabaseProvider({ children }: { children: ReactNode }) {
     const { isLoggedIn, webId, session, isLoading } = useSolidPod()
     const [db, setDb] = useState<PackingAppDatabase | null>(null)
+    const [namespace, setNamespace] = useState<string | null>(null)
     const [isResolvingPod, setIsResolvingPod] = useState(false)
 
     useEffect(() => {
@@ -33,6 +34,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
 
         if (!isLoggedIn || !webId) {
             // Not logged in — use the local namespace immediately
+            setNamespace(LOCAL_NAMESPACE)
             setDb(PackingAppDatabase.getInstance(LOCAL_NAMESPACE))
             return
         }
@@ -44,11 +46,12 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
         getPrimaryPodUrl(session).then(podUrl => {
             if (cancelled) return
 
-            const namespace = podUrl
+            const resolvedNamespace = podUrl
                 ? PackingAppDatabase.sanitizePodUrl(podUrl)
                 : PackingAppDatabase.sanitizePodUrl(webId)
 
-            setDb(PackingAppDatabase.getInstance(namespace))
+            setNamespace(resolvedNamespace)
+            setDb(PackingAppDatabase.getInstance(resolvedNamespace))
             setIsResolvingPod(false)
         })
 
@@ -57,13 +60,18 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
         }
     }, [isLoggedIn, webId, session, isLoading])
 
-    if (isLoading || isResolvingPod || !db) {
+    if (isLoading || isResolvingPod || !db || !namespace) {
         return null
     }
 
+    // The Fragment key causes all children to remount whenever the active database
+    // namespace changes (e.g. login / logout). This ensures every page re-fetches
+    // its data from the correct database instead of showing stale state.
     return (
         <DatabaseContext.Provider value={{ db }}>
-            {children}
+            <Fragment key={namespace}>
+                {children}
+            </Fragment>
         </DatabaseContext.Provider>
     )
 }

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useContext, useState, useEffect } from "react";
+import { createContext, ReactNode, useContext, useState, useEffect, useRef } from "react";
 import {
   Session,
   handleIncomingRedirect,
@@ -28,20 +28,23 @@ function setupSessionEventListeners(
   session: Session,
   showToast: (message: string, type: 'success' | 'error') => void,
   setSession: (session: Session) => void,
-  setSessionVersion: (updater: (v: number) => number) => void
+  setSessionVersion: (updater: (v: number) => number) => void,
+  intentionalLogoutRef: React.MutableRefObject<boolean>
 ) {
-  // Listen for logout events (including session expiration)
+  // Listen for logout events — fires for both intentional logout and session expiry.
+  // Use intentionalLogoutRef to distinguish between the two.
   session.events.on("logout", () => {
     console.log("Session logout event fired");
-    // Update UI state
     setSession(getDefaultSession());
     setSessionVersion(v => v + 1);
 
-    // Notify user that session has expired
-    showToast(
-      "Your Solid session has expired. Your data is saved locally - log in again to sync with your Pod.",
-      "error"
-    );
+    if (!intentionalLogoutRef.current) {
+      showToast(
+        "Your Solid session has expired. Your data is saved locally - log in again to sync with your Pod.",
+        "error"
+      );
+    }
+    intentionalLogoutRef.current = false;
   });
 
   // Listen for login events
@@ -66,6 +69,7 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [, setSessionVersion] = useState(0);
   const { showToast } = useToast();
+  const intentionalLogoutRef = useRef(false);
 
   useEffect(() => {
     const initializeSession = async () => {
@@ -82,7 +86,7 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
         setSessionVersion(v => v + 1);
 
         // Set up session event listeners
-        setupSessionEventListeners(currentSession, showToast, setSession, setSessionVersion);
+        setupSessionEventListeners(currentSession, showToast, setSession, setSessionVersion, intentionalLogoutRef);
       } catch (error) {
         console.error("Error initializing session:", error);
         console.log("Session restoration failed, clearing any corrupted session data...");
@@ -164,6 +168,7 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
   };
 
   const logout = async () => {
+    intentionalLogoutRef.current = true;
     await solidLogout();
     const updatedSession = getDefaultSession();
     setSession(updatedSession);

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -3,7 +3,7 @@ import { useForm, SubmitHandler } from 'react-hook-form'
 import { Link, useNavigate } from 'react-router-dom'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList, PackingListFormData, PackingListItem } from '../create-packing-list/types'
-import { packingAppDb } from '../services/database'
+import { useDatabase } from '../components/DatabaseContext'
 import { Input } from '../components/Input'
 import { Button } from '../components/Button'
 import { useToast } from '../components/ToastContext'
@@ -16,6 +16,7 @@ export function CreatePackingList() {
     const [selectedPeopleIds, setSelectedPeopleIds] = useState<string[]>([])
     const { showToast } = useToast()
     const { isLoggedIn } = useSolidPod()
+    const { db } = useDatabase()
     const navigate = useNavigate()
 
     const { register, handleSubmit, setValue, watch } = useForm<PackingListFormData>({
@@ -29,7 +30,7 @@ export function CreatePackingList() {
         const fetchQuestionSet = async () => {
             setIsLoading(true)
             try {
-                const doc = await packingAppDb.getQuestionSet()
+                const doc = await db.getQuestionSet()
                 setQuestionSet(doc)
                 setNoQuestionsFound(false)
                 // Initialize with all people selected by default
@@ -108,7 +109,7 @@ export function CreatePackingList() {
             items: [...questionBasedItems, ...alwaysNeededItems]
         }
         try {
-            await packingAppDb.savePackingList(packingList)
+            await db.savePackingList(packingList)
             showToast('Packing list created successfully!', 'success')
             // Navigate to the newly created packing list
             navigate(`/view-lists/${packingList.id}`)

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { useForm, SubmitHandler, useFieldArray, useWatch } from "react-hook-form"
 import { useDebouncedCallback } from 'use-debounce'
 import { PackingListQuestionSet, newDraftQuestion } from '../edit-questions/types'
-import { packingAppDb } from '../services/database'
+import { useDatabase } from '../components/DatabaseContext'
 import { DatabaseMigration } from '../services/migration'
 import { QuestionSection } from '../edit-questions/question-section'
 import { PeopleSection } from '../edit-questions/people-section'
@@ -37,6 +37,7 @@ export function EditQuestionsForm() {
   });
   const { showToast } = useToast();
   const { isLoggedIn } = useSolidPod();
+  const { db } = useDatabase();
 
   // Watch all form values for auto-save
   const watchedFormValues = useWatch({ control });
@@ -71,7 +72,7 @@ export function EditQuestionsForm() {
           ...data,
           _rev: rev,
         };
-        return await packingAppDb.saveQuestionSet(docToWrite);
+        return await db.saveQuestionSet(docToWrite);
       },
       updateFormAndState: (data, newRev) => {
         const updatedData = {
@@ -154,7 +155,7 @@ export function EditQuestionsForm() {
           ...dataToSave,
           lastModified: new Date().toISOString()
         };
-        const result = await packingAppDb.saveQuestionSet(dataWithTimestamp);
+        const result = await db.saveQuestionSet(dataWithTimestamp);
         const savedData = {
           ...dataWithTimestamp,
           _rev: result.rev
@@ -214,10 +215,10 @@ export function EditQuestionsForm() {
 
       try {
         // Check if migration is needed
-        const migrationCheck = await DatabaseMigration.checkMigrationNeeded()
+        const migrationCheck = await DatabaseMigration.checkMigrationNeeded(db)
         if (migrationCheck.needed) {
           console.log('Migration needed, performing automatic migration')
-          const migrationResult = await DatabaseMigration.performMigration()
+          const migrationResult = await DatabaseMigration.performMigration(db)
           if (!migrationResult.success) {
             console.error('Migration failed:', migrationResult.errors)
             showToast('Database migration failed', 'error')
@@ -226,7 +227,7 @@ export function EditQuestionsForm() {
           showToast('Database migrated successfully', 'success')
         }
 
-        const doc = await packingAppDb.getQuestionSet()
+        const doc = await db.getQuestionSet()
         console.log("Document retrieved successfully:", {
           _id: doc._id,
           _rev: doc._rev,
@@ -254,7 +255,7 @@ export function EditQuestionsForm() {
             timestamp: new Date().toISOString()
           })
           try {
-            const result = await packingAppDb.saveQuestionSet(newDoc)
+            const result = await db.saveQuestionSet(newDoc)
             console.log("Document created successfully:", {
               rev: result.rev,
               timestamp: new Date().toISOString()
@@ -311,7 +312,7 @@ export function EditQuestionsForm() {
           ...dataToSave,
           lastModified: new Date().toISOString()
         };
-        const result = await packingAppDb.saveQuestionSet(dataWithTimestamp);
+        const result = await db.saveQuestionSet(dataWithTimestamp);
         const savedData = {
           ...dataWithTimestamp,
           _rev: result.rev
@@ -409,7 +410,7 @@ export function EditQuestionsForm() {
           ...dataToSave,
           lastModified: new Date().toISOString()
         };
-        const result = await packingAppDb.saveQuestionSet(dataWithTimestamp);
+        const result = await db.saveQuestionSet(dataWithTimestamp);
         const savedData = {
           ...dataWithTimestamp,
           _rev: result.rev

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { PackingList } from '../create-packing-list/types'
-import { packingAppDb } from '../services/database'
+import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
 import { Button } from '../components/Button'
@@ -21,6 +21,7 @@ export function PackingLists() {
     const navigate = useNavigate()
     const { isLoggedIn, session } = useSolidPod()
     const { showToast } = useToast()
+    const { db } = useDatabase()
     const handlePodError = usePodErrorHandler()
 
     const handleBannerDismiss = () => {
@@ -36,7 +37,7 @@ export function PackingLists() {
     const deletePackingList = async (id: string, event: React.MouseEvent) => {
         event.stopPropagation() // Prevent navigation when clicking delete
         try {
-            await packingAppDb.deletePackingList(id)
+            await db.deletePackingList(id)
             setPackingLists(packingLists.filter(list => list.id !== id))
         } catch (err) {
             console.error('Error deleting packing list:', err)
@@ -92,20 +93,20 @@ export function PackingLists() {
             }
 
             // First, delete all existing local packing lists
-            const existingLists = await packingAppDb.getAllPackingLists()
+            const existingLists = await db.getAllPackingLists()
             for (const existingList of existingLists) {
-                await packingAppDb.deletePackingList(existingList.id)
+                await db.deletePackingList(existingList.id)
             }
 
             // Then save each loaded list to local database
             for (const list of loadedLists) {
                 // Remove _rev to avoid conflicts with local database version
                 delete list._rev
-                await packingAppDb.savePackingList(list)
+                await db.savePackingList(list)
             }
 
             // Refresh the local list
-            const allLists = await packingAppDb.getAllPackingLists()
+            const allLists = await db.getAllPackingLists()
             setPackingLists(allLists)
 
             if (result.success) {
@@ -123,7 +124,7 @@ export function PackingLists() {
     useEffect(() => {
         const fetchPackingLists = async () => {
             try {
-                const lists = await packingAppDb.getAllPackingLists()
+                const lists = await db.getAllPackingLists()
                 setPackingLists(lists)
 
                 // Show banner if:

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useToast } from '../components/ToastContext'
-import { packingAppDb } from '../services/database'
+import { useDatabase } from '../components/DatabaseContext'
 import { createExampleData } from '../edit-questions/example-data'
 import { QUESTION_SET_ID } from '../constants'
 import { WizardFormData } from './wizard-types'
@@ -9,6 +9,7 @@ import { Person } from '../edit-questions/types'
 
 export function useWizardGeneration() {
     const { showToast } = useToast()
+    const { db } = useDatabase()
     const [isLoading, setIsLoading] = useState(false)
     const [isSuccess, setIsSuccess] = useState(false)
 
@@ -27,7 +28,7 @@ export function useWizardGeneration() {
         try {
             const questionSet = generateQuestionSet(data)
 
-            await packingAppDb.saveQuestionSet({
+            await db.saveQuestionSet({
                 _id: QUESTION_SET_ID,
                 ...questionSet
             })

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useDebouncedCallback } from 'use-debounce'
 import { PackingList } from '../create-packing-list/types'
-import { packingAppDb } from '../services/database'
+import { useDatabase } from '../components/DatabaseContext'
 import { Button } from '../components/Button'
 import { useForm, useWatch } from 'react-hook-form'
 import { useSolidPod } from '../components/SolidPodContext'
@@ -26,6 +26,7 @@ export function ViewPackingList() {
     const [newItemInputs, setNewItemInputs] = useState<Record<string, string>>({})
     const { isLoggedIn } = useSolidPod()
     const { showToast } = useToast()
+    const { db } = useDatabase()
 
     const { register, setValue, getValues, control } = useForm<FormData>({
         defaultValues: {
@@ -41,7 +42,7 @@ export function ViewPackingList() {
         useSyncCoordinator<PackingList>({
             currentData: packingList,
             saveToLocalDb: async (data) => {
-                return await packingAppDb.savePackingList(data);
+                return await db.savePackingList(data);
             },
             updateFormAndState: (data, newRev) => {
                 setPackingList({
@@ -87,7 +88,7 @@ export function ViewPackingList() {
     useEffect(() => {
         const fetchPackingList = async () => {
             try {
-                const doc = await packingAppDb.getPackingList(id!)
+                const doc = await db.getPackingList(id!)
                 setPackingList(doc)
                 // Initialize form values with a clean slate
                 const initialValues: Record<string, boolean> = {}
@@ -163,7 +164,7 @@ export function ViewPackingList() {
                     ...updatedPackingList,
                     lastModified: new Date().toISOString()
                 };
-                const dbResult = await packingAppDb.savePackingList(dataWithTimestamp);
+                const dbResult = await db.savePackingList(dataWithTimestamp);
                 const savedPackingList = {
                     ...dataWithTimestamp,
                     _rev: dbResult.rev
@@ -226,7 +227,7 @@ export function ViewPackingList() {
                     ...updatedPackingList,
                     lastModified: new Date().toISOString()
                 };
-                const dbResult = await packingAppDb.savePackingList(dataWithTimestamp);
+                const dbResult = await db.savePackingList(dataWithTimestamp);
                 const savedPackingList = {
                     ...dataWithTimestamp,
                     _rev: dbResult.rev
@@ -287,7 +288,7 @@ export function ViewPackingList() {
                     ...updatedPackingList,
                     lastModified: new Date().toISOString()
                 };
-                const dbResult = await packingAppDb.savePackingList(dataWithTimestamp);
+                const dbResult = await db.savePackingList(dataWithTimestamp);
                 const savedPackingList = {
                     ...dataWithTimestamp,
                     _rev: dbResult.rev

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -7,7 +7,7 @@ import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { Modal } from '../components/Modal'
 import { SolidPodPrompt } from '../components/SolidPodPrompt'
 import { useSolidPod } from '../components/SolidPodContext'
-import { packingAppDb } from '../services/database'
+import { useDatabase } from '../components/DatabaseContext'
 import { ACTIVITIES, wizardSchema, WizardFormData } from './wizard-types'
 import { useWizardGeneration } from './useWizardGeneration'
 import { AGE_RANGE_OPTIONS } from '../edit-questions/types'
@@ -20,6 +20,7 @@ export const Wizard = () => {
     const [showPodPrompt, setShowPodPrompt] = useState(false)
     const [hasExistingData, setHasExistingData] = useState(false)
     const { isLoggedIn } = useSolidPod()
+    const { db } = useDatabase()
     const { isLoading, isSuccess, generateAndSave } = useWizardGeneration()
 
     const { register, control, handleSubmit, watch, formState: { errors } } = useForm<WizardFormData>({
@@ -39,7 +40,7 @@ export const Wizard = () => {
     useEffect(() => {
         const checkExistingData = async () => {
             try {
-                await packingAppDb.getQuestionSet()
+                await db.getQuestionSet()
                 setHasExistingData(true)
             } catch (err: any) {
                 if (err.name !== 'not_found') {

--- a/src/services/database.test.ts
+++ b/src/services/database.test.ts
@@ -8,6 +8,16 @@ import type { PackingList } from '../create-packing-list/types'
 // Setup PouchDB with memory adapter for testing
 PouchDB.plugin(PouchDBMemoryAdapter)
 
+async function clearAllInstances() {
+  // @ts-expect-error - Accessing private static property for testing
+  const instances = PackingAppDatabase.instances as Map<string, PackingAppDatabase>
+  for (const instance of instances.values()) {
+    // @ts-expect-error - Accessing private property for testing
+    await instance.db.destroy()
+  }
+  instances.clear()
+}
+
 describe('PackingAppDatabase', () => {
   let db: PackingAppDatabase
 
@@ -22,25 +32,62 @@ describe('PackingAppDatabase', () => {
     vi.restoreAllMocks()
   })
 
-  // Reset database instance before each test
+  // Reset all database instances before each test
   beforeEach(async () => {
-    // Force a new instance by clearing the singleton
-    // @ts-expect-error - Accessing private static property for testing
-    if (PackingAppDatabase.instance) {
-      // @ts-expect-error - Accessing private property for testing
-      const rawDb = PackingAppDatabase.instance.db
-      await rawDb.destroy()
-    }
-    // @ts-expect-error - Accessing private static property for testing
-    PackingAppDatabase.instance = undefined
-    db = PackingAppDatabase.getInstance()
+    await clearAllInstances()
+    db = PackingAppDatabase.getInstance('local')
   })
 
-  describe('Singleton Pattern', () => {
-    it('should return the same instance on multiple calls', () => {
-      const instance1 = PackingAppDatabase.getInstance()
-      const instance2 = PackingAppDatabase.getInstance()
-      expect(instance1).toBe(instance2)
+  describe('Namespacing', () => {
+    it('getInstance with same namespace returns same instance', () => {
+      const a = PackingAppDatabase.getInstance('local')
+      const b = PackingAppDatabase.getInstance('local')
+      expect(a).toBe(b)
+    })
+
+    it('getInstance with different namespaces returns different instances', () => {
+      const local = PackingAppDatabase.getInstance('local')
+      const pod = PackingAppDatabase.getInstance('pod.example.com')
+      expect(local).not.toBe(pod)
+    })
+
+    it('database name includes the namespace', async () => {
+      const info = await PackingAppDatabase.getInstance('mypod.example.com').getInfo()
+      expect(info.db_name).toContain('mypod.example.com')
+    })
+
+    it('data saved to one namespace is not visible in another', async () => {
+      const localDb = PackingAppDatabase.getInstance('local')
+      const podDb = PackingAppDatabase.getInstance('pod.example.com')
+
+      const list: PackingList = {
+        id: 'pl-local',
+        name: 'Local list',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        items: []
+      }
+      await localDb.savePackingList(list)
+
+      const podLists = await podDb.getAllPackingLists()
+      expect(podLists).toHaveLength(0)
+    })
+  })
+
+  describe('sanitizePodUrl', () => {
+    it('strips https protocol and trailing slash', () => {
+      expect(PackingAppDatabase.sanitizePodUrl('https://timgent.solidcommunity.net/')).toBe('timgent.solidcommunity.net')
+    })
+
+    it('strips http protocol and trailing slash', () => {
+      expect(PackingAppDatabase.sanitizePodUrl('http://example.com/')).toBe('example.com')
+    })
+
+    it('replaces path slashes with underscores', () => {
+      expect(PackingAppDatabase.sanitizePodUrl('https://pod.example.com/users/alice/')).toBe('pod.example.com_users_alice')
+    })
+
+    it('handles URL without trailing slash', () => {
+      expect(PackingAppDatabase.sanitizePodUrl('https://example.com')).toBe('example.com')
     })
   })
 
@@ -140,7 +187,6 @@ describe('PackingAppDatabase', () => {
 
       const retrieved1 = await db.getQuestionSet()
 
-      // Wait a bit to ensure timestamps would differ
       await new Promise(resolve => setTimeout(resolve, 10))
 
       await db.saveQuestionSet({
@@ -150,10 +196,9 @@ describe('PackingAppDatabase', () => {
       })
 
       const retrieved2 = await db.getQuestionSet()
-
-      // Get the underlying document to check timestamps
       const info = await db.getInfo()
       expect(info).toBeDefined()
+      expect(retrieved2).toBeDefined()
     })
   })
 
@@ -232,26 +277,9 @@ describe('PackingAppDatabase', () => {
     })
 
     it('should retrieve all packing lists', async () => {
-      const packingList1: PackingList = {
-        ...mockPackingList,
-        id: 'pl-1',
-        name: 'Beach Trip',
-        createdAt: '2025-01-01T00:00:00.000Z'
-      }
-
-      const packingList2: PackingList = {
-        ...mockPackingList,
-        id: 'pl-2',
-        name: 'Mountain Hiking',
-        createdAt: '2025-01-02T00:00:00.000Z'
-      }
-
-      const packingList3: PackingList = {
-        ...mockPackingList,
-        id: 'pl-3',
-        name: 'City Tour',
-        createdAt: '2025-01-03T00:00:00.000Z'
-      }
+      const packingList1: PackingList = { ...mockPackingList, id: 'pl-1', name: 'Beach Trip', createdAt: '2025-01-01T00:00:00.000Z' }
+      const packingList2: PackingList = { ...mockPackingList, id: 'pl-2', name: 'Mountain Hiking', createdAt: '2025-01-02T00:00:00.000Z' }
+      const packingList3: PackingList = { ...mockPackingList, id: 'pl-3', name: 'City Tour', createdAt: '2025-01-03T00:00:00.000Z' }
 
       await db.savePackingList(packingList1)
       await db.savePackingList(packingList2)
@@ -266,28 +294,10 @@ describe('PackingAppDatabase', () => {
     })
 
     it('should return packing lists sorted by createdAt (newest first)', async () => {
-      const packingList1: PackingList = {
-        ...mockPackingList,
-        id: 'pl-1',
-        name: 'Oldest',
-        createdAt: '2025-01-01T00:00:00.000Z'
-      }
+      const packingList1: PackingList = { ...mockPackingList, id: 'pl-1', name: 'Oldest', createdAt: '2025-01-01T00:00:00.000Z' }
+      const packingList2: PackingList = { ...mockPackingList, id: 'pl-2', name: 'Newest', createdAt: '2025-01-03T00:00:00.000Z' }
+      const packingList3: PackingList = { ...mockPackingList, id: 'pl-3', name: 'Middle', createdAt: '2025-01-02T00:00:00.000Z' }
 
-      const packingList2: PackingList = {
-        ...mockPackingList,
-        id: 'pl-2',
-        name: 'Newest',
-        createdAt: '2025-01-03T00:00:00.000Z'
-      }
-
-      const packingList3: PackingList = {
-        ...mockPackingList,
-        id: 'pl-3',
-        name: 'Middle',
-        createdAt: '2025-01-02T00:00:00.000Z'
-      }
-
-      // Save in random order
       await db.savePackingList(packingList1)
       await db.savePackingList(packingList3)
       await db.savePackingList(packingList2)
@@ -358,9 +368,6 @@ describe('PackingAppDatabase', () => {
       expect(result.questionSets).toBe(0)
       expect(result.packingLists).toBe(0)
     })
-
-    // Note: More comprehensive migration tests would require setting up
-    // legacy databases, which is complex in a test environment
   })
 
   describe('Database Info', () => {
@@ -375,14 +382,13 @@ describe('PackingAppDatabase', () => {
 
   describe('Error Handling', () => {
     it('should handle document type validation for question set', async () => {
-      // Directly insert a document with wrong type
-      const dbInstance = PackingAppDatabase.getInstance()
+      const dbInstance = PackingAppDatabase.getInstance('local')
       // @ts-expect-error - Accessing private property for testing
       const rawDb = dbInstance.db
 
       await rawDb.put({
         _id: 'question-set:1',
-        docType: 'packing-list', // Wrong type
+        docType: 'packing-list',
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         data: {}
@@ -392,14 +398,13 @@ describe('PackingAppDatabase', () => {
     })
 
     it('should handle document type validation for packing list', async () => {
-      // Directly insert a document with wrong type
-      const dbInstance = PackingAppDatabase.getInstance()
+      const dbInstance = PackingAppDatabase.getInstance('local')
       // @ts-expect-error - Accessing private property for testing
       const rawDb = dbInstance.db
 
       await rawDb.put({
         _id: 'packing-list:test',
-        docType: 'question-set', // Wrong type
+        docType: 'question-set',
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         data: {}
@@ -411,7 +416,6 @@ describe('PackingAppDatabase', () => {
     it('should log errors when saving fails', async () => {
       const consoleSpy = vi.spyOn(console, 'error')
 
-      // Force an error by using an invalid rev
       const invalidQuestionSet: PackingListQuestionSet = {
         _id: '1',
         _rev: 'invalid-rev',
@@ -434,15 +438,12 @@ describe('PackingAppDatabase', () => {
         questions: []
       }
 
-      // Save initial version
       await db.saveQuestionSet(mockQuestionSet)
       const firstVersion = await db.getQuestionSet()
 
-      // Update with correct rev
       const update1 = { ...mockQuestionSet, _rev: firstVersion._rev, people: [{ id: 'p1', name: 'Alice Updated' }] }
       await db.saveQuestionSet(update1)
 
-      // Try to update with old rev (should fail)
       const update2 = { ...mockQuestionSet, _rev: firstVersion._rev, people: [{ id: 'p2', name: 'Bob' }] }
       await expect(db.saveQuestionSet(update2)).rejects.toThrow()
     })
@@ -455,7 +456,6 @@ describe('PackingAppDatabase', () => {
         items: []
       }
 
-      // No _rev provided
       const result = await db.savePackingList(mockPackingList)
       expect(result.rev).toBeTruthy()
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -24,23 +24,48 @@ export interface PackingListDocument extends BaseDocument {
 
 export type AppDocument = QuestionSetDocument | PackingListDocument
 
+/**
+ * Namespace used when the user is not logged into a pod.
+ * Data saved here is local to this browser only.
+ */
+export const LOCAL_NAMESPACE = 'local'
+
 export class PackingAppDatabase {
     private db: PouchDB.Database<AppDocument>
-    private static instance: PackingAppDatabase
+    private static instances: Map<string, PackingAppDatabase> = new Map()
 
-    private constructor() {
-        this.db = new PouchDB<AppDocument>('packing-app-data')
-        console.log('Consolidated PouchDB instance created:', {
+    private constructor(namespace: string) {
+        this.db = new PouchDB<AppDocument>(`packing-app-data--${namespace}`)
+        console.log('PouchDB instance created:', {
             name: this.db.name,
+            namespace,
             timestamp: new Date().toISOString()
         })
     }
 
-    public static getInstance(): PackingAppDatabase {
-        if (!PackingAppDatabase.instance) {
-            PackingAppDatabase.instance = new PackingAppDatabase()
+    /**
+     * Returns the database instance for the given namespace.
+     * Use LOCAL_NAMESPACE for anonymous (not logged in) users.
+     * Use sanitizePodUrl(podUrl) for logged-in users.
+     *
+     * The same instance is returned for the same namespace (cached).
+     */
+    public static getInstance(namespace: string): PackingAppDatabase {
+        if (!PackingAppDatabase.instances.has(namespace)) {
+            PackingAppDatabase.instances.set(namespace, new PackingAppDatabase(namespace))
         }
-        return PackingAppDatabase.instance
+        return PackingAppDatabase.instances.get(namespace)!
+    }
+
+    /**
+     * Converts a pod URL into a safe, human-readable database namespace.
+     * Example: 'https://timgent.solidcommunity.net/' -> 'timgent.solidcommunity.net'
+     */
+    public static sanitizePodUrl(podUrl: string): string {
+        return podUrl
+            .replace(/^https?:\/\//, '')  // strip protocol
+            .replace(/\/+$/, '')           // strip trailing slashes
+            .replace(/\//g, '_')           // replace remaining slashes with underscores
     }
 
 
@@ -244,5 +269,3 @@ export class PackingAppDatabase {
         return this.db.info()
     }
 }
-
-export const packingAppDb = PackingAppDatabase.getInstance()

--- a/src/services/migration.ts
+++ b/src/services/migration.ts
@@ -1,7 +1,7 @@
 import PouchDB from 'pouchdb'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList } from '../create-packing-list/types'
-import { packingAppDb } from './database'
+import { PackingAppDatabase } from './database'
 
 export interface MigrationResult {
     success: boolean
@@ -107,7 +107,7 @@ export class DatabaseMigration {
         }
     }
 
-    public static async checkMigrationNeeded(): Promise<{ needed: boolean, hasLegacyData: boolean, hasNewData: boolean }> {
+    public static async checkMigrationNeeded(db: PackingAppDatabase): Promise<{ needed: boolean, hasLegacyData: boolean, hasNewData: boolean }> {
         const legacyQuestionDb = new PouchDB('packing-list-question-set')
         const legacyPackingListsDb = new PouchDB('packing-lists')
 
@@ -133,7 +133,7 @@ export class DatabaseMigration {
         }
 
         try {
-            await packingAppDb.getQuestionSet()
+            await db.getQuestionSet()
             hasNewData = true
         } catch (err: any) {
             if (err.name !== 'not_found') {
@@ -142,7 +142,7 @@ export class DatabaseMigration {
         }
 
         try {
-            const lists = await packingAppDb.getAllPackingLists()
+            const lists = await db.getAllPackingLists()
             if (lists.length > 0) {
                 hasNewData = true
             }
@@ -155,7 +155,7 @@ export class DatabaseMigration {
         return { needed, hasLegacyData, hasNewData }
     }
 
-    public static async performMigration(): Promise<MigrationResult> {
+    public static async performMigration(db: PackingAppDatabase): Promise<MigrationResult> {
         const result: MigrationResult = {
             success: false,
             questionSetsFound: 0,
@@ -172,11 +172,11 @@ export class DatabaseMigration {
             result.questionSetsFound = backup.questionSets.length
             result.packingListsFound = backup.packingLists.length
 
-            const migrationResult = await packingAppDb.migrateFromLegacyDatabases()
+            const migrationResult = await db.migrateFromLegacyDatabases()
             result.questionSetsMigrated = migrationResult.questionSets
             result.packingListsMigrated = migrationResult.packingLists
 
-            const verification = await DatabaseMigration.verifyMigration(backup)
+            const verification = await DatabaseMigration.verifyMigration(backup, db)
             if (!verification.success) {
                 result.errors.push(...verification.errors)
                 throw new Error('Migration verification failed')
@@ -193,12 +193,12 @@ export class DatabaseMigration {
         return result
     }
 
-    private static async verifyMigration(backup: BackupData): Promise<{ success: boolean, errors: string[] }> {
+    private static async verifyMigration(backup: BackupData, db: PackingAppDatabase): Promise<{ success: boolean, errors: string[] }> {
         const errors: string[] = []
 
         try {
             if (backup.questionSets.length > 0) {
-                const migratedQuestionSet = await packingAppDb.getQuestionSet()
+                const migratedQuestionSet = await db.getQuestionSet()
                 const originalQuestionSet = backup.questionSets[0]
 
                 if (migratedQuestionSet.people.length !== originalQuestionSet.people.length) {
@@ -212,7 +212,7 @@ export class DatabaseMigration {
                 }
             }
 
-            const migratedLists = await packingAppDb.getAllPackingLists()
+            const migratedLists = await db.getAllPackingLists()
             if (migratedLists.length !== backup.packingLists.length) {
                 errors.push(`Packing lists count mismatch: expected ${backup.packingLists.length}, got ${migratedLists.length}`)
             }


### PR DESCRIPTION
## What this PR does

Gives each pod identity its own PouchDB database, preventing local data from leaking into pod data and stopping different pod users from sharing the same local store.

**Before:** single `packing-app-data` database shared by all identities — local data could conflict with or be overwritten by pod sync on login.

**After:** separate databases per identity:
- Not logged in → `packing-app-data--local`
- Logged in → `packing-app-data--timgent.solidcommunity.net` (pod URL sanitized)

### Key changes

- `PackingAppDatabase.getInstance(namespace)` replaces the old singleton; `sanitizePodUrl()` converts pod URLs to safe IndexedDB-friendly names
- New `DatabaseProvider` + `useDatabase()` context resolves the pod URL on login and switches all components to the correct namespaced database atomically — children don't render until the database is ready
- `DatabaseMigration` methods now accept a `db` parameter instead of importing a module-level singleton
- All 6 page/hook consumers updated to use `useDatabase()`
- 36 tests (6 new context tests + updated database tests)

### Note on scope

This is a foundation step. It fixes the scenario where pre-login local data contaminates pod data. Conflict resolution once already logged in (timestamp-based sync in `useSyncCoordinator`) is unchanged and is a separate follow-up. Importing local data into a pod on first login is also a straightforward follow-up.

## Manual testing steps

1. Open the app while not logged in — open browser DevTools → Application → IndexedDB and confirm only `_pouch_packing-app-data--local` exists
2. Create a packing list while not logged in
3. Log in with a Solid Pod — confirm a second database `_pouch_packing-app-data--{your-pod-host}` appears in IndexedDB
4. Confirm the packing list from step 2 is **not** visible (pod database starts empty)
5. Log out — confirm the app switches back and the original local packing list is visible again
6. Log back in — confirm pod database data is still intact