### PR TITLE
Fix onboarding UX: remove confusing wizard link and direct-create option

### DIFF
--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -49,17 +49,10 @@ describe('Navigation', () => {
         expect(screen.queryByText('Reconfigure Questions')).toBeNull()
     })
 
-    it('shows "Reconfigure Questions" nav link when questions exist', () => {
+    it('hides the wizard link from nav when questions already exist', () => {
         mockUseHasQuestions.mockReturnValue(true)
-
-        render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
-
-        expect(screen.getAllByText('Reconfigure Questions').length).toBeGreaterThan(0)
-        expect(screen.queryByText('Travel Profile')).toBeNull()
+        render(<MemoryRouter><Navigation /></MemoryRouter>)
+        expect(screen.queryByRole('link', { name: /reconfigure questions/i })).toBeNull()
     })
 
     it('hides Backups link when not logged in', () => {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -35,12 +35,14 @@ export const Navigation = () => {
                             </div>
                             <div className="hidden md:block">
                                 <div className="ml-10 flex items-baseline space-x-2">
-                                    <Link
-                                        to="/wizard"
-                                        className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
-                                    >
-                                        {hasQuestions ? 'Reconfigure Questions' : 'Travel Profile'}
-                                    </Link>
+                                    {!hasQuestions && (
+                                        <Link
+                                            to="/wizard"
+                                            className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
+                                        >
+                                            Travel Profile
+                                        </Link>
+                                    )}
                                     <Link
                                         to="/manage-questions"
                                         className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
@@ -133,13 +135,15 @@ export const Navigation = () => {
                 {/* Mobile menu */}
                 <div className={`${isOpen ? 'block' : 'hidden'} md:hidden bg-primary-950`}>
                     <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-                        <Link
-                            to="/wizard"
-                            className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
-                            onClick={() => setIsOpen(false)}
-                        >
-                            {hasQuestions ? 'Reconfigure Questions' : 'Travel Profile'}
-                        </Link>
+                        {!hasQuestions && (
+                            <Link
+                                to="/wizard"
+                                className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
+                                onClick={() => setIsOpen(false)}
+                            >
+                                Travel Profile
+                            </Link>
+                        )}
                         <Link
                             to="/manage-questions"
                             className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"

--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -68,6 +68,12 @@ describe('LandingPage', () => {
         expect(screen.getByRole('link', { name: /reconfigure your questions/i })).toBeTruthy()
     })
 
+    it('does not show "create a packing list directly" link when no questions exist', () => {
+        mockUseHasQuestions.mockReturnValue(false)
+        render(<MemoryRouter><LandingPage /></MemoryRouter>)
+        expect(screen.queryByRole('link', { name: /create a packing list directly/i })).toBeNull()
+    })
+
     it('displays the correct h1 heading', () => {
         mockUseHasQuestions.mockReturnValue(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -92,15 +92,6 @@ export const LandingPage = () => {
                             >
                                 ✨ Get Started with the Wizard
                             </Link>
-                            <div className="text-gray-600">
-                                or{' '}
-                                <Link
-                                    to="/create-packing-list"
-                                    className="text-primary-700 font-semibold hover:underline"
-                                >
-                                    create a packing list directly
-                                </Link>
-                            </div>
                         </>
                     )}
                 </div>


### PR DESCRIPTION
## What this PR does

- Removes the "create a packing list directly" link from the first-time onboarding screen, since creating a list without questions set up doesn't make sense — the wizard is the only valid first step.
- Hides the wizard nav link ("Travel Profile" / "Reconfigure Questions") once questions are already set up, since it's a destructive action that shouldn't be easily reachable. Users can still access it via the "reconfigure your questions" secondary link on the landing page.

## Manual testing steps

1. Open the app with no questions set up — confirm only the "Get Started with the Wizard" CTA is shown, with no "create directly" link.
2. Complete the wizard — confirm the "Travel Profile" link disappears from the nav.
3. On the landing page with questions set up, confirm the "reconfigure your questions" secondary link still appears.