### PR TITLE
Enable Solid session auto-restore and upgrade authn-browser to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.2.2",
         "@inrupt/solid-client": "^2.1.2",
-        "@inrupt/solid-client-authn-browser": "^3.1.0",
+        "@inrupt/solid-client-authn-browser": "^4.0.0",
         "@inrupt/vocab-common-rdf": "^1.0.5",
         "@inrupt/vocab-solid": "^1.0.4",
         "@tailwindcss/vite": "^4.1.4",
@@ -1140,28 +1140,15 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@inrupt/oidc-client": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client/-/oidc-client-1.11.6.tgz",
-      "integrity": "sha512-1rCTk1T6pdm/7gKozutZutk7jwmYBADlnkGGoI5ypke099NOCa5KFXjkQpbjsps0PRkKZ+0EaR70XN5+xqmViA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^7.4.1",
-        "base64-js": "^1.5.1",
-        "core-js": "^3.8.3",
-        "crypto-js": "^4.0.0",
-        "serialize-javascript": "^4.0.0"
-      }
-    },
     "node_modules/@inrupt/oidc-client-ext": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-3.1.1.tgz",
-      "integrity": "sha512-vftKD2u5nufZTFkdUDMS3Uxj5xNQwArP11OFaALFkq6/3RwCAhe3lwOv8hNzL7Scv98T+KbAErBM0TwGGrS69g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-4.0.0.tgz",
+      "integrity": "sha512-E32/yElFpADyWRFO6FdCyB1Ew1svsNX/fFdvHWP3qCBhSlfJVq2hMChWxs/RIRmTjHePyjT2UKEuItM09WXaWA==",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^3.1.1",
+        "@inrupt/solid-client-authn-core": "^4.0.0",
         "jose": "^5.1.3",
+        "oidc-client-ts": "^3.5.0",
         "uuid": "^11.1.0"
       }
     },
@@ -1201,13 +1188,13 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-3.1.1.tgz",
-      "integrity": "sha512-Wd7TREmvdhTp+Sk88ei3hlg54sG1fNqkkPkuS+2tDBkcsXaViRQAEugVyh5pWRkd1xSFKrEzftb7UYEG4mJ0CQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-4.0.0.tgz",
+      "integrity": "sha512-b7DpLMjYVMPiRv3QWqOmCeYqKL1t2THYQawuYM1zNqtN1SJGG5XEkXIy3ZQxx12tzAjeLNjH3ZAOg/CK/ehg2w==",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/oidc-client-ext": "^3.1.1",
-        "@inrupt/solid-client-authn-core": "^3.1.1",
+        "@inrupt/oidc-client-ext": "^4.0.0",
+        "@inrupt/solid-client-authn-core": "^4.0.0",
         "events": "^3.3.0",
         "jose": "^5.1.3",
         "uuid": "^11.1.0"
@@ -1227,9 +1214,9 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-3.1.1.tgz",
-      "integrity": "sha512-1oDSQCh/pVtPlTyvLQ2uwHo+hpLJF7izg82tjB+Ge8jqGYwkQyId0BrfncpCk//uJXxgRIcfAQp2MhXYbZo80Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-4.0.0.tgz",
+      "integrity": "sha512-q4iur4TxEkhk9XaGAvyRP/+MjU1oBv2xlBdGE+uoXmDHAnIqUN71zZjCWZfZlyQFRETgH3OfZ9tPrNSDIPA/wg==",
       "license": "MIT",
       "dependencies": {
         "events": "^3.3.0",
@@ -1237,7 +1224,7 @@
         "uuid": "^11.1.0"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@inrupt/solid-client-authn-core/node_modules/uuid": {
@@ -2912,7 +2899,9 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3250,17 +3239,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/core-js": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.46.0.tgz",
-      "integrity": "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -3306,12 +3284,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "license": "MIT"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -4395,6 +4367,15 @@
         "url": "https://github.com/sponsors/rubensworks/"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5222,6 +5203,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oidc-client-ts": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
+      "integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5739,15 +5732,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rdf-data-factory": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
@@ -6045,6 +6029,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -6061,15 +6046,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/set-cookie-parser": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^5.2.2",
     "@inrupt/solid-client": "^2.1.2",
-    "@inrupt/solid-client-authn-browser": "^3.1.0",
+    "@inrupt/solid-client-authn-browser": "^4.0.0",
     "@inrupt/vocab-common-rdf": "^1.0.5",
     "@inrupt/vocab-solid": "^1.0.4",
     "@tailwindcss/vite": "^4.1.4",

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -99,7 +99,7 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
     const initializeSession = async () => {
       try {
         console.log("Initializing Solid session...");
-        await handleIncomingRedirect({ restorePreviousSession: false });
+        await handleIncomingRedirect({ restorePreviousSession: true });
         const currentSession = getDefaultSession();
         console.log("Session initialized:", {
           isLoggedIn: currentSession.info.isLoggedIn,


### PR DESCRIPTION
## What this PR does

- Re-enables `restorePreviousSession: true` in `handleIncomingRedirect` so users are automatically logged back in on page refresh.
- Upgrades `@inrupt/solid-client-authn-browser` from v3.1.0 to v4.0.0, which replaces the underlying OIDC dependency (`@inrupt/oidc-client`) with the actively-maintained `oidc-client-ts`.

## Manual testing steps

1. Log in to a Solid Pod.
2. Refresh the page — you should remain logged in without having to re-authenticate.