### PR TITLE
Replace nav login instructions with inline login buttons

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -15,7 +15,7 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
             <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
                 <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={onClose} />
 
-                <div className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+                <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                     <div className="absolute right-0 top-0 pr-4 pt-4">
                         <button
                             type="button"

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -1,6 +1,34 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { deduplicateItems } from './create-packing-list'
 import { PackingListItem } from '../create-packing-list/types'
+
+vi.mock('../components/SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+vi.mock('../components/DatabaseContext', () => ({
+    useDatabase: vi.fn(),
+}))
+
+vi.mock('../components/ToastContext', () => ({
+    useToast: vi.fn(),
+}))
+
+vi.mock('../hooks/useHasQuestions', () => ({
+    useHasQuestions: vi.fn(),
+}))
+
+import { useSolidPod } from '../components/SolidPodContext'
+import { useDatabase } from '../components/DatabaseContext'
+import { useToast } from '../components/ToastContext'
+import { CreatePackingList } from './create-packing-list'
+
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockUseToast = vi.mocked(useToast)
 
 const makeItem = (overrides: Partial<PackingListItem> & { itemText: string; personId: string }): PackingListItem => ({
     id: 'test-id',
@@ -70,5 +98,40 @@ describe('deduplicateItems', () => {
         // total: 4
         const result = deduplicateItems(items)
         expect(result).toHaveLength(4)
+    })
+})
+
+describe('CreatePackingList - login button', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: null } as any)
+        mockUseToast.mockReturnValue({ showToast: vi.fn() } as any)
+    })
+
+    it('shows a "Login with Solid Pod" button in the page when not logged in and no questions found', () => {
+        render(
+            <MemoryRouter>
+                <CreatePackingList />
+            </MemoryRouter>
+        )
+        expect(screen.getByRole('button', { name: /login with solid pod/i })).toBeTruthy()
+    })
+
+    it('opens the provider selector modal when the login button is clicked', () => {
+        render(
+            <MemoryRouter>
+                <CreatePackingList />
+            </MemoryRouter>
+        )
+        const loginButton = screen.getByRole('button', { name: /login with solid pod/i })
+        fireEvent.click(loginButton)
+        expect(screen.getByRole('dialog')).toBeTruthy()
     })
 })

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -24,6 +24,8 @@ vi.mock('../hooks/useHasQuestions', () => ({
 import { useSolidPod } from '../components/SolidPodContext'
 import { useDatabase } from '../components/DatabaseContext'
 import { useToast } from '../components/ToastContext'
+import { ToastType } from '../components/Toast'
+import { PackingAppDatabase } from '../services/database'
 import { CreatePackingList } from './create-packing-list'
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
@@ -111,8 +113,8 @@ describe('CreatePackingList - login button', () => {
             login: vi.fn(),
             logout: vi.fn(),
         })
-        mockUseDatabase.mockReturnValue({ db: null } as any)
-        mockUseToast.mockReturnValue({ showToast: vi.fn() } as any)
+        mockUseDatabase.mockReturnValue({ db: null as unknown as PackingAppDatabase })
+        mockUseToast.mockReturnValue({ showToast: vi.fn() as (message: string, type: ToastType) => void })
     })
 
     it('shows a "Login with Solid Pod" button in the page when not logged in and no questions found', () => {

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -8,6 +8,7 @@ import { Input } from '../components/Input'
 import { Button } from '../components/Button'
 import { useToast } from '../components/ToastContext'
 import { useSolidPod } from '../components/SolidPodContext'
+import { SolidProviderSelector } from '../components/SolidProviderSelector'
 
 export function deduplicateItems(items: PackingListItem[]): PackingListItem[] {
     const seen = new Set<string>()
@@ -25,7 +26,8 @@ export function CreatePackingList() {
     const [noQuestionsFound, setNoQuestionsFound] = useState(false)
     const [selectedPeopleIds, setSelectedPeopleIds] = useState<string[]>([])
     const { showToast } = useToast()
-    const { isLoggedIn } = useSolidPod()
+    const { isLoggedIn, login } = useSolidPod()
+    const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
     const { db } = useDatabase()
     const navigate = useNavigate()
 
@@ -38,6 +40,11 @@ export function CreatePackingList() {
 
     useEffect(() => {
         const fetchQuestionSet = async () => {
+            if (!db) {
+                setNoQuestionsFound(true)
+                setIsLoading(false)
+                return
+            }
             setIsLoading(true)
             try {
                 const doc = await db.getQuestionSet()
@@ -146,60 +153,70 @@ export function CreatePackingList() {
 
     if (noQuestionsFound) {
         return (
-            <div className="max-w-4xl mx-auto py-8 px-4">
-                <div className="mb-8">
-                    <h1 className="text-2xl font-bold text-gray-900">Create New Packing List</h1>
-                    <p className="mt-2 text-gray-600">Let's set up your packing list questions first!</p>
-                </div>
-
-                <div className="bg-white rounded-2xl shadow-soft border-2 border-primary-200 p-8">
-                    <div className="text-center mb-6">
-                        <div className="text-6xl mb-4">📋</div>
-                        <h2 className="text-2xl font-bold text-gray-900 mb-2">No Questions Found</h2>
-                        <p className="text-gray-600">
-                            Before you can create a packing list, you need to set up your packing list questions.
-                        </p>
+            <>
+                <div className="max-w-4xl mx-auto py-8 px-4">
+                    <div className="mb-8">
+                        <h1 className="text-2xl font-bold text-gray-900">Create New Packing List</h1>
+                        <p className="mt-2 text-gray-600">Let's set up your packing list questions first!</p>
                     </div>
 
-                    <div className="space-y-4 max-w-2xl mx-auto">
-                        <div className="bg-gradient-to-br from-primary-50 to-primary-100 p-6 rounded-xl border-2 border-primary-200">
-                            <h3 className="text-lg font-bold text-primary-900 mb-2">✨ Quick Start with Wizard</h3>
-                            <p className="text-gray-700 mb-4">
-                                Answer a few simple questions and we'll generate a personalized question set for you.
+                    <div className="bg-white rounded-2xl shadow-soft border-2 border-primary-200 p-8">
+                        <div className="text-center mb-6">
+                            <div className="text-6xl mb-4">📋</div>
+                            <h2 className="text-2xl font-bold text-gray-900 mb-2">No Questions Found</h2>
+                            <p className="text-gray-600">
+                                Before you can create a packing list, you need to set up your packing list questions.
                             </p>
-                            <Link to="/wizard">
-                                <Button variant="primary" className="w-full">
-                                    Use the Wizard
-                                </Button>
-                            </Link>
                         </div>
 
-                        {!isLoggedIn && (
-                            <div className="bg-gradient-to-br from-accent-50 to-accent-100 p-6 rounded-xl border-2 border-accent-200">
-                                <h3 className="text-lg font-bold text-accent-900 mb-2">🔒 Login to Sync Questions</h3>
+                        <div className="space-y-4 max-w-2xl mx-auto">
+                            <div className="bg-gradient-to-br from-primary-50 to-primary-100 p-6 rounded-xl border-2 border-primary-200">
+                                <h3 className="text-lg font-bold text-primary-900 mb-2">✨ Quick Start with Wizard</h3>
                                 <p className="text-gray-700 mb-4">
-                                    If you've already created questions and saved them to your Solid Pod, login to sync them.
+                                    Answer a few simple questions and we'll generate a personalized question set for you.
                                 </p>
-                                <p className="text-sm text-gray-600">
-                                    Click "Login with Solid Pod" in the navigation bar above to continue.
-                                </p>
+                                <Link to="/wizard">
+                                    <Button variant="primary" className="w-full">
+                                        Use the Wizard
+                                    </Button>
+                                </Link>
                             </div>
-                        )}
 
-                        <div className="bg-gradient-to-br from-secondary-50 to-secondary-100 p-6 rounded-xl border-2 border-secondary-200">
-                            <h3 className="text-lg font-bold text-secondary-900 mb-2">✏️ Create Manually</h3>
-                            <p className="text-gray-700 mb-4">
-                                Prefer full control? Create your packing list questions from scratch.
-                            </p>
-                            <Link to="/manage-questions">
-                                <Button variant="secondary" className="w-full">
-                                    Edit Questions
-                                </Button>
-                            </Link>
+                            {!isLoggedIn && (
+                                <div className="bg-gradient-to-br from-accent-50 to-accent-100 p-6 rounded-xl border-2 border-accent-200">
+                                    <h3 className="text-lg font-bold text-accent-900 mb-2">🔒 Login to Sync Questions</h3>
+                                    <p className="text-gray-700 mb-4">
+                                        If you've already created questions and saved them to your Solid Pod, login to sync them.
+                                    </p>
+                                    <button
+                                        className="text-sm font-semibold text-accent-700 underline hover:text-accent-900"
+                                        onClick={() => setIsProviderSelectorOpen(true)}
+                                    >
+                                        Login with Solid Pod
+                                    </button>
+                                </div>
+                            )}
+
+                            <div className="bg-gradient-to-br from-secondary-50 to-secondary-100 p-6 rounded-xl border-2 border-secondary-200">
+                                <h3 className="text-lg font-bold text-secondary-900 mb-2">✏️ Create Manually</h3>
+                                <p className="text-gray-700 mb-4">
+                                    Prefer full control? Create your packing list questions from scratch.
+                                </p>
+                                <Link to="/manage-questions">
+                                    <Button variant="secondary" className="w-full">
+                                        Edit Questions
+                                    </Button>
+                                </Link>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
+                <SolidProviderSelector
+                    isOpen={isProviderSelectorOpen}
+                    onClose={() => setIsProviderSelectorOpen(false)}
+                    onSelect={(issuer) => login(issuer)}
+                />
+            </>
         )
     }
 

--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { LandingPage } from './landing-page'
@@ -95,5 +95,19 @@ describe('LandingPage', () => {
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         const solidPodHeading = screen.getByRole('heading', { name: /own your data/i })
         expect(solidPodHeading.closest('[class*="bg-primary-950"]')).toBeNull()
+    })
+
+    it('shows a "Login with Solid Pod" button on the page when not logged in', () => {
+        mockUseHasQuestions.mockReturnValue(false)
+        render(<MemoryRouter><LandingPage /></MemoryRouter>)
+        expect(screen.getByRole('button', { name: /login with solid pod/i })).toBeTruthy()
+    })
+
+    it('opens the provider selector modal when the login button is clicked', () => {
+        mockUseHasQuestions.mockReturnValue(false)
+        render(<MemoryRouter><LandingPage /></MemoryRouter>)
+        const loginButton = screen.getByRole('button', { name: /login with solid pod/i })
+        fireEvent.click(loginButton)
+        expect(screen.getByRole('dialog')).toBeTruthy()
     })
 })

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -1,9 +1,12 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useHasQuestions } from '../hooks/useHasQuestions'
+import { SolidProviderSelector } from '../components/SolidProviderSelector'
 
 export const LandingPage = () => {
-    const { isLoggedIn, webId } = useSolidPod()
+    const { isLoggedIn, webId, login } = useSolidPod()
+    const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
     const hasQuestions = useHasQuestions()
     return (
         <>
@@ -106,10 +109,23 @@ export const LandingPage = () => {
                     <h2 className="font-semibold text-gray-600 inline">Own Your Data</h2>
                     {' '}— Login with your Solid Pod to store your lists in personal storage you control.
                     {!isLoggedIn && (
-                        <span className="block mt-1">Click "Login with Solid Pod" above to get started.</span>
+                        <span className="block mt-1">
+                            <button
+                                className="font-semibold text-primary-700 underline hover:text-primary-900"
+                                onClick={() => setIsProviderSelectorOpen(true)}
+                            >
+                                Login with Solid Pod
+                            </button>
+                            {' '}to get started.
+                        </span>
                     )}
                 </div>
             </div>
+            <SolidProviderSelector
+                isOpen={isProviderSelectorOpen}
+                onClose={() => setIsProviderSelectorOpen(false)}
+                onSelect={(issuer) => login(issuer)}
+            />
         </>
     )
-} 
+}


### PR DESCRIPTION
Users on create-packing-list and landing pages now see a real
"Login with Solid Pod" button instead of text telling them to
click the nav bar button.

https://claude.ai/code/session_011p6MEkiiKaKV3vPeD4Qrdv