### PR TITLE
Add feedback email link to navigation component

### DIFF
--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -51,6 +51,18 @@ describe('Navigation', () => {
         expect(screen.queryByText('Edit Questions')).toBeNull()
     })
 
+    it('shows feedback email link', () => {
+        render(
+            <MemoryRouter>
+                <Navigation />
+            </MemoryRouter>
+        )
+
+        const feedbackLinks = screen.getAllByRole('link', { name: /feedback/i })
+        expect(feedbackLinks.length).toBeGreaterThan(0)
+        expect(feedbackLinks[0].getAttribute('href')).toBe('mailto:tim.packmeup@gmail.com')
+    })
+
     it('shows Backups link when logged in', () => {
         mockUseSolidPod.mockReturnValue({
             session: null,

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -63,7 +63,13 @@ export const Navigation = () => {
                             </div>
                         </div>
                         {/* Solid Login/Logout section */}
-                        <div className="hidden md:flex items-center gap-2">
+                        <div className="hidden md:flex items-center gap-4">
+                            <a
+                                href="mailto:tim.packmeup@gmail.com"
+                                className="px-3 py-1.5 rounded-lg text-sm font-medium text-white/70 hover:text-white transition-colors duration-200"
+                            >
+                                Feedback
+                            </a>
                             {isLoggedIn ? (
                                 <div className="flex items-center gap-3 bg-white/10 backdrop-blur-sm px-4 py-2 rounded-xl">
                                     <span className="text-sm font-medium truncate max-w-xs" title={webId}>
@@ -155,6 +161,13 @@ export const Navigation = () => {
                                 Backups
                             </Link>
                         )}
+                        <a
+                            href="mailto:tim.packmeup@gmail.com"
+                            className="block px-3 py-2 rounded-xl text-base font-medium text-white/70 hover:text-white transition-colors duration-200"
+                            onClick={() => setIsOpen(false)}
+                        >
+                            Feedback
+                        </a>
                         {/* Mobile Solid Login/Logout */}
                         <div className="border-t border-white/20 pt-2 mt-2">
                             {isLoggedIn ? (


### PR DESCRIPTION
## Summary
Added a feedback email link to the Navigation component, making it accessible to users in both desktop and mobile views.

## Key Changes
- Added a "Feedback" link in the desktop navigation bar (md breakpoint and above) that opens the user's email client with a pre-filled recipient address
- Added the same "Feedback" link to the mobile navigation menu for consistency across all screen sizes
- Increased gap spacing in the desktop navigation from `gap-2` to `gap-4` to accommodate the new link
- Added test coverage to verify the feedback email link is rendered and points to the correct email address

## Implementation Details
- The feedback link uses a `mailto:` href pointing to `tim.packmeup@gmail.com`
- Styling matches the existing navigation link patterns with hover effects and transitions
- Mobile version includes `onClick={() => setIsOpen(false)}` to close the menu when the link is clicked
- Both desktop and mobile versions use consistent styling with `text-white/70` and `hover:text-white` states

https://claude.ai/code/session_01RaDC5Naati8VMKjYBUsnWG