### PR TITLE
Fix post-refresh redirect to restore correct page after OAuth

### DIFF
--- a/src/components/SolidPodContext.test.tsx
+++ b/src/components/SolidPodContext.test.tsx
@@ -61,16 +61,29 @@ function ConsumerWithActions() {
 }
 
 describe('SolidPodContext', () => {
+    let originalLocation: Location
+
     beforeEach(() => {
         vi.spyOn(console, 'log').mockImplementation(() => {})
         vi.spyOn(console, 'error').mockImplementation(() => {})
         mockSession = makeMockSession()
         mockGetDefaultSession.mockReturnValue(mockSession as never)
+        sessionStorage.clear()
+        originalLocation = window.location
     })
 
     afterEach(() => {
         vi.restoreAllMocks()
+        sessionStorage.clear()
+        Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
     })
+
+    function setWindowLocation(search: string, hash = '') {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { ...originalLocation, search, hash },
+        })
+    }
 
     it('starts with isLoggedIn false and sessionExpired false', async () => {
         render(
@@ -172,6 +185,35 @@ describe('SolidPodContext', () => {
         await waitFor(() => {
             expect(screen.getByTestId('isLoggedIn').textContent).toBe('true')
             expect(screen.getByTestId('sessionExpired').textContent).toBe('false')
+        })
+    })
+
+    it('saves current route to sessionStorage before session restore when not in OAuth callback', async () => {
+        setWindowLocation('', '#/create-packing-list')
+
+        render(
+            <Wrapper>
+                <Consumer />
+            </Wrapper>
+        )
+
+        await waitFor(() => {
+            expect(sessionStorage.getItem('authReturnTo')).toBe('/create-packing-list')
+        })
+    })
+
+    it('does not overwrite sessionStorage authReturnTo when in OAuth callback', async () => {
+        setWindowLocation('?code=abc123&state=xyz', '#/solid-pod-handle-redirect')
+        sessionStorage.setItem('authReturnTo', '/existing-route')
+
+        render(
+            <Wrapper>
+                <Consumer />
+            </Wrapper>
+        )
+
+        await waitFor(() => {
+            expect(sessionStorage.getItem('authReturnTo')).toBe('/existing-route')
         })
     })
 

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -7,6 +7,7 @@ import {
   logout as solidLogout
 } from "@inrupt/solid-client-authn-browser";
 import { isAuthenticationError } from "../services/solidPod";
+import { AUTH_RETURN_TO_KEY } from "../pages/solid-pod-handle-redirect-page";
 
 interface SolidPodContextValue {
   session: Session | null;
@@ -99,6 +100,17 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
     const initializeSession = async () => {
       try {
         console.log("Initializing Solid session...");
+
+        // Save the current route before session restore may redirect away.
+        // sessionStorage persists through redirect cycles in the same tab, so
+        // SolidPodHandleRedirectPage can use this to return the user to the
+        // correct page instead of the stale returnTo stored at login time.
+        const isOAuthCallback = new URLSearchParams(window.location.search).has("code") ||
+          new URLSearchParams(window.location.search).has("state");
+        if (!isOAuthCallback) {
+          sessionStorage.setItem(AUTH_RETURN_TO_KEY, window.location.hash.substring(1) || "/");
+        }
+
         await handleIncomingRedirect({ restorePreviousSession: true });
         const currentSession = getDefaultSession();
         console.log("Session initialized:", {

--- a/src/pages/solid-pod-handle-redirect-page.test.tsx
+++ b/src/pages/solid-pod-handle-redirect-page.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import React from 'react'
+import { SolidPodHandleRedirectPage } from './solid-pod-handle-redirect-page'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => mockNavigate,
+}))
+
+describe('SolidPodHandleRedirectPage', () => {
+    let originalLocation: Location
+
+    beforeEach(() => {
+        mockNavigate.mockClear()
+        sessionStorage.clear()
+        originalLocation = window.location
+    })
+
+    afterEach(() => {
+        sessionStorage.clear()
+        Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+    })
+
+    function setWindowLocation(search: string) {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { ...originalLocation, search },
+        })
+    }
+
+    it('navigates to sessionStorage authReturnTo route when set, and clears it', async () => {
+        sessionStorage.setItem('authReturnTo', '/create-packing-list')
+        setWindowLocation('?returnTo=%2Fmanage-questions')
+
+        render(<SolidPodHandleRedirectPage />)
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith('/create-packing-list')
+        })
+        expect(sessionStorage.getItem('authReturnTo')).toBeNull()
+    })
+
+    it('falls back to returnTo URL param when sessionStorage is empty', async () => {
+        setWindowLocation('?returnTo=%2Fview-lists')
+
+        render(<SolidPodHandleRedirectPage />)
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith('/view-lists')
+        })
+    })
+
+    it('navigates to "/" when both sessionStorage authReturnTo and returnTo param are absent', async () => {
+        setWindowLocation('')
+
+        render(<SolidPodHandleRedirectPage />)
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith('/')
+        })
+    })
+})

--- a/src/pages/solid-pod-handle-redirect-page.tsx
+++ b/src/pages/solid-pod-handle-redirect-page.tsx
@@ -1,16 +1,22 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
+export const AUTH_RETURN_TO_KEY = "authReturnTo";
+
 export const SolidPodHandleRedirectPage = () => {
     const navigate = useNavigate();
 
     useEffect(() => {
-        // Get the returnTo parameter from the URL
-        const params = new URLSearchParams(window.location.search);
-        const returnTo = params.get("returnTo") || "/";
+        const storedRoute = sessionStorage.getItem(AUTH_RETURN_TO_KEY);
+        if (storedRoute) {
+            sessionStorage.removeItem(AUTH_RETURN_TO_KEY);
+            navigate(storedRoute);
+            return;
+        }
 
-        // Redirect to the return route
-        navigate(returnTo);
+        // Fallback: use returnTo from URL params (covers cases where sessionStorage was not set)
+        const params = new URLSearchParams(window.location.search);
+        navigate(params.get("returnTo") || "/");
     }, [navigate]);
 
     return (


### PR DESCRIPTION
## What this PR does
When Solid session auto-restore triggers a silent OAuth redirect on page refresh, the previous code redirected to a stale `returnTo` URL param set at login time. This PR saves the current route to `sessionStorage` just before `handleIncomingRedirect` runs (skipping OAuth callbacks), so `SolidPodHandleRedirectPage` can restore the user to the page they were actually on.

## Manual testing steps
1. Log in to a Solid Pod and navigate to a non-home page (e.g. `/create-packing-list`)
2. Refresh the page
3. Verify you are returned to `/create-packing-list` after the silent OAuth cycle, not to the home page or a stale route