### PR TITLE
Allow saving suggested items to specific question options

### DIFF
--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -355,7 +355,7 @@ describe('CreatePackingList – suggestion card', () => {
         expect(screen.queryByText('Sunscreen SPF50')).toBeNull()
     })
 
-    it('"Always include" calls db.saveQuestionSet and db.savePackingList with reviewed:true', async () => {
+    it('"Add" calls db.saveQuestionSet and db.savePackingList with reviewed:true', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
 
@@ -363,7 +363,7 @@ describe('CreatePackingList – suggestion card', () => {
         await waitFor(() => screen.getByText(/past trips you added items/i))
         fireEvent.click(screen.getByRole('button', { name: /review/i }))
 
-        fireEvent.click(screen.getByRole('button', { name: /always include/i }))
+        fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
 
         await waitFor(() => {
             expect(db.saveQuestionSet).toHaveBeenCalledWith(
@@ -384,14 +384,14 @@ describe('CreatePackingList – suggestion card', () => {
         expect(screen.queryByText('Sunscreen SPF50')).toBeNull()
     })
 
-    it('"Always include" sets selected:true for the matching person in personSelections', async () => {
+    it('"Add" sets selected:true for the matching person in personSelections', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
         fireEvent.click(screen.getByRole('button', { name: /review/i }))
-        fireEvent.click(screen.getByRole('button', { name: /always include/i }))
+        fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
 
         await waitFor(() => expect(db.saveQuestionSet).toHaveBeenCalled())
 
@@ -444,7 +444,7 @@ describe('CreatePackingList – suggestion card', () => {
         expect((select as HTMLSelectElement).value).toBe('always')
     })
 
-    it('"Always include" with default selection adds to alwaysNeededItems', async () => {
+    it('"Add" with default selection adds to alwaysNeededItems', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
 
@@ -453,7 +453,7 @@ describe('CreatePackingList – suggestion card', () => {
         fireEvent.click(screen.getByRole('button', { name: /review/i }))
 
         // default is "always" — don't change the select
-        fireEvent.click(screen.getByRole('button', { name: /always include/i }))
+        fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
 
         await waitFor(() => expect(db.saveQuestionSet).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -466,7 +466,7 @@ describe('CreatePackingList – suggestion card', () => {
         expect(savedQs.questions[0].options[0].items).toHaveLength(0)
     })
 
-    it('"Always include" with a question/option selected adds to that option\'s items, not alwaysNeededItems', async () => {
+    it('"Add" with a question/option selected adds to that option\'s items, not alwaysNeededItems', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
 
@@ -477,7 +477,7 @@ describe('CreatePackingList – suggestion card', () => {
         const select = screen.getByRole('combobox', { name: /destination for sunscreen spf50/i })
         fireEvent.change(select, { target: { value: 'q1::o1' } })
 
-        fireEvent.click(screen.getByRole('button', { name: /always include/i }))
+        fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
 
         await waitFor(() => expect(db.saveQuestionSet).toHaveBeenCalled())
         const savedQs = db.saveQuestionSet.mock.calls[0][0] as PackingListQuestionSet
@@ -487,7 +487,7 @@ describe('CreatePackingList – suggestion card', () => {
         )
     })
 
-    it('"Always include" uses updated _rev from first save when processing second item', async () => {
+    it('"Add" uses updated _rev from first save when processing second item', async () => {
         const secondItem: PackingListItem = {
             ...customItem,
             id: 'custom-2',
@@ -506,9 +506,9 @@ describe('CreatePackingList – suggestion card', () => {
         await waitFor(() => screen.getByText(/past trips you added items/i))
         fireEvent.click(screen.getByRole('button', { name: /review/i }))
 
-        fireEvent.click(screen.getAllByRole('button', { name: /always include/i })[0])
+        fireEvent.click(screen.getAllByRole('button', { name: /^add$/i })[0])
         await waitFor(() => expect(saveQuestionSet).toHaveBeenCalledTimes(1))
-        fireEvent.click(screen.getByRole('button', { name: /always include/i }))
+        fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
         await waitFor(() => expect(saveQuestionSet).toHaveBeenCalledTimes(2))
 
         // Second save must use the _rev returned by the first save

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -429,6 +429,64 @@ describe('CreatePackingList – suggestion card', () => {
         expect(secondCallArg._rev).toBe('rev-2')
     })
 
+    it('destination select renders with "Always Needed Items" default and question/option entries', async () => {
+        mockUseDatabase.mockReturnValue({ db: makeDb() } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/past trips you added items/i))
+        fireEvent.click(screen.getByRole('button', { name: /review/i }))
+
+        const select = screen.getByRole('combobox', { name: /destination for sunscreen spf50/i })
+        expect(select).toBeDefined()
+        const options = Array.from((select as HTMLSelectElement).options).map(o => o.text)
+        expect(options).toContain('Always Needed Items')
+        expect(options).toContain('Where are you going?: Beach')
+        expect((select as HTMLSelectElement).value).toBe('always')
+    })
+
+    it('"Always include" with default selection adds to alwaysNeededItems', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/past trips you added items/i))
+        fireEvent.click(screen.getByRole('button', { name: /review/i }))
+
+        // default is "always" — don't change the select
+        fireEvent.click(screen.getByRole('button', { name: /always include/i }))
+
+        await waitFor(() => expect(db.saveQuestionSet).toHaveBeenCalledWith(
+            expect.objectContaining({
+                alwaysNeededItems: expect.arrayContaining([
+                    expect.objectContaining({ text: 'Sunscreen SPF50' }),
+                ]),
+            })
+        ))
+        const savedQs = db.saveQuestionSet.mock.calls[0][0] as PackingListQuestionSet
+        expect(savedQs.questions[0].options[0].items).toHaveLength(0)
+    })
+
+    it('"Always include" with a question/option selected adds to that option\'s items, not alwaysNeededItems', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/past trips you added items/i))
+        fireEvent.click(screen.getByRole('button', { name: /review/i }))
+
+        const select = screen.getByRole('combobox', { name: /destination for sunscreen spf50/i })
+        fireEvent.change(select, { target: { value: 'q1::o1' } })
+
+        fireEvent.click(screen.getByRole('button', { name: /always include/i }))
+
+        await waitFor(() => expect(db.saveQuestionSet).toHaveBeenCalled())
+        const savedQs = db.saveQuestionSet.mock.calls[0][0] as PackingListQuestionSet
+        expect(savedQs.alwaysNeededItems).toHaveLength(0)
+        expect(savedQs.questions[0].options[0].items).toContainEqual(
+            expect.objectContaining({ text: 'Sunscreen SPF50' })
+        )
+    })
+
     it('"Always include" uses updated _rev from first save when processing second item', async () => {
         const secondItem: PackingListItem = {
             ...customItem,

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -117,19 +117,19 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                             return { type: 'option', questionId, optionId }
                                         })()
                                     return (
-                                    <div key={item.id} className="flex items-center justify-between gap-2 bg-white rounded border border-amber-200 px-3 py-2">
+                                    <div key={item.id} className="flex flex-col gap-2 bg-white rounded border border-amber-200 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
                                         <div>
                                             <span className="font-medium text-gray-900">{item.itemText}</span>
                                             {item.personName && (
                                                 <span className="ml-2 text-sm text-gray-500">for {item.personName}</span>
                                             )}
                                         </div>
-                                        <div className="flex gap-2 flex-shrink-0 items-center">
+                                        <div className="flex gap-2 items-center flex-wrap">
                                             <select
                                                 aria-label={`Destination for ${item.itemText}`}
                                                 value={destValue}
                                                 onChange={(e) => setDestinations(prev => ({ ...prev, [item.id]: e.target.value }))}
-                                                className="text-sm border border-amber-300 rounded px-2 py-1"
+                                                className="text-sm border border-amber-300 rounded px-2 py-1 flex-1 min-w-0"
                                             >
                                                 <option value="always">Always Needed Items</option>
                                                 {questionSet.questions.flatMap(q =>

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -82,7 +82,7 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
         <div className="bg-amber-50 rounded-lg border border-amber-200 p-4">
             <div className="flex items-start justify-between gap-4">
                 <p className="text-amber-900 font-medium">
-                    On past trips you added items that aren't in your question set yet. Want to save any for next time?
+                    On past trips you added items that aren't in your question set yet. Want to add any for next time?
                 </p>
                 <button
                     type="button"
@@ -145,7 +145,7 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                                 variant="primary"
                                                 onClick={() => onSaveToQuestionSet(listId, item, destination)}
                                             >
-                                                Always include
+                                                Add
                                             </Button>
                                             <Button
                                                 type="button"

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -50,15 +50,21 @@ export function getUnreviewedCustomItems(
     return results
 }
 
+type SaveDestination =
+    | { type: 'always' }
+    | { type: 'option'; questionId: string; optionId: string }
+
 interface SuggestionCardProps {
     suggestions: Array<{ listId: string; listName: string; item: PackingListItem }>
-    onAlwaysInclude: (listId: string, item: PackingListItem) => void
+    questionSet: PackingListQuestionSet
+    onSaveToQuestionSet: (listId: string, item: PackingListItem, destination: SaveDestination) => void
     onSkip: (listId: string, item: PackingListItem) => void
     onDismiss: () => void
 }
 
-function SuggestionCard({ suggestions, onAlwaysInclude, onSkip, onDismiss }: SuggestionCardProps) {
+function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip, onDismiss }: SuggestionCardProps) {
     const [isExpanded, setIsExpanded] = useState(false)
+    const [destinations, setDestinations] = useState<Record<string, string>>({})
 
     // Group by list
     const grouped = useMemo(() => {
@@ -102,7 +108,15 @@ function SuggestionCard({ suggestions, onAlwaysInclude, onSkip, onDismiss }: Sug
                         <div key={listName}>
                             <p className="text-sm text-amber-700 font-semibold mb-2">From: {listName}</p>
                             <div className="space-y-2">
-                                {items.map(({ listId, item }) => (
+                                {items.map(({ listId, item }) => {
+                                    const destValue = destinations[item.id] ?? 'always'
+                                    const destination: SaveDestination = destValue === 'always'
+                                        ? { type: 'always' }
+                                        : (() => {
+                                            const [questionId, optionId] = destValue.split('::')
+                                            return { type: 'option', questionId, optionId }
+                                        })()
+                                    return (
                                     <div key={item.id} className="flex items-center justify-between gap-2 bg-white rounded border border-amber-200 px-3 py-2">
                                         <div>
                                             <span className="font-medium text-gray-900">{item.itemText}</span>
@@ -110,11 +124,26 @@ function SuggestionCard({ suggestions, onAlwaysInclude, onSkip, onDismiss }: Sug
                                                 <span className="ml-2 text-sm text-gray-500">for {item.personName}</span>
                                             )}
                                         </div>
-                                        <div className="flex gap-2 flex-shrink-0">
+                                        <div className="flex gap-2 flex-shrink-0 items-center">
+                                            <select
+                                                aria-label={`Destination for ${item.itemText}`}
+                                                value={destValue}
+                                                onChange={(e) => setDestinations(prev => ({ ...prev, [item.id]: e.target.value }))}
+                                                className="text-sm border border-amber-300 rounded px-2 py-1"
+                                            >
+                                                <option value="always">Always Needed Items</option>
+                                                {questionSet.questions.flatMap(q =>
+                                                    q.options.map(o => (
+                                                        <option key={`${q.id}::${o.id}`} value={`${q.id}::${o.id}`}>
+                                                            {q.text}: {o.text}
+                                                        </option>
+                                                    ))
+                                                )}
+                                            </select>
                                             <Button
                                                 type="button"
                                                 variant="primary"
-                                                onClick={() => onAlwaysInclude(listId, item)}
+                                                onClick={() => onSaveToQuestionSet(listId, item, destination)}
                                             >
                                                 Always include
                                             </Button>
@@ -127,7 +156,8 @@ function SuggestionCard({ suggestions, onAlwaysInclude, onSkip, onDismiss }: Sug
                                             </Button>
                                         </div>
                                     </div>
-                                ))}
+                                    )
+                                })}
                             </div>
                         </div>
                     ))}
@@ -195,26 +225,40 @@ export function CreatePackingList() {
         [allPackingLists, questionSet]
     )
 
-    const handleAlwaysInclude = async (listId: string, item: PackingListItem) => {
+    const handleSaveToQuestionSet = async (listId: string, item: PackingListItem, destination: SaveDestination) => {
         if (!questionSet) return
 
-        // Build personSelections for every person in the question set
         const personSelections = questionSet.people.map(p => ({
             personId: p.id,
             selected: p.name.toLowerCase() === item.personName.toLowerCase(),
         }))
+        const newItem = { text: item.itemText, personSelections }
 
-        const updatedQs: PackingListQuestionSet = {
-            ...questionSet,
-            alwaysNeededItems: [
-                ...questionSet.alwaysNeededItems,
-                { text: item.itemText, personSelections },
-            ],
+        let updatedQs: PackingListQuestionSet
+        if (destination.type === 'always') {
+            updatedQs = {
+                ...questionSet,
+                alwaysNeededItems: [...questionSet.alwaysNeededItems, newItem],
+            }
+        } else {
+            updatedQs = {
+                ...questionSet,
+                questions: questionSet.questions.map(q =>
+                    q.id !== destination.questionId ? q : {
+                        ...q,
+                        options: q.options.map(o =>
+                            o.id !== destination.optionId ? o : {
+                                ...o,
+                                items: [...o.items, newItem],
+                            }
+                        ),
+                    }
+                ),
+            }
         }
         const { rev } = await db.saveQuestionSet(updatedQs)
         setQuestionSet({ ...updatedQs, _rev: rev })
 
-        // Mark reviewed on the packing list
         await markReviewed(listId, item)
     }
 
@@ -411,7 +455,8 @@ export function CreatePackingList() {
                 <div className="mb-6">
                     <SuggestionCard
                         suggestions={suggestions}
-                        onAlwaysInclude={handleAlwaysInclude}
+                        questionSet={questionSet}
+                        onSaveToQuestionSet={handleSaveToQuestionSet}
                         onSkip={handleSkip}
                         onDismiss={() => setIsSuggestionDismissed(true)}
                     />

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -124,12 +124,12 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                                 <span className="ml-2 text-sm text-gray-500">for {item.personName}</span>
                                             )}
                                         </div>
-                                        <div className="flex gap-2 items-center flex-wrap">
+                                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                                             <select
                                                 aria-label={`Destination for ${item.itemText}`}
                                                 value={destValue}
                                                 onChange={(e) => setDestinations(prev => ({ ...prev, [item.id]: e.target.value }))}
-                                                className="text-sm border border-amber-300 rounded px-2 py-1 flex-1 min-w-0"
+                                                className="w-full text-sm border border-amber-300 rounded px-2 py-1 sm:flex-1 sm:min-w-0"
                                             >
                                                 <option value="always">Always Needed Items</option>
                                                 {questionSet.questions.flatMap(q =>
@@ -140,20 +140,22 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                                     ))
                                                 )}
                                             </select>
-                                            <Button
-                                                type="button"
-                                                variant="primary"
-                                                onClick={() => onSaveToQuestionSet(listId, item, destination)}
-                                            >
-                                                Add
-                                            </Button>
-                                            <Button
-                                                type="button"
-                                                variant="secondary"
-                                                onClick={() => onSkip(listId, item)}
-                                            >
-                                                Skip
-                                            </Button>
+                                            <div className="flex gap-2">
+                                                <Button
+                                                    type="button"
+                                                    variant="primary"
+                                                    onClick={() => onSaveToQuestionSet(listId, item, destination)}
+                                                >
+                                                    Add
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    variant="secondary"
+                                                    onClick={() => onSkip(listId, item)}
+                                                >
+                                                    Skip
+                                                </Button>
+                                            </div>
                                         </div>
                                     </div>
                                     )


### PR DESCRIPTION
## Summary
Enhanced the suggestion card feature to allow users to save suggested packing list items to specific question options, rather than only to the "Always Needed Items" section. Users can now select a destination (either "Always Needed Items" or a specific question/option pair) before saving an item.

## Key Changes
- Added `SaveDestination` type to represent where an item should be saved (always needed or to a specific question option)
- Updated `SuggestionCard` component to:
  - Accept `questionSet` prop and new `onSaveToQuestionSet` callback
  - Render a destination dropdown for each item showing "Always Needed Items" and all available question/option combinations
  - Track selected destinations in local state
- Modified `handleSaveToQuestionSet` (formerly `handleAlwaysInclude`) to:
  - Accept a `destination` parameter
  - Conditionally update either `alwaysNeededItems` or the specific question option's items based on the selected destination
- Updated component prop passing to pass `questionSet` and the new callback to `SuggestionCard`

## Notable Implementation Details
- Destination values are encoded as `"always"` or `"questionId::optionId"` strings in the select element, then parsed back into the `SaveDestination` type before saving
- The dropdown is populated by flattening all questions and their options from the question set
- Person selections are correctly maintained when saving items to any destination
- All existing tests updated and new tests added to verify both default "always" behavior and custom question/option selection

https://claude.ai/code/session_01A8fb8UijKGQQ4r9SAdE5jC