### PR TITLE
Fix truncated Toddler/Baby age range labels in dropdown

### DIFF
--- a/src/edit-questions/types.test.ts
+++ b/src/edit-questions/types.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { AGE_RANGE_OPTIONS } from './types'
+
+describe('AGE_RANGE_OPTIONS', () => {
+  it('all option labels fit within 40 characters for mobile display', () => {
+    AGE_RANGE_OPTIONS.forEach(opt => {
+      expect(opt.label.length).toBeLessThanOrEqual(40)
+    })
+  })
+
+  it('Toddler label still mentions pull-ups', () => {
+    const toddler = AGE_RANGE_OPTIONS.find(o => o.value === 'Toddler')!
+    expect(toddler.label).toContain('pull-ups')
+  })
+
+  it('Baby label still mentions nappies', () => {
+    const baby = AGE_RANGE_OPTIONS.find(o => o.value === 'Baby')!
+    expect(baby.label).toContain('nappies')
+  })
+})

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -6,8 +6,8 @@ export type AgeRange = z.infer<typeof AgeRangeSchema>
 
 // Age range options for dropdowns with descriptions
 export const AGE_RANGE_OPTIONS = [
-  { value: 'Baby' as const, label: '👶 Baby (0-1) - nappies, wipes, change mat' },
-  { value: 'Toddler' as const, label: '🧒 Toddler (1-3) - potty, pull-ups, extra clothes' },
+  { value: 'Baby' as const, label: '👶 Baby (0-1) - nappies & wipes' },
+  { value: 'Toddler' as const, label: '🧒 Toddler (1-3) - potty & pull-ups' },
   { value: 'Child' as const, label: '👧 Child (3-12)' },
   { value: 'Teenager' as const, label: '👦 Teenager (12-17)' },
   { value: 'Adult' as const, label: '🧑 Adult (18+)' }


### PR DESCRIPTION
Fixes #66. The Baby and Toddler age range option labels were too long to display without truncation on narrow mobile screens, where native `<select>` dropdowns are constrained to the element width.

Shortened the labels to fit within ~36 characters while retaining the key descriptive terms (nappies, pull-ups). Added a test suite for `AGE_RANGE_OPTIONS` to enforce the 40-char limit going forward.