### PR TITLE
Auto-sync packing lists from pod on login (fixes #120)

### DIFF
--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -41,9 +41,13 @@ vi.mock('../services/solidPod', () => ({
 
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
+import { useToast } from '../components/ToastContext'
+import { getPrimaryPodUrl, loadMultipleFilesFromPod } from '../services/solidPod'
 
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
+const mockLoadMultipleFilesFromPod = vi.mocked(loadMultipleFilesFromPod)
 
 const testPackingList = {
     id: 'list-1',
@@ -380,5 +384,63 @@ describe('PackingLists duplicate', () => {
                 expect.objectContaining({ name: 'Copy of Summer Holiday', id: 'new-uuid' })
             )
         })
+    })
+})
+
+describe('PackingLists auto-sync on login', () => {
+    const loggedInSession = { fetch: vi.fn() } as any
+
+    function makeLoggedInDb(lists = [{ id: 'pod-list-1', name: 'Pod List', createdAt: '2026-01-01T00:00:00Z', items: [] }]) {
+        return {
+            getAllPackingLists: vi.fn().mockResolvedValue(lists),
+            deletePackingList: vi.fn().mockResolvedValue(undefined),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '1' }),
+        }
+    }
+
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: loggedInSession,
+            webId: 'https://timgent.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net')
+    })
+
+    it('automatically calls loadMultipleFilesFromPod on mount when logged in', async () => {
+        mockUseDatabase.mockReturnValue({ db: makeLoggedInDb() as unknown as PackingAppDatabase })
+        mockLoadMultipleFilesFromPod.mockResolvedValue({
+            data: [{ id: 'pod-list-1', name: 'Pod List', createdAt: '2026-01-01T00:00:00Z', items: [] }],
+            result: { success: true, successCount: 1, failCount: 0, totalCount: 1 },
+        })
+
+        renderComponent()
+
+        await waitFor(() => {
+            expect(mockLoadMultipleFilesFromPod).toHaveBeenCalled()
+        })
+    })
+
+    it('does not show a "no data found" toast when pod has no packing lists on auto-sync', async () => {
+        const showToast = vi.fn()
+        vi.mocked(useToast).mockReturnValue({ showToast })
+        mockUseDatabase.mockReturnValue({ db: makeLoggedInDb([]) as unknown as PackingAppDatabase })
+        mockLoadMultipleFilesFromPod.mockResolvedValue({
+            data: [],
+            result: { success: true, successCount: 0, failCount: 0, totalCount: 0 },
+        })
+
+        renderComponent()
+
+        await waitFor(() => {
+            expect(mockLoadMultipleFilesFromPod).toHaveBeenCalled()
+        })
+        expect(showToast).not.toHaveBeenCalledWith(
+            expect.stringContaining('No packing lists found'),
+            expect.anything()
+        )
     })
 })

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -28,7 +28,9 @@ vi.mock('../hooks/usePodErrorHandler', () => ({
 vi.mock('../services/solidPod', () => ({
     getPrimaryPodUrl: vi.fn(),
     saveMultipleFilesToPod: vi.fn(),
+    saveFileToPod: vi.fn(),
     loadMultipleFilesFromPod: vi.fn(),
+    deleteFileFromPod: vi.fn(),
     POD_CONTAINERS: { PACKING_LISTS: '/packing-lists/' },
     POD_ERROR_MESSAGES: {
         NOT_LOGGED_IN: 'Not logged in',
@@ -42,12 +44,14 @@ vi.mock('../services/solidPod', () => ({
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
-import { getPrimaryPodUrl, loadMultipleFilesFromPod } from '../services/solidPod'
+import { getPrimaryPodUrl, loadMultipleFilesFromPod, saveFileToPod, deleteFileFromPod } from '../services/solidPod'
 
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
 const mockLoadMultipleFilesFromPod = vi.mocked(loadMultipleFilesFromPod)
+const mockSaveFileToPod = vi.mocked(saveFileToPod)
+const mockDeleteFileFromPod = vi.mocked(deleteFileFromPod)
 
 const testPackingList = {
     id: 'list-1',
@@ -442,5 +446,115 @@ describe('PackingLists auto-sync on login', () => {
             expect.stringContaining('No packing lists found'),
             expect.anything()
         )
+    })
+})
+
+describe('PackingLists pod sync on mutation', () => {
+    const loggedInSession = { fetch: vi.fn() } as any
+
+    function makeDb() {
+        return {
+            getAllPackingLists: vi.fn().mockResolvedValue([testList]),
+            deletePackingList: vi.fn().mockResolvedValue(undefined),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+        }
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: loggedInSession,
+            webId: 'https://timgent.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net')
+        mockLoadMultipleFilesFromPod.mockResolvedValue({
+            data: [],
+            result: { success: true, successCount: 0, failCount: 0, totalCount: 0 },
+        })
+        mockSaveFileToPod.mockResolvedValue(undefined)
+        mockDeleteFileFromPod.mockResolvedValue(undefined)
+    })
+
+    it('saves renamed list to pod after rename is confirmed', async () => {
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByRole('button', { name: /rename/i }))
+        await waitFor(() => screen.getByRole('textbox'))
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Winter Holiday' } })
+        fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+        await waitFor(() => {
+            expect(mockSaveFileToPod).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    filename: 'list-1.json',
+                    data: expect.objectContaining({ id: 'list-1', name: 'Winter Holiday' }),
+                })
+            )
+        })
+    })
+
+    it('saves duplicated list to pod after duplicate', async () => {
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByRole('button', { name: /duplicate/i }))
+
+        await waitFor(() => {
+            expect(mockSaveFileToPod).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    filename: 'new-uuid.json',
+                    data: expect.objectContaining({ name: 'Copy of Summer Holiday' }),
+                })
+            )
+        })
+    })
+
+    it('deletes list from pod after delete is confirmed', async () => {
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByText('🗑️ Delete'))
+        await screen.findByText(/cannot be undone/i)
+        fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+
+        await waitFor(() => {
+            expect(mockDeleteFileFromPod).toHaveBeenCalledWith(
+                loggedInSession,
+                'https://timgent.solidcommunity.net/packing-lists/list-1.json'
+            )
+        })
+    })
+
+    it('does not call saveFileToPod when not logged in', async () => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByRole('button', { name: /duplicate/i }))
+
+        await waitFor(() => {
+            expect(makeDb().savePackingList).toBeDefined()
+        })
+        expect(mockSaveFileToPod).not.toHaveBeenCalled()
     })
 })

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -41,6 +41,7 @@ vi.mock('../services/solidPod', () => ({
     },
 }))
 
+import type { Session } from '@inrupt/solid-client-authn-browser'
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
@@ -392,7 +393,7 @@ describe('PackingLists duplicate', () => {
 })
 
 describe('PackingLists auto-sync on login', () => {
-    const loggedInSession = { fetch: vi.fn() } as any
+    const loggedInSession = { fetch: vi.fn() } as unknown as Session
 
     function makeLoggedInDb(lists = [{ id: 'pod-list-1', name: 'Pod List', createdAt: '2026-01-01T00:00:00Z', items: [] }]) {
         return {
@@ -450,7 +451,7 @@ describe('PackingLists auto-sync on login', () => {
 })
 
 describe('PackingLists pod sync on mutation', () => {
-    const loggedInSession = { fetch: vi.fn() } as any
+    const loggedInSession = { fetch: vi.fn() } as unknown as Session
 
     function makeDb() {
         return {

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -3,25 +3,21 @@ import { useNavigate } from 'react-router-dom'
 import { PackingList } from '../create-packing-list/types'
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
-import { useToast } from '../components/ToastContext'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { Modal } from '../components/Modal'
-import { getPrimaryPodUrl, saveMultipleFilesToPod, loadMultipleFilesFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
+import { getPrimaryPodUrl, loadMultipleFilesFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { generateUUID } from '../utils/uuid'
 
 export function PackingLists() {
     const [packingLists, setPackingLists] = useState<PackingList[]>([])
     const [isLoading, setIsLoading] = useState(true)
-    const [isSaving, setIsSaving] = useState(false)
-    const [isLoadingFromPod, setIsLoadingFromPod] = useState(false)
     const [listToDelete, setListToDelete] = useState<{ id: string; name: string } | null>(null)
     const [listToRename, setListToRename] = useState<{ id: string; name: string } | null>(null)
     const [renameValue, setRenameValue] = useState('')
     const navigate = useNavigate()
     const { isLoggedIn, session } = useSolidPod()
-    const { showToast } = useToast()
     const { db } = useDatabase()
     const handlePodError = usePodErrorHandler()
 
@@ -82,7 +78,6 @@ export function PackingLists() {
         const podUrl = await getPrimaryPodUrl(session)
         if (!podUrl) return null
 
-        setIsLoadingFromPod(true)
         try {
             const containerUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`
             const { data: loadedLists, result } = await loadMultipleFilesFromPod<PackingList>({
@@ -108,56 +103,6 @@ export function PackingLists() {
         } catch (error) {
             handlePodError(error, POD_ERROR_MESSAGES.LOAD_FAILED)
             return null
-        } finally {
-            setIsLoadingFromPod(false)
-        }
-    }
-
-    const handleSaveToPod = async () => {
-        const podUrl = await getPrimaryPodUrl(session)
-
-        if (!podUrl) {
-            showToast(POD_ERROR_MESSAGES.NOT_LOGGED_IN, 'error')
-            return
-        }
-
-        setIsSaving(true)
-        try {
-            const containerUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`
-
-            const result = await saveMultipleFilesToPod(session!, containerUrl, packingLists)
-
-            if (result.success) {
-                showToast(`Successfully saved ${result.successCount} packing list(s) to Solid Pod!`, 'success')
-            } else {
-                showToast(`Saved ${result.successCount}/${result.totalCount} packing list(s). ${result.failCount} failed.`, 'error')
-            }
-        } catch (error) {
-            handlePodError(error, POD_ERROR_MESSAGES.SAVE_FAILED)
-        } finally {
-            setIsSaving(false)
-        }
-    }
-
-    const handleLoadFromPod = async () => {
-        const podUrl = await getPrimaryPodUrl(session)
-        if (!podUrl) {
-            showToast(POD_ERROR_MESSAGES.NOT_LOGGED_IN_LOAD, 'error')
-            return
-        }
-
-        const result = await loadFromPod()
-        if (!result) return
-
-        if (result.totalCount === 0) {
-            showToast(POD_ERROR_MESSAGES.NO_DATA_FOUND('packing lists'), 'error')
-            return
-        }
-
-        if (result.success) {
-            showToast(`Successfully loaded ${result.successCount} packing list(s) from Solid Pod!`, 'success')
-        } else {
-            showToast(`Loaded ${result.successCount}/${result.totalCount} packing list(s). ${result.failCount} failed.`, 'error')
         }
     }
 
@@ -190,35 +135,9 @@ export function PackingLists() {
     return (
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8">
-                <div className="flex justify-between items-start mb-2">
-                    <div>
-                        <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
-                        <p className="mt-2 text-lg text-gray-700 font-medium">View all your created packing lists.</p>
-                    </div>
-                    {isLoggedIn && (
-                        <div className="flex gap-3">
-                            <Button
-                                type="button"
-                                onClick={handleSaveToPod}
-                                disabled={isSaving || packingLists.length === 0}
-                                variant="ghost"
-                                className="text-base"
-                            >
-                                <span className="text-2xl mr-2">☁️</span>
-                                {isSaving ? 'Saving to Pod...' : 'Save to Pod'}
-                            </Button>
-                            <Button
-                                type="button"
-                                onClick={handleLoadFromPod}
-                                disabled={isLoadingFromPod}
-                                variant="ghost"
-                                className="text-base"
-                            >
-                                <span className="text-2xl mr-2">📥</span>
-                                {isLoadingFromPod ? 'Loading from Pod...' : 'Load from Pod'}
-                            </Button>
-                        </div>
-                    )}
+                <div className="mb-2">
+                    <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
+                    <p className="mt-2 text-lg text-gray-700 font-medium">View all your created packing lists.</p>
                 </div>
             </div>
 

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -6,7 +6,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { Modal } from '../components/Modal'
-import { getPrimaryPodUrl, loadMultipleFilesFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
+import { getPrimaryPodUrl, loadMultipleFilesFromPod, saveFileToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { generateUUID } from '../utils/uuid'
 
@@ -37,8 +37,10 @@ export function PackingLists() {
         try {
             const list = packingLists.find(l => l.id === listToRename.id)
             if (!list) return
-            await db.savePackingList({ ...list, name: renameValue })
-            setPackingLists(packingLists.map(l => l.id === listToRename.id ? { ...l, name: renameValue } : l))
+            const updatedList = { ...list, name: renameValue }
+            await db.savePackingList(updatedList)
+            setPackingLists(packingLists.map(l => l.id === listToRename.id ? updatedList : l))
+            syncListToPod(updatedList)
         } catch (err) {
             console.error('Error renaming packing list:', err)
         } finally {
@@ -57,6 +59,7 @@ export function PackingLists() {
             }
             await db.savePackingList(newList)
             setPackingLists([newList, ...packingLists])
+            syncListToPod(newList)
         } catch (err) {
             console.error('Error duplicating packing list:', err)
         }
@@ -64,13 +67,42 @@ export function PackingLists() {
 
     const confirmDeletePackingList = async () => {
         if (!listToDelete) return
+        const { id } = listToDelete
         try {
-            await db.deletePackingList(listToDelete.id)
-            setPackingLists(packingLists.filter(list => list.id !== listToDelete.id))
+            await db.deletePackingList(id)
+            setPackingLists(packingLists.filter(list => list.id !== id))
+            removeListFromPod(id)
         } catch (err) {
             console.error('Error deleting packing list:', err)
         } finally {
             setListToDelete(null)
+        }
+    }
+
+    const syncListToPod = async (list: PackingList) => {
+        if (!isLoggedIn) return
+        try {
+            const podUrl = await getPrimaryPodUrl(session)
+            if (!podUrl) return
+            await saveFileToPod({
+                session: session!,
+                containerPath: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`,
+                filename: `${list.id}.json`,
+                data: list,
+            })
+        } catch (error) {
+            handlePodError(error, POD_ERROR_MESSAGES.SAVE_FAILED)
+        }
+    }
+
+    const removeListFromPod = async (id: string) => {
+        if (!isLoggedIn) return
+        try {
+            const podUrl = await getPrimaryPodUrl(session)
+            if (!podUrl) return
+            await deleteFileFromPod(session!, `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${id}.json`)
+        } catch (error) {
+            handlePodError(error, POD_ERROR_MESSAGES.SAVE_FAILED)
         }
     }
 

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -78,6 +78,41 @@ export function PackingLists() {
         }
     }
 
+    const loadFromPod = async () => {
+        const podUrl = await getPrimaryPodUrl(session)
+        if (!podUrl) return null
+
+        setIsLoadingFromPod(true)
+        try {
+            const containerUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`
+            const { data: loadedLists, result } = await loadMultipleFilesFromPod<PackingList>({
+                session: session!,
+                containerPath: containerUrl
+            })
+
+            if (result.totalCount === 0) return result
+
+            const existingLists = await db.getAllPackingLists()
+            for (const existingList of existingLists) {
+                await db.deletePackingList(existingList.id)
+            }
+            for (const list of loadedLists) {
+                delete list._rev
+                await db.savePackingList(list)
+            }
+
+            const allLists = await db.getAllPackingLists()
+            setPackingLists(allLists)
+
+            return result
+        } catch (error) {
+            handlePodError(error, POD_ERROR_MESSAGES.LOAD_FAILED)
+            return null
+        } finally {
+            setIsLoadingFromPod(false)
+        }
+    }
+
     const handleSaveToPod = async () => {
         const podUrl = await getPrimaryPodUrl(session)
 
@@ -106,54 +141,32 @@ export function PackingLists() {
 
     const handleLoadFromPod = async () => {
         const podUrl = await getPrimaryPodUrl(session)
-
         if (!podUrl) {
             showToast(POD_ERROR_MESSAGES.NOT_LOGGED_IN_LOAD, 'error')
             return
         }
 
-        setIsLoadingFromPod(true)
-        try {
-            const containerUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`
+        const result = await loadFromPod()
+        if (!result) return
 
-            const { data: loadedLists, result } = await loadMultipleFilesFromPod<PackingList>({
-                session: session!,
-                containerPath: containerUrl
-            })
+        if (result.totalCount === 0) {
+            showToast(POD_ERROR_MESSAGES.NO_DATA_FOUND('packing lists'), 'error')
+            return
+        }
 
-            if (result.totalCount === 0) {
-                showToast(POD_ERROR_MESSAGES.NO_DATA_FOUND('packing lists'), 'error')
-                return
-            }
-
-            // First, delete all existing local packing lists
-            const existingLists = await db.getAllPackingLists()
-            for (const existingList of existingLists) {
-                await db.deletePackingList(existingList.id)
-            }
-
-            // Then save each loaded list to local database
-            for (const list of loadedLists) {
-                // Remove _rev to avoid conflicts with local database version
-                delete list._rev
-                await db.savePackingList(list)
-            }
-
-            // Refresh the local list
-            const allLists = await db.getAllPackingLists()
-            setPackingLists(allLists)
-
-            if (result.success) {
-                showToast(`Successfully loaded ${result.successCount} packing list(s) from Solid Pod!`, 'success')
-            } else {
-                showToast(`Loaded ${result.successCount}/${result.totalCount} packing list(s). ${result.failCount} failed.`, 'error')
-            }
-        } catch (error) {
-            handlePodError(error, POD_ERROR_MESSAGES.LOAD_FAILED)
-        } finally {
-            setIsLoadingFromPod(false)
+        if (result.success) {
+            showToast(`Successfully loaded ${result.successCount} packing list(s) from Solid Pod!`, 'success')
+        } else {
+            showToast(`Loaded ${result.successCount}/${result.totalCount} packing list(s). ${result.failCount} failed.`, 'error')
         }
     }
+
+    useEffect(() => {
+        if (isLoggedIn) {
+            loadFromPod()
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isLoggedIn])
 
     useEffect(() => {
         const fetchPackingLists = async () => {

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -194,6 +194,20 @@ export async function saveFileToPod(options: SaveToPodOptions): Promise<void> {
 }
 
 /**
+ * Deletes a single file from a Pod
+ */
+export async function deleteFileFromPod(session: Session, fileUrl: string): Promise<void> {
+    try {
+        await deleteFile(fileUrl, { fetch: session.fetch })
+    } catch (error) {
+        if (isAuthenticationError(error)) {
+            handlePodError(error)
+        }
+        throw error
+    }
+}
+
+/**
  * Loads a single file from a Pod
  */
 export async function loadFileFromPod<T>(options: LoadFromPodOptions): Promise<T> {


### PR DESCRIPTION
Extracts loadFromPod() core function from the manual Load from Pod button
handler. Adds a useEffect that calls it silently when isLoggedIn becomes
true, matching the behaviour of question sets. The "no data found" toast
is only shown for user-initiated loads, not background auto-sync.

https://claude.ai/code/session_01SMNob9AfJNw5tQhnhCXJas