### PR TITLE
Fix: always show remove button for all persons in wizard (#76)

### DIFF
--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -169,6 +169,33 @@ describe('Wizard', () => {
         expect(localStorage.getItem('solid-pod-upsell-shown')).toBe('true')
     })
 
+    describe("Who's Packing? - remove person", () => {
+        function renderWizard() {
+            const db = makeDb()
+            mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+            return render(
+                <MemoryRouter>
+                    <Wizard />
+                </MemoryRouter>
+            )
+        }
+
+        it('shows a remove button for the first person even when only one person exists', async () => {
+            renderWizard()
+            const removeBtn = await screen.findByTitle('Remove person')
+            expect(removeBtn).toBeTruthy()
+        })
+
+        it('clicking remove on the only person clears their name field', async () => {
+            renderWizard()
+            const removeBtn = await screen.findByTitle('Remove person')
+            removeBtn.click()
+            await waitFor(() => expect(screen.getByDisplayValue('')).toBeTruthy())
+            // Ensure there is still exactly one person entry
+            expect(screen.getAllByTitle('Remove person')).toHaveLength(1)
+        })
+    })
+
     it('does not show pod prompt when solid-pod-upsell-shown is already set', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -33,7 +33,7 @@ export const Wizard = () => {
         }
     })
 
-    const { fields, append, remove } = useFieldArray({
+    const { fields, append, remove, update } = useFieldArray({
         control,
         name: 'people'
     })
@@ -102,6 +102,8 @@ export const Wizard = () => {
     const handleRemovePerson = (index: number) => {
         if (fields.length > 1) {
             remove(index)
+        } else {
+            update(0, { name: '', ageRange: undefined })
         }
     }
 
@@ -179,18 +181,16 @@ export const Wizard = () => {
                                             )}
                                         </div>
                                     </div>
-                                    {fields.length > 1 && (
-                                        <button
-                                            type="button"
-                                            onClick={() => handleRemovePerson(index)}
-                                            className="mt-8 p-2 text-danger-500 hover:bg-danger-50 rounded-lg transition-colors"
-                                            title="Remove person"
-                                        >
-                                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                                <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
-                                            </svg>
-                                        </button>
-                                    )}
+                                    <button
+                                        type="button"
+                                        onClick={() => handleRemovePerson(index)}
+                                        className="mt-8 p-2 text-danger-500 hover:bg-danger-50 rounded-lg transition-colors"
+                                        title="Remove person"
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                            <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+                                        </svg>
+                                    </button>
                                 </div>
                             </div>
                         ))}


### PR DESCRIPTION
The remove button in the wizard's "Who's Packing?" step was hidden when only one person was in the list, making it impossible to clear the default entry and start fresh. All person entries now always show the remove button. Removing the last remaining person resets their fields to empty rather than dropping below one entry.

Closes #76