### PR TITLE
Add Playwright E2E test suite (35 tests, all scenarios)

### DIFF
--- a/.claude/skills/solid-dev/start.sh
+++ b/.claude/skills/solid-dev/start.sh
@@ -1,13 +1,38 @@
 #!/usr/bin/env bash
 set -e
 
+# Install JQ
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not found, installing..."
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    if ! command -v brew >/dev/null 2>&1; then
+      echo "Homebrew not found. Please install Homebrew first: https://brew.sh/"
+      exit 1
+    fi
+    brew install jq
+
+  elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Ubuntu / Debian
+    sudo apt-get update
+    sudo apt-get install -y jq
+
+  else
+    echo "Unsupported OS: $OSTYPE"
+    exit 1
+  fi
+else
+  echo "jq is already installed"
+fi
+
 PORT=4000
 
 # 1. Free the port
 lsof -ti:$PORT | xargs kill -9 2>/dev/null || true
 
 # 2. Start CSS in background
-npx --yes @solid/community-server -p $PORT > /tmp/css.log 2>&1 &
+npx --yes @solid/community-server -p $PORT >/tmp/css.log 2>&1 &
 CSS_PID=$!
 echo "CSS starting (PID $CSS_PID)..."
 
@@ -19,25 +44,32 @@ for i in $(seq 1 30); do
 done
 
 # 4a. Create account, capture token and account-specific URLs
+echo "Creating account..."
 ACCOUNT_RESP=$(curl -s -X POST http://localhost:$PORT/.account/account/ \
   -H 'Content-Type: application/json' -d '{}')
+echo "ACCOUNT_RESP is $ACCOUNT_RESP"
 TOKEN=$(echo "$ACCOUNT_RESP" | grep -o '"authorization":"[^"]*"' | cut -d'"' -f4)
 # Discover account-specific URLs via authenticated GET
 CONTROLS=$(curl -s -H "Authorization: CSS-Account-Token $TOKEN" http://localhost:$PORT/.account/)
 POD_URL=$(echo "$CONTROLS" | grep -o '"pod":"http://[^"]*"' | cut -d'"' -f4)
-PASSWORD_URL=$(echo "$CONTROLS" | grep -o '"create":"http://[^"]*password[^"]*"' | cut -d'"' -f4)
+PASSWORD_URL=$(echo "$CONTROLS" | jq -r '.controls.password.create')
+
+echo PASSWORD_URL is $PASSWORD_URL
+echo TOKEN is $TOKEN
 
 # 4b. Register email/password login
+echo "Registering email/password login"
 curl -s -X POST "$PASSWORD_URL" \
   -H 'Content-Type: application/json' \
   -H "Authorization: CSS-Account-Token $TOKEN" \
-  -d '{"email":"test@example.com","password":"test1234"}' > /dev/null
+  -d '{"email":"test@example.com","password":"test1234"}'
 
 # 4c. Create pod
+echo "Creating pod"
 curl -s -X POST "$POD_URL" \
   -H 'Content-Type: application/json' \
   -H "Authorization: CSS-Account-Token $TOKEN" \
-  -d '{"name":"test"}' > /dev/null
+  -d '{"name":"test"}'
 
 echo ""
 echo "============================================"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,36 @@ jobs:
 
       - name: Run linter
         run: npm run lint
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser & OS dependencies
+        run: npx playwright install chromium --with-deps
+
+      - name: Build app
+        run: npm run build
+
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,12 @@ packing-app-data--*/
 packing-list-question-set/
 packing-lists/
 
+# E2E test artefacts
+e2e/.auth/
+playwright-report/
+test-results/
+.e2e-css-pid
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,52 @@
+import { test as base, BrowserContext, Page } from '@playwright/test'
+import { AUTH_STATE_FILE, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD } from '../playwright.config'
+import { loginToCss } from './helpers/login'
+
+type MyFixtures = {
+  /** A page with a fresh (empty) browser context — no auth, no local data */
+  freshPage: Page
+  /** A page already logged into the Solid Pod (uses saved storage state) */
+  authedPage: Page
+  /** A fresh context with a pre-loaded auth state */
+  authedContext: BrowserContext
+}
+
+export const test = base.extend<MyFixtures>({
+  freshPage: async ({ browser }, use) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    await use(page)
+    await context.close()
+  },
+
+  authedContext: async ({ browser }, use) => {
+    let context: BrowserContext
+    try {
+      context = await browser.newContext({ storageState: AUTH_STATE_FILE })
+    } catch {
+      // Auth file doesn't exist — do a fresh login
+      context = await browser.newContext()
+      const page = await context.newPage()
+      await page.goto('/')
+      await loginToCss(page, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD)
+      await context.storageState({ path: AUTH_STATE_FILE })
+    }
+    await use(context)
+    await context.close()
+  },
+
+  authedPage: async ({ authedContext }, use) => {
+    const page = await authedContext.newPage()
+    await page.goto('/')
+    // Verify we're still logged in
+    const isLoggedIn = await page.locator('button:has-text("Logout")').isVisible({ timeout: 5_000 }).catch(() => false)
+    if (!isLoggedIn) {
+      // Session expired — re-login
+      await loginToCss(page, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD)
+      await authedContext.storageState({ path: AUTH_STATE_FILE })
+    }
+    await use(page)
+  },
+})
+
+export { expect } from '@playwright/test'

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,63 @@
+import { chromium } from '@playwright/test'
+import { spawn } from 'child_process'
+import { mkdirSync, writeFileSync } from 'fs'
+import path from 'path'
+import { createCssAccount } from './helpers/css-api'
+import { loginToCss } from './helpers/login'
+import {
+  CSS_PORT, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD, TEST_POD_NAME,
+  AUTH_STATE_FILE, CSS_PID_FILE, CHROMIUM_PATH, APP_URL
+} from '../playwright.config'
+
+async function waitForUrl(url: string, maxWaitMs = 30_000): Promise<void> {
+  const deadline = Date.now() + maxWaitMs
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(2000) })
+      if (res.status < 500) return
+    } catch { /* not ready yet */ }
+    await new Promise(r => setTimeout(r, 500))
+  }
+  throw new Error(`${url} did not become available within ${maxWaitMs}ms`)
+}
+
+export default async function globalSetup() {
+  // 1. Start CSS
+  const cssProc = spawn(
+    'npx',
+    ['--yes', '@solid/community-server', '-p', String(CSS_PORT)],
+    { stdio: 'pipe', shell: true, detached: false }
+  )
+  writeFileSync(CSS_PID_FILE, String(cssProc.pid))
+  process.env.CSS_ISSUER = CSS_ISSUER
+
+  console.log(`[setup] Starting CSS on port ${CSS_PORT} (pid ${cssProc.pid})...`)
+  await waitForUrl(`http://localhost:${CSS_PORT}/.account/`)
+  console.log('[setup] CSS ready')
+
+  // 2. Create test account
+  await createCssAccount(CSS_PORT, TEST_EMAIL, TEST_PASSWORD, TEST_POD_NAME)
+  console.log(`[setup] Test account created: ${TEST_EMAIL}`)
+
+  // 3. Wait for app
+  console.log('[setup] Waiting for app...')
+  await waitForUrl(APP_URL)
+  console.log('[setup] App ready')
+
+  // 4. Browser login → save storage state
+  mkdirSync(path.dirname(AUTH_STATE_FILE), { recursive: true })
+  const browser = await chromium.launch({
+    executablePath: CHROMIUM_PATH,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  })
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  try {
+    await page.goto(APP_URL)
+    await loginToCss(page, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD)
+    await context.storageState({ path: AUTH_STATE_FILE })
+    console.log('[setup] Auth state saved')
+  } finally {
+    await browser.close()
+  }
+}

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,14 @@
+import { existsSync, readFileSync, unlinkSync } from 'fs'
+import { CSS_PID_FILE } from '../playwright.config'
+
+export default async function globalTeardown() {
+  if (!existsSync(CSS_PID_FILE)) return
+  const pid = parseInt(readFileSync(CSS_PID_FILE, 'utf8'), 10)
+  try {
+    process.kill(pid)
+    console.log(`[teardown] Killed CSS process ${pid}`)
+  } catch {
+    // Process may have already exited
+  }
+  unlinkSync(CSS_PID_FILE)
+}

--- a/e2e/helpers/css-api.ts
+++ b/e2e/helpers/css-api.ts
@@ -1,0 +1,73 @@
+/**
+ * CSS (Community Solid Server) v7 REST API helpers.
+ *
+ * Account creation flow:
+ *  1. POST /.account/account/  → { authorization: TOKEN, controls: {...} }
+ *  2. GET  /.account/          with CSS-Account-Token header → { controls: {...} }
+ *  3. POST controls.password.create URL  → register email+password login
+ *  4. POST controls.account.pod URL      → create pod
+ */
+export async function createCssAccount(
+  port: number,
+  email: string,
+  password: string,
+  podName: string,
+): Promise<void> {
+  const base = `http://localhost:${port}`
+
+  // Step 1: Create blank account
+  const accountRes = await fetch(`${base}/.account/account/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}',
+  })
+  if (!accountRes.ok) {
+    throw new Error(`CSS account creation failed: ${accountRes.status} ${await accountRes.text()}`)
+  }
+  const accountData = await accountRes.json() as Record<string, unknown>
+  const token = accountData.authorization as string
+
+  // Step 2: Get controls for this account
+  const controlsRes = await fetch(`${base}/.account/`, {
+    headers: { Authorization: `CSS-Account-Token ${token}` },
+  })
+  const controlsData = await controlsRes.json() as Record<string, unknown>
+
+  // Extract URLs by searching the serialised JSON (matches shell script approach)
+  const controlsStr = JSON.stringify(controlsData)
+  const passwordUrl = extractUrl(controlsStr, /"create":"(http:\/\/[^"]*password[^"]*)"/)?.[1]
+  const podUrl = extractUrl(controlsStr, /"pod":"(http:\/\/[^"]*)"/)?.[1]
+
+  if (!passwordUrl) throw new Error('Could not find password create URL in CSS controls')
+  if (!podUrl) throw new Error('Could not find pod create URL in CSS controls')
+
+  // Step 3: Register email+password login
+  const pwRes = await fetch(passwordUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `CSS-Account-Token ${token}`,
+    },
+    body: JSON.stringify({ email, password }),
+  })
+  if (!pwRes.ok) {
+    throw new Error(`CSS password registration failed: ${pwRes.status} ${await pwRes.text()}`)
+  }
+
+  // Step 4: Create pod
+  const podRes = await fetch(podUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `CSS-Account-Token ${token}`,
+    },
+    body: JSON.stringify({ name: podName }),
+  })
+  if (!podRes.ok) {
+    throw new Error(`CSS pod creation failed: ${podRes.status} ${await podRes.text()}`)
+  }
+}
+
+function extractUrl(json: string, pattern: RegExp): RegExpMatchArray | null {
+  return json.match(pattern)
+}

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,0 +1,57 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Automates the full Solid Pod OAuth login flow through the app's UI.
+ *
+ * Steps:
+ *  1. Click "Login with Solid Pod" in the navigation
+ *  2. Open provider selector modal → "Other providers" → "Use Custom Provider"
+ *  3. Enter the CSS issuer URL → "Connect"
+ *  4. Wait for redirect to CSS, fill login form
+ *  5. Approve consent if shown
+ *  6. Wait for redirect back to app and session to be established
+ */
+export async function loginToCss(
+  page: Page,
+  cssIssuer: string,
+  email: string,
+  password: string,
+): Promise<void> {
+  // Open provider selector
+  await page.getByRole('button', { name: 'Login with Solid Pod' }).click()
+  await page.getByRole('dialog').waitFor()
+
+  // Show other providers
+  await page.getByText('Other providers').click()
+
+  // Show custom provider input
+  await page.getByRole('button', { name: 'Use Custom Provider' }).click()
+
+  // Fill in CSS URL
+  await page.getByLabel('Custom Provider URL').fill(cssIssuer)
+  await page.getByRole('button', { name: 'Connect' }).click()
+
+  // Wait for navigation to CSS
+  await page.waitForURL(url => url.hostname === 'localhost' && url.port === new URL(cssIssuer).port, { timeout: 15_000 })
+
+  // Fill CSS login form
+  await page.locator('input[name="email"], input[type="email"], #email').fill(email)
+  await page.locator('input[name="password"], input[type="password"], #password').fill(password)
+  await page.locator('button[type="submit"], input[type="submit"]').first().click()
+
+  // Handle optional consent page
+  try {
+    await page.waitForURL(url => url.pathname.includes('consent') || url.pathname.includes('authorize'), { timeout: 4_000 })
+    const allowBtn = page.locator('[name="accept"], button:has-text("Allow"), button:has-text("Approve")').first()
+    await allowBtn.click()
+  } catch {
+    // No consent page — continue
+  }
+
+  // Wait for redirect back to the app's OAuth callback
+  await page.waitForURL(/pod-auth-callback\.html/, { timeout: 20_000 })
+
+  // Wait for app to process auth and show the logged-in state
+  await page.waitForURL(/localhost:4173/, { timeout: 10_000 })
+  await page.locator('button:has-text("Logout"), [title*="Logout"]').first().waitFor({ timeout: 20_000 })
+}

--- a/e2e/tests/a-onboarding.spec.ts
+++ b/e2e/tests/a-onboarding.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '../fixtures'
+
+test.describe('A – Onboarding & Wizard', () => {
+  test('A1: fresh start shows Get Started button', async ({ freshPage: page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('link', { name: /Get Started with the Wizard/i })).toBeVisible()
+    await expect(page.getByRole('link', { name: /View Packing Lists/i })).not.toBeVisible()
+  })
+
+  test('A2: wizard with one person redirects to create-packing-list after dismissing pod prompt', async ({ freshPage: page }) => {
+    await page.goto('/#/wizard')
+    // name field is pre-filled with "Me"
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    // Success modal
+    await expect(page.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: /Create My First Packing List/i }).click()
+    // Pod prompt appears for non-logged-in users
+    await expect(page.getByText("Great! Your Questions Are Ready")).toBeVisible({ timeout: 5_000 })
+    await page.getByRole('button', { name: 'Maybe Later' }).click()
+    // Should be on create-packing-list page
+    await expect(page).toHaveURL(/#\/create-packing-list/, { timeout: 5_000 })
+    // Landing page now shows "View Packing Lists"
+    await page.goto('/')
+    await expect(page.getByRole('link', { name: /View Packing Lists/i })).toBeVisible()
+  })
+
+  test('A3: wizard with two people saves both to question set', async ({ freshPage: page }) => {
+    await page.goto('/#/wizard')
+    // First person already present — set name
+    await page.getByLabel('Name').first().fill('Alice')
+    // Add second person
+    await page.getByRole('button', { name: /Add Another Person/i }).click()
+    const nameInputs = page.getByLabel('Name')
+    await nameInputs.nth(1).fill('Bob')
+    // Generate
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(page.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+    // Dismiss pod prompt path
+    await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
+    await page.getByRole('button', { name: 'Maybe Later' }).click()
+    // On manage-questions page, both names should appear
+    await expect(page).toHaveURL(/#\/manage-questions/, { timeout: 5_000 })
+    await expect(page.getByText('Alice')).toBeVisible()
+    await expect(page.getByText('Bob')).toBeVisible()
+  })
+
+  test('A4: wizard shows warning when questions already exist and confirmation on submit', async ({ freshPage: page }) => {
+    // First run: create questions
+    await page.goto('/#/wizard')
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(page.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
+    await page.getByRole('button', { name: 'Maybe Later' }).click()
+    // Second run: wizard should warn
+    await page.goto('/#/wizard')
+    await expect(page.getByText(/already have packing list questions/i)).toBeVisible()
+    // Submit again → confirmation dialog
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(page.getByText('Existing Data Found')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Yes, Override' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
+  })
+})

--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '../fixtures'
+
+async function setupWizardAndGoToQuestions(page: import('@playwright/test').Page) {
+  await page.goto('/#/wizard')
+  await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+  await expect(page.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+  await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
+  // handle pod prompt
+  try {
+    await page.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 })
+  } catch { /* already dismissed or logged in */ }
+  await page.waitForURL(/#\/manage-questions/, { timeout: 5_000 })
+}
+
+test.describe('B – Editing Questions', () => {
+  test('B1: manage-questions page loads with sections', async ({ freshPage: page }) => {
+    await setupWizardAndGoToQuestions(page)
+    await expect(page.getByText("My Questions & Items")).toBeVisible()
+    // Page has a section for people
+    await expect(page.getByText(/Who.*packing|People/i)).toBeVisible()
+  })
+
+  test('B2: add a person to the question set', async ({ freshPage: page }) => {
+    await setupWizardAndGoToQuestions(page)
+    // Find and click "Add Person" button
+    await page.getByRole('button', { name: /Add Person/i }).click()
+    // A new person entry should appear — type a name
+    const nameInputs = page.getByPlaceholder(/name|person/i)
+    const count = await nameInputs.count()
+    await nameInputs.nth(count - 1).fill('Charlie')
+    // Wait for auto-save
+    await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 8_000 })
+    // Reload to confirm persistence
+    await page.reload()
+    await expect(page.getByText('Charlie')).toBeVisible()
+  })
+
+  test('B3: remove a person from the question set', async ({ freshPage: page }) => {
+    // Wizard creates one person "Me" — we need at least 2 to remove one
+    await page.goto('/#/wizard')
+    await page.getByLabel('Name').first().fill('PersonA')
+    await page.getByRole('button', { name: /Add Another Person/i }).click()
+    const nameInputs = page.getByLabel('Name')
+    await nameInputs.nth(1).fill('PersonB')
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(page.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
+    try { await page.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 }) } catch { /* ok */ }
+    await page.waitForURL(/#\/manage-questions/)
+    await expect(page.getByText('PersonB')).toBeVisible()
+    // Click delete/remove button next to PersonB
+    const personBSection = page.locator(':has-text("PersonB")').last()
+    await personBSection.getByRole('button', { name: /remove|delete/i }).click()
+    await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 8_000 })
+    await page.reload()
+    await expect(page.getByText('PersonB')).not.toBeVisible()
+  })
+
+  test('B4: add an always-needed item', async ({ freshPage: page }) => {
+    await setupWizardAndGoToQuestions(page)
+    // Find "Always Needed Items" section and add an item
+    const alwaysSection = page.getByText(/always.needed|always needed/i).first()
+    await expect(alwaysSection).toBeVisible()
+    // There should be an input or "Add Item" button nearby
+    const addItemBtn = page.getByRole('button', { name: /Add.*item|New.*item/i }).first()
+    await addItemBtn.click()
+    // Type in the new item text
+    const newItemInput = page.getByPlaceholder(/item.*text|new item/i).last()
+    await newItemInput.fill('Passport')
+    await page.keyboard.press('Enter')
+    await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 8_000 })
+    await page.reload()
+    await expect(page.getByText('Passport')).toBeVisible()
+  })
+
+  test('B5: switch to JSON editor mode and back', async ({ freshPage: page }) => {
+    await setupWizardAndGoToQuestions(page)
+    // Click "JSON" or "Edit as JSON" button
+    const jsonBtn = page.getByRole('button', { name: /json|edit.*json/i }).first()
+    await jsonBtn.click()
+    // Should see a textarea with JSON content
+    const textarea = page.locator('textarea')
+    await expect(textarea).toBeVisible()
+    const content = await textarea.inputValue()
+    expect(content).toContain('"questions"')
+    // Switch back to visual editor
+    await page.getByRole('button', { name: /visual|form|back/i }).first().click()
+    // Visual editor should be back
+    await expect(page.getByText(/Questions|People/i)).toBeVisible()
+  })
+})

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '../fixtures'
+
+async function runWizard(page: import('@playwright/test').Page) {
+  await page.goto('/#/wizard')
+  await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+  await expect(page.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+  await page.getByRole('button', { name: /Create My First Packing List/i }).click()
+  try { await page.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 }) } catch { /* ok */ }
+  await page.waitForURL(/#\/create-packing-list/, { timeout: 5_000 })
+}
+
+async function createList(page: import('@playwright/test').Page, name: string) {
+  await page.getByLabel('Packing List Name').fill(name)
+  await page.getByRole('button', { name: 'Create Packing List' }).click()
+  // Navigates to /view-lists/:id
+  await page.waitForURL(/#\/view-lists\//, { timeout: 5_000 })
+}
+
+test.describe('C – Packing Lists', () => {
+  test('C1: create a packing list navigates to the new list view', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'Beach Holiday')
+    await expect(page.getByText('Beach Holiday')).toBeVisible()
+  })
+
+  test('C2: check item as packed persists on reload', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'Test Trip')
+    // Find the first unchecked item and check it
+    const firstCheckbox = page.locator('input[type="checkbox"]').first()
+    await firstCheckbox.check()
+    // Wait for auto-save
+    await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 8_000 })
+    // Reload and verify the item is still checked
+    await page.reload()
+    await expect(page.locator('input[type="checkbox"]').first()).toBeChecked()
+  })
+
+  test('C3: uncheck a packed item', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'Test Trip 2')
+    // Check first item
+    const firstCheckbox = page.locator('input[type="checkbox"]').first()
+    await firstCheckbox.check()
+    await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 8_000 })
+    // Uncheck it
+    await firstCheckbox.uncheck()
+    await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 8_000 })
+    await page.reload()
+    await expect(page.locator('input[type="checkbox"]').first()).not.toBeChecked()
+  })
+
+  test('C4: rename a packing list', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'Old Name')
+    await page.goto('/#/view-lists')
+    await page.getByRole('button', { name: /Rename/i }).first().click()
+    // Rename modal input
+    const renameInput = page.locator('[role="dialog"] input[type="text"]')
+    await renameInput.clear()
+    await renameInput.fill('New Name')
+    await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click()
+    await expect(page.getByText('New Name')).toBeVisible()
+    await expect(page.getByText('Old Name')).not.toBeVisible()
+  })
+
+  test('C5: duplicate a packing list', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'Original List')
+    await page.goto('/#/view-lists')
+    await page.getByRole('button', { name: /Duplicate/i }).first().click()
+    await expect(page.getByText(/Copy of Original List/i)).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('C6: delete a packing list with confirmation', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'To Delete')
+    await page.goto('/#/view-lists')
+    await expect(page.getByText('To Delete')).toBeVisible()
+    await page.getByRole('button', { name: /Delete/i }).first().click()
+    // Confirmation dialog
+    await expect(page.getByText(/Are you sure.*delete/i)).toBeVisible()
+    await page.getByRole('button', { name: /^Delete$/ }).click()
+    await expect(page.getByText('To Delete')).not.toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/e2e/tests/d-navigation.spec.ts
+++ b/e2e/tests/d-navigation.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '../fixtures'
+
+test.describe('D – Navigation & UI', () => {
+  test('D1: nav links navigate to the correct pages', async ({ freshPage: page }) => {
+    await page.goto('/')
+    await page.getByRole('link', { name: /My Questions & Items/i }).click()
+    await expect(page).toHaveURL(/#\/manage-questions/)
+
+    await page.getByRole('link', { name: /Create List/i }).click()
+    await expect(page).toHaveURL(/#\/create-packing-list/)
+
+    await page.getByRole('link', { name: /View Lists/i }).click()
+    await expect(page).toHaveURL(/#\/view-lists/)
+  })
+
+  test('D2: Backups nav link is hidden when not logged in', async ({ freshPage: page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('link', { name: 'Backups' })).not.toBeVisible()
+  })
+
+  test('D3: mobile hamburger opens and closes the nav', async ({ freshPage: page }) => {
+    // Use mobile viewport
+    await page.setViewportSize({ width: 375, height: 812 })
+    await page.goto('/')
+    // Desktop nav links should be hidden
+    await expect(page.locator('.md\\:block .space-x-2')).not.toBeVisible()
+    // Click hamburger
+    await page.getByRole('button', { name: 'Open main menu' }).click()
+    // Mobile nav links visible
+    await expect(page.getByRole('link', { name: /My Questions & Items/i }).nth(1)).toBeVisible()
+    // Click hamburger again to close
+    await page.getByRole('button', { name: 'Open main menu' }).click()
+    await expect(page.getByRole('link', { name: /My Questions & Items/i }).nth(1)).not.toBeVisible()
+  })
+})

--- a/e2e/tests/e-auth.spec.ts
+++ b/e2e/tests/e-auth.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '../fixtures'
+import { loginToCss } from '../helpers/login'
+
+const CSS_ISSUER = process.env.CSS_ISSUER ?? 'http://localhost:4001'
+const TEST_EMAIL = 'test@example.com'
+const TEST_PASSWORD = 'test1234'
+
+test.describe('E – Solid Pod Authentication', () => {
+  test('E1: full login flow completes and shows logged-in state', async ({ freshPage: page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('button', { name: 'Login with Solid Pod' })).toBeVisible()
+    await loginToCss(page, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD)
+    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
+    // webId should be displayed
+    await expect(page.getByText(/testuser.*profile|profile.*testuser/i).or(
+      page.locator('span:has-text("localhost:4001/testuser")')
+    )).toBeVisible()
+  })
+
+  test('E2: logout returns to unauthenticated state', async ({ authedPage: page }) => {
+    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
+    await page.getByRole('button', { name: 'Logout' }).click()
+    await expect(page.getByRole('button', { name: 'Login with Solid Pod' })).toBeVisible({ timeout: 8_000 })
+    await expect(page.getByRole('button', { name: 'Logout' })).not.toBeVisible()
+  })
+
+  test('E3: Backups nav link appears only when logged in', async ({ authedPage: page }) => {
+    await expect(page.getByRole('link', { name: 'Backups' })).toBeVisible()
+    await page.getByRole('button', { name: 'Logout' }).click()
+    await expect(page.getByRole('link', { name: 'Backups' })).not.toBeVisible({ timeout: 8_000 })
+  })
+
+  test('E4: session restored on page reload', async ({ authedPage: page }) => {
+    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
+    await page.reload()
+    // Session should be restored from storage
+    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/e2e/tests/f-sync.spec.ts
+++ b/e2e/tests/f-sync.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '../fixtures'
+
+const CSS_POD_BASE = process.env.CSS_ISSUER
+  ? `${process.env.CSS_ISSUER}/testuser/`
+  : 'http://localhost:4001/testuser/'
+
+test.describe('F – Solid Pod Sync', () => {
+  // Helper to run the wizard while logged in
+  async function runWizardLoggedIn(page: import('@playwright/test').Page) {
+    await page.goto('/#/wizard')
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(page.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: /Create My First Packing List/i }).click()
+    await page.waitForURL(/#\/create-packing-list/, { timeout: 5_000 })
+  }
+
+  test('F1: questions sync to Pod after wizard completes', async ({ authedPage: page }) => {
+    await runWizardLoggedIn(page)
+    // Wait a moment for sync (auto-save + pod upload)
+    await page.waitForTimeout(3_000)
+    // Verify the questions file exists in the pod
+    const fileUrl = `${CSS_POD_BASE}pack-me-up/packing-list-questions.json`
+    const exists = await page.evaluate(async (url: string) => {
+      try {
+        const res = await fetch(url, { credentials: 'include' })
+        return res.ok
+      } catch { return false }
+    }, fileUrl)
+    expect(exists).toBe(true)
+  })
+
+  test('F2: packing list syncs to Pod after creation', async ({ authedPage: page, browser }) => {
+    await runWizardLoggedIn(page)
+    await page.getByLabel('Packing List Name').fill('Sync Test List')
+    await page.getByRole('button', { name: 'Create Packing List' }).click()
+    await page.waitForURL(/#\/view-lists\//, { timeout: 5_000 })
+    // Wait for sync
+    await page.waitForTimeout(4_000)
+    // Open a second context with same auth state and check the list appears
+    const context2 = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+    const page2 = await context2.newPage()
+    await page2.goto('/#/view-lists')
+    await expect(page2.getByText('Sync Test List')).toBeVisible({ timeout: 15_000 })
+    await context2.close()
+  })
+
+  test('F3: deleting a packing list removes it from Pod', async ({ authedPage: page, browser }) => {
+    // Create a list first
+    await runWizardLoggedIn(page)
+    await page.getByLabel('Packing List Name').fill('Delete Sync Test')
+    await page.getByRole('button', { name: 'Create Packing List' }).click()
+    await page.waitForURL(/#\/view-lists\//)
+    await page.waitForTimeout(3_000)
+    // Delete via view-lists
+    await page.goto('/#/view-lists')
+    await page.getByRole('button', { name: /Delete/i }).first().click()
+    await page.getByRole('button', { name: /^Delete$/ }).click()
+    await page.waitForTimeout(3_000)
+    // Second context: list should not appear
+    const context2 = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+    const page2 = await context2.newPage()
+    await page2.goto('/#/view-lists')
+    // Give it time to load from Pod
+    await page2.waitForTimeout(5_000)
+    await expect(page2.getByText('Delete Sync Test')).not.toBeVisible()
+    await context2.close()
+  })
+
+  test('F4: item check state syncs to Pod', async ({ authedPage: page, browser }) => {
+    await runWizardLoggedIn(page)
+    await page.getByLabel('Packing List Name').fill('Check Sync Test')
+    await page.getByRole('button', { name: 'Create Packing List' }).click()
+    await page.waitForURL(/#\/view-lists\//)
+    // Check first item
+    const firstCheckbox = page.locator('input[type="checkbox"]').first()
+    await firstCheckbox.check()
+    await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 8_000 })
+    // Wait for pod sync (poll interval is 5s)
+    await page.waitForTimeout(8_000)
+    // Second context: item should be checked
+    const context2 = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+    const page2 = await context2.newPage()
+    await page2.goto('/#/view-lists')
+    await page2.getByText('Check Sync Test').click()
+    await page2.waitForURL(/#\/view-lists\//)
+    await page2.waitForTimeout(3_000)
+    // The item should be checked (and hidden unless "Show Packed" is clicked)
+    await page2.getByRole('button', { name: /Show Packed/i }).click()
+    await expect(page2.locator('input[type="checkbox"]:checked').first()).toBeVisible({ timeout: 5_000 })
+    await context2.close()
+  })
+})

--- a/e2e/tests/g-cross-context.spec.ts
+++ b/e2e/tests/g-cross-context.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '../fixtures'
+
+test.describe('G – Cross-context Pod Sync', () => {
+  async function runWizardAndCreateList(page: import('@playwright/test').Page, listName: string) {
+    await page.goto('/#/wizard')
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(page.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: /Create My First Packing List/i }).click()
+    await page.waitForURL(/#\/create-packing-list/)
+    await page.getByLabel('Packing List Name').fill(listName)
+    await page.getByRole('button', { name: 'Create Packing List' }).click()
+    await page.waitForURL(/#\/view-lists\//)
+  }
+
+  test('G1: list created in context A appears in context B after polling', async ({ authedPage: page, browser }) => {
+    await runWizardAndCreateList(page, 'Cross-Context List A')
+    // Wait for pod sync
+    await page.waitForTimeout(4_000)
+
+    // Context B: same auth state
+    const ctxB = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+    const pageB = await ctxB.newPage()
+    await pageB.goto('/#/view-lists')
+    // Pod polling happens on page load (useEffect triggers load from Pod)
+    await expect(pageB.getByText('Cross-Context List A')).toBeVisible({ timeout: 15_000 })
+    await ctxB.close()
+  })
+
+  test('G2: list renamed in context A reflects in context B after polling', async ({ authedPage: page, browser }) => {
+    await runWizardAndCreateList(page, 'Rename Cross Sync')
+    await page.waitForTimeout(3_000)
+    // Rename in context A
+    await page.goto('/#/view-lists')
+    await page.getByRole('button', { name: /Rename/i }).first().click()
+    const renameInput = page.locator('[role="dialog"] input[type="text"]')
+    await renameInput.clear()
+    await renameInput.fill('Renamed Cross Sync')
+    await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click()
+    await page.waitForTimeout(4_000)
+
+    // Context B: should see renamed list
+    const ctxB = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+    const pageB = await ctxB.newPage()
+    await pageB.goto('/#/view-lists')
+    await expect(pageB.getByText('Renamed Cross Sync')).toBeVisible({ timeout: 15_000 })
+    await ctxB.close()
+  })
+})

--- a/e2e/tests/h-backups.spec.ts
+++ b/e2e/tests/h-backups.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '../fixtures'
+
+test.describe('H – Backups', () => {
+  async function setupWithList(page: import('@playwright/test').Page) {
+    // Run wizard and create a list while logged in
+    await page.goto('/#/wizard')
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(page.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: /Create My First Packing List/i }).click()
+    await page.waitForURL(/#\/create-packing-list/)
+    await page.getByLabel('Packing List Name').fill('Backup Test List')
+    await page.getByRole('button', { name: 'Create Packing List' }).click()
+    await page.waitForURL(/#\/view-lists\//)
+    // Give pod sync time
+    await page.waitForTimeout(3_000)
+  }
+
+  test('H1: create a backup appears in the backups list', async ({ authedPage: page }) => {
+    await setupWithList(page)
+    await page.goto('/#/backups')
+    await expect(page.getByRole('button', { name: 'Create Backup' })).toBeVisible()
+    await page.getByRole('button', { name: 'Create Backup' }).click()
+    // Toast success
+    await expect(page.getByText(/backup created/i)).toBeVisible({ timeout: 10_000 })
+    // Backup entry appears
+    await expect(page.getByRole('button', { name: 'Restore' })).toBeVisible()
+    await expect(page.locator('text=/packing list/')).toBeVisible()
+  })
+
+  test('H2: restore from backup replaces current data', async ({ authedPage: page }) => {
+    await setupWithList(page)
+    await page.goto('/#/backups')
+    await page.getByRole('button', { name: 'Create Backup' }).click()
+    await expect(page.getByText(/backup created/i)).toBeVisible({ timeout: 10_000 })
+    // Handle window.confirm for restore
+    page.on('dialog', dialog => dialog.accept())
+    await page.getByRole('button', { name: 'Restore' }).first().click()
+    await expect(page.getByText(/restored/i)).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('H3: delete a backup removes it from the list', async ({ authedPage: page }) => {
+    await page.goto('/#/backups')
+    // Ensure at least one backup exists (create one if needed)
+    const hasBackups = await page.getByRole('button', { name: 'Restore' }).isVisible({ timeout: 3_000 }).catch(() => false)
+    if (!hasBackups) {
+      await page.getByRole('button', { name: 'Create Backup' }).click()
+      await expect(page.getByText(/backup created/i)).toBeVisible({ timeout: 10_000 })
+    }
+    const initialCount = await page.getByRole('button', { name: 'Restore' }).count()
+    await page.getByRole('button', { name: 'Delete' }).first().click()
+    await expect(page.getByText(/deleted/i)).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByRole('button', { name: 'Restore' })).toHaveCount(initialCount - 1, { timeout: 5_000 })
+  })
+})

--- a/e2e/tests/i-migration.spec.ts
+++ b/e2e/tests/i-migration.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '../fixtures'
+import { createCssAccount } from '../helpers/css-api'
+import { loginToCss } from '../helpers/login'
+
+const CSS_ISSUER = process.env.CSS_ISSUER ?? 'http://localhost:4001'
+const CSS_PORT = new URL(CSS_ISSUER).port ? parseInt(new URL(CSS_ISSUER).port) : 4001
+
+test.describe('I – Data Migration', () => {
+  // Each test creates a unique account to ensure a clean pod
+  let migrationEmail: string
+  let migrationPassword: string
+  let migrationPodName: string
+
+  test.beforeEach(async () => {
+    const id = Date.now()
+    migrationEmail = `migration-${id}@example.com`
+    migrationPassword = 'migration1234'
+    migrationPodName = `migration${id}`
+    await createCssAccount(CSS_PORT, migrationEmail, migrationPassword, migrationPodName)
+  })
+
+  test('I1: first login with local data shows migration prompt', async ({ browser }) => {
+    // Create local data (no login)
+    const localCtx = await browser.newContext()
+    const localPage = await localCtx.newPage()
+    await localPage.goto('/#/wizard')
+    await localPage.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(localPage.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+    // Dismiss pod prompt
+    await localPage.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 5_000 }).catch(() => {})
+    await localPage.waitForURL(/#\/create-packing-list|#\/manage-questions/, { timeout: 5_000 })
+    // Now log in for first time with this fresh account
+    await loginToCss(localPage, CSS_ISSUER, migrationEmail, migrationPassword)
+    // Migration prompt should appear
+    await expect(localPage.getByText(/copy.*local|migrate.*data|import.*data/i)
+      .or(localPage.getByRole('dialog').getByText(/local data|existing data/i))
+    ).toBeVisible({ timeout: 10_000 })
+    await localCtx.close()
+  })
+
+  test('I2: accepting migration makes local data available under pod namespace', async ({ browser }) => {
+    const localCtx = await browser.newContext()
+    const localPage = await localCtx.newPage()
+    await localPage.goto('/#/wizard')
+    await localPage.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(localPage.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+    await localPage.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 5_000 }).catch(() => {})
+    await localPage.waitForURL(/#\/create-packing-list|#\/manage-questions/, { timeout: 5_000 })
+    await loginToCss(localPage, CSS_ISSUER, migrationEmail, migrationPassword)
+    // Accept migration
+    const dialog = localPage.getByRole('dialog')
+    const confirmBtn = dialog.getByRole('button').filter({ hasText: /copy|yes|migrate|confirm/i }).first()
+    await confirmBtn.click({ timeout: 10_000 })
+    // Navigate to manage-questions — should see data
+    await localPage.goto('/#/manage-questions')
+    await expect(localPage.getByText(/questions|who.*packing/i)).toBeVisible({ timeout: 5_000 })
+    await localCtx.close()
+  })
+
+  test('I3: cancelling migration starts fresh in pod namespace', async ({ browser }) => {
+    const localCtx = await browser.newContext()
+    const localPage = await localCtx.newPage()
+    await localPage.goto('/#/wizard')
+    await localPage.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(localPage.getByText('Questions Generated Successfully')).toBeVisible({ timeout: 10_000 })
+    await localPage.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 5_000 }).catch(() => {})
+    await localPage.waitForURL(/#\/create-packing-list|#\/manage-questions/, { timeout: 5_000 })
+    await loginToCss(localPage, CSS_ISSUER, migrationEmail, migrationPassword)
+    // Cancel migration
+    const dialog = localPage.getByRole('dialog')
+    const cancelBtn = dialog.getByRole('button').filter({ hasText: /no|cancel|skip|start fresh/i }).first()
+    await cancelBtn.click({ timeout: 10_000 })
+    // Landing page should show "Get Started" (empty pod namespace)
+    await localPage.goto('/')
+    await expect(localPage.getByRole('link', { name: /Get Started/i })).toBeVisible({ timeout: 5_000 })
+    await localCtx.close()
+  })
+})

--- a/e2e/tests/j-session-expiry.spec.ts
+++ b/e2e/tests/j-session-expiry.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '../fixtures'
+import { loginToCss } from '../helpers/login'
+
+const CSS_ISSUER = process.env.CSS_ISSUER ?? 'http://localhost:4001'
+const TEST_EMAIL = 'test@example.com'
+const TEST_PASSWORD = 'test1234'
+
+test.describe('J – Session Expiry', () => {
+  test('J1: session expired banner shows when pod returns 401', async ({ authedPage: page }) => {
+    // Invalidate the Solid session by clearing OIDC tokens from storage
+    // The app stores solid-client-authn session info in sessionStorage
+    await page.evaluate(() => {
+      // Clear all OIDC-related storage so next Pod request returns 401
+      const keysToRemove: string[] = []
+      for (let i = 0; i < sessionStorage.length; i++) {
+        const key = sessionStorage.key(i)
+        if (key) keysToRemove.push(key)
+      }
+      keysToRemove.forEach(k => sessionStorage.removeItem(k))
+      // Also clear relevant localStorage entries
+      const lsKeys: string[] = []
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i)
+        if (key && (key.includes('solid') || key.includes('oidc') || key.includes('inrupt'))) {
+          lsKeys.push(key)
+        }
+      }
+      lsKeys.forEach(k => localStorage.removeItem(k))
+    })
+    // Trigger a Pod operation by navigating to a page that loads from Pod
+    await page.goto('/#/view-lists')
+    // The session-expired banner or re-login prompt should appear
+    // The SessionExpiredBanner component shows when session expires
+    await expect(
+      page.getByText(/session expired|login again|re-login/i)
+    ).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.10",
@@ -1341,6 +1342,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -5353,6 +5370,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "test:e2e": "npm run build && playwright test",
+    "test:e2e:ui": "npm run build && playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -36,6 +40,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.10",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from '@playwright/test'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export const CSS_PORT = 4001
+export const CSS_ISSUER = `http://localhost:${CSS_PORT}`
+export const TEST_EMAIL = 'test@example.com'
+export const TEST_PASSWORD = 'test1234'
+export const TEST_POD_NAME = 'testuser'
+export const AUTH_STATE_FILE = path.join(__dirname, 'e2e/.auth/user.json')
+export const CSS_PID_FILE = path.join(__dirname, '.e2e-css-pid')
+export const CHROMIUM_PATH = process.env.CHROMIUM_PATH ?? '/opt/pw-browsers/chromium-1194/chrome-linux/chrome'
+export const APP_URL = 'http://localhost:4173'
+
+export default defineConfig({
+  testDir: './e2e/tests',
+  fullyParallel: true,
+  retries: 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  globalSetup: './e2e/global-setup.ts',
+  globalTeardown: './e2e/global-teardown.ts',
+  use: {
+    baseURL: APP_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    launchOptions: {
+      executablePath: CHROMIUM_PATH,
+      args: ['--no-sandbox', '--disable-dev-shm-usage'],
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run preview',
+    url: APP_URL,
+    reuseExistingServer: true,
+    timeout: 30_000,
+  },
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
+import { existsSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
@@ -11,13 +12,17 @@ export const TEST_PASSWORD = 'test1234'
 export const TEST_POD_NAME = 'testuser'
 export const AUTH_STATE_FILE = path.join(__dirname, 'e2e/.auth/user.json')
 export const CSS_PID_FILE = path.join(__dirname, '.e2e-css-pid')
-export const CHROMIUM_PATH = process.env.CHROMIUM_PATH ?? '/opt/pw-browsers/chromium-1194/chrome-linux/chrome'
 export const APP_URL = 'http://localhost:4173'
+
+// Use local pre-installed Chromium if present (dev environment);
+// in CI Playwright downloads its own browser when this is undefined.
+const localChromium = process.env.CHROMIUM_PATH ?? '/opt/pw-browsers/chromium-1194/chrome-linux/chrome'
+const executablePath = existsSync(localChromium) ? localChromium : undefined
 
 export default defineConfig({
   testDir: './e2e/tests',
   fullyParallel: true,
-  retries: 0,
+  retries: process.env.CI ? 1 : 0,
   reporter: [['list'], ['html', { open: 'never' }]],
   globalSetup: './e2e/global-setup.ts',
   globalTeardown: './e2e/global-teardown.ts',
@@ -26,7 +31,7 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     launchOptions: {
-      executablePath: CHROMIUM_PATH,
+      executablePath,
       args: ['--no-sandbox', '--disable-dev-shm-usage'],
     },
   },
@@ -39,7 +44,7 @@ export default defineConfig({
   webServer: {
     command: 'npm run preview',
     url: APP_URL,
-    reuseExistingServer: true,
+    reuseExistingServer: !process.env.CI,
     timeout: 30_000,
   },
 })


### PR DESCRIPTION
## What this PR does

Adds a full Playwright E2E test suite covering every major user journey in the app, plus a new `e2e` CI job that runs on every PR.

**Tech stack:**
- **Playwright** with `fullyParallel: true` — all tests run concurrently against a single Chromium instance
- **Community Solid Server (CSS)** started in-memory in `globalSetup` — real OAuth flows, no mocks
- **`vite preview`** serves the built app; saved OAuth storage state is reused across Pod-dependent tests for speed

**35 tests across 10 groups:**

| Group | Tests |
|---|---|
| A – Onboarding & Wizard | fresh start CTA, 1/2-person wizard, override guard |
| B – Editing Questions | add/remove people, always-needed items, JSON editor |
| C – Packing Lists | create, check/uncheck persistence, rename, duplicate, delete |
| D – Navigation | all nav links, Backups link gating, mobile hamburger |
| E – Solid Pod Auth | full login flow, logout, session restore on reload |
| F – Pod Sync | questions/lists/deletion/checked-state verified in second context |
| G – Cross-context Sync | changes in context A appear in context B after polling |
| H – Backups | create, restore, delete |
| I – Data Migration | prompt on first login, accept copies data, cancel = fresh start |
| J – Session Expiry | `SessionExpiredBanner` appears after OIDC tokens cleared |

**CI:** new `e2e` job installs Playwright's Chromium + OS deps, builds the app, runs all tests, and uploads the HTML report as a 14-day artifact on every run.

## Manual testing steps

```bash
# Build the app first, then run all E2E tests
npm run test:e2e

# Or skip rebuild if already built
npx playwright test

# View results
npx playwright show-report
```