### PR TITLE
Show banner when packed items are hidden (fixes #65)

### DIFF
--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { ViewPackingList } from './view-packing-list'
+import type { PackingAppDatabase } from '../services/database'
+
+vi.mock('../components/DatabaseContext', () => ({
+    useDatabase: vi.fn(),
+}))
+
+vi.mock('../components/SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+vi.mock('../components/ToastContext', () => ({
+    useToast: vi.fn(() => ({ showToast: vi.fn() })),
+}))
+
+vi.mock('../hooks/usePodSync', () => ({
+    usePodSync: vi.fn(),
+}))
+
+vi.mock('../hooks/useSyncCoordinator', () => ({
+    useSyncCoordinator: vi.fn(),
+}))
+
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+import { usePodSync } from '../hooks/usePodSync'
+import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
+
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockUsePodSync = vi.mocked(usePodSync)
+const mockUseSyncCoordinator = vi.mocked(useSyncCoordinator)
+
+const testPackingList = {
+    id: 'test-list-1',
+    name: 'Test Trip',
+    createdAt: '2026-01-01T00:00:00Z',
+    items: [
+        {
+            id: 'item-1',
+            itemText: 'Passport',
+            personName: 'Alice',
+            personId: 'p1',
+            questionId: 'q1',
+            optionId: 'o1',
+            packed: false,
+        },
+    ],
+}
+
+function makeDb() {
+    return {
+        getPackingList: vi.fn().mockResolvedValue(testPackingList),
+        savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+    }
+}
+
+function renderComponent() {
+    return render(
+        <MemoryRouter initialEntries={['/view-list/test-list-1']}>
+            <Routes>
+                <Route path="/view-list/:id" element={<ViewPackingList />} />
+            </Routes>
+        </MemoryRouter>
+    )
+}
+
+describe('ViewPackingList hidden items banner', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({
+            saveToPod: vi.fn(),
+        })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('does not show the hidden items banner when no items are checked', async () => {
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        expect(screen.queryByText(/item.* hidden/i)).toBeNull()
+    })
+
+    it('shows the hidden items banner when an item is checked', async () => {
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('checkbox'))
+
+        await waitFor(() => {
+            expect(screen.getByText(/item.* hidden/i)).toBeTruthy()
+        })
+    })
+
+    it('hides the banner when "Show Packed" is clicked', async () => {
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('checkbox'))
+
+        await waitFor(() => expect(screen.getByText(/item.* hidden/i)).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /show packed/i }))
+
+        expect(screen.queryByText(/item.* hidden/i)).toBeNull()
+    })
+
+    it('uses primary button variant for "Show Packed" when items are hidden', async () => {
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('checkbox'))
+
+        await waitFor(() => {
+            const showPackedBtn = screen.getByRole('button', { name: /show packed/i })
+            expect(showPackedBtn.className).toContain('bg-gradient-primary')
+        })
+    })
+})

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -320,6 +320,10 @@ export function ViewPackingList() {
         return !watchedItems[item.id]
     })
 
+    const hiddenPackedCount = !showPacked
+        ? packingList.items.filter(item => watchedItems[item.id]).length
+        : 0
+
     return (
         <div className="w-full flex flex-col items-center py-8 px-4">
             {/* Sticky top toolbar */}
@@ -362,7 +366,7 @@ export function ViewPackingList() {
                             <div className="flex flex-wrap items-center gap-2">
                                 <Button
                                     type="button"
-                                    variant="secondary"
+                                    variant={hiddenPackedCount > 0 ? 'primary' : 'secondary'}
                                     onClick={() => setShowPacked(!showPacked)}
                                 >
                                     {showPacked ? 'Hide Packed' : 'Show Packed'}
@@ -384,6 +388,17 @@ export function ViewPackingList() {
                     </div>
                 </div>
             </div>
+
+            {/* Hidden packed items banner */}
+            {hiddenPackedCount > 0 && (
+                <div className="w-full max-w-screen-2xl mb-4">
+                    <div className="bg-amber-50 border border-amber-200 rounded-xl px-4 py-3">
+                        <p className="text-sm text-amber-800">
+                            {hiddenPackedCount} packed item{hiddenPackedCount !== 1 ? 's' : ''} hidden — tap <strong>Show Packed</strong> to see them.
+                        </p>
+                    </div>
+                </div>
+            )}
 
             {/* Main content */}
             <div className="w-full">


### PR DESCRIPTION
When a user ticks an item it silently disappears, causing first-time users to think they've lost data. This adds an amber banner below the toolbar that appears whenever packed items are hidden, explaining the behaviour and prompting the user to click "Show Packed". The "Show Packed" button also switches to the primary (highlighted) variant when there are hidden items so it is easier to spot. New tests cover all four banner states.

Closes #65