### PR TITLE
Add progress indicators to packing list view (#72)

### DIFF
--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -250,6 +250,76 @@ describe('ViewPackingList Solid Pod inline box', () => {
     })
 })
 
+const testPackingListWithProgress = {
+    id: 'test-list-progress',
+    name: 'Progress Trip',
+    createdAt: '2026-01-01T00:00:00Z',
+    items: [
+        { id: 'item-1', itemText: 'Passport', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', packed: true },
+        { id: 'item-2', itemText: 'Sunscreen', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o2', packed: false },
+        { id: 'item-3', itemText: 'Hat', personName: 'Bob', personId: 'p2', questionId: 'q2', optionId: 'o1', packed: true },
+        { id: 'item-4', itemText: 'Shoes', personName: 'Bob', personId: 'p2', questionId: 'q2', optionId: 'o2', packed: false },
+    ],
+}
+// Alice: 1/2 packed; Bob: 1/2 packed; Overall: 2/4 packed (50%)
+
+function makeDbWithProgress() {
+    return {
+        getPackingList: vi.fn().mockResolvedValue(testPackingListWithProgress),
+        savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+    }
+}
+
+describe('progress indicators', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingListWithProgress, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDbWithProgress() as unknown as PackingAppDatabase })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function renderProgressComponent() {
+        return render(
+            <MemoryRouter initialEntries={['/view-list/test-list-progress']}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+    }
+
+    it('shows overall packed count and percentage in toolbar', async () => {
+        renderProgressComponent()
+        await waitFor(() => expect(screen.getByText('Sunscreen')).toBeTruthy())
+
+        expect(screen.getByText(/2 \/ 4 packed \(50%\)/)).toBeTruthy()
+    })
+
+    it('shows per-person packed count in each column header', async () => {
+        renderProgressComponent()
+        await waitFor(() => expect(screen.getByText('Sunscreen')).toBeTruthy())
+
+        const badges = screen.getAllByText(/1 \/ 2/)
+        expect(badges.length).toBe(2)
+    })
+})
+
 describe('ViewPackingList checked item styling', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -326,6 +326,17 @@ export function ViewPackingList() {
         ? packingList.items.filter(item => watchedItems[item.id]).length
         : 0
 
+    const totalCount = packingList.items.length
+    const packedCount = packingList.items.filter(item => watchedItems[item.id]).length
+    const percentComplete = totalCount > 0 ? Math.round((packedCount / totalCount) * 100) : 0
+
+    const personStats = packingList.items.reduce((acc, item) => {
+        if (!acc[item.personName]) acc[item.personName] = { packed: 0, total: 0 }
+        acc[item.personName].total++
+        if (watchedItems[item.id]) acc[item.personName].packed++
+        return acc
+    }, {} as Record<string, { packed: number; total: number }>)
+
     return (
         <>
         <div className="w-full flex flex-col items-center py-8 px-4">
@@ -344,6 +355,9 @@ export function ViewPackingList() {
                         <div className="flex flex-wrap items-center justify-between gap-3">
                             <div className="flex items-center gap-3">
                                 <h1 className="text-xl font-bold text-gray-900">{packingList.name}</h1>
+                                <span className="text-sm text-gray-600 font-medium">
+                                    {packedCount} / {totalCount} packed ({percentComplete}%)
+                                </span>
                                 {/* Always reserve space for auto-save status to prevent layout jump */}
                                 <div className={`flex items-center space-x-2 min-w-[120px] transition-opacity duration-200 ${autoSaveStatus === 'idle' ? 'opacity-0' : 'opacity-100'}`}>
                                     {autoSaveStatus === 'saving' && (
@@ -410,9 +424,14 @@ export function ViewPackingList() {
                                 acc[item.personName].push(item);
                                 return acc;
                             }, {} as Record<string, typeof filteredItems>)
-                        ).sort(([nameA], [nameB]) => nameA.localeCompare(nameB)).map(([personName, items]) => (
+                        ).sort(([nameA], [nameB]) => nameA.localeCompare(nameB)).map(([personName, items]) => {
+                            const stats = personStats[personName] ?? { packed: 0, total: 0 }
+                            return (
                             <div key={personName} className="border border-gray-200 rounded-lg p-4 bg-white shadow-sm">
-                                <h2 className="text-xl font-semibold text-gray-800 mb-4 pb-2 border-b border-gray-200">{personName}'s Items</h2>
+                                <h2 className="text-xl font-semibold text-gray-800 mb-4 pb-2 border-b border-gray-200">
+                                    {personName}'s Items
+                                    <span className="ml-2 text-sm font-normal text-gray-500">{stats.packed} / {stats.total}</span>
+                                </h2>
                                 <div className="space-y-2">
                                     {items
                                         .sort((a, b) => a.itemText.localeCompare(b.itemText))
@@ -473,7 +492,7 @@ export function ViewPackingList() {
                                     </div>
                                 </div>
                             </div>
-                        ))}
+                        )})}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Closes #72.

Adds an overall "X / Y packed (Z%)" counter to the sticky toolbar in the packing list view, so users can see progress without leaving the page. Each person's column header now also shows a "packed / total" badge. Both indicators use live form state and update instantly as items are checked.