### PR TITLE
Add Jumper to default overnight packing items

### DIFF
--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -203,6 +203,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                             item("Socks", people),
                             item("T-shirt/Top", people),
                             item("Trousers/Shorts", people),
+                            item("Jumper", people),
                             // Baby items
                             item("Baby monitor", people, getBabies),
                             item("Nightlight", people, getBabies),


### PR DESCRIPTION
## What this PR does

Adds a Jumper to the default items suggested for all people when answering "Yes" to the overnight stay question in the wizard.

## Manual testing steps

1. Run the wizard to create a new question set
2. Create a packing list and answer "Yes" to "Will you be staying overnight?"
3. Verify "Jumper" appears in the generated packing list for all people