### PR TITLE
Make landing page and wizard context-aware for returning users

### DIFF
--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { Navigation } from './Navigation'
+
+vi.mock('../hooks/useHasQuestions', () => ({
+    useHasQuestions: vi.fn(),
+}))
+
+vi.mock('./SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+vi.mock('./SolidProviderSelector', () => ({
+    SolidProviderSelector: () => null,
+}))
+
+import { useHasQuestions } from '../hooks/useHasQuestions'
+import { useSolidPod } from './SolidPodContext'
+
+const mockUseHasQuestions = vi.mocked(useHasQuestions)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+
+describe('Navigation', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+    })
+
+    it('shows "Get Started" nav link when no questions exist', () => {
+        mockUseHasQuestions.mockReturnValue(false)
+
+        render(
+            <MemoryRouter>
+                <Navigation />
+            </MemoryRouter>
+        )
+
+        expect(screen.getAllByText('Get Started').length).toBeGreaterThan(0)
+        expect(screen.queryByText('Reconfigure Questions')).toBeNull()
+    })
+
+    it('shows "Reconfigure Questions" nav link when questions exist', () => {
+        mockUseHasQuestions.mockReturnValue(true)
+
+        render(
+            <MemoryRouter>
+                <Navigation />
+            </MemoryRouter>
+        )
+
+        expect(screen.getAllByText('Reconfigure Questions').length).toBeGreaterThan(0)
+        expect(screen.queryByText('Get Started')).toBeNull()
+    })
+})

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,11 +2,13 @@ import { Link } from 'react-router-dom'
 import { useState } from 'react'
 import { useSolidPod } from './SolidPodContext'
 import { SolidProviderSelector } from './SolidProviderSelector'
+import { useHasQuestions } from '../hooks/useHasQuestions'
 
 export const Navigation = () => {
     const [isOpen, setIsOpen] = useState(false)
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
     const { login, logout, isLoggedIn, webId } = useSolidPod()
+    const hasQuestions = useHasQuestions()
 
     const handleSolidLogin = () => {
         setIsProviderSelectorOpen(true)
@@ -37,7 +39,7 @@ export const Navigation = () => {
                                         to="/wizard"
                                         className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
                                     >
-                                        Get Started
+                                        {hasQuestions ? 'Reconfigure Questions' : 'Get Started'}
                                     </Link>
                                     <Link
                                         to="/manage-questions"
@@ -134,7 +136,7 @@ export const Navigation = () => {
                             className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                             onClick={() => setIsOpen(false)}
                         >
-                            Get Started
+                            {hasQuestions ? 'Reconfigure Questions' : 'Get Started'}
                         </Link>
                         <Link
                             to="/manage-questions"

--- a/src/hooks/useHasQuestions.test.ts
+++ b/src/hooks/useHasQuestions.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useHasQuestions } from './useHasQuestions'
+
+vi.mock('../components/DatabaseContext', () => ({
+    useDatabase: vi.fn(),
+}))
+
+import { useDatabase } from '../components/DatabaseContext'
+
+const mockUseDatabase = vi.mocked(useDatabase)
+
+function makeDb(overrides: { getQuestionSet?: ReturnType<typeof vi.fn> } = {}) {
+    return {
+        getQuestionSet: overrides.getQuestionSet ?? vi.fn().mockResolvedValue({ questions: [] }),
+    }
+}
+
+describe('useHasQuestions', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('returns false when no questions exist (not_found)', async () => {
+        const db = makeDb({ getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }) })
+        mockUseDatabase.mockReturnValue({ db: db as any })
+
+        const { result } = renderHook(() => useHasQuestions())
+
+        await waitFor(() => expect(result.current).toBe(false))
+    })
+
+    it('returns true when questions exist', async () => {
+        const db = makeDb({ getQuestionSet: vi.fn().mockResolvedValue({ questions: [] }) })
+        mockUseDatabase.mockReturnValue({ db: db as any })
+
+        const { result } = renderHook(() => useHasQuestions())
+
+        await waitFor(() => expect(result.current).toBe(true))
+    })
+
+    it('returns false and logs error for unexpected errors', async () => {
+        const db = makeDb({ getQuestionSet: vi.fn().mockRejectedValue(new Error('unexpected')) })
+        mockUseDatabase.mockReturnValue({ db: db as any })
+
+        const { result } = renderHook(() => useHasQuestions())
+
+        await waitFor(() => expect(result.current).toBe(false))
+        expect(console.error).toHaveBeenCalled()
+    })
+})

--- a/src/hooks/useHasQuestions.ts
+++ b/src/hooks/useHasQuestions.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react'
+import { useDatabase } from '../components/DatabaseContext'
+
+export const useHasQuestions = () => {
+    const { db } = useDatabase()
+    const [hasQuestions, setHasQuestions] = useState(false)
+
+    useEffect(() => {
+        db.getQuestionSet()
+            .then(() => setHasQuestions(true))
+            .catch((err: any) => {
+                if (err.name !== 'not_found') console.error(err)
+                setHasQuestions(false)
+            })
+    }, [db])
+
+    return hasQuestions
+}

--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { LandingPage } from './landing-page'
+
+vi.mock('../hooks/useHasQuestions', () => ({
+    useHasQuestions: vi.fn(),
+}))
+
+vi.mock('../components/SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+import { useHasQuestions } from '../hooks/useHasQuestions'
+import { useSolidPod } from '../components/SolidPodContext'
+
+const mockUseHasQuestions = vi.mocked(useHasQuestions)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+
+describe('LandingPage', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+    })
+
+    it('shows "Get Started with the Wizard" as primary CTA when no questions exist', () => {
+        mockUseHasQuestions.mockReturnValue(false)
+
+        render(
+            <MemoryRouter>
+                <LandingPage />
+            </MemoryRouter>
+        )
+
+        expect(screen.getByRole('link', { name: /get started with the wizard/i })).toBeTruthy()
+        expect(screen.queryByRole('link', { name: /view packing lists/i })).toBeNull()
+    })
+
+    it('shows "View Packing Lists" as primary CTA when questions exist', () => {
+        mockUseHasQuestions.mockReturnValue(true)
+
+        render(
+            <MemoryRouter>
+                <LandingPage />
+            </MemoryRouter>
+        )
+
+        expect(screen.getByRole('link', { name: /view packing lists/i })).toBeTruthy()
+        expect(screen.queryByRole('link', { name: /get started with the wizard/i })).toBeNull()
+    })
+
+    it('shows "Reconfigure your questions" as secondary link when questions exist', () => {
+        mockUseHasQuestions.mockReturnValue(true)
+
+        render(
+            <MemoryRouter>
+                <LandingPage />
+            </MemoryRouter>
+        )
+
+        expect(screen.getByRole('link', { name: /reconfigure your questions/i })).toBeTruthy()
+    })
+})

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -1,8 +1,10 @@
 import { Link } from 'react-router-dom'
 import { useSolidPod } from '../components/SolidPodContext'
+import { useHasQuestions } from '../hooks/useHasQuestions'
 
 export const LandingPage = () => {
     const { isLoggedIn, webId } = useSolidPod()
+    const hasQuestions = useHasQuestions()
     return (
         <>
             {isLoggedIn && (
@@ -70,21 +72,49 @@ export const LandingPage = () => {
                 </div>
 
                 <div className="text-center space-y-4">
-                    <Link
-                        to="/wizard"
-                        className="inline-block bg-gradient-primary text-white px-8 py-4 rounded-2xl text-lg font-bold hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
-                    >
-                        ✨ Get Started with the Wizard
-                    </Link>
-                    <div className="text-gray-600">
-                        or{' '}
-                        <Link
-                            to="/create-packing-list"
-                            className="text-primary-700 font-semibold hover:underline"
-                        >
-                            create a packing list directly
-                        </Link>
-                    </div>
+                    {hasQuestions ? (
+                        <>
+                            <Link
+                                to="/view-lists"
+                                className="inline-block bg-gradient-primary text-white px-8 py-4 rounded-2xl text-lg font-bold hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
+                            >
+                                📋 View Packing Lists
+                            </Link>
+                            <div className="text-gray-600 space-x-3">
+                                <Link
+                                    to="/create-packing-list"
+                                    className="text-primary-700 font-semibold hover:underline"
+                                >
+                                    create a new packing list
+                                </Link>
+                                <span>·</span>
+                                <Link
+                                    to="/wizard"
+                                    className="text-primary-700 font-semibold hover:underline"
+                                >
+                                    reconfigure your questions
+                                </Link>
+                            </div>
+                        </>
+                    ) : (
+                        <>
+                            <Link
+                                to="/wizard"
+                                className="inline-block bg-gradient-primary text-white px-8 py-4 rounded-2xl text-lg font-bold hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
+                            >
+                                ✨ Get Started with the Wizard
+                            </Link>
+                            <div className="text-gray-600">
+                                or{' '}
+                                <Link
+                                    to="/create-packing-list"
+                                    className="text-primary-700 font-semibold hover:underline"
+                                >
+                                    create a packing list directly
+                                </Link>
+                            </div>
+                        </>
+                    )}
                 </div>
             </div>
         </>

--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { Wizard } from './wizard'
+
+vi.mock('../components/DatabaseContext', () => ({
+    useDatabase: vi.fn(),
+}))
+
+vi.mock('../components/SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+vi.mock('./useWizardGeneration', () => ({
+    useWizardGeneration: vi.fn(),
+}))
+
+vi.mock('../components/ToastContext', () => ({
+    useToast: vi.fn(() => ({ showToast: vi.fn() })),
+}))
+
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+import { useWizardGeneration } from './useWizardGeneration'
+
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockUseWizardGeneration = vi.mocked(useWizardGeneration)
+
+function makeDb(overrides: { getQuestionSet?: ReturnType<typeof vi.fn> } = {}) {
+    return {
+        getQuestionSet: overrides.getQuestionSet ?? vi.fn().mockRejectedValue({ name: 'not_found' }),
+    }
+}
+
+describe('Wizard', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+
+        mockUseWizardGeneration.mockReturnValue({
+            isLoading: false,
+            isSuccess: false,
+            generateAndSave: vi.fn(),
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('shows warning banner when questions already exist', async () => {
+        const db = makeDb({ getQuestionSet: vi.fn().mockResolvedValue({ questions: [] }) })
+        mockUseDatabase.mockReturnValue({ db: db as any })
+
+        render(
+            <MemoryRouter>
+                <Wizard />
+            </MemoryRouter>
+        )
+
+        await waitFor(() =>
+            expect(screen.getByText(/you already have packing list questions set up/i)).toBeTruthy()
+        )
+    })
+
+    it('does not show warning banner when no questions exist', async () => {
+        const db = makeDb({ getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }) })
+        mockUseDatabase.mockReturnValue({ db: db as any })
+
+        render(
+            <MemoryRouter>
+                <Wizard />
+            </MemoryRouter>
+        )
+
+        await waitFor(() => screen.getByRole('button', { name: /generate/i }))
+        expect(screen.queryByText(/you already have packing list questions set up/i)).toBeNull()
+    })
+})

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useForm, useFieldArray } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { Modal } from '../components/Modal'
@@ -50,7 +50,7 @@ export const Wizard = () => {
             }
         }
         checkExistingData()
-    }, [])
+    }, [db])
 
     // Show Solid Pod prompt after successful generation if not logged in
     useEffect(() => {
@@ -96,6 +96,18 @@ export const Wizard = () => {
                     Answer a few quick questions to set up your personalized packing list
                 </p>
             </div>
+
+            {hasExistingData && (
+                <div className="mb-6 p-4 bg-warning-50 border-2 border-warning-300 rounded-2xl">
+                    <p className="text-warning-900 font-semibold">
+                        ⚠️ You already have packing list questions set up. Completing this wizard will replace them.
+                    </p>
+                    <p className="text-sm text-warning-800 mt-1">
+                        To keep your existing questions, go to{' '}
+                        <Link to="/manage-questions" className="underline font-semibold">Edit Questions</Link> instead.
+                    </p>
+                </div>
+            )}
 
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
                 {/* People Section */}


### PR DESCRIPTION
## What this PR does

Makes the app aware of whether the user already has packing list questions set up, and adjusts the UI accordingly across three surfaces:

- **Landing page**: returning users (who have existing questions) see "View Packing Lists" as the primary CTA, with secondary links to create a new list or reconfigure questions. New users continue to see "Get Started with the Wizard".
- **Wizard**: shows an upfront warning banner above the form when the user already has questions set up, so they know before filling anything in that their data will be replaced. Also fixes a missing `db` dependency in the `useEffect`.
- **Navigation**: "Get Started" label changes to "Reconfigure Questions" for returning users.

Extracts a shared `useHasQuestions` hook to avoid duplicating the `db.getQuestionSet()` check across components.

All changes implemented with TDD (red-green-refactor). 10 new tests added.

## Manual testing steps

1. **New user**: open the app without any local data and not logged in — landing page should show "Get Started with the Wizard" as the primary button, nav should show "Get Started", wizard should show no warning.
2. **Returning user (local)**: generate a question set via the wizard, then return to the landing page — should now show "View Packing Lists" as primary, with "reconfigure your questions" as a secondary link. Nav should show "Reconfigure Questions". Opening the wizard should immediately show the warning banner above the form.
3. **Returning user (pod)**: log into a Solid Pod that has existing data — same behaviour as above, since `useHasQuestions` uses the namespaced db.