### PR TITLE
Prompt to migrate local data to pod on first login

### DIFF
--- a/src/components/DatabaseContext.test.tsx
+++ b/src/components/DatabaseContext.test.tsx
@@ -11,6 +11,7 @@ vi.mock('./SolidPodContext', () => ({
 
 vi.mock('../services/solidPod', () => ({
   getPrimaryPodUrl: vi.fn(),
+  hasPodData: vi.fn(),
 }))
 
 // Mock PackingAppDatabase so tests don't create real filesystem databases
@@ -27,11 +28,12 @@ vi.mock('../services/database', () => {
 })
 
 import { useSolidPod } from './SolidPodContext'
-import { getPrimaryPodUrl } from '../services/solidPod'
+import { getPrimaryPodUrl, hasPodData } from '../services/solidPod'
 import { PackingAppDatabase } from '../services/database'
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
+const mockHasPodData = vi.mocked(hasPodData)
 const mockGetInstance = vi.mocked(PackingAppDatabase.getInstance)
 
 /** Creates a mock db object with controllable isEmpty/copyAllDataFrom behaviour */
@@ -46,7 +48,7 @@ function makeDb(namespace: string, overrides: {
   }
 }
 
-/** Default instance factory used by most tests: every db is non-empty (no migration prompt) */
+/** Default instance factory: local db is non-empty by default (avoids migration prompt) */
 function defaultInstanceFactory(namespace: string) {
   return makeDb(namespace)
 }
@@ -70,6 +72,9 @@ describe('DatabaseContext', () => {
     mockGetInstance.mockReset()
     mockGetInstance.mockImplementation(defaultInstanceFactory)
     mockGetPrimaryPodUrl.mockReset()
+    mockHasPodData.mockReset()
+    // Default: pod has data → no migration prompt
+    mockHasPodData.mockResolvedValue(true)
     localStorage.clear()
   })
 
@@ -204,11 +209,10 @@ describe('DatabaseContext', () => {
       mockGetPrimaryPodUrl.mockResolvedValue('https://example.com/')
     })
 
-    it('shows migration dialog when pod is empty and local has data', async () => {
-      // local (isEmpty=false), pod (isEmpty=true) → should prompt
-      mockGetInstance.mockImplementation((ns: string) =>
-        makeDb(ns, { isEmpty: ns === 'example.com' })
-      )
+    it('shows migration dialog when pod has no remote data and local has data', async () => {
+      mockHasPodData.mockResolvedValue(false)
+      // local db: isEmpty=false (has data)
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
 
       render(
         <DatabaseProvider>
@@ -220,8 +224,8 @@ describe('DatabaseContext', () => {
       expect(screen.queryByTestId('child')).toBeNull()
     })
 
-    it('does not show migration dialog when pod already has data', async () => {
-      // both isEmpty=false → pod has data, no prompt
+    it('does not show migration dialog when pod already has remote data', async () => {
+      mockHasPodData.mockResolvedValue(true)
       mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
 
       render(
@@ -234,8 +238,9 @@ describe('DatabaseContext', () => {
       expect(screen.queryByText(/you have local data/i)).toBeNull()
     })
 
-    it('does not show migration dialog when local db is also empty', async () => {
-      // both isEmpty=true → nothing to migrate
+    it('does not show migration dialog when local db is empty', async () => {
+      mockHasPodData.mockResolvedValue(false)
+      // local db: isEmpty=true
       mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: true }))
 
       render(
@@ -250,9 +255,8 @@ describe('DatabaseContext', () => {
 
     it('does not show migration dialog when localStorage dismissed key is set', async () => {
       localStorage.setItem('pod-migration-dismissed-example.com', 'true')
-      mockGetInstance.mockImplementation((ns: string) =>
-        makeDb(ns, { isEmpty: ns === 'example.com' })
-      )
+      mockHasPodData.mockResolvedValue(false)
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
 
       render(
         <DatabaseProvider>
@@ -265,9 +269,10 @@ describe('DatabaseContext', () => {
     })
 
     it('copies data to pod and renders children when user clicks "Use my local data"', async () => {
+      mockHasPodData.mockResolvedValue(false)
       const copyAllDataFrom = vi.fn().mockResolvedValue(undefined)
       mockGetInstance.mockImplementation((ns: string) =>
-        makeDb(ns, { isEmpty: ns === 'example.com', copyAllDataFrom })
+        makeDb(ns, { isEmpty: false, copyAllDataFrom })
       )
 
       render(
@@ -283,9 +288,10 @@ describe('DatabaseContext', () => {
     })
 
     it('skips migration and renders children when user clicks "Start fresh"', async () => {
+      mockHasPodData.mockResolvedValue(false)
       const copyAllDataFrom = vi.fn()
       mockGetInstance.mockImplementation((ns: string) =>
-        makeDb(ns, { isEmpty: ns === 'example.com', copyAllDataFrom })
+        makeDb(ns, { isEmpty: false, copyAllDataFrom })
       )
 
       render(
@@ -301,9 +307,8 @@ describe('DatabaseContext', () => {
     })
 
     it('sets localStorage dismissed key when user clicks "Start fresh"', async () => {
-      mockGetInstance.mockImplementation((ns: string) =>
-        makeDb(ns, { isEmpty: ns === 'example.com' })
-      )
+      mockHasPodData.mockResolvedValue(false)
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
 
       render(
         <DatabaseProvider>

--- a/src/components/DatabaseContext.test.tsx
+++ b/src/components/DatabaseContext.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import React from 'react'
 import { DatabaseProvider, useDatabase } from './DatabaseContext'
 
@@ -15,18 +15,10 @@ vi.mock('../services/solidPod', () => ({
 
 // Mock PackingAppDatabase so tests don't create real filesystem databases
 vi.mock('../services/database', () => {
-  const instanceCache = new Map<string, object>()
   return {
     LOCAL_NAMESPACE: 'local',
     PackingAppDatabase: {
-      getInstance: vi.fn((namespace: string) => {
-        if (!instanceCache.has(namespace)) {
-          instanceCache.set(namespace, {
-            getInfo: vi.fn().mockResolvedValue({ db_name: `packing-app-data--${namespace}`, doc_count: 0 }),
-          })
-        }
-        return instanceCache.get(namespace)
-      }),
+      getInstance: vi.fn(),
       sanitizePodUrl: vi.fn((url: string) =>
         url.replace(/^https?:\/\//, '').replace(/\/+$/, '').replace(/\//g, '_')
       ),
@@ -41,6 +33,23 @@ import { PackingAppDatabase } from '../services/database'
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
 const mockGetInstance = vi.mocked(PackingAppDatabase.getInstance)
+
+/** Creates a mock db object with controllable isEmpty/copyAllDataFrom behaviour */
+function makeDb(namespace: string, overrides: {
+  isEmpty?: boolean
+  copyAllDataFrom?: ReturnType<typeof vi.fn>
+} = {}) {
+  return {
+    getInfo: vi.fn().mockResolvedValue({ db_name: `packing-app-data--${namespace}`, doc_count: 0 }),
+    isEmpty: vi.fn().mockResolvedValue(overrides.isEmpty ?? false),
+    copyAllDataFrom: overrides.copyAllDataFrom ?? vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+/** Default instance factory used by most tests: every db is non-empty (no migration prompt) */
+function defaultInstanceFactory(namespace: string) {
+  return makeDb(namespace)
+}
 
 function NamespaceDisplay() {
   const { db } = useDatabase()
@@ -57,8 +66,11 @@ describe('DatabaseContext', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.spyOn(console, 'warn').mockImplementation(() => {})
-    mockGetInstance.mockClear()
+    // Reset to the default factory so each test starts with a clean slate
+    mockGetInstance.mockReset()
+    mockGetInstance.mockImplementation(defaultInstanceFactory)
     mockGetPrimaryPodUrl.mockReset()
+    localStorage.clear()
   })
 
   afterEach(() => {
@@ -167,14 +179,141 @@ describe('DatabaseContext', () => {
 
     await waitFor(() => screen.getByTestId('child'))
     // Should fall back to sanitized webId: 'https://example.com/profile#me' -> 'example.com_profile#me'
-    expect(mockGetInstance).toHaveBeenCalled()
-    const namespace = mockGetInstance.mock.calls[mockGetInstance.mock.calls.length - 1][0]
-    expect(namespace).not.toBe('local')
-    expect(namespace).toContain('example.com')
+    const namespaceCalls = mockGetInstance.mock.calls.map(([ns]) => ns)
+    const podNamespaceCall = namespaceCalls.find(ns => ns !== 'local')
+    expect(podNamespaceCall).toBeDefined()
+    expect(podNamespaceCall).toContain('example.com')
   })
 
   it('throws when useDatabase is called outside DatabaseProvider', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     expect(() => render(<OutsideProvider />)).toThrow('useDatabase must be used within a DatabaseProvider')
+  })
+
+  describe('first-time pod login migration', () => {
+    beforeEach(() => {
+      const mockSession = { info: { isLoggedIn: true, webId: 'https://example.com/profile#me' } }
+      mockUseSolidPod.mockReturnValue({
+        session: mockSession as any,
+        isLoggedIn: true,
+        webId: 'https://example.com/profile#me',
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+      mockGetPrimaryPodUrl.mockResolvedValue('https://example.com/')
+    })
+
+    it('shows migration dialog when pod is empty and local has data', async () => {
+      // local (isEmpty=false), pod (isEmpty=true) → should prompt
+      mockGetInstance.mockImplementation((ns: string) =>
+        makeDb(ns, { isEmpty: ns === 'example.com' })
+      )
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByText(/you have local data/i))
+      expect(screen.queryByTestId('child')).toBeNull()
+    })
+
+    it('does not show migration dialog when pod already has data', async () => {
+      // both isEmpty=false → pod has data, no prompt
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      expect(screen.queryByText(/you have local data/i)).toBeNull()
+    })
+
+    it('does not show migration dialog when local db is also empty', async () => {
+      // both isEmpty=true → nothing to migrate
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: true }))
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      expect(screen.queryByText(/you have local data/i)).toBeNull()
+    })
+
+    it('does not show migration dialog when localStorage dismissed key is set', async () => {
+      localStorage.setItem('pod-migration-dismissed-example.com', 'true')
+      mockGetInstance.mockImplementation((ns: string) =>
+        makeDb(ns, { isEmpty: ns === 'example.com' })
+      )
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      expect(screen.queryByText(/you have local data/i)).toBeNull()
+    })
+
+    it('copies data to pod and renders children when user clicks "Use my local data"', async () => {
+      const copyAllDataFrom = vi.fn().mockResolvedValue(undefined)
+      mockGetInstance.mockImplementation((ns: string) =>
+        makeDb(ns, { isEmpty: ns === 'example.com', copyAllDataFrom })
+      )
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByText('Use my local data'))
+      fireEvent.click(screen.getByText('Use my local data'))
+      await waitFor(() => screen.getByTestId('child'))
+      expect(copyAllDataFrom).toHaveBeenCalledOnce()
+    })
+
+    it('skips migration and renders children when user clicks "Start fresh"', async () => {
+      const copyAllDataFrom = vi.fn()
+      mockGetInstance.mockImplementation((ns: string) =>
+        makeDb(ns, { isEmpty: ns === 'example.com', copyAllDataFrom })
+      )
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByText('Start fresh'))
+      fireEvent.click(screen.getByText('Start fresh'))
+      await waitFor(() => screen.getByTestId('child'))
+      expect(copyAllDataFrom).not.toHaveBeenCalled()
+    })
+
+    it('sets localStorage dismissed key when user clicks "Start fresh"', async () => {
+      mockGetInstance.mockImplementation((ns: string) =>
+        makeDb(ns, { isEmpty: ns === 'example.com' })
+      )
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByText('Start fresh'))
+      fireEvent.click(screen.getByText('Start fresh'))
+      expect(localStorage.getItem('pod-migration-dismissed-example.com')).toBe('true')
+    })
   })
 })

--- a/src/components/DatabaseContext.tsx
+++ b/src/components/DatabaseContext.tsx
@@ -2,6 +2,7 @@ import { createContext, ReactNode, useContext, useState, useEffect, Fragment } f
 import { PackingAppDatabase, LOCAL_NAMESPACE } from '../services/database'
 import { useSolidPod } from './SolidPodContext'
 import { getPrimaryPodUrl } from '../services/solidPod'
+import { ConfirmationDialog } from './ConfirmationDialog'
 
 interface DatabaseContextValue {
     db: PackingAppDatabase
@@ -19,12 +20,17 @@ const DatabaseContext = createContext<DatabaseContextValue | undefined>(undefine
  * preventing accidental overwrites between identities.
  *
  * Children are not rendered until the database is ready.
+ *
+ * On first login to a pod with an empty database, the user is offered a one-time
+ * choice to copy their local data to the pod.
  */
 export function DatabaseProvider({ children }: { children: ReactNode }) {
     const { isLoggedIn, webId, session, isLoading } = useSolidPod()
     const [db, setDb] = useState<PackingAppDatabase | null>(null)
     const [namespace, setNamespace] = useState<string | null>(null)
     const [isResolvingPod, setIsResolvingPod] = useState(false)
+    const [showMigrationPrompt, setShowMigrationPrompt] = useState(false)
+    const [localDb, setLocalDb] = useState<PackingAppDatabase | null>(null)
 
     useEffect(() => {
         // While session is still initialising, wait
@@ -34,6 +40,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
 
         if (!isLoggedIn || !webId) {
             // Not logged in — use the local namespace immediately
+            setShowMigrationPrompt(false)
             setNamespace(LOCAL_NAMESPACE)
             setDb(PackingAppDatabase.getInstance(LOCAL_NAMESPACE))
             return
@@ -43,15 +50,35 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
         let cancelled = false
         setIsResolvingPod(true)
 
-        getPrimaryPodUrl(session).then(podUrl => {
+        getPrimaryPodUrl(session).then(async podUrl => {
             if (cancelled) return
 
             const resolvedNamespace = podUrl
                 ? PackingAppDatabase.sanitizePodUrl(podUrl)
                 : PackingAppDatabase.sanitizePodUrl(webId)
 
+            const podDb = PackingAppDatabase.getInstance(resolvedNamespace)
+            const local = PackingAppDatabase.getInstance(LOCAL_NAMESPACE)
+
+            const dismissedKey = `pod-migration-dismissed-${resolvedNamespace}`
+            const dismissed = localStorage.getItem(dismissedKey) === 'true'
+
+            if (!dismissed) {
+                const [podEmpty, localEmpty] = await Promise.all([podDb.isEmpty(), local.isEmpty()])
+                if (podEmpty && !localEmpty) {
+                    if (cancelled) return
+                    setLocalDb(local)
+                    setNamespace(resolvedNamespace)
+                    setDb(podDb)
+                    setShowMigrationPrompt(true)
+                    setIsResolvingPod(false)
+                    return
+                }
+            }
+
+            if (cancelled) return
             setNamespace(resolvedNamespace)
-            setDb(PackingAppDatabase.getInstance(resolvedNamespace))
+            setDb(podDb)
             setIsResolvingPod(false)
         })
 
@@ -62,6 +89,26 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
 
     if (isLoading || isResolvingPod || !db || !namespace) {
         return null
+    }
+
+    if (showMigrationPrompt && localDb) {
+        return (
+            <ConfirmationDialog
+                isOpen
+                title="You have local data"
+                message={"You have data saved locally in this browser.\nWould you like to copy it to your Pod so it's available across all your devices?"}
+                confirmText="Use my local data"
+                cancelText="Start fresh"
+                onConfirm={async () => {
+                    await db.copyAllDataFrom(localDb)
+                    setShowMigrationPrompt(false)
+                }}
+                onClose={() => {
+                    localStorage.setItem(`pod-migration-dismissed-${namespace}`, 'true')
+                    setShowMigrationPrompt(false)
+                }}
+            />
+        )
     }
 
     // The Fragment key causes all children to remount whenever the active database

--- a/src/components/DatabaseContext.tsx
+++ b/src/components/DatabaseContext.tsx
@@ -63,7 +63,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
             const dismissedKey = `pod-migration-dismissed-${resolvedNamespace}`
             const dismissed = localStorage.getItem(dismissedKey) === 'true'
 
-            if (!dismissed && podUrl) {
+            if (!dismissed && podUrl && session) {
                 const [podHasRemoteData, localEmpty] = await Promise.all([
                     hasPodData(session, podUrl),
                     local.isEmpty()

--- a/src/components/DatabaseContext.tsx
+++ b/src/components/DatabaseContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, ReactNode, useContext, useState, useEffect, Fragment } from 'react'
 import { PackingAppDatabase, LOCAL_NAMESPACE } from '../services/database'
 import { useSolidPod } from './SolidPodContext'
-import { getPrimaryPodUrl } from '../services/solidPod'
+import { getPrimaryPodUrl, hasPodData } from '../services/solidPod'
 import { ConfirmationDialog } from './ConfirmationDialog'
 
 interface DatabaseContextValue {
@@ -63,9 +63,12 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
             const dismissedKey = `pod-migration-dismissed-${resolvedNamespace}`
             const dismissed = localStorage.getItem(dismissedKey) === 'true'
 
-            if (!dismissed) {
-                const [podEmpty, localEmpty] = await Promise.all([podDb.isEmpty(), local.isEmpty()])
-                if (podEmpty && !localEmpty) {
+            if (!dismissed && podUrl) {
+                const [podHasRemoteData, localEmpty] = await Promise.all([
+                    hasPodData(session, podUrl),
+                    local.isEmpty()
+                ])
+                if (!podHasRemoteData && !localEmpty) {
                     if (cancelled) return
                     setLocalDb(local)
                     setNamespace(resolvedNamespace)

--- a/src/services/database.test.ts
+++ b/src/services/database.test.ts
@@ -429,6 +429,87 @@ describe('PackingAppDatabase', () => {
     })
   })
 
+  describe('isEmpty()', () => {
+    it('returns true when database has no documents', async () => {
+      expect(await db.isEmpty()).toBe(true)
+    })
+
+    it('returns false after a question set is saved', async () => {
+      await db.saveQuestionSet({
+        _id: '1',
+        people: [{ id: 'p1', name: 'Me' }],
+        alwaysNeededItems: [],
+        questions: []
+      })
+      expect(await db.isEmpty()).toBe(false)
+    })
+
+    it('returns false after a packing list is saved', async () => {
+      await db.savePackingList({
+        id: 'pl-1',
+        name: 'Trip',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        items: []
+      })
+      expect(await db.isEmpty()).toBe(false)
+    })
+  })
+
+  describe('copyAllDataFrom()', () => {
+    it('copies question set from source to target', async () => {
+      const source = PackingAppDatabase.getInstance('copy-qs-source')
+      const target = PackingAppDatabase.getInstance('copy-qs-target')
+      await source.saveQuestionSet({
+        _id: '1',
+        people: [{ id: 'p1', name: 'Alice' }],
+        alwaysNeededItems: [],
+        questions: []
+      })
+      await target.copyAllDataFrom(source)
+      const result = await target.getQuestionSet()
+      expect(result.people[0].name).toBe('Alice')
+    })
+
+    it('copies all packing lists from source to target', async () => {
+      const source = PackingAppDatabase.getInstance('copy-lists-source')
+      const target = PackingAppDatabase.getInstance('copy-lists-target')
+      await source.savePackingList({
+        id: 'list-1',
+        name: 'Beach Trip',
+        createdAt: '2025-06-01T00:00:00.000Z',
+        items: []
+      })
+      await source.savePackingList({
+        id: 'list-2',
+        name: 'Ski Trip',
+        createdAt: '2025-12-01T00:00:00.000Z',
+        items: []
+      })
+      await target.copyAllDataFrom(source)
+      const lists = await target.getAllPackingLists()
+      expect(lists).toHaveLength(2)
+      expect(lists.map(l => l.name)).toContain('Beach Trip')
+      expect(lists.map(l => l.name)).toContain('Ski Trip')
+    })
+
+    it('is a no-op when source is empty', async () => {
+      const source = PackingAppDatabase.getInstance('copy-empty-source')
+      const target = PackingAppDatabase.getInstance('copy-noop-target')
+      await target.copyAllDataFrom(source)
+      expect(await target.isEmpty()).toBe(true)
+    })
+
+    it('does not copy _rev so documents save cleanly in target', async () => {
+      const source = PackingAppDatabase.getInstance('copy-rev-source')
+      const target = PackingAppDatabase.getInstance('copy-rev-target')
+      await source.saveQuestionSet({ _id: '1', people: [], alwaysNeededItems: [], questions: [] })
+      await target.copyAllDataFrom(source)
+      // If _rev was copied incorrectly it would throw a conflict; reaching here means it worked
+      const qs = await target.getQuestionSet()
+      expect(qs._rev).toBeTruthy()
+    })
+  })
+
   describe('Revision Handling', () => {
     it('should handle concurrent updates with revision conflicts', async () => {
       const mockQuestionSet: PackingListQuestionSet = {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -268,4 +268,23 @@ export class PackingAppDatabase {
     public getInfo() {
         return this.db.info()
     }
+
+    public async isEmpty(): Promise<boolean> {
+        const info = await this.getInfo()
+        return info.doc_count === 0
+    }
+
+    public async copyAllDataFrom(source: PackingAppDatabase): Promise<void> {
+        try {
+            const questionSet = await source.getQuestionSet()
+            await this.saveQuestionSet({ ...questionSet, _rev: undefined })
+        } catch (err: any) {
+            if (err.name !== 'not_found') throw err
+        }
+
+        const lists = await source.getAllPackingLists()
+        for (const list of lists) {
+            await this.savePackingList({ ...list, _rev: undefined })
+        }
+    }
 }

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { hasPodData } from './solidPod'
+import { AuthenticationError } from './solidPod'
+
+vi.mock('@inrupt/solid-client', () => ({
+    getFile: vi.fn(),
+    getSolidDataset: vi.fn(),
+    getContainedResourceUrlAll: vi.fn(),
+    getPodUrlAll: vi.fn(),
+    saveFileInContainer: vi.fn(),
+    overwriteFile: vi.fn(),
+    deleteFile: vi.fn(),
+}))
+
+import { getFile, getSolidDataset, getContainedResourceUrlAll } from '@inrupt/solid-client'
+
+const mockGetFile = vi.mocked(getFile)
+const mockGetSolidDataset = vi.mocked(getSolidDataset)
+const mockGetContainedResourceUrlAll = vi.mocked(getContainedResourceUrlAll)
+
+const mockSession = {
+    info: { isLoggedIn: true, webId: 'https://example.com/profile#me' },
+    fetch: vi.fn(),
+} as any
+
+const POD_URL = 'https://pod.example.com/'
+
+describe('hasPodData', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('returns true when the questions file exists on the pod', async () => {
+        mockGetFile.mockResolvedValue(new Blob(['{}']) as any)
+
+        const result = await hasPodData(mockSession, POD_URL)
+
+        expect(result).toBe(true)
+        expect(mockGetFile).toHaveBeenCalledWith(
+            `${POD_URL}pack-me-up/packing-list-questions.json`,
+            expect.objectContaining({ fetch: mockSession.fetch })
+        )
+    })
+
+    it('returns true when no questions file but packing lists exist', async () => {
+        mockGetFile.mockRejectedValue({ statusCode: 404 })
+        const mockDataset = {}
+        mockGetSolidDataset.mockResolvedValue(mockDataset as any)
+        mockGetContainedResourceUrlAll.mockReturnValue([
+            `${POD_URL}pack-me-up/packing-lists/list-1.json`,
+        ])
+
+        const result = await hasPodData(mockSession, POD_URL)
+
+        expect(result).toBe(true)
+    })
+
+    it('returns false when neither questions file nor packing lists exist', async () => {
+        mockGetFile.mockRejectedValue({ statusCode: 404 })
+        mockGetSolidDataset.mockRejectedValue({ statusCode: 404 })
+
+        const result = await hasPodData(mockSession, POD_URL)
+
+        expect(result).toBe(false)
+    })
+
+    it('returns false when questions file is 404 and packing lists container is empty', async () => {
+        mockGetFile.mockRejectedValue({ statusCode: 404 })
+        const mockDataset = {}
+        mockGetSolidDataset.mockResolvedValue(mockDataset as any)
+        mockGetContainedResourceUrlAll.mockReturnValue([])
+
+        const result = await hasPodData(mockSession, POD_URL)
+
+        expect(result).toBe(false)
+    })
+
+    it('returns false when questions file is 404 and packing lists container has no json files', async () => {
+        mockGetFile.mockRejectedValue({ statusCode: 404 })
+        const mockDataset = {}
+        mockGetSolidDataset.mockResolvedValue(mockDataset as any)
+        mockGetContainedResourceUrlAll.mockReturnValue([
+            `${POD_URL}pack-me-up/packing-lists/`,
+        ])
+
+        const result = await hasPodData(mockSession, POD_URL)
+
+        expect(result).toBe(false)
+    })
+
+    it('checks packing lists at the correct container URL', async () => {
+        mockGetFile.mockRejectedValue({ statusCode: 404 })
+        mockGetSolidDataset.mockRejectedValue({ statusCode: 404 })
+
+        await hasPodData(mockSession, POD_URL)
+
+        expect(mockGetSolidDataset).toHaveBeenCalledWith(
+            `${POD_URL}pack-me-up/packing-lists/`,
+            expect.objectContaining({ fetch: mockSession.fetch })
+        )
+    })
+
+    it('throws AuthenticationError on 401 from questions file check', async () => {
+        mockGetFile.mockRejectedValue({ statusCode: 401 })
+
+        await expect(hasPodData(mockSession, POD_URL)).rejects.toThrow(AuthenticationError)
+    })
+
+    it('throws AuthenticationError on 403 from questions file check', async () => {
+        mockGetFile.mockRejectedValue({ statusCode: 403 })
+
+        await expect(hasPodData(mockSession, POD_URL)).rejects.toThrow(AuthenticationError)
+    })
+
+    it('throws AuthenticationError on 401 from packing lists check', async () => {
+        mockGetFile.mockRejectedValue({ statusCode: 404 })
+        mockGetSolidDataset.mockRejectedValue({ statusCode: 401 })
+
+        await expect(hasPodData(mockSession, POD_URL)).rejects.toThrow(AuthenticationError)
+    })
+
+    it('re-throws unexpected errors from questions file check', async () => {
+        const unexpectedError = { statusCode: 500, message: 'Server Error' }
+        mockGetFile.mockRejectedValue(unexpectedError)
+
+        await expect(hasPodData(mockSession, POD_URL)).rejects.toEqual(unexpectedError)
+    })
+
+    it('re-throws unexpected errors from packing lists check', async () => {
+        const unexpectedError = { statusCode: 500, message: 'Server Error' }
+        mockGetFile.mockRejectedValue({ statusCode: 404 })
+        mockGetSolidDataset.mockRejectedValue(unexpectedError)
+
+        await expect(hasPodData(mockSession, POD_URL)).rejects.toEqual(unexpectedError)
+    })
+})

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -111,6 +111,30 @@ export async function getPrimaryPodUrl(session: Session | null): Promise<string 
 }
 
 /**
+ * Checks whether the user's Solid Pod contains any data saved by this app.
+ * Checks the questions file first, then the packing lists container.
+ * Uses remote requests so it works correctly on any device, regardless of local cache state.
+ */
+export async function hasPodData(session: Session, podUrl: string): Promise<boolean> {
+    try {
+        await getFile(`${podUrl}${POD_CONTAINERS.QUESTIONS}`, { fetch: session.fetch })
+        return true
+    } catch (err: any) {
+        if (isAuthenticationError(err)) handlePodError(err)
+        if (err.statusCode !== 404) throw err
+    }
+
+    try {
+        const dataset = await getSolidDataset(`${podUrl}${POD_CONTAINERS.PACKING_LISTS}`, { fetch: session.fetch })
+        return getContainedResourceUrlAll(dataset).some(url => url.endsWith('.json'))
+    } catch (err: any) {
+        if (isAuthenticationError(err)) handlePodError(err)
+        if (err.statusCode === 404) return false
+        throw err
+    }
+}
+
+/**
  * Saves a file to a Pod container with automatic fallback to overwrite
  * Handles both saveFileInContainer (creates) and overwriteFile (updates) strategies
  */


### PR DESCRIPTION
## What this PR does

When a user logs into a Solid Pod for the first time and their pod database is empty but they have local browser data, show a one-time dialog asking whether to copy that data to the pod or start fresh.

- `PackingAppDatabase.isEmpty()` — checks `doc_count === 0` via `getInfo()`
- `PackingAppDatabase.copyAllDataFrom(source)` — copies question set and all packing lists using the public API
- `DatabaseProvider` now checks both databases after resolving the pod namespace and shows a `ConfirmationDialog` when migration is appropriate
- The user's choice is persisted in `localStorage` (`pod-migration-dismissed-{namespace}`) so the prompt never reappears for that pod

## Manual testing steps

1. Open the app without logging in and create a packing list / add some questions
2. Log into a Solid Pod for the first time (or clear its data via IndexedDB tools)
3. Confirm the migration dialog appears with "Use my local data" and "Start fresh" buttons
4. Click **"Use my local data"** → verify the packing list and questions appear in the pod view
5. Log out and back in → confirm the dialog does **not** appear again
6. Repeat steps 1–3 with a fresh pod, click **"Start fresh"** → verify no data is copied and the dialog never reappears