### PR TITLE
Group packing list items by category with collapsible sections

### DIFF
--- a/src/create-packing-list/types.ts
+++ b/src/create-packing-list/types.ts
@@ -15,6 +15,7 @@ export interface PackingListItem {
     questionId: string
     optionId: string
     packed: boolean
+    category?: string
 }
 
 export interface PackingListFormData {

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -86,7 +86,8 @@ export function CreatePackingList() {
                             personName,
                             questionId: question.id,
                             optionId: selectedOption.id,
-                            packed: false
+                            packed: false,
+                            category: question.questionType === 'multiple-choice' ? selectedOption.text : question.text,
                         }
                     })
                 })
@@ -108,7 +109,8 @@ export function CreatePackingList() {
                     personName,
                     questionId: 'always-needed',
                     optionId: 'always-needed',
-                    packed: false
+                    packed: false,
+                    category: 'Essentials',
                 }
             })
         })

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -141,6 +141,119 @@ describe('ViewPackingList item deletion confirmation', () => {
     })
 })
 
+const multiCategoryPackingList = {
+    id: 'test-list-2',
+    name: 'Multi Category Trip',
+    createdAt: '2026-01-01T00:00:00Z',
+    items: [
+        { id: 'item-a1', itemText: 'Toothbrush', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', packed: false, category: 'Essentials' },
+        { id: 'item-a2', itemText: 'Tent', personName: 'Alice', personId: 'p1', questionId: 'q2', optionId: 'o2', packed: false, category: 'Hiking' },
+        { id: 'item-a3', itemText: 'Legacy item', personName: 'Alice', personId: 'p1', questionId: 'q3', optionId: 'o3', packed: false },
+        { id: 'item-b1', itemText: 'Nappies', personName: 'Bob', personId: 'p2', questionId: 'q1', optionId: 'o1', packed: false, category: 'Essentials' },
+    ],
+}
+
+function makeDbMultiCategory() {
+    return {
+        getPackingList: vi.fn().mockResolvedValue(multiCategoryPackingList),
+        savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+    }
+}
+
+function renderComponentMultiCategory() {
+    return render(
+        <MemoryRouter initialEntries={['/view-list/test-list-2']}>
+            <Routes>
+                <Route path="/view-list/:id" element={<ViewPackingList />} />
+            </Routes>
+        </MemoryRouter>
+    )
+}
+
+describe('ViewPackingList category grouping', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...multiCategoryPackingList, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDbMultiCategory() as unknown as PackingAppDatabase })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('renders category headings within a person card', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        expect(screen.getAllByRole('button', { name: /Collapse Essentials/i }).length).toBeGreaterThan(0)
+        expect(screen.getByRole('button', { name: /Collapse Hiking/i })).toBeTruthy()
+    })
+
+    it('shows items without category under "Other"', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Legacy item')).toBeTruthy())
+        expect(screen.getByRole('button', { name: /Collapse Other/i })).toBeTruthy()
+    })
+
+    it('items are visible by default', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+    })
+
+    it('collapses a category when its toggle is clicked', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: /Collapse Hiking/i }))
+        expect(screen.queryByText('Tent')).toBeNull()
+    })
+
+    it('re-expands a category when its toggle is clicked again', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: /Collapse Hiking/i }))
+        fireEvent.click(screen.getByRole('button', { name: /Expand Hiking/i }))
+        expect(screen.getByText('Tent')).toBeTruthy()
+    })
+
+    it('shows a "Check all" button per category section', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        // 3 expanded categories (Essentials for Alice, Hiking, Other) plus Essentials for Bob = 4
+        const checkAllButtons = screen.getAllByRole('button', { name: /check all/i })
+        expect(checkAllButtons.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('checking all items in a category makes the hidden-items banner appear', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+        // Click "Check all" for the first Hiking-section "Check all" button
+        const checkAllButtons = screen.getAllByRole('button', { name: /check all/i })
+        fireEvent.click(checkAllButtons[0])
+        await waitFor(() => {
+            expect(screen.getByText(/item.* hidden/i)).toBeTruthy()
+        })
+    })
+
+    it('renders Essentials category independently for each person', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        const essentialsToggles = screen.getAllByRole('button', { name: /Collapse Essentials/i })
+        expect(essentialsToggles.length).toBe(2)
+    })
+})
+
 describe('ViewPackingList hidden items banner', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useDebouncedCallback } from 'use-debounce'
-import { PackingList } from '../create-packing-list/types'
+import { PackingList, PackingListItem } from '../create-packing-list/types'
 import { useDatabase } from '../components/DatabaseContext'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
@@ -16,6 +16,27 @@ type FormData = {
     items: Record<string, boolean>
 }
 
+function groupByCategory(items: PackingListItem[]) {
+    const map = new Map<string, PackingListItem[]>()
+    for (const item of items) {
+        const cat = item.category ?? 'Other'
+        if (!map.has(cat)) map.set(cat, [])
+        map.get(cat)!.push(item)
+    }
+    return [...map.entries()]
+        .sort(([a], [b]) => {
+            if (a === 'Essentials') return -1
+            if (b === 'Essentials') return 1
+            if (a === 'Other') return 1
+            if (b === 'Other') return -1
+            return a.localeCompare(b)
+        })
+        .map(([category, catItems]) => ({
+            category,
+            items: catItems.sort((a, b) => a.itemText.localeCompare(b.itemText)),
+        }))
+}
+
 
 export function ViewPackingList() {
     const { id } = useParams<{ id: string }>()
@@ -26,6 +47,17 @@ export function ViewPackingList() {
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
     const [newItemInputs, setNewItemInputs] = useState<Record<string, string>>({})
     const [itemToDelete, setItemToDelete] = useState<string | null>(null)
+    const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
+
+    const toggleCategory = (key: string) =>
+        setCollapsedCategories(prev => {
+            const next = new Set(prev)
+            next.has(key) ? next.delete(key) : next.add(key)
+            return next
+        })
+
+    const handleCheckAll = (items: PackingListItem[]) =>
+        items.forEach(item => setValue(`items.${item.id}`, true))
     const { isLoggedIn } = useSolidPod()
     const { showToast } = useToast()
     const { db } = useDatabase()
@@ -418,38 +450,70 @@ export function ViewPackingList() {
                         ).sort(([nameA], [nameB]) => nameA.localeCompare(nameB)).map(([personName, items]) => (
                             <div key={personName} className="border border-gray-200 rounded-lg p-4 bg-white shadow-sm">
                                 <h2 className="text-xl font-semibold text-gray-800 mb-4 pb-2 border-b border-gray-200">{personName}'s Items</h2>
-                                <div className="space-y-2">
-                                    {items
-                                        .sort((a, b) => a.itemText.localeCompare(b.itemText))
-                                        .map((item) => (
-                                            <div
-                                                key={`${item.id}-${personName}`}
-                                                className="bg-gray-50 rounded-lg p-3"
-                                            >
-                                                <div className="flex items-center justify-between">
-                                                    <label className="flex items-center space-x-3 cursor-pointer flex-1">
-                                                        <input
-                                                            type="checkbox"
-                                                            {...register(`items.${item.id}`)}
-                                                            className="h-5 w-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
-                                                        />
-                                                        <span className="text-gray-700">
-                                                            {item.itemText}
-                                                        </span>
-                                                    </label>
+                                <div>
+                                    {groupByCategory(items).map(({ category, items: catItems }) => {
+                                        const sectionKey = `${personName}::${category}`
+                                        const isCollapsed = collapsedCategories.has(sectionKey)
+                                        return (
+                                            <div key={sectionKey} className="mb-3">
+                                                <div className="flex items-center justify-between py-1 mb-1">
                                                     <button
                                                         type="button"
-                                                        onClick={() => setItemToDelete(item.id)}
-                                                        className="ml-2 text-red-600 hover:text-red-800 hover:bg-red-50 rounded-md p-1 transition-colors"
-                                                        title="Delete item"
+                                                        aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${category}`}
+                                                        onClick={() => toggleCategory(sectionKey)}
+                                                        className="flex items-center gap-1 text-sm font-semibold text-gray-600 hover:text-gray-900"
                                                     >
-                                                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                                            <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
-                                                        </svg>
+                                                        <span>{isCollapsed ? '▶' : '▼'}</span>
+                                                        <span>{category}</span>
+                                                        <span className="text-xs font-normal text-gray-400 ml-1">({catItems.length})</span>
                                                     </button>
+                                                    {!isCollapsed && (
+                                                        <button
+                                                            type="button"
+                                                            aria-label="Check all"
+                                                            onClick={() => handleCheckAll(catItems)}
+                                                            className="text-xs text-blue-600 hover:text-blue-800"
+                                                        >
+                                                            Check all
+                                                        </button>
+                                                    )}
                                                 </div>
+                                                {!isCollapsed && (
+                                                    <div className="space-y-2">
+                                                        {catItems.map((item) => (
+                                                            <div
+                                                                key={`${item.id}-${personName}`}
+                                                                className="bg-gray-50 rounded-lg p-3"
+                                                            >
+                                                                <div className="flex items-center justify-between">
+                                                                    <label className="flex items-center space-x-3 cursor-pointer flex-1">
+                                                                        <input
+                                                                            type="checkbox"
+                                                                            {...register(`items.${item.id}`)}
+                                                                            className="h-5 w-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+                                                                        />
+                                                                        <span className="text-gray-700">
+                                                                            {item.itemText}
+                                                                        </span>
+                                                                    </label>
+                                                                    <button
+                                                                        type="button"
+                                                                        onClick={() => setItemToDelete(item.id)}
+                                                                        className="ml-2 text-red-600 hover:text-red-800 hover:bg-red-50 rounded-md p-1 transition-colors"
+                                                                        title="Delete item"
+                                                                    >
+                                                                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                                                            <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+                                                                        </svg>
+                                                                    </button>
+                                                                </div>
+                                                            </div>
+                                                        ))}
+                                                    </div>
+                                                )}
                                             </div>
-                                        ))}
+                                        )
+                                    })}
 
                                     {/* Add new item input */}
                                     <div className="mt-4 pt-4 border-t border-gray-200">

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -52,7 +52,7 @@ export function ViewPackingList() {
     const toggleCategory = (key: string) =>
         setCollapsedCategories(prev => {
             const next = new Set(prev)
-            next.has(key) ? next.delete(key) : next.add(key)
+            if (next.has(key)) { next.delete(key) } else { next.add(key) }
             return next
         })
 


### PR DESCRIPTION
## Summary

- Adds `category?: string` to `PackingListItem` (backward compatible — existing lists without the field fall back to "Other")
- Categories are derived at generation time from existing question/option data — no LLM, no manual tagging:
  - Multi-choice questions (activities, weather): `category = option.text` (e.g. "Swimming", "Hiking", "Hot")
  - Single-choice questions (overnight, self-catering): `category = question.text`
  - Always-needed items: `category = 'Essentials'`
  - Works automatically for user-added custom questions and items
- Each person card now shows collapsible category sections with a "▼/▶" toggle and a "Check all" button per section
- Items without a category (manually added inline, or from old lists) appear under "Other"

## Test plan

- [x] All 140 tests passing (`npm test`)
- [ ] Create a packing list with 2+ people and 2+ activities — verify items are grouped by category within each person card
- [ ] Collapse a category — items hidden; expand — items visible again
- [ ] Click "Check all" in a category — all items in that category checked, hidden-items banner appears
- [ ] Load an old list (no `category` on items) — all items appear under "Other", no crash

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)