### PR TITLE
Migrate Vercel Analytics from inject() to React component

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import React from 'react'
+
+vi.mock('@vercel/analytics/react', () => ({
+  Analytics: vi.fn(() => null),
+}))
+
+vi.mock('./components/SolidPodContext', () => ({
+  SolidPodProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSolidPod: vi.fn(),
+}))
+
+vi.mock('./components/DatabaseContext', () => ({
+  DatabaseProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('./components/ToastContext', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('./components/Navigation', () => ({
+  Navigation: () => null,
+}))
+
+vi.mock('./components/SessionExpiredBanner', () => ({
+  SessionExpiredBanner: () => null,
+}))
+
+vi.mock('./pages/landing-page', () => ({ LandingPage: () => null }))
+vi.mock('./pages/edit-questions-form', () => ({ EditQuestionsForm: () => null }))
+vi.mock('./pages/create-packing-list', () => ({ CreatePackingList: () => null }))
+vi.mock('./pages/packing-lists', () => ({ PackingLists: () => null }))
+vi.mock('./pages/view-packing-list', () => ({ ViewPackingList: () => null }))
+vi.mock('./pages/solid-pod-handle-redirect-page', () => ({ SolidPodHandleRedirectPage: () => null }))
+vi.mock('./pages/wizard', () => ({ Wizard: () => null }))
+vi.mock('./pages/backups', () => ({ BackupsPage: () => null }))
+
+import { Analytics } from '@vercel/analytics/react'
+import App from './App'
+
+const mockAnalytics = vi.mocked(Analytics)
+
+describe('App', () => {
+  beforeEach(() => {
+    mockAnalytics.mockClear()
+  })
+
+  it('renders the Analytics component for page view tracking', () => {
+    render(<App />)
+    expect(mockAnalytics).toHaveBeenCalled()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from '@vercel/analytics/react'
 import { HashRouter } from 'react-router-dom'
 import { Route } from 'react-router-dom'
 import { Routes } from 'react-router-dom'
@@ -22,6 +23,7 @@ function App() {
       <SolidPodProvider>
         <DatabaseProvider>
         <HashRouter>
+            <Analytics />
           <div className="min-h-screen bg-gradient-to-br from-primary-50 via-white to-accent-50">
             <Navigation />
             <SessionExpiredBanner />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { inject } from '@vercel/analytics'
 import './index.css'
 import App from './App.tsx'
-
-inject()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
Migrated Vercel Analytics integration from the imperative `inject()` API to the declarative React `<Analytics />` component approach for better integration with React's component lifecycle.

## Key Changes
- Removed `inject()` call from `main.tsx` that was initializing analytics at the root level
- Added `<Analytics />` component import and rendering in `App.tsx` within the component tree
- Added comprehensive test coverage in `App.test.tsx` to verify the Analytics component is rendered

## Implementation Details
- The `<Analytics />` component is now rendered as a child of the `HashRouter`, ensuring it's part of the React component hierarchy
- All provider components (SolidPodProvider, DatabaseProvider, ToastProvider) wrap the Analytics component, giving it access to the full application context
- Test file includes proper mocking of all dependencies and verifies that the Analytics component is called during render

https://claude.ai/code/session_01QEaEdpQCMvLn7DhBjnUCwj