### PR TITLE
Remove Setup Wizard link from nav

### DIFF
--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -4,10 +4,6 @@ import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { Navigation } from './Navigation'
 
-vi.mock('../hooks/useHasQuestions', () => ({
-    useHasQuestions: vi.fn(),
-}))
-
 vi.mock('./SolidPodContext', () => ({
     useSolidPod: vi.fn(),
 }))
@@ -16,10 +12,8 @@ vi.mock('./SolidProviderSelector', () => ({
     SolidProviderSelector: () => null,
 }))
 
-import { useHasQuestions } from '../hooks/useHasQuestions'
 import { useSolidPod } from './SolidPodContext'
 
-const mockUseHasQuestions = vi.mocked(useHasQuestions)
 const mockUseSolidPod = vi.mocked(useSolidPod)
 
 describe('Navigation', () => {
@@ -36,35 +30,7 @@ describe('Navigation', () => {
         })
     })
 
-    it('shows "Setup Wizard" nav link when no questions exist', () => {
-        mockUseHasQuestions.mockReturnValue(false)
-
-        render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
-
-        expect(screen.getAllByText('Setup Wizard').length).toBeGreaterThan(0)
-        expect(screen.queryByText('Redo Setup Wizard')).toBeNull()
-    })
-
-    it('hides the wizard nav link when questions exist', () => {
-        mockUseHasQuestions.mockReturnValue(true)
-
-        render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
-
-        expect(screen.queryByText('Setup Wizard')).toBeNull()
-        expect(screen.queryByText('Redo Setup Wizard')).toBeNull()
-    })
-
     it('hides Backups link when not logged in', () => {
-        mockUseHasQuestions.mockReturnValue(false)
-
         render(
             <MemoryRouter>
                 <Navigation />
@@ -75,8 +41,6 @@ describe('Navigation', () => {
     })
 
     it('shows "My Questions & Items" nav link instead of "Edit Questions"', () => {
-        mockUseHasQuestions.mockReturnValue(false)
-
         render(
             <MemoryRouter>
                 <Navigation />
@@ -98,7 +62,6 @@ describe('Navigation', () => {
             login: vi.fn(),
             logout: vi.fn(),
         })
-        mockUseHasQuestions.mockReturnValue(false)
 
         render(
             <MemoryRouter>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,13 +2,11 @@ import { Link } from 'react-router-dom'
 import { useState } from 'react'
 import { useSolidPod } from './SolidPodContext'
 import { SolidProviderSelector } from './SolidProviderSelector'
-import { useHasQuestions } from '../hooks/useHasQuestions'
 
 export const Navigation = () => {
     const [isOpen, setIsOpen] = useState(false)
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
     const { login, logout, isLoggedIn, webId } = useSolidPod()
-    const hasQuestions = useHasQuestions()
 
     const handleSolidLogin = () => {
         setIsProviderSelectorOpen(true)
@@ -35,14 +33,6 @@ export const Navigation = () => {
                             </div>
                             <div className="hidden md:block">
                                 <div className="ml-10 flex items-baseline space-x-2">
-                                    {!hasQuestions && (
-                                        <Link
-                                            to="/wizard"
-                                            className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
-                                        >
-                                            Setup Wizard
-                                        </Link>
-                                    )}
                                     <Link
                                         to="/manage-questions"
                                         className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
@@ -135,15 +125,6 @@ export const Navigation = () => {
                 {/* Mobile menu */}
                 <div className={`${isOpen ? 'block' : 'hidden'} md:hidden bg-primary-950`}>
                     <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-                        {!hasQuestions && (
-                            <Link
-                                to="/wizard"
-                                className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
-                                onClick={() => setIsOpen(false)}
-                            >
-                                Setup Wizard
-                            </Link>
-                        )}
                         <Link
                             to="/manage-questions"
                             className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"


### PR DESCRIPTION
The Setup Wizard link in the nav was conditional on `!hasQuestions`, but had a stale-state bug where it wouldn't disappear until a page refresh. Since the landing page already shows a prominent "Get Started with the Wizard" CTA when no questions exist, the nav link is redundant. This PR removes it from both desktop and mobile nav, along with the now-unused `useHasQuestions` import and the related tests.