### PR TITLE
Hide Backups nav link for non-Solid users (#74)

### DIFF
--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -61,4 +61,38 @@ describe('Navigation', () => {
         expect(screen.getAllByText('Reconfigure Questions').length).toBeGreaterThan(0)
         expect(screen.queryByText('Get Started')).toBeNull()
     })
+
+    it('hides Backups link when not logged in', () => {
+        mockUseHasQuestions.mockReturnValue(false)
+
+        render(
+            <MemoryRouter>
+                <Navigation />
+            </MemoryRouter>
+        )
+
+        expect(screen.queryByText('Backups')).toBeNull()
+    })
+
+    it('shows Backups link when logged in', () => {
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: true,
+            sessionExpired: false,
+            clearSessionExpired: vi.fn(),
+            webId: 'https://user.solidpod.example/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseHasQuestions.mockReturnValue(false)
+
+        render(
+            <MemoryRouter>
+                <Navigation />
+            </MemoryRouter>
+        )
+
+        expect(screen.getAllByText('Backups').length).toBeGreaterThan(0)
+    })
 })

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -59,12 +59,14 @@ export const Navigation = () => {
                                     >
                                         View Lists
                                     </Link>
-                                    <Link
-                                        to="/backups"
-                                        className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
-                                    >
-                                        Backups
-                                    </Link>
+                                    {isLoggedIn && (
+                                        <Link
+                                            to="/backups"
+                                            className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
+                                        >
+                                            Backups
+                                        </Link>
+                                    )}
                                 </div>
                             </div>
                         </div>
@@ -159,13 +161,15 @@ export const Navigation = () => {
                         >
                             View Lists
                         </Link>
-                        <Link
-                            to="/backups"
-                            className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
-                            onClick={() => setIsOpen(false)}
-                        >
-                            Backups
-                        </Link>
+                        {isLoggedIn && (
+                            <Link
+                                to="/backups"
+                                className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
+                                onClick={() => setIsOpen(false)}
+                            >
+                                Backups
+                            </Link>
+                        )}
                         {/* Mobile Solid Login/Logout */}
                         <div className="border-t border-white/20 pt-2 mt-2">
                             {isLoggedIn ? (


### PR DESCRIPTION
## What this PR does

The Backups page was a dead end for users not logged in to a Solid Pod, showing only a message with no useful functionality. This PR hides the Backups link in both the desktop and mobile nav when the user is not logged in, removing the confusing dead end entirely.

Closes #74.

## Manual testing steps

1. Open the app without logging in to a Solid Pod — confirm the Backups link is absent from the nav.
2. Log in with a Solid Pod — confirm the Backups link reappears.
3. Check the mobile menu (narrow viewport) for the same behaviour.