### PR TITLE
Reframe wizard as family profile setup and remove activities (#78)

### DIFF
--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -36,7 +36,7 @@ describe('Navigation', () => {
         })
     })
 
-    it('shows "Family Setup" nav link when no questions exist', () => {
+    it('shows "Travel Profile" nav link when no questions exist', () => {
         mockUseHasQuestions.mockReturnValue(false)
 
         render(
@@ -45,7 +45,7 @@ describe('Navigation', () => {
             </MemoryRouter>
         )
 
-        expect(screen.getAllByText('Family Setup').length).toBeGreaterThan(0)
+        expect(screen.getAllByText('Travel Profile').length).toBeGreaterThan(0)
         expect(screen.queryByText('Reconfigure Questions')).toBeNull()
     })
 
@@ -59,7 +59,7 @@ describe('Navigation', () => {
         )
 
         expect(screen.getAllByText('Reconfigure Questions').length).toBeGreaterThan(0)
-        expect(screen.queryByText('Family Setup')).toBeNull()
+        expect(screen.queryByText('Travel Profile')).toBeNull()
     })
 
     it('hides Backups link when not logged in', () => {

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -36,7 +36,7 @@ describe('Navigation', () => {
         })
     })
 
-    it('shows "Get Started" nav link when no questions exist', () => {
+    it('shows "Family Setup" nav link when no questions exist', () => {
         mockUseHasQuestions.mockReturnValue(false)
 
         render(
@@ -45,7 +45,7 @@ describe('Navigation', () => {
             </MemoryRouter>
         )
 
-        expect(screen.getAllByText('Get Started').length).toBeGreaterThan(0)
+        expect(screen.getAllByText('Family Setup').length).toBeGreaterThan(0)
         expect(screen.queryByText('Reconfigure Questions')).toBeNull()
     })
 
@@ -59,7 +59,7 @@ describe('Navigation', () => {
         )
 
         expect(screen.getAllByText('Reconfigure Questions').length).toBeGreaterThan(0)
-        expect(screen.queryByText('Get Started')).toBeNull()
+        expect(screen.queryByText('Family Setup')).toBeNull()
     })
 
     it('hides Backups link when not logged in', () => {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -39,7 +39,7 @@ export const Navigation = () => {
                                         to="/wizard"
                                         className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
                                     >
-                                        {hasQuestions ? 'Reconfigure Questions' : 'Get Started'}
+                                        {hasQuestions ? 'Reconfigure Questions' : 'Family Setup'}
                                     </Link>
                                     <Link
                                         to="/manage-questions"
@@ -138,7 +138,7 @@ export const Navigation = () => {
                             className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                             onClick={() => setIsOpen(false)}
                         >
-                            {hasQuestions ? 'Reconfigure Questions' : 'Get Started'}
+                            {hasQuestions ? 'Reconfigure Questions' : 'Family Setup'}
                         </Link>
                         <Link
                             to="/manage-questions"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -39,7 +39,7 @@ export const Navigation = () => {
                                         to="/wizard"
                                         className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
                                     >
-                                        {hasQuestions ? 'Reconfigure Questions' : 'Family Setup'}
+                                        {hasQuestions ? 'Reconfigure Questions' : 'Travel Profile'}
                                     </Link>
                                     <Link
                                         to="/manage-questions"
@@ -138,7 +138,7 @@ export const Navigation = () => {
                             className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                             onClick={() => setIsOpen(false)}
                         >
-                            {hasQuestions ? 'Reconfigure Questions' : 'Family Setup'}
+                            {hasQuestions ? 'Reconfigure Questions' : 'Travel Profile'}
                         </Link>
                         <Link
                             to="/manage-questions"

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -19,7 +19,7 @@ export function useWizardGeneration() {
             name: p.name,
             ageRange: p.ageRange
         }))
-        return createExampleData(people, data.activities)
+        return createExampleData(people, [])
     }
 
     const generateAndSave = async (data: WizardFormData) => {

--- a/src/pages/wizard-types.ts
+++ b/src/pages/wizard-types.ts
@@ -1,23 +1,11 @@
 import { z } from 'zod'
 import { AgeRangeSchema } from '../edit-questions/types'
-import { ACTIVITY_OPTION_IDS } from '../edit-questions/example-data'
-
-export const ACTIVITIES = [
-    { id: ACTIVITY_OPTION_IDS.swimming, label: 'Swimming (pool)', icon: '🏊' },
-    { id: ACTIVITY_OPTION_IDS.watersports, label: 'Watersports (surfing, kayaking, beach & lake swimming)', icon: '🏄' },
-    { id: ACTIVITY_OPTION_IDS.cycling, label: 'Cycling', icon: '🚴' },
-    { id: ACTIVITY_OPTION_IDS.climbing, label: 'Climbing', icon: '🧗' },
-    { id: ACTIVITY_OPTION_IDS.hiking, label: 'Hiking', icon: '🥾' },
-] as const
-
-export type ActivityId = typeof ACTIVITIES[number]['id']
 
 export const wizardSchema = z.object({
     people: z.array(z.object({
         name: z.string().min(1, 'Name is required'),
         ageRange: AgeRangeSchema.optional()
     })).min(1, 'At least 1 person required').max(10, 'Maximum 10 people allowed'),
-    activities: z.array(z.string())
 })
 
 export type WizardFormData = z.infer<typeof wizardSchema>

--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -84,7 +84,7 @@ describe('Wizard', () => {
             </MemoryRouter>
         )
 
-        await waitFor(() => screen.getByRole('button', { name: /save my family profile/i }))
+        await waitFor(() => screen.getByRole('button', { name: /save my travel profile/i }))
         expect(screen.queryByText(/you already have packing list questions set up/i)).toBeNull()
     })
 
@@ -169,7 +169,7 @@ describe('Wizard', () => {
         expect(localStorage.getItem('solid-pod-upsell-shown')).toBe('true')
     })
 
-    it('shows the family profile heading', async () => {
+    it('shows the travel profile heading', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
@@ -180,7 +180,7 @@ describe('Wizard', () => {
         )
 
         await waitFor(() =>
-            expect(screen.getByText(/set up your family profile/i)).toBeTruthy()
+            expect(screen.getByText(/set up your travel profile/i)).toBeTruthy()
         )
     })
 
@@ -209,11 +209,11 @@ describe('Wizard', () => {
             </MemoryRouter>
         )
 
-        await waitFor(() => screen.getByRole('button', { name: /save my family profile/i }))
+        await waitFor(() => screen.getByRole('button', { name: /save my travel profile/i }))
         expect(screen.queryByText(/what activities are you planning/i)).toBeNull()
     })
 
-    it('submit button says "Save My Family Profile"', async () => {
+    it('submit button says "Save My Travel Profile"', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
@@ -224,7 +224,7 @@ describe('Wizard', () => {
         )
 
         await waitFor(() =>
-            expect(screen.getByRole('button', { name: /save my family profile/i })).toBeTruthy()
+            expect(screen.getByRole('button', { name: /save my travel profile/i })).toBeTruthy()
         )
     })
 

--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -84,7 +84,7 @@ describe('Wizard', () => {
             </MemoryRouter>
         )
 
-        await waitFor(() => screen.getByRole('button', { name: /generate/i }))
+        await waitFor(() => screen.getByRole('button', { name: /save my family profile/i }))
         expect(screen.queryByText(/you already have packing list questions set up/i)).toBeNull()
     })
 
@@ -167,6 +167,65 @@ describe('Wizard', () => {
         getByRole('button', { name: /maybe later/i }).click()
 
         expect(localStorage.getItem('solid-pod-upsell-shown')).toBe('true')
+    })
+
+    it('shows the family profile heading', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        render(
+            <MemoryRouter>
+                <Wizard />
+            </MemoryRouter>
+        )
+
+        await waitFor(() =>
+            expect(screen.getByText(/set up your family profile/i)).toBeTruthy()
+        )
+    })
+
+    it('shows the one-time setup note', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        render(
+            <MemoryRouter>
+                <Wizard />
+            </MemoryRouter>
+        )
+
+        await waitFor(() =>
+            expect(screen.getByText(/you only need to do this once/i)).toBeTruthy()
+        )
+    })
+
+    it('does not render the activities section', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        render(
+            <MemoryRouter>
+                <Wizard />
+            </MemoryRouter>
+        )
+
+        await waitFor(() => screen.getByRole('button', { name: /save my family profile/i }))
+        expect(screen.queryByText(/what activities are you planning/i)).toBeNull()
+    })
+
+    it('submit button says "Save My Family Profile"', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        render(
+            <MemoryRouter>
+                <Wizard />
+            </MemoryRouter>
+        )
+
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: /save my family profile/i })).toBeTruthy()
+        )
     })
 
     describe("Who's Packing? - remove person", () => {

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -110,13 +110,13 @@ export const Wizard = () => {
         <div className="max-w-3xl mx-auto">
             <div className="mb-8 text-center animate-slide-up">
                 <h1 className="text-4xl font-bold mb-4 text-primary-900">
-                    Set Up Your Family Profile
+                    Set Up Your Travel Profile
                 </h1>
                 <p className="text-lg text-gray-700">
                     Tell us who you travel with — we'll use this to personalise your packing lists every time
                 </p>
                 <p className="text-sm text-gray-500 mt-2 italic">
-                    You only need to do this once. You can always update your family profile later.
+                    You only need to do this once. You can always update your travel profile later.
                 </p>
             </div>
 
@@ -232,7 +232,7 @@ export const Wizard = () => {
                         disabled={isLoading}
                         className="px-8 py-4 text-lg"
                     >
-                        {isLoading ? '🔄 Saving...' : '✅ Save My Family Profile'}
+                        {isLoading ? '🔄 Saving...' : '✅ Save My Travel Profile'}
                     </Button>
                 </div>
             </form>

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -8,7 +8,7 @@ import { Modal } from '../components/Modal'
 import { SolidPodPrompt } from '../components/SolidPodPrompt'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useDatabase } from '../components/DatabaseContext'
-import { ACTIVITIES, wizardSchema, WizardFormData } from './wizard-types'
+import { wizardSchema, WizardFormData } from './wizard-types'
 import { useWizardGeneration } from './useWizardGeneration'
 import { AGE_RANGE_OPTIONS } from '../edit-questions/types'
 
@@ -29,7 +29,6 @@ export const Wizard = () => {
         resolver: zodResolver(wizardSchema),
         defaultValues: {
             people: [{ name: 'Me', ageRange: undefined }],
-            activities: []
         }
     })
 
@@ -111,10 +110,13 @@ export const Wizard = () => {
         <div className="max-w-3xl mx-auto">
             <div className="mb-8 text-center animate-slide-up">
                 <h1 className="text-4xl font-bold mb-4 text-primary-900">
-                    Welcome! Let's Get Started
+                    Set Up Your Family Profile
                 </h1>
                 <p className="text-lg text-gray-700">
-                    Answer a few quick questions to set up your personalized packing list
+                    Tell us who you travel with — we'll use this to personalise your packing lists every time
+                </p>
+                <p className="text-sm text-gray-500 mt-2 italic">
+                    You only need to do this once. You can always update your family profile later.
                 </p>
             </div>
 
@@ -222,33 +224,6 @@ export const Wizard = () => {
                     )}
                 </div>
 
-                {/* Activities Section */}
-                <div className="bg-white p-6 rounded-2xl shadow-soft border-2 border-secondary-200">
-                    <h2 className="text-2xl font-bold mb-4 text-secondary-900">🏖️ What Activities Are You Planning?</h2>
-                    <p className="text-sm text-gray-600 mb-4">
-                        Select all activities you're planning — we'll pre-fill your packing list items
-                    </p>
-
-                    <div className="space-y-3">
-                        {ACTIVITIES.map((activity) => (
-                            <label
-                                key={activity.id}
-                                className="flex items-center space-x-3 p-3 rounded-xl hover:bg-secondary-50 transition-colors cursor-pointer"
-                            >
-                                <input
-                                    type="checkbox"
-                                    value={activity.id}
-                                    {...register('activities')}
-                                    className="w-5 h-5 text-secondary-600 rounded focus:ring-2 focus:ring-secondary-500"
-                                />
-                                <span className="text-gray-800 font-medium">
-                                    {activity.icon} {activity.label}
-                                </span>
-                            </label>
-                        ))}
-                    </div>
-                </div>
-
                 {/* Submit Button */}
                 <div className="flex justify-center">
                     <Button
@@ -257,7 +232,7 @@ export const Wizard = () => {
                         disabled={isLoading}
                         className="px-8 py-4 text-lg"
                     >
-                        {isLoading ? '🔄 Generating...' : '✨ Generate My Packing List Questions'}
+                        {isLoading ? '🔄 Saving...' : '✅ Save My Family Profile'}
                     </Button>
                 </div>
             </form>


### PR DESCRIPTION
## What this PR does

Addresses issue #78. The wizard was framed as a per-trip list creation step, confusing users about its purpose. This PR reframes it as a one-time travel profile setup and removes the activities section (activities are trip-specific and already exist in the Create List form).

Changes:
- Nav link: "Get Started" → "Travel Profile"
- Wizard heading/subheading/button updated to reflect travel profile framing
- Added note: "You only need to do this once. You can always update your travel profile later."
- Removed the "What Activities Are You Planning?" section and dropped `activities` from the wizard schema

## Manual testing steps

1. Open the app — confirm the nav shows "Travel Profile" (not "Get Started")
2. Navigate to Travel Profile — confirm heading reads "Set Up Your Travel Profile", the one-time note is visible, and there is no activities section
3. Submit the form — confirm the button reads "Save My Travel Profile" and the flow completes successfully
4. Create a packing list — confirm activities are still present as options there