### PR TITLE
Improve onboarding copy to explain the setup → refine → pack flow

### DIFF
--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -36,7 +36,7 @@ describe('Navigation', () => {
         })
     })
 
-    it('shows "Travel Profile" nav link when no questions exist', () => {
+    it('shows "Setup Wizard" nav link when no questions exist', () => {
         mockUseHasQuestions.mockReturnValue(false)
 
         render(
@@ -45,11 +45,11 @@ describe('Navigation', () => {
             </MemoryRouter>
         )
 
-        expect(screen.getAllByText('Travel Profile').length).toBeGreaterThan(0)
-        expect(screen.queryByText('Reconfigure Questions')).toBeNull()
+        expect(screen.getAllByText('Setup Wizard').length).toBeGreaterThan(0)
+        expect(screen.queryByText('Redo Setup Wizard')).toBeNull()
     })
 
-    it('shows "Reconfigure Questions" nav link when questions exist', () => {
+    it('shows "Redo Setup Wizard" nav link when questions exist', () => {
         mockUseHasQuestions.mockReturnValue(true)
 
         render(
@@ -58,8 +58,8 @@ describe('Navigation', () => {
             </MemoryRouter>
         )
 
-        expect(screen.getAllByText('Reconfigure Questions').length).toBeGreaterThan(0)
-        expect(screen.queryByText('Travel Profile')).toBeNull()
+        expect(screen.getAllByText('Redo Setup Wizard').length).toBeGreaterThan(0)
+        expect(screen.queryByText('Setup Wizard')).toBeNull()
     })
 
     it('hides Backups link when not logged in', () => {
@@ -74,7 +74,7 @@ describe('Navigation', () => {
         expect(screen.queryByText('Backups')).toBeNull()
     })
 
-    it('shows "Customise My Lists" nav link instead of "Edit Questions"', () => {
+    it('shows "My Questions & Items" nav link instead of "Edit Questions"', () => {
         mockUseHasQuestions.mockReturnValue(false)
 
         render(
@@ -83,7 +83,7 @@ describe('Navigation', () => {
             </MemoryRouter>
         )
 
-        expect(screen.getAllByText('Customise My Lists').length).toBeGreaterThan(0)
+        expect(screen.getAllByText('My Questions & Items').length).toBeGreaterThan(0)
         expect(screen.queryByText('Edit Questions')).toBeNull()
     })
 

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -49,7 +49,7 @@ describe('Navigation', () => {
         expect(screen.queryByText('Redo Setup Wizard')).toBeNull()
     })
 
-    it('shows "Redo Setup Wizard" nav link when questions exist', () => {
+    it('hides the wizard nav link when questions exist', () => {
         mockUseHasQuestions.mockReturnValue(true)
 
         render(
@@ -58,8 +58,8 @@ describe('Navigation', () => {
             </MemoryRouter>
         )
 
-        expect(screen.getAllByText('Redo Setup Wizard').length).toBeGreaterThan(0)
         expect(screen.queryByText('Setup Wizard')).toBeNull()
+        expect(screen.queryByText('Redo Setup Wizard')).toBeNull()
     })
 
     it('hides Backups link when not logged in', () => {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -39,13 +39,13 @@ export const Navigation = () => {
                                         to="/wizard"
                                         className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
                                     >
-                                        {hasQuestions ? 'Reconfigure Questions' : 'Travel Profile'}
+                                        {hasQuestions ? 'Redo Setup Wizard' : 'Setup Wizard'}
                                     </Link>
                                     <Link
                                         to="/manage-questions"
                                         className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
                                     >
-                                        Customise My Lists
+                                        My Questions & Items
                                     </Link>
                                     <Link
                                         to="/create-packing-list"
@@ -138,14 +138,14 @@ export const Navigation = () => {
                             className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                             onClick={() => setIsOpen(false)}
                         >
-                            {hasQuestions ? 'Reconfigure Questions' : 'Travel Profile'}
+                            {hasQuestions ? 'Redo Setup Wizard' : 'Setup Wizard'}
                         </Link>
                         <Link
                             to="/manage-questions"
                             className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                             onClick={() => setIsOpen(false)}
                         >
-                            Customise My Lists
+                            My Questions & Items
                         </Link>
                         <Link
                             to="/create-packing-list"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -35,12 +35,14 @@ export const Navigation = () => {
                             </div>
                             <div className="hidden md:block">
                                 <div className="ml-10 flex items-baseline space-x-2">
-                                    <Link
-                                        to="/wizard"
-                                        className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
-                                    >
-                                        {hasQuestions ? 'Redo Setup Wizard' : 'Setup Wizard'}
-                                    </Link>
+                                    {!hasQuestions && (
+                                        <Link
+                                            to="/wizard"
+                                            className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
+                                        >
+                                            Setup Wizard
+                                        </Link>
+                                    )}
                                     <Link
                                         to="/manage-questions"
                                         className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
@@ -133,13 +135,15 @@ export const Navigation = () => {
                 {/* Mobile menu */}
                 <div className={`${isOpen ? 'block' : 'hidden'} md:hidden bg-primary-950`}>
                     <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-                        <Link
-                            to="/wizard"
-                            className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
-                            onClick={() => setIsOpen(false)}
-                        >
-                            {hasQuestions ? 'Redo Setup Wizard' : 'Setup Wizard'}
-                        </Link>
+                        {!hasQuestions && (
+                            <Link
+                                to="/wizard"
+                                className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
+                                onClick={() => setIsOpen(false)}
+                            >
+                                Setup Wizard
+                            </Link>
+                        )}
                         <Link
                             to="/manage-questions"
                             className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"

--- a/src/hooks/useHasQuestions.test.ts
+++ b/src/hooks/useHasQuestions.test.ts
@@ -35,8 +35,17 @@ describe('useHasQuestions', () => {
         await waitFor(() => expect(result.current).toBe(false))
     })
 
-    it('returns true when questions exist', async () => {
+    it('returns false when document exists but has no questions', async () => {
         const db = makeDb({ getQuestionSet: vi.fn().mockResolvedValue({ questions: [] }) })
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        const { result } = renderHook(() => useHasQuestions())
+
+        await waitFor(() => expect(result.current).toBe(false))
+    })
+
+    it('returns true when at least one question exists', async () => {
+        const db = makeDb({ getQuestionSet: vi.fn().mockResolvedValue({ questions: [{ id: '1', text: 'Do you need a jacket?' }] }) })
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
         const { result } = renderHook(() => useHasQuestions())

--- a/src/hooks/useHasQuestions.ts
+++ b/src/hooks/useHasQuestions.ts
@@ -7,7 +7,7 @@ export const useHasQuestions = () => {
 
     useEffect(() => {
         db.getQuestionSet()
-            .then(() => setHasQuestions(true))
+            .then((doc) => setHasQuestions(doc.questions.length > 0))
             .catch((err: unknown) => {
                 const hasName = typeof err === 'object' && err !== null && 'name' in err
                 if (!hasName || (err as { name: string }).name !== 'not_found') console.error(err)

--- a/src/pages/edit-questions-form.test.tsx
+++ b/src/pages/edit-questions-form.test.tsx
@@ -105,7 +105,7 @@ describe('EditQuestionsForm', () => {
         expect(screen.queryByText(/Store in Your Pod/i)).toBeNull()
     })
 
-    it('shows user-friendly page heading "Customise My Lists"', async () => {
+    it('shows user-friendly page heading "My Questions & Items"', async () => {
         render(
             <MemoryRouter>
                 <EditQuestionsForm />
@@ -113,7 +113,7 @@ describe('EditQuestionsForm', () => {
         )
 
         await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull())
-        expect(screen.getByRole('heading', { name: 'Customise My Lists' })).toBeDefined()
+        expect(screen.getByRole('heading', { name: 'My Questions & Items' })).toBeDefined()
         expect(screen.queryByText('Packing List Questions')).toBeNull()
     })
 

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
+import { Link } from 'react-router-dom'
 import { useForm, SubmitHandler, useFieldArray, useWatch } from "react-hook-form"
 import { useDebouncedCallback } from 'use-debounce'
 import { PackingListQuestionSet, newDraftQuestion } from '../edit-questions/types'
@@ -425,6 +426,7 @@ export function EditQuestionsForm() {
       <div className="mb-8 w-full max-w-5xl">
         <h1 className="text-2xl font-bold text-gray-900">My Questions & Items</h1>
         <p className="mt-2 text-gray-600">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>
+        <p className="mt-1 text-sm text-gray-400">Want to start from scratch? <Link to="/wizard" className="text-primary-600 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</p>
       </div>
       {editorMode === 'visual' ? (
         <>

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -423,8 +423,8 @@ export function EditQuestionsForm() {
   return (
     <div className="w-full flex flex-col items-center py-8 px-4">
       <div className="mb-8 w-full max-w-5xl">
-        <h1 className="text-2xl font-bold text-gray-900">Customise My Lists</h1>
-        <p className="mt-2 text-gray-600">Add, remove, and personalise the items on your packing lists.</p>
+        <h1 className="text-2xl font-bold text-gray-900">My Questions & Items</h1>
+        <p className="mt-2 text-gray-600">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>
       </div>
       {editorMode === 'visual' ? (
         <>

--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -56,7 +56,7 @@ describe('LandingPage', () => {
         expect(screen.queryByRole('link', { name: /get started with the wizard/i })).toBeNull()
     })
 
-    it('shows "Reconfigure your questions" as secondary link when questions exist', () => {
+    it('does not show secondary action links when questions exist', () => {
         mockUseHasQuestions.mockReturnValue(true)
 
         render(
@@ -65,7 +65,8 @@ describe('LandingPage', () => {
             </MemoryRouter>
         )
 
-        expect(screen.getByRole('link', { name: /reconfigure your questions/i })).toBeTruthy()
+        expect(screen.queryByRole('link', { name: /reconfigure your questions/i })).toBeNull()
+        expect(screen.queryByRole('link', { name: /create a new packing list/i })).toBeNull()
     })
 
     it('displays the correct h1 heading', () => {

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -62,21 +62,6 @@ export const LandingPage = () => {
                             >
                                 📋 View Packing Lists
                             </Link>
-                            <div className="text-gray-600 space-x-3">
-                                <Link
-                                    to="/create-packing-list"
-                                    className="text-primary-700 font-semibold hover:underline"
-                                >
-                                    create a new packing list
-                                </Link>
-                                <span>·</span>
-                                <Link
-                                    to="/wizard"
-                                    className="text-primary-700 font-semibold hover:underline"
-                                >
-                                    reconfigure your questions
-                                </Link>
-                            </div>
                         </>
                     ) : (
                         <>
@@ -86,15 +71,6 @@ export const LandingPage = () => {
                             >
                                 ✨ Get Started with the Wizard
                             </Link>
-                            <div className="text-gray-600">
-                                or{' '}
-                                <Link
-                                    to="/create-packing-list"
-                                    className="text-primary-700 font-semibold hover:underline"
-                                >
-                                    create a packing list directly
-                                </Link>
-                            </div>
                         </>
                     )}
                 </div>

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -24,39 +24,33 @@ export const LandingPage = () => {
                     </h1>
                 </div>
 
-                <div className="grid md:grid-cols-2 gap-6 mb-12">
-                    <div className="bg-gradient-to-br from-primary-50 to-primary-100 p-6 rounded-2xl shadow-soft hover:shadow-glow-primary transition-all duration-300 hover:scale-105 border-2 border-primary-200">
-                        <div className="text-3xl mb-2">📋</div>
-                        <h2 className="text-2xl font-bold mb-3 text-primary-900">Smart Questionnaires</h2>
-                        <p className="text-gray-700">
-                            Answer a few simple questions about your trip, and we'll generate a customized packing list tailored to your needs.
-                        </p>
-                    </div>
+                <div className="mb-12">
+                    <h2 className="text-center text-sm font-semibold uppercase tracking-widest text-gray-500 mb-6">How it works</h2>
+                    <div className="grid md:grid-cols-3 gap-6">
+                        <div className="bg-gradient-to-br from-primary-50 to-primary-100 p-6 rounded-2xl shadow-soft hover:shadow-glow-primary transition-all duration-300 hover:scale-105 border-2 border-primary-200">
+                            <div className="text-3xl mb-2">✨</div>
+                            <h3 className="text-xl font-bold mb-3 text-primary-900">1. Set up once</h3>
+                            <p className="text-gray-700">
+                                Run the quick wizard — tell us who you travel with and we'll generate a starter set of packing questions for you.
+                            </p>
+                        </div>
 
-                    <div className="bg-gradient-to-br from-secondary-50 to-secondary-100 p-6 rounded-2xl shadow-soft hover:shadow-glow-secondary transition-all duration-300 hover:scale-105 border-2 border-secondary-200">
-                        <div className="text-3xl mb-2">💾</div>
-                        <h2 className="text-2xl font-bold mb-3 text-secondary-900">Save & Reuse Lists</h2>
-                        <p className="text-gray-700">
-                            Save your packing lists for future trips and easily modify them for different occasions.
-                        </p>
-                    </div>
+                        <div className="bg-gradient-to-br from-secondary-50 to-secondary-100 p-6 rounded-2xl shadow-soft hover:shadow-glow-secondary transition-all duration-300 hover:scale-105 border-2 border-secondary-200">
+                            <div className="text-3xl mb-2">✏️</div>
+                            <h3 className="text-xl font-bold mb-3 text-secondary-900">2. Fine-tune your questions</h3>
+                            <p className="text-gray-700">
+                                Add, remove, and customise questions and packing items until they perfectly match how you travel.
+                            </p>
+                        </div>
 
-                    <div className="bg-gradient-to-br from-accent-50 to-accent-100 p-6 rounded-2xl shadow-soft hover:shadow-glow-accent transition-all duration-300 hover:scale-105 border-2 border-accent-200">
-                        <div className="text-3xl mb-2">✏️</div>
-                        <h2 className="text-2xl font-bold mb-3 text-accent-900">Customizable Items</h2>
-                        <p className="text-gray-700">
-                            Add, remove, or modify items to perfectly match your packing requirements.
-                        </p>
+                        <div className="bg-gradient-to-br from-success-50 to-success-100 p-6 rounded-2xl shadow-soft hover:shadow-lg transition-all duration-300 hover:scale-105 border-2 border-success-200">
+                            <div className="text-3xl mb-2">📋</div>
+                            <h3 className="text-xl font-bold mb-3 text-success-900">3. Pack for every trip</h3>
+                            <p className="text-gray-700">
+                                Before each trip, answer your questions to instantly generate a personalised packing list.
+                            </p>
+                        </div>
                     </div>
-
-                    <div className="bg-gradient-to-br from-success-50 to-success-100 p-6 rounded-2xl shadow-soft hover:shadow-lg transition-all duration-300 hover:scale-105 border-2 border-success-200">
-                        <div className="text-3xl mb-2">✨</div>
-                        <h2 className="text-2xl font-bold mb-3 text-success-900">Easy to Use</h2>
-                        <p className="text-gray-700">
-                            Simple and intuitive interface that makes packing preparation a breeze.
-                        </p>
-                    </div>
-
                 </div>
 
                 <div className="text-center space-y-4">

--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -84,7 +84,7 @@ describe('Wizard', () => {
             </MemoryRouter>
         )
 
-        await waitFor(() => screen.getByRole('button', { name: /save my travel profile/i }))
+        await waitFor(() => screen.getByRole('button', { name: /generate my packing questions/i }))
         expect(screen.queryByText(/you already have packing list questions set up/i)).toBeNull()
     })
 
@@ -169,7 +169,7 @@ describe('Wizard', () => {
         expect(localStorage.getItem('solid-pod-upsell-shown')).toBe('true')
     })
 
-    it('shows the travel profile heading', async () => {
+    it('shows the create packing questions heading', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
@@ -180,7 +180,7 @@ describe('Wizard', () => {
         )
 
         await waitFor(() =>
-            expect(screen.getByText(/set up your travel profile/i)).toBeTruthy()
+            expect(screen.getByText(/create your packing questions/i)).toBeTruthy()
         )
     })
 
@@ -195,7 +195,7 @@ describe('Wizard', () => {
         )
 
         await waitFor(() =>
-            expect(screen.getByText(/you only need to do this once/i)).toBeTruthy()
+            expect(screen.getByText(/do this once to get started/i)).toBeTruthy()
         )
     })
 
@@ -209,11 +209,11 @@ describe('Wizard', () => {
             </MemoryRouter>
         )
 
-        await waitFor(() => screen.getByRole('button', { name: /save my travel profile/i }))
+        await waitFor(() => screen.getByRole('button', { name: /generate my packing questions/i }))
         expect(screen.queryByText(/what activities are you planning/i)).toBeNull()
     })
 
-    it('submit button says "Save My Travel Profile"', async () => {
+    it('submit button says "Generate My Packing Questions"', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
@@ -224,7 +224,7 @@ describe('Wizard', () => {
         )
 
         await waitFor(() =>
-            expect(screen.getByRole('button', { name: /save my travel profile/i })).toBeTruthy()
+            expect(screen.getByRole('button', { name: /generate my packing questions/i })).toBeTruthy()
         )
     })
 

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -110,13 +110,13 @@ export const Wizard = () => {
         <div className="max-w-3xl mx-auto">
             <div className="mb-8 text-center animate-slide-up">
                 <h1 className="text-4xl font-bold mb-4 text-primary-900">
-                    Set Up Your Travel Profile
+                    Create Your Packing Questions
                 </h1>
                 <p className="text-lg text-gray-700">
-                    Tell us who you travel with — we'll use this to personalise your packing lists every time
+                    Tell us who you travel with — we'll generate a starter set of packing questions tailored to your group.
                 </p>
                 <p className="text-sm text-gray-500 mt-2 italic">
-                    You only need to do this once. You can always update your travel profile later.
+                    Do this once to get started. Afterwards, fine-tune your questions and packing items from 'My Questions &amp; Items' to match exactly what you need.
                 </p>
             </div>
 
@@ -232,7 +232,7 @@ export const Wizard = () => {
                         disabled={isLoading}
                         className="px-8 py-4 text-lg"
                     >
-                        {isLoading ? '🔄 Saving...' : '✅ Save My Travel Profile'}
+                        {isLoading ? '🔄 Generating...' : '✅ Generate My Packing Questions'}
                     </Button>
                 </div>
             </form>
@@ -259,7 +259,7 @@ Are you sure you want to continue?"
             >
                 <div className="space-y-6">
                     <p className="text-gray-700 text-center">
-                        Your packing list questions are ready! What would you like to do next?
+                        Your starter questions are ready! Head to 'My Questions &amp; Items' to add, remove, or tweak them to match how you travel — then create your first list.
                     </p>
 
                     <div className="space-y-4">


### PR DESCRIPTION
Replaces the generic feature cards on the landing page with a 3-step "How it works" section (Set up once → Fine-tune your questions → Pack for every trip) so the core concept is immediately clear. The wizard page is updated to frame it as creating a question bank rather than a travel profile, with copy that sets the expectation to refine questions afterwards. Navigation links and the edit-questions page are renamed to "My Questions & Items" to connect the pieces consistently.