### PR TITLE
Simplify pod login to show one provider with progressive disclosure

### DIFF
--- a/src/components/SolidProviderSelector.test.tsx
+++ b/src/components/SolidProviderSelector.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { SolidProviderSelector, LAST_PROVIDER_KEY } from './SolidProviderSelector'
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onSelect: vi.fn(),
+}
+
+describe('SolidProviderSelector', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('default provider (no last-used stored)', () => {
+    it('shows solidcommunity.net as the primary option', () => {
+      render(<SolidProviderSelector {...defaultProps} />)
+      const primaryButton = screen.getByRole('button', { name: /solidcommunity\.net/i })
+      expect(primaryButton).toBeTruthy()
+    })
+
+    it('hides other providers by default', () => {
+      render(<SolidProviderSelector {...defaultProps} />)
+      expect(screen.queryByRole('button', { name: /inrupt podspaces/i })).toBeNull()
+      expect(screen.queryByRole('button', { name: /solidweb\.org/i })).toBeNull()
+      expect(screen.queryByRole('button', { name: /private data pod/i })).toBeNull()
+    })
+
+    it('shows other providers when "Other providers" is clicked', () => {
+      render(<SolidProviderSelector {...defaultProps} />)
+      fireEvent.click(screen.getByRole('button', { name: /other providers/i }))
+      expect(screen.getByRole('button', { name: /inrupt podspaces/i })).toBeTruthy()
+      expect(screen.getByRole('button', { name: /solidweb\.org/i })).toBeTruthy()
+      expect(screen.getByRole('button', { name: /private data pod/i })).toBeTruthy()
+    })
+  })
+
+  describe('with last-used provider stored', () => {
+    it('shows the last-used provider as the primary option', () => {
+      localStorage.setItem(LAST_PROVIDER_KEY, 'https://solidweb.org')
+      render(<SolidProviderSelector {...defaultProps} />)
+      const primaryButton = screen.getByRole('button', { name: /solidweb\.org/i })
+      expect(primaryButton).toBeTruthy()
+    })
+
+    it('does not show other providers by default', () => {
+      localStorage.setItem(LAST_PROVIDER_KEY, 'https://solidweb.org')
+      render(<SolidProviderSelector {...defaultProps} />)
+      expect(screen.queryByRole('button', { name: /solidcommunity\.net/i })).toBeNull()
+      expect(screen.queryByRole('button', { name: /inrupt podspaces/i })).toBeNull()
+    })
+
+    it('falls back to solidcommunity.net for an unrecognised issuer', () => {
+      localStorage.setItem(LAST_PROVIDER_KEY, 'https://unknown-provider.example.com')
+      render(<SolidProviderSelector {...defaultProps} />)
+      expect(screen.getByRole('button', { name: /solidcommunity\.net/i })).toBeTruthy()
+    })
+  })
+
+  describe('saving last-used provider', () => {
+    it('saves the selected provider issuer to localStorage', () => {
+      render(<SolidProviderSelector {...defaultProps} />)
+      fireEvent.click(screen.getByRole('button', { name: /solidcommunity\.net/i }))
+      expect(localStorage.getItem(LAST_PROVIDER_KEY)).toBe('https://solidcommunity.net')
+    })
+
+    it('saves a different provider when selected from the expanded list', () => {
+      render(<SolidProviderSelector {...defaultProps} />)
+      fireEvent.click(screen.getByRole('button', { name: /other providers/i }))
+      fireEvent.click(screen.getByRole('button', { name: /inrupt podspaces/i }))
+      expect(localStorage.getItem(LAST_PROVIDER_KEY)).toBe('https://login.inrupt.com')
+    })
+
+    it('calls onSelect with the issuer', () => {
+      const onSelect = vi.fn()
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+      fireEvent.click(screen.getByRole('button', { name: /solidcommunity\.net/i }))
+      expect(onSelect).toHaveBeenCalledWith('https://solidcommunity.net')
+    })
+  })
+})

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -32,6 +32,16 @@ export const COMMON_PROVIDERS: SolidProvider[] = [
   }
 ];
 
+export const LAST_PROVIDER_KEY = 'solid-last-provider-issuer';
+
+const DEFAULT_PROVIDER = COMMON_PROVIDERS.find(p => p.issuer === 'https://solidcommunity.net')!;
+
+function getLastUsedProvider(): SolidProvider | null {
+  const issuer = localStorage.getItem(LAST_PROVIDER_KEY);
+  if (!issuer) return null;
+  return COMMON_PROVIDERS.find(p => p.issuer === issuer) ?? null;
+}
+
 interface SolidProviderSelectorProps {
   isOpen: boolean;
   onClose: () => void;
@@ -39,12 +49,18 @@ interface SolidProviderSelectorProps {
 }
 
 export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProviderSelectorProps) {
+  const primaryProvider = getLastUsedProvider() ?? DEFAULT_PROVIDER;
+  const otherProviders = COMMON_PROVIDERS.filter(p => p.issuer !== primaryProvider.issuer);
+
+  const [showOthers, setShowOthers] = useState(false);
   const [showCustomInput, setShowCustomInput] = useState(false);
   const [customIssuer, setCustomIssuer] = useState('');
 
   const handleProviderSelect = (issuer: string) => {
+    localStorage.setItem(LAST_PROVIDER_KEY, issuer);
     onSelect(issuer);
     onClose();
+    setShowOthers(false);
     setShowCustomInput(false);
     setCustomIssuer('');
   };
@@ -57,9 +73,12 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
 
   const handleClose = () => {
     onClose();
+    setShowOthers(false);
     setShowCustomInput(false);
     setCustomIssuer('');
   };
+
+  const isLastUsed = localStorage.getItem(LAST_PROVIDER_KEY) === primaryProvider.issuer;
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose} title="Login with Your Solid Pod">
@@ -78,79 +97,101 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
         </div>
 
         <div className="border-t border-gray-200 pt-4">
-          <p className="text-sm text-gray-600 mb-1">
-            Choose your Solid Pod provider to get started:
+          <p className="text-sm text-gray-600 mb-3">
+            {isLastUsed ? 'Continue with your last-used provider:' : 'Get started with a free provider:'}
           </p>
-          <p className="text-xs text-green-700 font-medium mb-3">
-            All providers below are free — no payment required.
-          </p>
+
+          {/* Primary provider */}
+          <button
+            onClick={() => handleProviderSelect(primaryProvider.issuer)}
+            className="w-full text-left px-4 py-3 border-2 border-blue-400 bg-blue-50 hover:bg-blue-100 hover:border-blue-500 rounded-md transition-colors"
+          >
+            <div className="font-medium text-gray-900">{primaryProvider.name}</div>
+            {primaryProvider.description && (
+              <div className="text-xs text-green-700 font-medium">{primaryProvider.description}</div>
+            )}
+            <div className="text-xs text-gray-400">{primaryProvider.issuer}</div>
+          </button>
         </div>
 
+        {/* Other providers toggle */}
         <div className="space-y-2">
-          {COMMON_PROVIDERS.map((provider) => (
-            <button
-              key={provider.issuer}
-              onClick={() => handleProviderSelect(provider.issuer)}
-              className="w-full text-left px-4 py-3 border border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
-            >
-              <div className="font-medium text-gray-900">{provider.name}</div>
-              {provider.description && (
-                <div className="text-xs text-green-700 font-medium">{provider.description}</div>
+          <button
+            type="button"
+            onClick={() => setShowOthers(v => !v)}
+            className="w-full text-sm text-gray-500 hover:text-gray-700 transition-colors text-center"
+          >
+            {showOthers ? 'Hide other providers ▲' : 'Other providers ▼'}
+          </button>
+
+          {showOthers && (
+            <div className="space-y-2">
+              {otherProviders.map((provider) => (
+                <button
+                  key={provider.issuer}
+                  onClick={() => handleProviderSelect(provider.issuer)}
+                  className="w-full text-left px-4 py-3 border border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
+                >
+                  <div className="font-medium text-gray-900">{provider.name}</div>
+                  {provider.description && (
+                    <div className="text-xs text-green-700 font-medium">{provider.description}</div>
+                  )}
+                  <div className="text-xs text-gray-400">{provider.issuer}</div>
+                </button>
+              ))}
+
+              {!showCustomInput ? (
+                <Button
+                  type="button"
+                  onClick={() => setShowCustomInput(true)}
+                  variant="secondary"
+                  className="w-full"
+                >
+                  Use Custom Provider
+                </Button>
+              ) : (
+                <div className="space-y-3 pt-2 border-t border-gray-200">
+                  <label className="block">
+                    <span className="text-sm font-medium text-gray-700">Custom Provider URL</span>
+                    <input
+                      type="url"
+                      value={customIssuer}
+                      onChange={(e) => setCustomIssuer(e.target.value)}
+                      placeholder="https://your-provider.com"
+                      className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                      autoFocus
+                    />
+                  </label>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      onClick={handleCustomSubmit}
+                      disabled={!customIssuer.trim()}
+                      className="flex-1"
+                    >
+                      Connect
+                    </Button>
+                    <Button
+                      type="button"
+                      onClick={() => {
+                        setShowCustomInput(false);
+                        setCustomIssuer('');
+                      }}
+                      variant="secondary"
+                      className="flex-1"
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
               )}
-              <div className="text-xs text-gray-400">{provider.issuer}</div>
-            </button>
-          ))}
+            </div>
+          )}
         </div>
 
         <p className="text-xs text-gray-500 text-center">
           No Pod? No problem — your data saves locally in your browser automatically.
         </p>
-
-        {!showCustomInput ? (
-          <Button
-            type="button"
-            onClick={() => setShowCustomInput(true)}
-            variant="secondary"
-            className="w-full"
-          >
-            Use Custom Provider
-          </Button>
-        ) : (
-          <div className="space-y-3 pt-2 border-t border-gray-200">
-            <label className="block">
-              <span className="text-sm font-medium text-gray-700">Custom Provider URL</span>
-              <input
-                type="url"
-                value={customIssuer}
-                onChange={(e) => setCustomIssuer(e.target.value)}
-                placeholder="https://your-provider.com"
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-                autoFocus
-              />
-            </label>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                onClick={handleCustomSubmit}
-                disabled={!customIssuer.trim()}
-                className="flex-1"
-              >
-                Connect
-              </Button>
-              <Button
-                type="button"
-                onClick={() => {
-                  setShowCustomInput(false);
-                  setCustomIssuer('');
-                }}
-                variant="secondary"
-                className="flex-1"
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
       </div>
     </Modal>
   );


### PR DESCRIPTION
Shows the last-used provider (or solidcommunity.net as default) as the
primary option. Other providers are collapsed behind an "Other providers"
toggle. Saves the selected provider to localStorage for next time.

https://claude.ai/code/session_01RBXnY28EVAfJDMXjkYbn5Y