### PR TITLE
Add solid-dev skill for local E2E testing

### DIFF
--- a/.claude/skills/solid-dev/SKILL.md
+++ b/.claude/skills/solid-dev/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: solid-dev
+version: 1.0.0
+description: |
+  Start a local Community Solid Server (CSS) for manual E2E testing.
+  Launches CSS on port 4000, creates a test account and pod, then prints
+  credentials and the OIDC issuer URL ready to paste into the app.
+allowed-tools:
+  - Bash
+---
+
+# solid-dev: Local Solid Server for E2E Testing
+
+Starts Community Solid Server (in-memory, ephemeral) and provisions a test account.
+
+## Steps
+
+1. Kill any process on port 4000
+2. Start CSS in the background
+3. Wait until CSS is ready
+4. Register a test account + pod via the CSS HTTP API
+5. Print credentials
+
+## Instructions
+
+Run the following as a single Bash block:
+
+```bash
+# 1. Free port 4000
+lsof -ti:4000 | xargs kill -9 2>/dev/null || true
+
+# 2. Start CSS in background
+npx --yes @solid/community-server -p 4000 > /tmp/css.log 2>&1 &
+CSS_PID=$!
+echo "CSS starting (PID $CSS_PID)..."
+
+# 3. Wait until ready
+for i in $(seq 1 30); do
+  curl -sf http://localhost:4000/ -o /dev/null && break
+  sleep 1
+done
+
+# 4a. Create account
+curl -s -c /tmp/css-cookies.txt -X POST http://localhost:4000/.account/ \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"test@example.com","password":"test1234"}' > /dev/null
+
+# 4b. Create pod
+curl -s -b /tmp/css-cookies.txt -X POST http://localhost:4000/.account/pod/ \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"test"}' > /dev/null
+
+# 5. Print credentials
+echo ""
+echo "============================================"
+echo "  Local Solid Server ready"
+echo "============================================"
+echo "  OIDC Issuer : http://localhost:4000"
+echo "  WebID       : http://localhost:4000/test/profile/card#me"
+echo "  Email       : test@example.com"
+echo "  Password    : test1234"
+echo "============================================"
+echo "  In the app: Custom provider → http://localhost:4000"
+echo "  Stop server: kill $CSS_PID"
+echo "============================================"
+```
+
+> **Note:** Data is in-memory — all pod content is lost when the server stops.
+> Re-run the skill to get a fresh server with a clean account.

--- a/.claude/skills/solid-dev/SKILL.md
+++ b/.claude/skills/solid-dev/SKILL.md
@@ -13,57 +13,13 @@ allowed-tools:
 
 Starts Community Solid Server (in-memory, ephemeral) and provisions a test account.
 
-## Steps
-
-1. Kill any process on port 4000
-2. Start CSS in the background
-3. Wait until CSS is ready
-4. Register a test account + pod via the CSS HTTP API
-5. Print credentials
-
 ## Instructions
 
-Run the following as a single Bash block:
+Run the start script:
 
 ```bash
-# 1. Free port 4000
-lsof -ti:4000 | xargs kill -9 2>/dev/null || true
-
-# 2. Start CSS in background
-npx --yes @solid/community-server -p 4000 > /tmp/css.log 2>&1 &
-CSS_PID=$!
-echo "CSS starting (PID $CSS_PID)..."
-
-# 3. Wait until ready
-for i in $(seq 1 30); do
-  curl -sf http://localhost:4000/ -o /dev/null && break
-  sleep 1
-done
-
-# 4a. Create account
-curl -s -c /tmp/css-cookies.txt -X POST http://localhost:4000/.account/ \
-  -H 'Content-Type: application/json' \
-  -d '{"email":"test@example.com","password":"test1234"}' > /dev/null
-
-# 4b. Create pod
-curl -s -b /tmp/css-cookies.txt -X POST http://localhost:4000/.account/pod/ \
-  -H 'Content-Type: application/json' \
-  -d '{"name":"test"}' > /dev/null
-
-# 5. Print credentials
-echo ""
-echo "============================================"
-echo "  Local Solid Server ready"
-echo "============================================"
-echo "  OIDC Issuer : http://localhost:4000"
-echo "  WebID       : http://localhost:4000/test/profile/card#me"
-echo "  Email       : test@example.com"
-echo "  Password    : test1234"
-echo "============================================"
-echo "  In the app: Custom provider → http://localhost:4000"
-echo "  Stop server: kill $CSS_PID"
-echo "============================================"
+bash .claude/skills/solid-dev/start.sh
 ```
 
 > **Note:** Data is in-memory — all pod content is lost when the server stops.
-> Re-run the skill to get a fresh server with a clean account.
+> Re-run the script to get a fresh server with a clean account.

--- a/.claude/skills/solid-dev/start.sh
+++ b/.claude/skills/solid-dev/start.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -e
+
+PORT=4000
+
+# 1. Free the port
+lsof -ti:$PORT | xargs kill -9 2>/dev/null || true
+
+# 2. Start CSS in background
+npx --yes @solid/community-server -p $PORT > /tmp/css.log 2>&1 &
+CSS_PID=$!
+echo "CSS starting (PID $CSS_PID)..."
+
+# 3. Wait until ready
+for i in $(seq 1 30); do
+  curl -sf http://localhost:$PORT/ -o /dev/null && break
+  echo "Waiting... ($i/30)"
+  sleep 1
+done
+
+# 4a. Create account
+curl -s -c /tmp/css-cookies.txt -X POST http://localhost:$PORT/.account/ \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"test@example.com","password":"test1234"}' > /dev/null
+
+# 4b. Create pod
+curl -s -b /tmp/css-cookies.txt -X POST http://localhost:$PORT/.account/pod/ \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"test"}' > /dev/null
+
+echo ""
+echo "============================================"
+echo "  Local Solid Server ready"
+echo "============================================"
+echo "  OIDC Issuer : http://localhost:$PORT"
+echo "  WebID       : http://localhost:$PORT/test/profile/card#me"
+echo "  Email       : test@example.com"
+echo "  Password    : test1234"
+echo "============================================"
+echo "  In the app: Custom provider -> http://localhost:$PORT"
+echo "  Stop server: kill $CSS_PID"
+echo "============================================"


### PR DESCRIPTION
## What this PR does

Research task to enable manual end-to-end testing without a real Solid POD provider. 

This PR adds a reusable `solid-dev` skill that automates starting Community Solid Server (CSS) in in-memory mode on localhost:4000 and provisioning a test account. The skill is concise, user-invokable, and prints ready-to-use OIDC issuer URL and test credentials.

## Manual testing steps

1. Run `/solid-dev` skill
2. Copy the printed OIDC issuer URL and credentials
3. Start the app with `npm run dev`
4. In the app, select "Custom provider" and paste `http://localhost:4000`
5. Log in with the provided email/password
6. Verify you can create/edit packing lists and have them persist to the local Solid pod