### PR TITLE
Add strikethrough styling to checked packing list items

### DIFF
--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -142,3 +142,52 @@ describe('ViewPackingList hidden items banner', () => {
         })
     })
 })
+
+describe('ViewPackingList checked item styling', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({
+            saveToPod: vi.fn(),
+        })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('applies strikethrough styling to item text when checked', async () => {
+        renderComponent()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        // Enable "Show Packed" so the item remains visible after checking
+        fireEvent.click(screen.getByRole('button', { name: /show packed/i }))
+        fireEvent.click(screen.getByRole('checkbox'))
+
+        await waitFor(() => {
+            const span = screen.getByText('Passport')
+            expect(span.className).toContain('line-through')
+        })
+    })
+
+    it('does not apply strikethrough styling when item is unchecked', async () => {
+        renderComponent()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        const span = screen.getByText('Passport')
+        expect(span.className).not.toContain('line-through')
+    })
+})

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -430,7 +430,7 @@ export function ViewPackingList() {
                                                             {...register(`items.${item.id}`)}
                                                             className="h-5 w-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
                                                         />
-                                                        <span className="text-gray-700">
+                                                        <span className={watchedItems[item.id] ? 'text-gray-400 line-through' : 'text-gray-700'}>
                                                             {item.itemText}
                                                         </span>
                                                     </label>


### PR DESCRIPTION
## What this PR does

Fixes #69. When a packing list item is checked, its text now renders with a strikethrough and muted grey colour (`line-through text-gray-400`), making packed vs unpacked items visually distinct at a glance — especially useful on long lists.

## Manual testing steps

1. Open a packing list with at least one item.
2. Enable **Show Packed** so items remain visible after checking.
3. Check an item — verify the text gains a strikethrough and turns grey.
4. Uncheck the item — verify the text returns to normal styling.