### PR TITLE
Remove example questions UI (wizard replaces it)

### DIFF
--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -338,20 +338,3 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
         ]
     };
 }
-
-// Helper function to create people for examples
-function createExamplePeople(count: number): Person[] {
-    return Array.from({ length: count }, (_, i) => ({
-        id: generateUUID(),
-        name: i === 0 ? "Me" : `Person ${i + 1}`,
-        ageRange: undefined
-    }));
-}
-
-export const exampleData = {
-    "Basic packing list for 1": createExampleData(createExamplePeople(1)),
-    "Basic packing list for 2": createExampleData(createExamplePeople(2)),
-    "Basic packing list for 3": createExampleData(createExamplePeople(3)),
-    "Basic packing list for 4": createExampleData(createExamplePeople(4)),
-    "Basic packing list for 5": createExampleData(createExamplePeople(5)),
-}; 

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -10,9 +10,7 @@ import { PeopleSection } from '../edit-questions/people-section'
 import { Button } from '../components/Button'
 import { useToast } from '../components/ToastContext'
 import { AlwaysNeededItemsSection } from '../edit-questions/always-needed-items-section'
-import { Modal } from '../components/Modal'
-import { exampleData } from '../edit-questions/example-data'
-import { Callout } from '../components/Callout'
+
 import { useSolidPod } from '../components/SolidPodContext'
 import { usePodSync } from '../hooks/usePodSync'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
@@ -26,7 +24,7 @@ export function EditQuestionsForm() {
     defaultValues: { questions: [], people: [{ id: crypto.randomUUID(), name: "Me" }], alwaysNeededItems: [] }
   });
   const [rev, setRev] = useState<string | undefined>(undefined)
-  const [isExampleModalOpen, setIsExampleModalOpen] = useState(false)
+
   const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const [editorMode] = useState<'visual' | 'json'>('visual')
   const [jsonValue, setJsonValue] = useState<string>('')
@@ -333,18 +331,6 @@ export function EditQuestionsForm() {
     }
   };
 
-  const handleLoadExample = (exampleName: string) => {
-    const data = exampleData[exampleName as keyof typeof exampleData];
-    if (data) {
-      const dataWithRev = { ...data, _rev: rev };
-      reset(dataWithRev);
-      setCurrentQuestionSet(dataWithRev);
-      setIsExampleModalOpen(false);
-      showToast('Example loaded successfully!', 'success');
-    }
-  };
-
-
   // Manual save handler for JSON mode
   const handleSaveJson = useCallback(async () => {
     try {
@@ -406,8 +392,6 @@ export function EditQuestionsForm() {
   }, [db, jsonValue, rev, isLoggedIn, saveWithSyncPrevention, saveToPod, showToast]);
 
 
-  const isFormEmpty = questionFields.length === 0 && people.length === 1 && getValues("alwaysNeededItems").length === 0;
-
   // Format last sync time for display
   const formatLastSync = (date: Date | null) => {
     if (!date) return 'Never';
@@ -430,18 +414,6 @@ export function EditQuestionsForm() {
       </div>
       {editorMode === 'visual' ? (
         <>
-          {isFormEmpty && (
-            <div className="w-full max-w-5xl mb-8">
-              <Callout
-                title="Get Started with Example Questions"
-                description="Your form is empty. Load an example to see how questions and options work, or start building your own from scratch."
-                action={{
-                  label: "Load Example",
-                  onClick: () => setIsExampleModalOpen(true)
-                }}
-              />
-            </div>
-          )}
           <div className="w-full max-w-5xl flex flex-col lg:flex-row lg:items-start lg:gap-8">
         {/* Main form content */}
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-6 flex-1 pb-32 lg:pb-8" id="edit-questions-form">
@@ -581,13 +553,6 @@ export function EditQuestionsForm() {
               setCurrentQuestionSet(defaultData);
               showToast('Form has been reset to default state', 'success');
             }}>Reset form</Button>
-            <Button
-              type="button"
-              onClick={() => setIsExampleModalOpen(true)}
-              variant="secondary"
-            >
-              Load Example
-            </Button>
           </div>
         </div>
       </div>
@@ -668,13 +633,6 @@ export function EditQuestionsForm() {
               setCurrentQuestionSet(defaultData);
               showToast('Form has been reset to default state', 'success');
             }}>Reset form</Button>
-            <Button
-              type="button"
-              onClick={() => setIsExampleModalOpen(true)}
-              variant="secondary"
-            >
-              Load Example
-            </Button>
             </div>
           </div>
         </div>
@@ -699,23 +657,6 @@ export function EditQuestionsForm() {
         </div>
       )}
 
-      <Modal
-        isOpen={isExampleModalOpen}
-        onClose={() => setIsExampleModalOpen(false)}
-        title="Load Example"
-      >
-        <div className="space-y-2">
-          {Object.keys(exampleData).map((exampleName) => (
-            <button
-              key={exampleName}
-              onClick={() => handleLoadExample(exampleName)}
-              className="w-full text-left px-4 py-2 hover:bg-gray-100 rounded-md transition-colors"
-            >
-              {exampleName}
-            </button>
-          ))}
-        </div>
-      </Modal>
     </div>
   )
 } 


### PR DESCRIPTION
## What this PR does

Removes the "Load Example" feature from the edit-questions form — the setup wizard now generates a question set for users, making it redundant. This includes the empty-state callout, the Load Example buttons (sidebar and mobile bar), the modal, and the now-unused `exampleData` export and `createExamplePeople` helper from `example-data.ts`.

## Manual testing steps

- Go to the edit-questions form and confirm there is no "Load Example" button or empty-state callout
- Run through the setup wizard and confirm it still generates a question set correctly