### PR TITLE
Improve Solid Pod onboarding with provider descriptions and local storage messaging

### DIFF
--- a/src/components/SolidPodPrompt.tsx
+++ b/src/components/SolidPodPrompt.tsx
@@ -60,6 +60,9 @@ export function SolidPodPrompt({
             <h4 className="font-bold text-primary-900 text-sm">Benefits of using a Solid Pod:</h4>
             <ul className="text-sm text-gray-700 space-y-1.5 ml-4 list-disc">
               <li>
+                <strong>Free</strong> - All major Pod providers are free to sign up
+              </li>
+              <li>
                 <strong>Multi-device access</strong> - Access your packing lists from any device
               </li>
               <li>

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -75,16 +75,6 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
             <li><strong>Privacy-focused</strong> - you choose who can access it</li>
             <li><strong>Portable</strong> - use your Pod with any Solid app</li>
           </ul>
-          <p className="text-xs text-gray-600 mt-2">
-            <a
-              href="https://solidproject.org/users/get-a-pod"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:text-blue-800 underline"
-            >
-              Get a free Pod
-            </a>
-          </p>
         </div>
 
         <div className="border-t border-gray-200 pt-4">

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -5,21 +5,30 @@ import { Button } from './Button';
 export interface SolidProvider {
   name: string;
   issuer: string;
+  description?: string;
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const COMMON_PROVIDERS: SolidProvider[] = [
   {
-    name: 'Inrupt',
-    issuer: 'https://login.inrupt.com'
+    name: 'Inrupt PodSpaces',
+    issuer: 'https://login.inrupt.com',
+    description: 'Free · run by Inrupt (Tim Berners-Lee\'s company)'
   },
   {
     name: 'solidcommunity.net',
-    issuer: 'https://solidcommunity.net'
+    issuer: 'https://solidcommunity.net',
+    description: 'Free · community-run, backed by the Open Data Institute'
   },
   {
     name: 'solidweb.org',
-    issuer: 'https://solidweb.org'
+    issuer: 'https://solidweb.org',
+    description: 'Free · EU-hosted'
+  },
+  {
+    name: 'Private Data Pod',
+    issuer: 'https://privatedatapod.com',
+    description: 'Free · 1 GB storage · beginner-friendly'
   }
 ];
 
@@ -73,14 +82,17 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
               rel="noopener noreferrer"
               className="text-blue-600 hover:text-blue-800 underline"
             >
-              Learn more about Solid
+              Get a free Pod
             </a>
           </p>
         </div>
 
         <div className="border-t border-gray-200 pt-4">
-          <p className="text-sm text-gray-600 mb-3">
+          <p className="text-sm text-gray-600 mb-1">
             Choose your Solid Pod provider to get started:
+          </p>
+          <p className="text-xs text-green-700 font-medium mb-3">
+            All providers below are free — no payment required.
           </p>
         </div>
 
@@ -92,10 +104,17 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
               className="w-full text-left px-4 py-3 border border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
             >
               <div className="font-medium text-gray-900">{provider.name}</div>
-              <div className="text-sm text-gray-500">{provider.issuer}</div>
+              {provider.description && (
+                <div className="text-xs text-green-700 font-medium">{provider.description}</div>
+              )}
+              <div className="text-xs text-gray-400">{provider.issuer}</div>
             </button>
           ))}
         </div>
+
+        <p className="text-xs text-gray-500 text-center">
+          No Pod? No problem — your data saves locally in your browser automatically.
+        </p>
 
         {!showCustomInput ? (
           <Button

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -13,7 +13,7 @@ export const COMMON_PROVIDERS: SolidProvider[] = [
   {
     name: 'Inrupt PodSpaces',
     issuer: 'https://login.inrupt.com',
-    description: 'Free · run by Inrupt (Tim Berners-Lee\'s company)'
+    description: 'Free · run by Inrupt (founded by Tim Berners-Lee, inventor of the Web)'
   },
   {
     name: 'solidcommunity.net',

--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -98,16 +98,16 @@ describe('LandingPage', () => {
         expect(solidPodHeading.closest('[class*="bg-primary-950"]')).toBeNull()
     })
 
-    it('shows a "Login with Solid Pod" button on the page when not logged in', () => {
+    it('shows a "Get a free Solid Pod" button on the page when not logged in', () => {
         mockUseHasQuestions.mockReturnValue(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
-        expect(screen.getByRole('button', { name: /login with solid pod/i })).toBeTruthy()
+        expect(screen.getByRole('button', { name: /get a free solid pod/i })).toBeTruthy()
     })
 
     it('opens the provider selector modal when the login button is clicked', () => {
         mockUseHasQuestions.mockReturnValue(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
-        const loginButton = screen.getByRole('button', { name: /login with solid pod/i })
+        const loginButton = screen.getByRole('button', { name: /get a free solid pod/i })
         fireEvent.click(loginButton)
         expect(screen.getByRole('dialog')).toBeTruthy()
     })

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -77,16 +77,16 @@ export const LandingPage = () => {
 
                 <div className="mt-10 p-4 rounded-xl border border-gray-200 bg-gray-50 text-center text-sm text-gray-500">
                     <h2 className="font-semibold text-gray-600 inline">Own Your Data</h2>
-                    {' '}— Login with your Solid Pod to store your lists in personal storage you control.
+                    {' '}— Login with your Solid Pod to store your lists in your own free personal storage you control. Your data saves locally in your browser automatically, even without an account.
                     {!isLoggedIn && (
                         <span className="block mt-1">
                             <button
                                 className="font-semibold text-primary-700 underline hover:text-primary-900"
                                 onClick={() => setIsProviderSelectorOpen(true)}
                             >
-                                Login with Solid Pod
+                                Get a free Solid Pod
                             </button>
-                            {' '}to get started.
+                            {' '}to sync across devices.
                         </span>
                     )}
                 </div>


### PR DESCRIPTION
## Summary
Enhanced the Solid Pod provider selector and landing page to better communicate the value proposition and lower barriers to entry. Added descriptive information about each provider, clarified that all providers are free, and emphasized that data persists locally in the browser even without an account.

## Key Changes

- **Enhanced SolidProvider interface**: Added optional `description` field to display provider-specific information
- **Updated provider list**: 
  - Renamed "Inrupt" to "Inrupt PodSpaces" for clarity
  - Added descriptions for all existing providers highlighting their key features (free, community-run, EU-hosted, etc.)
  - Added new "Private Data Pod" provider with beginner-friendly positioning
- **Improved provider selector UI**:
  - Display provider descriptions prominently in green text
  - Added explicit messaging that "All providers below are free — no payment required"
  - Changed CTA link text from "Learn more about Solid" to "Get a free Pod"
  - Added reassuring message about local browser storage as fallback
- **Updated landing page messaging**:
  - Clarified that personal storage is "free" and "your own"
  - Emphasized automatic local browser storage even without an account
  - Changed button text from "Login with Solid Pod" to "Get a free Solid Pod"
  - Updated supporting text to emphasize sync across devices as the benefit
- **Enhanced benefits section**: Added "Free" as the first benefit in the Solid Pod prompt to immediately address cost concerns

## Implementation Details
- Provider descriptions use consistent styling (green text, smaller font) to distinguish from provider names
- Issuer URLs now display in smaller, lighter gray text as secondary information
- All messaging changes maintain the existing component structure and styling patterns

https://claude.ai/code/session_018vu2xtZsKDmETmkXYXsMF2