### PR TITLE
Fix: enforce minimum progress bar width on View Lists page

### DIFF
--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -106,6 +106,78 @@ describe('PackingLists', () => {
     })
 })
 
+describe('PackingLists progress bar minimum width', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+    })
+
+    it('shows at least 4% width when a small number of items are packed', async () => {
+        const items = Array.from({ length: 130 }, (_, i) => ({
+            id: `item-${i}`,
+            itemText: `Item ${i}`,
+            personName: 'Me',
+            personId: 'p1',
+            questionId: 'q1',
+            optionId: 'o1',
+            packed: i === 0, // only 1 of 130 packed → 1%
+        }))
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn().mockResolvedValue([{
+                    id: 'list-1', name: 'Big List', createdAt: '2026-01-01T00:00:00Z', items,
+                }]),
+                deletePackingList: vi.fn(),
+                savePackingList: vi.fn(),
+            } as unknown as PackingAppDatabase,
+        })
+
+        render(<MemoryRouter><PackingLists /></MemoryRouter>)
+
+        await screen.findByText(/Big List/)
+
+        const fill = document.querySelector('[data-testid="progress-fill"]') as HTMLElement
+        expect(fill).not.toBeNull()
+        const width = parseFloat(fill.style.width)
+        expect(width).toBeGreaterThanOrEqual(4)
+    })
+
+    it('shows 0% width when no items are packed', async () => {
+        const items = Array.from({ length: 10 }, (_, i) => ({
+            id: `item-${i}`,
+            itemText: `Item ${i}`,
+            personName: 'Me',
+            personId: 'p1',
+            questionId: 'q1',
+            optionId: 'o1',
+            packed: false,
+        }))
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn().mockResolvedValue([{
+                    id: 'list-2', name: 'Empty Progress', createdAt: '2026-01-01T00:00:00Z', items,
+                }]),
+                deletePackingList: vi.fn(),
+                savePackingList: vi.fn(),
+            } as unknown as PackingAppDatabase,
+        })
+
+        render(<MemoryRouter><PackingLists /></MemoryRouter>)
+
+        await screen.findByText(/Empty Progress/)
+
+        const fill = document.querySelector('[data-testid="progress-fill"]') as HTMLElement
+        expect(fill).not.toBeNull()
+        expect(fill.style.width).toBe('0%')
+    })
+})
+
 describe('PackingLists delete confirmation', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -181,6 +181,7 @@ export function PackingLists() {
                         const packedCount = list.items.filter(item => item.packed).length
                         const totalCount = list.items.length
                         const percentComplete = totalCount > 0 ? Math.round((packedCount / totalCount) * 100) : 0
+                        const displayWidth = packedCount === 0 ? 0 : Math.max(percentComplete, 4)
 
                         // Rotate through gradient colors
                         const gradients = [
@@ -214,8 +215,9 @@ export function PackingLists() {
                                 <div className="flex items-center gap-4">
                                     <div className="flex-1 bg-white/40 rounded-full h-3 overflow-hidden">
                                         <div
+                                            data-testid="progress-fill"
                                             className="bg-gradient-primary h-full transition-all duration-500 rounded-full"
-                                            style={{ width: `${percentComplete}%` }}
+                                            style={{ width: `${displayWidth}%` }}
                                         ></div>
                                     </div>
                                     <span className="text-sm font-bold text-gray-700 bg-white/60 px-3 py-1 rounded-lg">


### PR DESCRIPTION
Closes #80.

The progress bar fill on list cards was rendered at exactly `percentComplete%`, making it nearly invisible at low values (e.g. 1/130 items = 1%). A `displayWidth` variable now clamps the fill to a minimum of 4% whenever at least one item is packed, while zero-packed lists correctly show 0%. Two new tests cover the minimum-width and zero-progress cases.