### PR TITLE
Fix easy lint errors (16/138)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,10 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true },
       ],
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        ignoreRestSiblings: true,
+      }],
     },
   },
 )

--- a/src/edit-questions/json-editor.tsx
+++ b/src/edit-questions/json-editor.tsx
@@ -67,7 +67,7 @@ export function JsonEditor({ value, onChange, error, originalValue, onSave, hasU
           setValidationErrors(validation.errors || null)
           onValidationChange?.(validation.errors || null)
         }
-      } catch (e) {
+      } catch {
         // JSON syntax error - don't show validation errors yet
         setValidationErrors(null)
         onValidationChange?.(null)
@@ -92,7 +92,7 @@ export function JsonEditor({ value, onChange, error, originalValue, onSave, hasU
         setValidationErrors(validation.errors || null)
         onValidationChange?.(validation.errors || null)
       }
-    } catch (e) {
+    } catch {
       // Keep existing validation errors if JSON is invalid
     }
     setIsValidating(false)

--- a/src/edit-questions/validation.ts
+++ b/src/edit-questions/validation.ts
@@ -74,17 +74,11 @@ export function findLineNumberForPath(jsonText: string, path: string): number | 
   const lines = jsonText.split('\n')
 
   try {
-    let currentDepth = 0
-    let searchPath = [...pathParts]
+    const searchPath = [...pathParts]
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]
       const trimmed = line.trim()
-
-      // Track depth by counting braces
-      const openBraces = (line.match(/[{[]/g) || []).length
-      const closeBraces = (line.match(/[}\]]/g) || []).length
-      currentDepth += openBraces - closeBraces
 
       // Look for the current path part
       if (searchPath.length > 0) {
@@ -108,7 +102,7 @@ export function findLineNumberForPath(jsonText: string, path: string): number | 
         }
       }
     }
-  } catch (e) {
+  } catch {
     // If we can't find it, return undefined
   }
 

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -61,7 +61,7 @@ export function CreatePackingList() {
 
             // For each selected option, get all items
             return selectedOptionIds.flatMap((selectedOptionId) => {
-                const selectedOption = question?.options.find((option) => (option.id === selectedOptionId))!
+                const selectedOption = question.options.find((option) => (option.id === selectedOptionId))!
                 const packingListItems: PackingListItem[] = selectedOption.items.flatMap((item) => {
                     const selectedPeople = item.personSelections.filter((person) => (
                         person.selected && selectedPeopleIds.includes(person.personId)


### PR DESCRIPTION
## Summary
Fixed 16 of 138 lint errors by addressing easy-to-fix issues:

- Configured `@typescript-eslint/no-unused-vars` with `argsIgnorePattern` and `ignoreRestSiblings` to handle underscore-prefixed parameters and destructuring-to-omit patterns
- Removed unused catch bindings in json-editor and validation modules
- Changed `let searchPath` to `const searchPath` to satisfy prefer-const rule
- Removed unused `currentDepth` variable that was tracked but never read
- Fixed redundant optional chaining on already non-null-asserted value

The remaining ~122 errors are mostly `@typescript-eslint/no-explicit-any` violations requiring proper TypeScript typing, and a few hook dependency warnings. These are left for a separate effort.

🤖 Generated with Claude Code