### PR TITLE
Fix session expiry UI with persistent banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Route } from 'react-router-dom'
 import { Routes } from 'react-router-dom'
 import './App.css'
 import { Navigation } from './components/Navigation'
+import { SessionExpiredBanner } from './components/SessionExpiredBanner'
 import { ToastProvider } from './components/ToastContext'
 import { LandingPage } from './pages/landing-page'
 import { EditQuestionsForm } from './pages/edit-questions-form'
@@ -23,6 +24,7 @@ function App() {
         <HashRouter>
           <div className="min-h-screen bg-gradient-to-br from-primary-50 via-white to-accent-50">
             <Navigation />
+            <SessionExpiredBanner />
             <div className="container mx-auto px-4 py-8">
               <Routes>
                 <Route path="/" element={<LandingPage />} />

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -27,6 +27,8 @@ describe('Navigation', () => {
         mockUseSolidPod.mockReturnValue({
             session: null,
             isLoggedIn: false,
+            sessionExpired: false,
+            clearSessionExpired: vi.fn(),
             webId: undefined,
             isLoading: false,
             login: vi.fn(),

--- a/src/components/SessionExpiredBanner.test.tsx
+++ b/src/components/SessionExpiredBanner.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+
+vi.mock('./SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+vi.mock('./SolidProviderSelector', () => ({
+    SolidProviderSelector: ({ isOpen }: { isOpen: boolean }) =>
+        isOpen ? <div data-testid="provider-selector" /> : null,
+}))
+
+import { useSolidPod } from './SolidPodContext'
+import { SessionExpiredBanner } from './SessionExpiredBanner'
+
+const mockUseSolidPod = vi.mocked(useSolidPod)
+
+const defaultMock = {
+    session: null,
+    isLoggedIn: false,
+    sessionExpired: false,
+    clearSessionExpired: vi.fn(),
+    webId: undefined,
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+}
+
+describe('SessionExpiredBanner', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({ ...defaultMock, clearSessionExpired: vi.fn() })
+    })
+
+    it('does not render when sessionExpired is false', () => {
+        mockUseSolidPod.mockReturnValue({ ...defaultMock, sessionExpired: false, isLoggedIn: false })
+
+        render(<SessionExpiredBanner />)
+
+        expect(screen.queryByText(/session has expired/i)).toBeNull()
+    })
+
+    it('renders the banner when sessionExpired is true and user is not logged in', () => {
+        mockUseSolidPod.mockReturnValue({ ...defaultMock, sessionExpired: true, isLoggedIn: false })
+
+        render(<SessionExpiredBanner />)
+
+        expect(screen.getByText(/session has expired/i)).toBeDefined()
+    })
+
+    it('does not render when sessionExpired is true but user is logged in', () => {
+        mockUseSolidPod.mockReturnValue({ ...defaultMock, sessionExpired: true, isLoggedIn: true })
+
+        render(<SessionExpiredBanner />)
+
+        expect(screen.queryByText(/session has expired/i)).toBeNull()
+    })
+
+    it('calls clearSessionExpired when dismiss button is clicked', () => {
+        const clearSessionExpired = vi.fn()
+        mockUseSolidPod.mockReturnValue({ ...defaultMock, sessionExpired: true, isLoggedIn: false, clearSessionExpired })
+
+        render(<SessionExpiredBanner />)
+
+        fireEvent.click(screen.getByLabelText('Dismiss'))
+
+        expect(clearSessionExpired).toHaveBeenCalledOnce()
+    })
+
+    it('opens the provider selector when "Log in again" is clicked', () => {
+        mockUseSolidPod.mockReturnValue({ ...defaultMock, sessionExpired: true, isLoggedIn: false })
+
+        render(<SessionExpiredBanner />)
+
+        expect(screen.queryByTestId('provider-selector')).toBeNull()
+
+        fireEvent.click(screen.getByText('Log in again'))
+
+        expect(screen.getByTestId('provider-selector')).toBeDefined()
+    })
+})

--- a/src/components/SessionExpiredBanner.tsx
+++ b/src/components/SessionExpiredBanner.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { useSolidPod } from './SolidPodContext';
+import { SolidProviderSelector } from './SolidProviderSelector';
+
+export function SessionExpiredBanner() {
+    const { sessionExpired, isLoggedIn, clearSessionExpired, login } = useSolidPod();
+    const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false);
+
+    if (!sessionExpired || isLoggedIn) return null;
+
+    return (
+        <>
+            <div className="bg-amber-50 border-b border-amber-200 px-4 py-3 flex items-center justify-between">
+                <p className="text-amber-800 text-sm font-medium">
+                    Your session has expired. Your data is saved locally.
+                </p>
+                <div className="flex items-center gap-3">
+                    <button
+                        onClick={() => setIsProviderSelectorOpen(true)}
+                        className="text-sm font-semibold text-amber-900 underline hover:no-underline"
+                    >
+                        Log in again
+                    </button>
+                    <button onClick={clearSessionExpired} aria-label="Dismiss">
+                        <XMarkIcon className="h-4 w-4 text-amber-700 hover:text-amber-900" />
+                    </button>
+                </div>
+            </div>
+            <SolidProviderSelector
+                isOpen={isProviderSelectorOpen}
+                onClose={() => setIsProviderSelectorOpen(false)}
+                onSelect={(issuer) => login(issuer)}
+            />
+        </>
+    );
+}

--- a/src/components/SolidPodContext.test.tsx
+++ b/src/components/SolidPodContext.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import { EventEmitter } from 'events'
+import React from 'react'
+import { SolidPodProvider, useSolidPod } from './SolidPodContext'
+import { ToastProvider } from './ToastContext'
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+        <ToastProvider>
+            <SolidPodProvider>{children}</SolidPodProvider>
+        </ToastProvider>
+    )
+}
+
+// Build a controllable mock session backed by an EventEmitter
+function makeMockSession(isLoggedIn = false, webId?: string) {
+    const events = new EventEmitter()
+    return {
+        info: { isLoggedIn, webId, sessionId: 'test-session' },
+        events,
+        fetch: vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+    }
+}
+
+let mockSession = makeMockSession()
+
+vi.mock('@inrupt/solid-client-authn-browser', () => ({
+    handleIncomingRedirect: vi.fn().mockResolvedValue(undefined),
+    getDefaultSession: vi.fn(() => mockSession),
+    login: vi.fn(),
+    logout: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { getDefaultSession } from '@inrupt/solid-client-authn-browser'
+const mockGetDefaultSession = vi.mocked(getDefaultSession)
+
+/** Test consumer that renders context values as text */
+function Consumer() {
+    const { isLoggedIn, sessionExpired, webId } = useSolidPod()
+    return (
+        <div>
+            <span data-testid="isLoggedIn">{String(isLoggedIn)}</span>
+            <span data-testid="sessionExpired">{String(sessionExpired)}</span>
+            <span data-testid="webId">{webId ?? 'none'}</span>
+        </div>
+    )
+}
+
+/** Test consumer that also exposes clearSessionExpired */
+function ConsumerWithActions() {
+    const { isLoggedIn, sessionExpired, clearSessionExpired, logout } = useSolidPod()
+    return (
+        <div>
+            <span data-testid="isLoggedIn">{String(isLoggedIn)}</span>
+            <span data-testid="sessionExpired">{String(sessionExpired)}</span>
+            <button onClick={clearSessionExpired}>clear</button>
+            <button onClick={logout}>logout</button>
+        </div>
+    )
+}
+
+describe('SolidPodContext', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        mockSession = makeMockSession()
+        mockGetDefaultSession.mockReturnValue(mockSession as never)
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('starts with isLoggedIn false and sessionExpired false', async () => {
+        render(
+            <Wrapper>
+                <Consumer />
+            </Wrapper>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('false')
+            expect(screen.getByTestId('sessionExpired').textContent).toBe('false')
+        })
+    })
+
+    it('sets isLoggedIn true after session initialises with a logged-in session', async () => {
+        mockSession = makeMockSession(true, 'https://user.example.org/profile/card#me')
+        mockGetDefaultSession.mockReturnValue(mockSession as never)
+
+        render(
+            <Wrapper>
+                <Consumer />
+            </Wrapper>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('true')
+        })
+    })
+
+    it('sets isLoggedIn false and sessionExpired true on non-intentional logout', async () => {
+        mockSession = makeMockSession(true, 'https://user.example.org/profile/card#me')
+        mockGetDefaultSession.mockReturnValue(mockSession as never)
+
+        render(
+            <Wrapper>
+                <Consumer />
+            </Wrapper>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('true')
+        })
+
+        // Simulate session expiry: library fires logout event and resets session info
+        await act(async () => {
+            mockSession.info.isLoggedIn = false
+            const expiredSession = makeMockSession(false)
+            mockGetDefaultSession.mockReturnValue(expiredSession as never)
+            mockSession.events.emit('logout')
+        })
+
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('false')
+            expect(screen.getByTestId('sessionExpired').textContent).toBe('true')
+        })
+    })
+
+    it('sets isLoggedIn false but keeps sessionExpired false on intentional logout', async () => {
+        mockSession = makeMockSession(true, 'https://user.example.org/profile/card#me')
+        mockGetDefaultSession.mockReturnValue(mockSession as never)
+
+        render(
+            <Wrapper>
+                <ConsumerWithActions />
+            </Wrapper>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('true')
+        })
+
+        await act(async () => {
+            screen.getByRole('button', { name: 'logout' }).click()
+        })
+
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('false')
+            expect(screen.getByTestId('sessionExpired').textContent).toBe('false')
+        })
+    })
+
+    it('sets isLoggedIn true and sessionExpired false on login event', async () => {
+        render(
+            <Wrapper>
+                <Consumer />
+            </Wrapper>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('false')
+        })
+
+        await act(async () => {
+            mockSession.info.isLoggedIn = true
+            mockSession.info.webId = 'https://user.example.org/profile/card#me'
+            mockSession.events.emit('login')
+        })
+
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('true')
+            expect(screen.getByTestId('sessionExpired').textContent).toBe('false')
+        })
+    })
+
+    it('clearSessionExpired sets sessionExpired to false', async () => {
+        mockSession = makeMockSession(true, 'https://user.example.org/profile/card#me')
+        mockGetDefaultSession.mockReturnValue(mockSession as never)
+
+        render(
+            <Wrapper>
+                <ConsumerWithActions />
+            </Wrapper>
+        )
+
+        // Wait for initialization
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('true')
+        })
+
+        // Trigger session expiry
+        await act(async () => {
+            mockSession.info.isLoggedIn = false
+            const expiredSession = makeMockSession(false)
+            mockGetDefaultSession.mockReturnValue(expiredSession as never)
+            mockSession.events.emit('logout')
+        })
+
+        await waitFor(() => {
+            expect(screen.getByTestId('sessionExpired').textContent).toBe('true')
+        })
+
+        // Dismiss
+        await act(async () => {
+            screen.getByRole('button', { name: 'clear' }).click()
+        })
+
+        await waitFor(() => {
+            expect(screen.getByTestId('sessionExpired').textContent).toBe('false')
+        })
+    })
+})

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -12,6 +12,8 @@ import { isAuthenticationError } from "../services/solidPod";
 interface SolidPodContextValue {
   session: Session | null;
   isLoggedIn: boolean;
+  sessionExpired: boolean;
+  clearSessionExpired: () => void;
   webId: string | undefined;
   isLoading: boolean;
   login: (oidcIssuer: string, returnTo?: string) => Promise<void>;
@@ -26,9 +28,10 @@ const SolidPodContext = createContext<SolidPodContextValue | undefined>(undefine
  */
 function setupSessionEventListeners(
   session: Session,
-  showToast: (message: string, type: 'success' | 'error') => void,
   setSession: (session: Session) => void,
   setSessionVersion: (updater: (v: number) => number) => void,
+  setIsLoggedIn: (v: boolean) => void,
+  setSessionExpired: (v: boolean) => void,
   intentionalLogoutRef: React.MutableRefObject<boolean>
 ) {
   // Listen for logout events — fires for both intentional logout and session expiry.
@@ -37,12 +40,10 @@ function setupSessionEventListeners(
     console.log("Session logout event fired");
     setSession(getDefaultSession());
     setSessionVersion(v => v + 1);
+    setIsLoggedIn(false);
 
     if (!intentionalLogoutRef.current) {
-      showToast(
-        "Your Solid session has expired. Your data is saved locally - log in again to sync with your Pod.",
-        "error"
-      );
+      setSessionExpired(true);
     }
     intentionalLogoutRef.current = false;
   });
@@ -53,6 +54,8 @@ function setupSessionEventListeners(
     const updatedSession = getDefaultSession();
     setSession(updatedSession);
     setSessionVersion(v => v + 1);
+    setIsLoggedIn(true);
+    setSessionExpired(false);
   });
 
   // Listen for session restore events
@@ -61,11 +64,14 @@ function setupSessionEventListeners(
     const updatedSession = getDefaultSession();
     setSession(updatedSession);
     setSessionVersion(v => v + 1);
+    setIsLoggedIn(true);
   });
 }
 
 export function SolidPodProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [sessionExpired, setSessionExpired] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [, setSessionVersion] = useState(0);
   const { showToast } = useToast();
@@ -84,9 +90,10 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
         });
         setSession(currentSession);
         setSessionVersion(v => v + 1);
+        setIsLoggedIn(currentSession.info.isLoggedIn);
 
         // Set up session event listeners
-        setupSessionEventListeners(currentSession, showToast, setSession, setSessionVersion, intentionalLogoutRef);
+        setupSessionEventListeners(currentSession, setSession, setSessionVersion, setIsLoggedIn, setSessionExpired, intentionalLogoutRef);
       } catch (error) {
         console.error("Error initializing session:", error);
         console.log("Session restoration failed, clearing any corrupted session data...");
@@ -133,10 +140,8 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
           const updatedSession = getDefaultSession();
           setSession(updatedSession);
           setSessionVersion(v => v + 1);
-          showToast(
-            "Your session expired while you were away. Please log in again.",
-            "error"
-          );
+          setIsLoggedIn(false);
+          setSessionExpired(true);
         } else {
           // Network errors or other issues - log but don't logout
           console.error("Session validation failed with non-auth error:", error);
@@ -153,7 +158,7 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
-  }, [session, session?.info.isLoggedIn, session?.info.webId, showToast]);
+  }, [session, session?.info.isLoggedIn, session?.info.webId]);
 
   const login = async (oidcIssuer: string, returnTo?: string) => {
     const currentLocation = returnTo || window.location.hash.substring(1) || "/";
@@ -173,11 +178,16 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
     const updatedSession = getDefaultSession();
     setSession(updatedSession);
     setSessionVersion(v => v + 1);
+    setIsLoggedIn(false);
   };
+
+  const clearSessionExpired = () => setSessionExpired(false);
 
   const value: SolidPodContextValue = {
     session,
-    isLoggedIn: session?.info.isLoggedIn ?? false,
+    isLoggedIn,
+    sessionExpired,
+    clearSessionExpired,
     webId: session?.info.webId,
     isLoading,
     login,


### PR DESCRIPTION
## Summary
- Fixes UI bug where nav still shows logged-in after session timeout
- Root cause: singleton session object + derived state prevented re-renders
- Solution: explicit `isLoggedIn`/`sessionExpired` state + persistent amber banner
- Replaces 3-second auto-dismiss toast with actionable UI

## Changes
- `SolidPodContext.tsx`: Explicit state management for login/expiry status
- `SessionExpiredBanner.tsx`: New persistent notification component with "Log in again" CTA
- `App.tsx`: Wire banner into layout below nav
- Test coverage: 11 new tests (TDD approach), all 112 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)