### PR TITLE
Fix session expired toast on intentional logout

### DIFF
--- a/src/components/SolidPodContext.test.tsx
+++ b/src/components/SolidPodContext.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Hoisted variables (must be declared before vi.mock factory runs)
+// ---------------------------------------------------------------------------
+
+const { fakeEvents, fakeSession, mockSolidLogout, mockShowToast } = vi.hoisted(() => {
+  const { EventEmitter } = require('events') as typeof import('events')
+
+  const fakeEvents = new EventEmitter()
+  fakeEvents.setMaxListeners(50)
+
+  const fakeSession = {
+    info: { isLoggedIn: false, webId: undefined as string | undefined, sessionId: 'test' },
+    events: fakeEvents,
+    fetch: () => Promise.resolve(new Response()),
+  }
+
+  return {
+    fakeEvents,
+    fakeSession,
+    mockSolidLogout: vi.fn(),
+    mockShowToast: vi.fn(),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@inrupt/solid-client-authn-browser', () => ({
+  getDefaultSession: vi.fn(() => fakeSession),
+  handleIncomingRedirect: vi.fn().mockResolvedValue(undefined),
+  login: vi.fn(),
+  logout: mockSolidLogout,
+}))
+
+// Stable showToast reference — the real bug is React StrictMode double-invoking
+// effects with no cleanup, not an unstable showToast reference.
+vi.mock('./ToastContext', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}))
+
+import { SolidPodProvider, useSolidPod } from './SolidPodContext'
+
+// ---------------------------------------------------------------------------
+// Helper component
+// ---------------------------------------------------------------------------
+
+function LogoutButton() {
+  const { logout } = useSolidPod()
+  return <button onClick={() => { void logout() }}>Logout</button>
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SolidPodContext', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    mockShowToast.mockClear()
+    mockSolidLogout.mockClear()
+
+    // solidLogout emits 'logout' on the shared fake session, mirroring the
+    // real Inrupt library behaviour
+    mockSolidLogout.mockImplementation(async () => {
+      fakeEvents.emit('logout')
+    })
+
+    // Remove any listeners left by the previous test's component
+    fakeEvents.removeAllListeners()
+    fakeSession.info = { isLoggedIn: false, webId: undefined, sessionId: 'test' }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // In React 18 StrictMode (used in development and the production app), effects
+  // are intentionally double-invoked to surface missing cleanups. Because
+  // setupSessionEventListeners has no cleanup, both invocations leave their
+  // listeners active. When the user logs out:
+  //   1st listener: sees intentionalLogoutRef=true → suppresses toast, resets flag to false
+  //   2nd listener: sees intentionalLogoutRef=false → shows "session expired" toast ← BUG
+  it('does not show session-expired toast when user intentionally logs out (StrictMode)', async () => {
+    render(
+      <React.StrictMode>
+        <SolidPodProvider>
+          <LogoutButton />
+        </SolidPodProvider>
+      </React.StrictMode>
+    )
+
+    await waitFor(() => screen.getByText('Logout'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Logout'))
+    })
+
+    expect(mockShowToast).not.toHaveBeenCalledWith(
+      expect.stringContaining('session has expired'),
+      'error'
+    )
+  })
+
+  it('shows session-expired toast when session expires unexpectedly', async () => {
+    render(
+      <SolidPodProvider>
+        <LogoutButton />
+      </SolidPodProvider>
+    )
+
+    await waitFor(() => screen.getByText('Logout'))
+
+    // Emit the logout event directly — no intentional flag set, so the toast
+    // should appear
+    act(() => {
+      fakeEvents.emit('logout')
+    })
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('session has expired'),
+      'error'
+    )
+  })
+})

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -21,47 +21,58 @@ interface SolidPodContextValue {
 const SolidPodContext = createContext<SolidPodContextValue | undefined>(undefined);
 
 /**
- * Sets up event listeners for session lifecycle events
- * Monitors login, logout, and session restoration events
+ * Sets up event listeners for session lifecycle events.
+ * Monitors login, logout, and session restoration events.
+ * Returns a cleanup function that removes all registered listeners.
  */
 function setupSessionEventListeners(
   session: Session,
-  showToast: (message: string, type: 'success' | 'error') => void,
+  showToastRef: React.MutableRefObject<(message: string, type: 'success' | 'error') => void>,
   setSession: (session: Session) => void,
   setSessionVersion: (updater: (v: number) => number) => void,
   intentionalLogoutRef: React.MutableRefObject<boolean>
-) {
+): () => void {
   // Listen for logout events — fires for both intentional logout and session expiry.
   // Use intentionalLogoutRef to distinguish between the two.
-  session.events.on("logout", () => {
+  const onLogout = () => {
     console.log("Session logout event fired");
     setSession(getDefaultSession());
     setSessionVersion(v => v + 1);
 
     if (!intentionalLogoutRef.current) {
-      showToast(
+      showToastRef.current(
         "Your Solid session has expired. Your data is saved locally - log in again to sync with your Pod.",
         "error"
       );
     }
     intentionalLogoutRef.current = false;
-  });
+  };
 
   // Listen for login events
-  session.events.on("login", () => {
+  const onLogin = () => {
     console.log("Session login event fired");
     const updatedSession = getDefaultSession();
     setSession(updatedSession);
     setSessionVersion(v => v + 1);
-  });
+  };
 
   // Listen for session restore events
-  session.events.on("sessionRestore", () => {
+  const onSessionRestore = () => {
     console.log("Session restore event fired");
     const updatedSession = getDefaultSession();
     setSession(updatedSession);
     setSessionVersion(v => v + 1);
-  });
+  };
+
+  session.events.on("logout", onLogout);
+  session.events.on("login", onLogin);
+  session.events.on("sessionRestore", onSessionRestore);
+
+  return () => {
+    session.events.off("logout", onLogout);
+    session.events.off("login", onLogin);
+    session.events.off("sessionRestore", onSessionRestore);
+  };
 }
 
 export function SolidPodProvider({ children }: { children: ReactNode }) {
@@ -69,9 +80,20 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [, setSessionVersion] = useState(0);
   const { showToast } = useToast();
+  const showToastRef = useRef(showToast);
+  useEffect(() => { showToastRef.current = showToast; }, [showToast]);
   const intentionalLogoutRef = useRef(false);
 
   useEffect(() => {
+    // Register listeners synchronously on the singleton session so the cleanup
+    // function is available immediately (before the async init work completes).
+    // This prevents React StrictMode's synchronous cleanup–remount cycle from
+    // leaving duplicate listeners when the async callback hasn't resolved yet.
+    const initialSession = getDefaultSession();
+    const cleanupListeners = setupSessionEventListeners(
+      initialSession, showToastRef, setSession, setSessionVersion, intentionalLogoutRef
+    );
+
     const initializeSession = async () => {
       try {
         console.log("Initializing Solid session...");
@@ -84,9 +106,6 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
         });
         setSession(currentSession);
         setSessionVersion(v => v + 1);
-
-        // Set up session event listeners
-        setupSessionEventListeners(currentSession, showToast, setSession, setSessionVersion, intentionalLogoutRef);
       } catch (error) {
         console.error("Error initializing session:", error);
         console.log("Session restoration failed, clearing any corrupted session data...");
@@ -113,7 +132,12 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
     };
 
     initializeSession();
-  }, [showToast]);
+
+    return cleanupListeners;
+  // showToast is intentionally excluded: we access it via showToastRef to keep
+  // this effect stable and prevent duplicate listener registration on re-renders.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Validate session when user returns to the tab
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixed a race condition where the "Your Solid session has expired" toast incorrectly appeared when users intentionally clicked Logout. The bug was a result of duplicate event listeners being registered due to React StrictMode's mount→cleanup→remount cycle.

## Root Cause

The `setupSessionEventListeners` function had no cleanup, causing React StrictMode to leave both listener invocations active. During logout, the first listener correctly suppressed the toast but reset the flag, allowing the second listener to show it.

## Changes

- Added cleanup function to `setupSessionEventListeners` that calls `.off()` for each listener
- Registered listeners synchronously (before async init) so cleanup is available immediately for StrictMode
- Used `showToastRef` instead of `showToast` dependency to prevent effect re-registration

## Testing

All 103 tests pass including new unit tests for SolidPodContext. Verified in browser: intentional logout shows no toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)