### PR TITLE
Add confirmation dialog before deleting a packing list (#68)

### DIFF
--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { PackingLists } from './packing-lists'
+import type { PackingAppDatabase } from '../services/database'
 
 vi.mock('../components/DatabaseContext', () => ({
     useDatabase: vi.fn(),
@@ -71,12 +72,12 @@ describe('PackingLists delete confirmation', () => {
             isLoading: false,
             login: vi.fn(),
             logout: vi.fn(),
-        } as any)
+        })
     })
 
     it('does not delete immediately when Delete is clicked', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db } as any)
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
         renderComponent()
 
@@ -89,7 +90,7 @@ describe('PackingLists delete confirmation', () => {
 
     it('shows a confirmation dialog with the list name when Delete is clicked', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db } as any)
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
         renderComponent()
 
@@ -105,7 +106,7 @@ describe('PackingLists delete confirmation', () => {
 
     it('cancels deletion when Cancel is clicked in the dialog', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db } as any)
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
         renderComponent()
 
@@ -125,7 +126,7 @@ describe('PackingLists delete confirmation', () => {
 
     it('deletes the list when confirmed in the dialog', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db } as any)
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
         renderComponent()
 

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { PackingLists } from './packing-lists'
+
+vi.mock('../components/DatabaseContext', () => ({
+    useDatabase: vi.fn(),
+}))
+
+vi.mock('../components/SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+vi.mock('../components/ToastContext', () => ({
+    useToast: vi.fn(() => ({ showToast: vi.fn() })),
+}))
+
+vi.mock('../hooks/usePodErrorHandler', () => ({
+    usePodErrorHandler: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('../services/solidPod', () => ({
+    getPrimaryPodUrl: vi.fn(),
+    saveMultipleFilesToPod: vi.fn(),
+    loadMultipleFilesFromPod: vi.fn(),
+    POD_CONTAINERS: { PACKING_LISTS: '/packing-lists/' },
+    POD_ERROR_MESSAGES: {
+        NOT_LOGGED_IN: 'Not logged in',
+        NOT_LOGGED_IN_LOAD: 'Not logged in to load',
+        SAVE_FAILED: 'Save failed',
+        LOAD_FAILED: 'Load failed',
+        NO_DATA_FOUND: (type: string) => `No ${type} found`,
+    },
+}))
+
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+
+const testList = {
+    id: 'list-1',
+    name: 'Summer Holiday',
+    createdAt: '2026-01-01T00:00:00Z',
+    items: [],
+}
+
+function makeDb() {
+    return {
+        getAllPackingLists: vi.fn().mockResolvedValue([testList]),
+        deletePackingList: vi.fn().mockResolvedValue(undefined),
+    }
+}
+
+function renderComponent() {
+    return render(
+        <MemoryRouter>
+            <PackingLists />
+        </MemoryRouter>
+    )
+}
+
+describe('PackingLists delete confirmation', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        } as any)
+    })
+
+    it('does not delete immediately when Delete is clicked', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db } as any)
+
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByText('🗑️ Delete'))
+
+        expect(db.deletePackingList).not.toHaveBeenCalled()
+    })
+
+    it('shows a confirmation dialog with the list name when Delete is clicked', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db } as any)
+
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByText('🗑️ Delete'))
+
+        await waitFor(() => {
+            expect(screen.getByText(/cannot be undone/i)).toBeTruthy()
+            expect(screen.getByText(/Summer Holiday/i, { selector: 'p' })).toBeTruthy()
+        })
+    })
+
+    it('cancels deletion when Cancel is clicked in the dialog', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db } as any)
+
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByText('🗑️ Delete'))
+
+        await waitFor(() => expect(screen.getByText(/cannot be undone/i)).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+        await waitFor(() => {
+            expect(screen.queryByText(/cannot be undone/i)).toBeNull()
+        })
+        expect(db.deletePackingList).not.toHaveBeenCalled()
+    })
+
+    it('deletes the list when confirmed in the dialog', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db } as any)
+
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByText('🗑️ Delete'))
+
+        await screen.findByText(/cannot be undone/i)
+
+        fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+
+        await waitFor(() => {
+            expect(db.deletePackingList).toHaveBeenCalledWith('list-1')
+        })
+    })
+})

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -5,6 +5,7 @@ import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
 import { Button } from '../components/Button'
+import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { SolidPodPrompt } from '../components/SolidPodPrompt'
 import { getPrimaryPodUrl, saveMultipleFilesToPod, loadMultipleFilesFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
@@ -18,6 +19,7 @@ export function PackingLists() {
     const [isLoadingFromPod, setIsLoadingFromPod] = useState(false)
     const [showBanner, setShowBanner] = useState(false)
     const [showPodPrompt, setShowPodPrompt] = useState(false)
+    const [listToDelete, setListToDelete] = useState<{ id: string; name: string } | null>(null)
     const navigate = useNavigate()
     const { isLoggedIn, session } = useSolidPod()
     const { showToast } = useToast()
@@ -34,13 +36,20 @@ export function PackingLists() {
         setShowPodPrompt(true)
     }
 
-    const deletePackingList = async (id: string, event: React.MouseEvent) => {
-        event.stopPropagation() // Prevent navigation when clicking delete
+    const requestDeletePackingList = (id: string, name: string, event: React.MouseEvent) => {
+        event.stopPropagation()
+        setListToDelete({ id, name })
+    }
+
+    const confirmDeletePackingList = async () => {
+        if (!listToDelete) return
         try {
-            await db.deletePackingList(id)
-            setPackingLists(packingLists.filter(list => list.id !== id))
+            await db.deletePackingList(listToDelete.id)
+            setPackingLists(packingLists.filter(list => list.id !== listToDelete.id))
         } catch (err) {
             console.error('Error deleting packing list:', err)
+        } finally {
+            setListToDelete(null)
         }
     }
 
@@ -265,7 +274,7 @@ export function PackingLists() {
                                             📅 {new Date(list.createdAt).toLocaleDateString()}
                                         </span>
                                         <button
-                                            onClick={(e) => deletePackingList(list.id, e)}
+                                            onClick={(e) => requestDeletePackingList(list.id, list.name, e)}
                                             className="text-danger-600 hover:text-danger-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
                                         >
                                             🗑️ Delete
@@ -288,6 +297,17 @@ export function PackingLists() {
                     })}
                 </div>
             )}
+
+            <ConfirmationDialog
+                isOpen={listToDelete !== null}
+                onClose={() => setListToDelete(null)}
+                onConfirm={confirmDeletePackingList}
+                title="Delete List"
+                message={`Are you sure you want to delete "${listToDelete?.name}"? This cannot be undone.`}
+                confirmText="Delete"
+                cancelText="Cancel"
+                confirmVariant="danger"
+            />
 
             {/* Solid Pod Setup Prompt */}
             <SolidPodPrompt


### PR DESCRIPTION
Fixes #68. Clicking the Delete button on a list card previously deleted the entire packing list immediately with no confirmation, making a misclick catastrophic and unrecoverable.

The delete button now opens a `ConfirmationDialog` (reusing the existing component) asking the user to confirm before deletion proceeds. Cancelling leaves the list intact. A new test file covers the no-immediate-delete, dialog-visible, cancel, and confirm flows.