### PR TITLE
Add confirmation dialog before deleting a packing list item

### DIFF
--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -69,6 +69,78 @@ function renderComponent() {
     )
 }
 
+describe('ViewPackingList item deletion confirmation', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({
+            saveToPod: vi.fn(),
+        })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('does not immediately delete item when X is clicked', async () => {
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(screen.getByTitle('Delete item'))
+
+        expect(screen.getByText('Passport')).toBeTruthy()
+    })
+
+    it('shows confirmation dialog when X is clicked', async () => {
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(screen.getByTitle('Delete item'))
+
+        expect(screen.getByText('Are you sure you want to remove this item?')).toBeTruthy()
+    })
+
+    it('does not delete item when Cancel is clicked in confirmation dialog', async () => {
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(screen.getByTitle('Delete item'))
+        fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+        expect(screen.getByText('Passport')).toBeTruthy()
+        expect(screen.queryByText('Are you sure you want to remove this item?')).toBeNull()
+    })
+
+    it('deletes item when Remove is clicked in confirmation dialog', async () => {
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(screen.getByTitle('Delete item'))
+        fireEvent.click(screen.getByRole('button', { name: /^remove$/i }))
+
+        await waitFor(() => {
+            expect(screen.queryByText('Passport')).toBeNull()
+        })
+    })
+})
+
 describe('ViewPackingList hidden items banner', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -4,6 +4,7 @@ import { useDebouncedCallback } from 'use-debounce'
 import { PackingList } from '../create-packing-list/types'
 import { useDatabase } from '../components/DatabaseContext'
 import { Button } from '../components/Button'
+import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { useForm, useWatch } from 'react-hook-form'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
@@ -24,6 +25,7 @@ export function ViewPackingList() {
     const [showPacked, setShowPacked] = useState(false)
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
     const [newItemInputs, setNewItemInputs] = useState<Record<string, string>>({})
+    const [itemToDelete, setItemToDelete] = useState<string | null>(null)
     const { isLoggedIn } = useSolidPod()
     const { showToast } = useToast()
     const { db } = useDatabase()
@@ -325,6 +327,7 @@ export function ViewPackingList() {
         : 0
 
     return (
+        <>
         <div className="w-full flex flex-col items-center py-8 px-4">
             {/* Sticky top toolbar */}
             <div className="sticky top-0 z-50 w-full mb-6 flex justify-center">
@@ -436,7 +439,7 @@ export function ViewPackingList() {
                                                     </label>
                                                     <button
                                                         type="button"
-                                                        onClick={() => handleDeleteItem(item.id)}
+                                                        onClick={() => setItemToDelete(item.id)}
                                                         className="ml-2 text-red-600 hover:text-red-800 hover:bg-red-50 rounded-md p-1 transition-colors"
                                                         title="Delete item"
                                                     >
@@ -480,5 +483,15 @@ export function ViewPackingList() {
                 </div>
             </div>
         </div>
+        <ConfirmationDialog
+            isOpen={itemToDelete !== null}
+            onClose={() => setItemToDelete(null)}
+            onConfirm={() => { handleDeleteItem(itemToDelete!); setItemToDelete(null) }}
+            title="Remove item"
+            message="Are you sure you want to remove this item?"
+            confirmText="Remove"
+            confirmVariant="danger"
+        />
+        </>
     )
 }


### PR DESCRIPTION
## What this PR does

Fixes #67. Items in a packing list could be permanently deleted with a single misclick on the red X button. This PR intercepts the click and shows a \"Remove item\" confirmation dialog (using the existing `ConfirmationDialog` component) before the deletion proceeds.

## Manual testing steps

1. Open a packing list with at least one item.
2. Click the red X next to any item.
3. Verify a confirmation dialog appears asking \"Are you sure you want to remove this item?\".
4. Click **Cancel** — confirm the item is still present.
5. Click the X again, then click **Remove** — confirm the item is deleted.