### PR TITLE
Reduce Solid Pod upsell to a single occurrence

### DIFF
--- a/src/pages/edit-questions-form.test.tsx
+++ b/src/pages/edit-questions-form.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { EditQuestionsForm } from './edit-questions-form'
+import type { PackingAppDatabase } from '../services/database'
+
+vi.mock('../components/DatabaseContext', () => ({
+    useDatabase: vi.fn(),
+}))
+
+vi.mock('../components/SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+vi.mock('../components/ToastContext', () => ({
+    useToast: vi.fn(() => ({ showToast: vi.fn() })),
+}))
+
+vi.mock('../hooks/usePodSync', () => ({
+    usePodSync: vi.fn(),
+}))
+
+vi.mock('../hooks/useSyncCoordinator', () => ({
+    useSyncCoordinator: vi.fn(),
+}))
+
+vi.mock('../services/migration', () => ({
+    DatabaseMigration: {
+        checkMigrationNeeded: vi.fn().mockResolvedValue({ needed: false }),
+        performMigration: vi.fn(),
+    },
+}))
+
+vi.mock('../services/solidPod', () => ({
+    POD_CONTAINERS: { ROOT: '/' },
+}))
+
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+import { usePodSync } from '../hooks/usePodSync'
+import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
+
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockUsePodSync = vi.mocked(usePodSync)
+const mockUseSyncCoordinator = vi.mocked(useSyncCoordinator)
+
+const testQuestionSet = {
+    _id: '1',
+    _rev: '1',
+    questions: [],
+    people: [{ id: 'p1', name: 'Me' }],
+    alwaysNeededItems: [],
+}
+
+describe('EditQuestionsForm', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getQuestionSet: vi.fn().mockResolvedValue(testQuestionSet),
+                saveQuestionSet: vi.fn().mockResolvedValue({ rev: '2' }),
+            } as unknown as PackingAppDatabase,
+        })
+
+        mockUsePodSync.mockReturnValue({
+            lastSync: null,
+            isSyncing: false,
+            error: null,
+            saveToPod: vi.fn(),
+        })
+
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn(),
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('does not show Store in Your Pod sidebar box for non-logged-in users', async () => {
+        render(
+            <MemoryRouter>
+                <EditQuestionsForm />
+            </MemoryRouter>
+        )
+
+        await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull())
+        expect(screen.queryByText(/Store in Your Pod/i)).toBeNull()
+    })
+})

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -613,7 +613,7 @@ export function EditQuestionsForm() {
               </div>
             </div>
 
-            {isLoggedIn ? (
+            {isLoggedIn && (
               <>
                 {/* Pod Sync Status */}
                 <div className="bg-gray-50 border border-gray-200 rounded-md p-3">
@@ -642,12 +642,6 @@ export function EditQuestionsForm() {
                   )}
                 </div>
               </>
-            ) : (
-              <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
-                <p className="text-xs text-gray-700 font-semibold mb-1">💡 Store in Your Pod</p>
-                <p className="text-xs text-gray-600 mb-2">Login with Solid Pod to save your questions privately in storage you control.</p>
-                <p className="text-xs text-blue-600">→ Click "Login with Solid Pod" above</p>
-              </div>
             )}
             <Button
               type="button"
@@ -732,12 +726,6 @@ export function EditQuestionsForm() {
                     </p>
                   </div>
                 </div>
-              </div>
-            )}
-
-            {!isLoggedIn && (
-              <div className="bg-blue-50 border border-blue-200 rounded-md p-2 mx-2">
-                <p className="text-xs text-gray-700 font-semibold">💡 Login with Solid Pod to save privately</p>
               </div>
             )}
 

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { PackingLists } from './packing-lists'
+import type { PackingAppDatabase } from '../services/database'
+
+vi.mock('../components/DatabaseContext', () => ({
+    useDatabase: vi.fn(),
+}))
+
+vi.mock('../components/SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+vi.mock('../components/ToastContext', () => ({
+    useToast: vi.fn(() => ({ showToast: vi.fn() })),
+}))
+
+vi.mock('../hooks/usePodErrorHandler', () => ({
+    usePodErrorHandler: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('../services/solidPod', () => ({
+    getPrimaryPodUrl: vi.fn(),
+    saveMultipleFilesToPod: vi.fn(),
+    loadMultipleFilesFromPod: vi.fn(),
+    POD_CONTAINERS: { PACKING_LISTS: '/packing-lists/' },
+    POD_ERROR_MESSAGES: {
+        NOT_LOGGED_IN: 'Not logged in',
+        NOT_LOGGED_IN_LOAD: 'Not logged in to load',
+        SAVE_FAILED: 'Save failed',
+        LOAD_FAILED: 'Load failed',
+        NO_DATA_FOUND: (t: string) => `No ${t} found`,
+    },
+}))
+
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+
+const testPackingList = {
+    id: 'list-1',
+    name: 'Beach Trip',
+    createdAt: '2026-01-01T00:00:00Z',
+    items: [{ id: 'i1', itemText: 'Sunscreen', personName: 'Me', personId: 'p1', questionId: 'q1', optionId: 'o1', packed: false }],
+}
+
+describe('PackingLists', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn().mockResolvedValue([testPackingList]),
+                deletePackingList: vi.fn(),
+                savePackingList: vi.fn(),
+            } as unknown as PackingAppDatabase,
+        })
+        localStorage.clear()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('does not show Protect Your Packing Lists banner for non-logged-in users with lists', async () => {
+        render(
+            <MemoryRouter>
+                <PackingLists />
+            </MemoryRouter>
+        )
+
+        await waitFor(() => expect(screen.getByText(/Beach Trip/)).toBeTruthy())
+        expect(screen.queryByText(/Protect Your Packing Lists/i)).toBeNull()
+    })
+})

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -5,34 +5,19 @@ import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
 import { Button } from '../components/Button'
-import { SolidPodPrompt } from '../components/SolidPodPrompt'
 import { getPrimaryPodUrl, saveMultipleFilesToPod, loadMultipleFilesFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
-
-const PACKING_LISTS_BANNER_KEY = 'packing-lists-pod-banner-dismissed'
 
 export function PackingLists() {
     const [packingLists, setPackingLists] = useState<PackingList[]>([])
     const [isLoading, setIsLoading] = useState(true)
     const [isSaving, setIsSaving] = useState(false)
     const [isLoadingFromPod, setIsLoadingFromPod] = useState(false)
-    const [showBanner, setShowBanner] = useState(false)
-    const [showPodPrompt, setShowPodPrompt] = useState(false)
     const navigate = useNavigate()
     const { isLoggedIn, session } = useSolidPod()
     const { showToast } = useToast()
     const { db } = useDatabase()
     const handlePodError = usePodErrorHandler()
-
-    const handleBannerDismiss = () => {
-        localStorage.setItem(PACKING_LISTS_BANNER_KEY, 'true')
-        setShowBanner(false)
-    }
-
-    const handleBannerSetup = () => {
-        setShowBanner(false)
-        setShowPodPrompt(true)
-    }
 
     const deletePackingList = async (id: string, event: React.MouseEvent) => {
         event.stopPropagation() // Prevent navigation when clicking delete
@@ -126,15 +111,6 @@ export function PackingLists() {
             try {
                 const lists = await db.getAllPackingLists()
                 setPackingLists(lists)
-
-                // Show banner if:
-                // 1. User is not logged in
-                // 2. User has packing lists
-                // 3. Banner hasn't been dismissed
-                const hasBannerBeenDismissed = localStorage.getItem(PACKING_LISTS_BANNER_KEY) === 'true'
-                if (!isLoggedIn && lists.length > 0 && !hasBannerBeenDismissed) {
-                    setShowBanner(true)
-                }
             } catch (err) {
                 console.error('Error fetching packing lists:', err)
             } finally {
@@ -183,52 +159,6 @@ export function PackingLists() {
                     )}
                 </div>
             </div>
-
-            {/* Solid Pod Banner for non-logged-in users */}
-            {showBanner && (
-                <div className="mb-6 bg-gradient-to-r from-amber-50 to-orange-50 border-2 border-amber-300 rounded-2xl shadow-soft p-5 animate-fade-in">
-                    <div className="flex items-start justify-between gap-4">
-                        <div className="flex-1">
-                            <h3 className="text-lg font-bold text-amber-900 mb-2 flex items-center gap-2">
-                                <span className="text-2xl">⚠️</span>
-                                Protect Your Packing Lists
-                            </h3>
-                            <p className="text-amber-800 mb-3 leading-relaxed">
-                                You have <strong>{packingLists.length} packing list{packingLists.length !== 1 ? 's' : ''}</strong> stored locally.
-                                They could be lost if you clear your browser data or switch devices.
-                                Secure them with a Solid Pod for multi-device access and peace of mind!
-                            </p>
-                            <div className="flex gap-3">
-                                <Button
-                                    type="button"
-                                    onClick={handleBannerSetup}
-                                    variant="primary"
-                                    className="text-sm"
-                                >
-                                    🔒 Secure My Data Now
-                                </Button>
-                                <Button
-                                    type="button"
-                                    onClick={handleBannerDismiss}
-                                    variant="ghost"
-                                    className="text-sm"
-                                >
-                                    Dismiss
-                                </Button>
-                            </div>
-                        </div>
-                        <button
-                            onClick={handleBannerDismiss}
-                            className="text-amber-600 hover:text-amber-800 transition-colors"
-                            aria-label="Close banner"
-                        >
-                            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-            )}
 
             {packingLists.length === 0 ? (
                 <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
@@ -289,14 +219,6 @@ export function PackingLists() {
                 </div>
             )}
 
-            {/* Solid Pod Setup Prompt */}
-            <SolidPodPrompt
-                isOpen={showPodPrompt}
-                onClose={() => setShowPodPrompt(false)}
-                title="🔒 Secure Your Packing Lists"
-                message="Protect your valuable packing lists from being lost! Set up a Solid Pod to store your data securely in personal storage that you control, accessible from any device."
-                dismissalKey={PACKING_LISTS_BANNER_KEY}
-            />
         </div>
     )
 } 

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -215,6 +215,41 @@ describe('ViewPackingList hidden items banner', () => {
     })
 })
 
+describe('ViewPackingList Solid Pod inline box', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({
+            saveToPod: vi.fn(),
+        })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('does not show Login with Solid Pod inline box', async () => {
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        expect(screen.queryByText(/Login with Solid Pod to save your packing list/i)).toBeNull()
+    })
+})
+
 describe('ViewPackingList checked item styling', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -383,11 +383,6 @@ export function ViewPackingList() {
                                 </Button>
                             </div>
                         </div>
-                        {!isLoggedIn && (
-                            <div className="mt-2 bg-blue-50 border border-blue-200 rounded-md p-2">
-                                <p className="text-xs text-gray-700">💡 Login with Solid Pod to save your packing list privately in storage you control.</p>
-                            </div>
-                        )}
                     </div>
                 </div>
             </div>

--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -117,7 +117,7 @@ describe('Wizard', () => {
             isSuccess: true,
             generateAndSave: vi.fn(),
         })
-        localStorage.removeItem('wizard-pod-prompt-dismissed')
+        localStorage.removeItem('solid-pod-upsell-shown')
 
         const { getByRole } = render(
             <MemoryRouter>
@@ -136,5 +136,63 @@ describe('Wizard', () => {
         await waitFor(() =>
             expect(screen.getByText(/great! your questions are ready/i)).toBeTruthy()
         )
+    })
+
+    it('sets solid-pod-upsell-shown global key when pod prompt is dismissed', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseWizardGeneration.mockReturnValue({
+            isLoading: false,
+            isSuccess: true,
+            generateAndSave: vi.fn(),
+        })
+        localStorage.removeItem('solid-pod-upsell-shown')
+
+        const { getByRole } = render(
+            <MemoryRouter>
+                <Wizard />
+            </MemoryRouter>
+        )
+
+        await waitFor(() =>
+            expect(screen.getByText(/questions generated successfully/i)).toBeTruthy()
+        )
+
+        getByRole('button', { name: /create my first packing list/i }).click()
+
+        await waitFor(() =>
+            expect(screen.getByText(/great! your questions are ready/i)).toBeTruthy()
+        )
+
+        getByRole('button', { name: /maybe later/i }).click()
+
+        expect(localStorage.getItem('solid-pod-upsell-shown')).toBe('true')
+    })
+
+    it('does not show pod prompt when solid-pod-upsell-shown is already set', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseWizardGeneration.mockReturnValue({
+            isLoading: false,
+            isSuccess: true,
+            generateAndSave: vi.fn(),
+        })
+        localStorage.setItem('solid-pod-upsell-shown', 'true')
+
+        const { getByRole } = render(
+            <MemoryRouter>
+                <Wizard />
+            </MemoryRouter>
+        )
+
+        await waitFor(() =>
+            expect(screen.getByText(/questions generated successfully/i)).toBeTruthy()
+        )
+
+        getByRole('button', { name: /create my first packing list/i }).click()
+
+        // Give React a chance to update - pod prompt should NOT appear
+        await new Promise(r => setTimeout(r, 50))
+        expect(screen.queryByText(/great! your questions are ready/i)).toBeNull()
     })
 })

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -12,7 +12,7 @@ import { ACTIVITIES, wizardSchema, WizardFormData } from './wizard-types'
 import { useWizardGeneration } from './useWizardGeneration'
 import { AGE_RANGE_OPTIONS } from '../edit-questions/types'
 
-const WIZARD_POD_PROMPT_KEY = 'wizard-pod-prompt-dismissed'
+const SOLID_POD_UPSELL_SHOWN_KEY = 'solid-pod-upsell-shown'
 
 export const Wizard = () => {
     const navigate = useNavigate()
@@ -63,7 +63,7 @@ export const Wizard = () => {
     const handleSuccessAction = (route: string) => {
         setShowSuccessModal(false)
         if (!isLoggedIn) {
-            const dismissed = localStorage.getItem(WIZARD_POD_PROMPT_KEY) === 'true'
+            const dismissed = localStorage.getItem(SOLID_POD_UPSELL_SHOWN_KEY) === 'true'
             if (!dismissed) {
                 setPendingNavRoute(route)
                 setShowPodPrompt(true)
@@ -315,7 +315,7 @@ Are you sure you want to continue?"
                 onClose={handlePodPromptClose}
                 title="🎉 Great! Your Questions Are Ready"
                 message="Want to keep your personalized packing questions safe and accessible from any device? Set up a Solid Pod to store your data securely in personal storage that you control."
-                dismissalKey={WIZARD_POD_PROMPT_KEY}
+                dismissalKey={SOLID_POD_UPSELL_SHOWN_KEY}
             />
         </div>
     )


### PR DESCRIPTION
Fixes #71

## Summary
- Replaced the per-page `wizard-pod-prompt-dismissed` key with a single global `solid-pod-upsell-shown` localStorage key so the wizard modal only ever shows once across the whole app
- Removed the amber "Protect Your Packing Lists" banner and its associated `SolidPodPrompt` modal from the Packing Lists page
- Removed the "💡 Store in Your Pod" sidebar boxes from Edit Questions (both desktop sidebar and mobile bottom bar)
- Removed the "💡 Login with Solid Pod" inline box from the View Packing List toolbar
- The navigation bar "Login with Solid Pod" button remains as the passive touchpoint

## Test plan
- [x] New tests in `wizard.test.tsx`: global key set on dismissal, prompt not shown when key already set
- [x] New test in `view-packing-list.test.tsx`: inline box no longer rendered
- [x] New `packing-lists.test.tsx`: banner no longer rendered
- [x] New `edit-questions-form.test.tsx`: sidebar box no longer rendered
- [x] All 139 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)