### PR TITLE
Fix modal order: success modal before Solid Pod upsell (#63)

### DIFF
--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -87,4 +87,54 @@ describe('Wizard', () => {
         await waitFor(() => screen.getByRole('button', { name: /generate/i }))
         expect(screen.queryByText(/you already have packing list questions set up/i)).toBeNull()
     })
+
+    it('shows success modal but not pod prompt immediately after generation succeeds', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseWizardGeneration.mockReturnValue({
+            isLoading: false,
+            isSuccess: true,
+            generateAndSave: vi.fn(),
+        })
+
+        render(
+            <MemoryRouter>
+                <Wizard />
+            </MemoryRouter>
+        )
+
+        await waitFor(() =>
+            expect(screen.getByText(/questions generated successfully/i)).toBeTruthy()
+        )
+        expect(screen.queryByText(/great! your questions are ready/i)).toBeNull()
+    })
+
+    it('shows pod prompt only after a success modal CTA is clicked', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseWizardGeneration.mockReturnValue({
+            isLoading: false,
+            isSuccess: true,
+            generateAndSave: vi.fn(),
+        })
+        localStorage.removeItem('wizard-pod-prompt-dismissed')
+
+        const { getByRole } = render(
+            <MemoryRouter>
+                <Wizard />
+            </MemoryRouter>
+        )
+
+        await waitFor(() =>
+            expect(screen.getByText(/questions generated successfully/i)).toBeTruthy()
+        )
+        expect(screen.queryByText(/great! your questions are ready/i)).toBeNull()
+
+        const createListBtn = getByRole('button', { name: /create my first packing list/i })
+        createListBtn.click()
+
+        await waitFor(() =>
+            expect(screen.getByText(/great! your questions are ready/i)).toBeTruthy()
+        )
+    })
 })

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -18,6 +18,8 @@ export const Wizard = () => {
     const navigate = useNavigate()
     const [showConfirmDialog, setShowConfirmDialog] = useState(false)
     const [showPodPrompt, setShowPodPrompt] = useState(false)
+    const [showSuccessModal, setShowSuccessModal] = useState(false)
+    const [pendingNavRoute, setPendingNavRoute] = useState<string | null>(null)
     const [hasExistingData, setHasExistingData] = useState(false)
     const { isLoggedIn } = useSolidPod()
     const { db } = useDatabase()
@@ -53,15 +55,31 @@ export const Wizard = () => {
         checkExistingData()
     }, [db])
 
-    // Show Solid Pod prompt after successful generation if not logged in
+    // Open success modal when generation completes
     useEffect(() => {
-        if (isSuccess && !isLoggedIn) {
-            const hasPromptBeenDismissed = localStorage.getItem(WIZARD_POD_PROMPT_KEY) === 'true'
-            if (!hasPromptBeenDismissed) {
+        if (isSuccess) setShowSuccessModal(true)
+    }, [isSuccess])
+
+    const handleSuccessAction = (route: string) => {
+        setShowSuccessModal(false)
+        if (!isLoggedIn) {
+            const dismissed = localStorage.getItem(WIZARD_POD_PROMPT_KEY) === 'true'
+            if (!dismissed) {
+                setPendingNavRoute(route)
                 setShowPodPrompt(true)
+                return
             }
         }
-    }, [isSuccess, isLoggedIn])
+        navigate(route)
+    }
+
+    const handlePodPromptClose = () => {
+        setShowPodPrompt(false)
+        if (pendingNavRoute) {
+            navigate(pendingNavRoute)
+            setPendingNavRoute(null)
+        }
+    }
 
     const onSubmit = async (data: WizardFormData) => {
         if (hasExistingData) {
@@ -260,7 +278,7 @@ Are you sure you want to continue?"
 
             {/* Success Modal */}
             <Modal
-                isOpen={isSuccess}
+                isOpen={showSuccessModal}
                 onClose={() => {}}
                 title="🎉 Questions Generated Successfully!"
             >
@@ -271,14 +289,14 @@ Are you sure you want to continue?"
 
                     <div className="space-y-4">
                         <button
-                            onClick={() => navigate('/create-packing-list')}
+                            onClick={() => handleSuccessAction('/create-packing-list')}
                             className="w-full bg-gradient-primary text-white px-6 py-4 rounded-xl font-bold text-lg hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
                         >
                             🚀 Create My First Packing List
                         </button>
 
                         <button
-                            onClick={() => navigate('/manage-questions')}
+                            onClick={() => handleSuccessAction('/manage-questions')}
                             className="w-full bg-gradient-secondary text-white px-6 py-4 rounded-xl font-bold text-lg hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-secondary"
                         >
                             ✏️ Refine My Packing List Questions
@@ -294,7 +312,7 @@ Are you sure you want to continue?"
             {/* Solid Pod Onboarding Prompt */}
             <SolidPodPrompt
                 isOpen={showPodPrompt}
-                onClose={() => setShowPodPrompt(false)}
+                onClose={handlePodPromptClose}
                 title="🎉 Great! Your Questions Are Ready"
                 message="Want to keep your personalized packing questions safe and accessible from any device? Set up a Solid Pod to store your data securely in personal storage that you control."
                 dismissalKey={WIZARD_POD_PROMPT_KEY}


### PR DESCRIPTION
Fixes #63. After question generation, the Solid Pod upsell was immediately appearing on top of the success modal, obscuring the primary CTAs ("Create My First Packing List" / "Refine My Questions").

The success modal now fully owns the screen first. The pod prompt only appears after the user clicks one of the CTAs, and then navigates to their chosen route once the pod prompt is dismissed. Two new tests cover the corrected sequencing.