### PR TITLE
Fix lists not showing in View Lists after creation

### DIFF
--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -24,12 +24,23 @@ vi.mock('../hooks/useHasQuestions', () => ({
     useHasQuestions: vi.fn(),
 }))
 
+vi.mock('../services/solidPod', () => ({
+    getPrimaryPodUrl: vi.fn(),
+    saveFileToPod: vi.fn(),
+    POD_CONTAINERS: { PACKING_LISTS: 'pack-me-up/packing-lists/' },
+    POD_ERROR_MESSAGES: { SAVE_FAILED: 'Save failed' },
+}))
+
 import { useSolidPod } from '../components/SolidPodContext'
 import { useDatabase } from '../components/DatabaseContext'
 import { useToast } from '../components/ToastContext'
 import { ToastType } from '../components/Toast'
 import { PackingAppDatabase } from '../services/database'
 import { CreatePackingList } from './create-packing-list'
+import { getPrimaryPodUrl, saveFileToPod } from '../services/solidPod'
+
+const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
+const mockSaveFileToPod = vi.mocked(saveFileToPod)
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockUseDatabase = vi.mocked(useDatabase)
@@ -506,5 +517,73 @@ describe('CreatePackingList - login button', () => {
         const loginButton = screen.getByRole('button', { name: /login with solid pod/i })
         fireEvent.click(loginButton)
         expect(screen.getByRole('dialog')).toBeTruthy()
+    })
+})
+
+describe('CreatePackingList – pod sync on creation', () => {
+    const loggedInSession = { fetch: vi.fn() } as ReturnType<typeof useSolidPod>['session']
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({
+            session: loggedInSession,
+            isLoggedIn: true,
+            webId: 'https://timgent.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseToast.mockReturnValue({ showToast: vi.fn() } as ReturnType<typeof useToast>)
+        mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net/')
+        mockSaveFileToPod.mockResolvedValue(undefined)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('syncs the newly created list to the pod immediately after saving', async () => {
+        mockUseDatabase.mockReturnValue({
+            db: makeDb({ getAllPackingLists: vi.fn().mockResolvedValue([]) }),
+        } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+
+        fireEvent.change(screen.getByPlaceholderText(/enter a name/i), { target: { value: 'My New List' } })
+        fireEvent.click(screen.getByRole('radio', { name: /beach/i }))
+        fireEvent.click(screen.getByRole('button', { name: /create packing list/i }))
+
+        await waitFor(() => {
+            expect(mockSaveFileToPod).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    containerPath: 'https://timgent.solidcommunity.net/pack-me-up/packing-lists/',
+                    data: expect.objectContaining({ name: 'My New List' }),
+                })
+            )
+        })
+    })
+
+    it('does not call saveFileToPod when not logged in', async () => {
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        const db = makeDb({ getAllPackingLists: vi.fn().mockResolvedValue([]) })
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+
+        fireEvent.change(screen.getByPlaceholderText(/enter a name/i), { target: { value: 'My New List' } })
+        fireEvent.click(screen.getByRole('radio', { name: /beach/i }))
+        fireEvent.click(screen.getByRole('button', { name: /create packing list/i }))
+
+        await waitFor(() => expect(vi.mocked(db.savePackingList)).toHaveBeenCalled())
+        expect(mockSaveFileToPod).not.toHaveBeenCalled()
     })
 })

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -9,6 +9,7 @@ import { Button } from '../components/Button'
 import { useToast } from '../components/ToastContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { SolidProviderSelector } from '../components/SolidProviderSelector'
+import { getPrimaryPodUrl, saveFileToPod, POD_CONTAINERS } from '../services/solidPod'
 
 export function deduplicateItems(items: PackingListItem[]): PackingListItem[] {
     const seen = new Set<string>()
@@ -144,7 +145,7 @@ export function CreatePackingList() {
     const [selectedPeopleIds, setSelectedPeopleIds] = useState<string[]>([])
     const [isSuggestionDismissed, setIsSuggestionDismissed] = useState(false)
     const { showToast } = useToast()
-    const { isLoggedIn, login } = useSolidPod()
+    const { isLoggedIn, login, session } = useSolidPod()
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
     const { db } = useDatabase()
     const navigate = useNavigate()
@@ -294,6 +295,17 @@ export function CreatePackingList() {
         }
         try {
             await db.savePackingList(packingList)
+            if (isLoggedIn) {
+                const podUrl = await getPrimaryPodUrl(session)
+                if (podUrl) {
+                    await saveFileToPod({
+                        session: session!,
+                        containerPath: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`,
+                        filename: `${packingList.id}.json`,
+                        data: packingList,
+                    })
+                }
+            }
             showToast('Packing list created successfully!', 'success')
             // Navigate to the newly created packing list
             navigate(`/view-lists/${packingList.id}`)

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -582,3 +582,54 @@ describe('PackingLists pod sync on mutation', () => {
         expect(mockSaveFileToPod).not.toHaveBeenCalled()
     })
 })
+
+describe('PackingLists local-only lists preserved when loading from pod', () => {
+    const loggedInSession = { fetch: vi.fn() } as unknown as Session
+
+    const podList = { id: 'pod-list-1', name: 'Old Pod List', createdAt: '2026-01-01T00:00:00Z', items: [] }
+    const localOnlyList = { id: 'local-only-1', name: 'Newly Created List', createdAt: '2026-02-01T00:00:00Z', items: [] }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: loggedInSession,
+            webId: 'https://timgent.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net')
+        // Pod has only the old list (local-only-1 was never synced)
+        mockLoadMultipleFilesFromPod.mockResolvedValue({
+            data: [podList],
+            result: { success: true, successCount: 1, failCount: 0, totalCount: 1 },
+        })
+        mockSaveFileToPod.mockResolvedValue(undefined)
+    })
+
+    it('shows locally created list that has not yet been synced to pod', async () => {
+        // Simulate a real DB: starts with both lists, and deletePackingList actually removes from state
+        const dbState = new Map([
+            [podList.id, podList],
+            [localOnlyList.id, localOnlyList],
+        ])
+
+        const db = {
+            getAllPackingLists: vi.fn().mockImplementation(async () => Array.from(dbState.values())),
+            deletePackingList: vi.fn().mockImplementation(async (id: string) => { dbState.delete(id) }),
+            savePackingList: vi.fn().mockImplementation(async (list: typeof podList) => {
+                dbState.set(list.id, list)
+                return { rev: '1' }
+            }),
+        }
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        renderComponent()
+
+        await waitFor(() => {
+            expect(screen.getByText(/Old Pod List/)).toBeTruthy()
+            expect(screen.getByText(/Newly Created List/)).toBeTruthy()
+        })
+    })
+})

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -120,12 +120,24 @@ export function PackingLists() {
             if (result.totalCount === 0) return result
 
             const existingLists = await db.getAllPackingLists()
+            const podListIds = new Set(loadedLists.map(l => l.id))
+
+            // Only delete local lists that are also in the pod (they'll be replaced with the pod version).
+            // Local-only lists (not yet synced) are preserved and synced up to the pod.
             for (const existingList of existingLists) {
-                await db.deletePackingList(existingList.id)
+                if (podListIds.has(existingList.id)) {
+                    await db.deletePackingList(existingList.id)
+                }
             }
             for (const list of loadedLists) {
                 delete list._rev
                 await db.savePackingList(list)
+            }
+
+            // Sync any local-only lists to the pod so they aren't lost on future loads
+            const localOnlyLists = existingLists.filter(l => !podListIds.has(l.id))
+            for (const localList of localOnlyLists) {
+                await syncListToPod(localList)
             }
 
             const allLists = await db.getAllPackingLists()


### PR DESCRIPTION
When loading from pod on the View Lists page, the app was replacing
ALL local packing lists with only the pod's lists. Any list created
locally but not yet synced to the pod (e.g. a freshly created list)
would be silently deleted.

Fix: only replace local lists that already exist in the pod.
Local-only lists are preserved and also synced up to the pod so they
won't be lost on subsequent loads.

https://claude.ai/code/session_016RLoVJefCvEdwPwG8XUFpv