### PR TITLE
Unify database operations through DatabaseContext

### DIFF
--- a/src/components/DatabaseContext.test.tsx
+++ b/src/components/DatabaseContext.test.tsx
@@ -13,6 +13,14 @@ vi.mock('./SolidPodContext', () => ({
 vi.mock('../services/solidPod', () => ({
   getPrimaryPodUrl: vi.fn(),
   hasPodData: vi.fn(),
+  saveFileToPod: vi.fn(),
+  deleteFileFromPod: vi.fn(),
+  POD_CONTAINERS: {
+    ROOT: 'pack-me-up/',
+    QUESTIONS: 'pack-me-up/packing-list-questions.json',
+    PACKING_LISTS: 'pack-me-up/packing-lists/',
+    BACKUPS: 'pack-me-up/backups/',
+  },
 }))
 
 // Mock PackingAppDatabase so tests don't create real filesystem databases
@@ -29,23 +37,39 @@ vi.mock('../services/database', () => {
 })
 
 import { useSolidPod } from './SolidPodContext'
-import { getPrimaryPodUrl, hasPodData } from '../services/solidPod'
+import { getPrimaryPodUrl, hasPodData, saveFileToPod, deleteFileFromPod } from '../services/solidPod'
 import { PackingAppDatabase } from '../services/database'
+import type { PackingList } from '../create-packing-list/types'
+import type { PackingListQuestionSet } from '../edit-questions/types'
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
 const mockHasPodData = vi.mocked(hasPodData)
 const mockGetInstance = vi.mocked(PackingAppDatabase.getInstance)
+const mockSaveFileToPod = vi.mocked(saveFileToPod)
+const mockDeleteFileFromPod = vi.mocked(deleteFileFromPod)
 
-/** Creates a mock db object with controllable isEmpty/copyAllDataFrom behaviour */
+/** Creates a mock db object with controllable method behaviour */
 function makeDb(namespace: string, overrides: {
   isEmpty?: boolean
   copyAllDataFrom?: ReturnType<typeof vi.fn>
+  savePackingList?: ReturnType<typeof vi.fn>
+  getPackingList?: ReturnType<typeof vi.fn>
+  getAllPackingLists?: ReturnType<typeof vi.fn>
+  deletePackingList?: ReturnType<typeof vi.fn>
+  saveQuestionSet?: ReturnType<typeof vi.fn>
+  getQuestionSet?: ReturnType<typeof vi.fn>
 } = {}) {
   return {
     getInfo: vi.fn().mockResolvedValue({ db_name: `packing-app-data--${namespace}`, doc_count: 0 }),
     isEmpty: vi.fn().mockResolvedValue(overrides.isEmpty ?? false),
     copyAllDataFrom: overrides.copyAllDataFrom ?? vi.fn().mockResolvedValue(undefined),
+    savePackingList: overrides.savePackingList ?? vi.fn().mockResolvedValue({ rev: 'rev-1' }),
+    getPackingList: overrides.getPackingList ?? vi.fn().mockResolvedValue({ id: 'list-1', name: 'Test List', createdAt: '2024-01-01', items: [] }),
+    getAllPackingLists: overrides.getAllPackingLists ?? vi.fn().mockResolvedValue([]),
+    deletePackingList: overrides.deletePackingList ?? vi.fn().mockResolvedValue(undefined),
+    saveQuestionSet: overrides.saveQuestionSet ?? vi.fn().mockResolvedValue({ rev: 'rev-1' }),
+    getQuestionSet: overrides.getQuestionSet ?? vi.fn().mockResolvedValue({ people: [], questions: [], alwaysNeededItems: [] }),
   }
 }
 
@@ -76,6 +100,10 @@ describe('DatabaseContext', () => {
     mockHasPodData.mockReset()
     // Default: pod has data → no migration prompt
     mockHasPodData.mockResolvedValue(true)
+    mockSaveFileToPod.mockReset()
+    mockSaveFileToPod.mockResolvedValue(undefined)
+    mockDeleteFileFromPod.mockReset()
+    mockDeleteFileFromPod.mockResolvedValue(undefined)
     localStorage.clear()
   })
 
@@ -320,6 +348,172 @@ describe('DatabaseContext', () => {
       await waitFor(() => screen.getByText('Start fresh'))
       fireEvent.click(screen.getByText('Start fresh'))
       expect(localStorage.getItem('pod-migration-dismissed-example.com')).toBe('true')
+    })
+  })
+
+  describe('unified data methods', () => {
+    let capturedCtx: ReturnType<typeof useDatabase> | undefined
+
+    function ContextCapture() {
+      capturedCtx = useDatabase()
+      return null
+    }
+
+    beforeEach(() => {
+      capturedCtx = undefined
+    })
+
+    function setupLoggedOut() {
+      mockUseSolidPod.mockReturnValue({
+        session: null,
+        isLoggedIn: false,
+        webId: undefined,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+    }
+
+    function setupLoggedIn() {
+      const mockSession = { fetch: vi.fn(), info: { isLoggedIn: true, webId: 'https://example.com/profile#me' } }
+      mockUseSolidPod.mockReturnValue({
+        session: mockSession as unknown as Session,
+        isLoggedIn: true,
+        webId: 'https://example.com/profile#me',
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+      mockGetPrimaryPodUrl.mockResolvedValue('https://example.com/')
+      return mockSession
+    }
+
+    it('savePackingList saves to PouchDB regardless of login state', async () => {
+      setupLoggedOut()
+      const mockDbSave = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { savePackingList: mockDbSave }))
+
+      render(<DatabaseProvider><ContextCapture /></DatabaseProvider>)
+      await waitFor(() => expect(capturedCtx).toBeDefined())
+
+      const testList: PackingList = { id: 'list-1', name: 'Test', createdAt: '2024-01-01', items: [] }
+      await capturedCtx!.savePackingList(testList)
+
+      expect(mockDbSave).toHaveBeenCalledWith(testList)
+    })
+
+    it('savePackingList also calls saveFileToPod when a session is present', async () => {
+      setupLoggedIn()
+      const mockDbSave = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { savePackingList: mockDbSave }))
+
+      render(<DatabaseProvider><ContextCapture /></DatabaseProvider>)
+      await waitFor(() => expect(capturedCtx).toBeDefined())
+
+      const testList: PackingList = { id: 'list-1', name: 'Test', createdAt: '2024-01-01', items: [] }
+      await capturedCtx!.savePackingList(testList)
+
+      expect(mockDbSave).toHaveBeenCalledWith(testList)
+      expect(mockSaveFileToPod).toHaveBeenCalledWith(expect.objectContaining({
+        filename: 'list-1.json',
+        data: testList,
+      }))
+    })
+
+    it('savePackingList does not call saveFileToPod when session is null', async () => {
+      setupLoggedOut()
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns))
+
+      render(<DatabaseProvider><ContextCapture /></DatabaseProvider>)
+      await waitFor(() => expect(capturedCtx).toBeDefined())
+
+      const testList: PackingList = { id: 'list-1', name: 'Test', createdAt: '2024-01-01', items: [] }
+      await capturedCtx!.savePackingList(testList)
+
+      expect(mockSaveFileToPod).not.toHaveBeenCalled()
+    })
+
+    it('loadPackingList returns the list from PouchDB', async () => {
+      setupLoggedOut()
+      const testList: PackingList = { id: 'list-1', name: 'Test', createdAt: '2024-01-01', items: [] }
+      const mockDbGet = vi.fn().mockResolvedValue(testList)
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { getPackingList: mockDbGet }))
+
+      render(<DatabaseProvider><ContextCapture /></DatabaseProvider>)
+      await waitFor(() => expect(capturedCtx).toBeDefined())
+
+      const result = await capturedCtx!.loadPackingList('list-1')
+
+      expect(mockDbGet).toHaveBeenCalledWith('list-1')
+      expect(result).toEqual(testList)
+    })
+
+    it('listPackingLists returns all lists from PouchDB', async () => {
+      setupLoggedOut()
+      const testLists: PackingList[] = [
+        { id: 'list-1', name: 'Test 1', createdAt: '2024-01-01', items: [] },
+        { id: 'list-2', name: 'Test 2', createdAt: '2024-01-02', items: [] },
+      ]
+      const mockDbGetAll = vi.fn().mockResolvedValue(testLists)
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { getAllPackingLists: mockDbGetAll }))
+
+      render(<DatabaseProvider><ContextCapture /></DatabaseProvider>)
+      await waitFor(() => expect(capturedCtx).toBeDefined())
+
+      const result = await capturedCtx!.listPackingLists()
+
+      expect(mockDbGetAll).toHaveBeenCalled()
+      expect(result).toEqual(testLists)
+    })
+
+    it('deletePackingList removes from PouchDB and calls pod delete when logged in', async () => {
+      setupLoggedIn()
+      const mockDbDelete = vi.fn().mockResolvedValue(undefined)
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { deletePackingList: mockDbDelete }))
+
+      render(<DatabaseProvider><ContextCapture /></DatabaseProvider>)
+      await waitFor(() => expect(capturedCtx).toBeDefined())
+
+      await capturedCtx!.deletePackingList('list-1')
+
+      expect(mockDbDelete).toHaveBeenCalledWith('list-1')
+      expect(mockDeleteFileFromPod).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('list-1.json'),
+      )
+    })
+
+    it('saveQuestionSet persists to PouchDB and to Pod when logged in', async () => {
+      setupLoggedIn()
+      const mockDbSaveQs = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { saveQuestionSet: mockDbSaveQs }))
+
+      render(<DatabaseProvider><ContextCapture /></DatabaseProvider>)
+      await waitFor(() => expect(capturedCtx).toBeDefined())
+
+      const testQs: PackingListQuestionSet = { people: [], questions: [], alwaysNeededItems: [] }
+      await capturedCtx!.saveQuestionSet(testQs)
+
+      expect(mockDbSaveQs).toHaveBeenCalledWith(testQs)
+      expect(mockSaveFileToPod).toHaveBeenCalledWith(expect.objectContaining({
+        filename: 'packing-list-questions.json',
+        data: testQs,
+      }))
+    })
+
+    it('loadQuestionSet returns the question set from PouchDB', async () => {
+      setupLoggedOut()
+      const testQs: PackingListQuestionSet = { people: [], questions: [], alwaysNeededItems: [] }
+      const mockDbGetQs = vi.fn().mockResolvedValue(testQs)
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { getQuestionSet: mockDbGetQs }))
+
+      render(<DatabaseProvider><ContextCapture /></DatabaseProvider>)
+      await waitFor(() => expect(capturedCtx).toBeDefined())
+
+      const result = await capturedCtx!.loadQuestionSet()
+
+      expect(mockDbGetQs).toHaveBeenCalled()
+      expect(result).toEqual(testQs)
     })
   })
 })

--- a/src/components/DatabaseContext.tsx
+++ b/src/components/DatabaseContext.tsx
@@ -1,11 +1,19 @@
-import { createContext, ReactNode, useContext, useState, useEffect, Fragment } from 'react'
+import { createContext, ReactNode, useContext, useState, useEffect, Fragment, useMemo } from 'react'
 import { PackingAppDatabase, LOCAL_NAMESPACE } from '../services/database'
 import { useSolidPod } from './SolidPodContext'
-import { getPrimaryPodUrl, hasPodData } from '../services/solidPod'
+import { getPrimaryPodUrl, hasPodData, saveFileToPod, deleteFileFromPod, POD_CONTAINERS } from '../services/solidPod'
 import { ConfirmationDialog } from './ConfirmationDialog'
+import { PackingList } from '../create-packing-list/types'
+import { PackingListQuestionSet } from '../edit-questions/types'
 
 interface DatabaseContextValue {
     db: PackingAppDatabase
+    savePackingList(list: PackingList): Promise<{ rev: string }>
+    loadPackingList(id: string): Promise<PackingList>
+    listPackingLists(): Promise<PackingList[]>
+    deletePackingList(id: string): Promise<void>
+    saveQuestionSet(qs: PackingListQuestionSet): Promise<{ rev: string }>
+    loadQuestionSet(): Promise<PackingListQuestionSet>
 }
 
 const DatabaseContext = createContext<DatabaseContextValue | undefined>(undefined)
@@ -31,6 +39,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
     const [isResolvingPod, setIsResolvingPod] = useState(false)
     const [showMigrationPrompt, setShowMigrationPrompt] = useState(false)
     const [localDb, setLocalDb] = useState<PackingAppDatabase | null>(null)
+    const [resolvedPodUrl, setResolvedPodUrl] = useState<string | null>(null)
 
     useEffect(() => {
         // While session is still initialising, wait
@@ -43,6 +52,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
             setShowMigrationPrompt(false)
             setNamespace(LOCAL_NAMESPACE)
             setDb(PackingAppDatabase.getInstance(LOCAL_NAMESPACE))
+            setResolvedPodUrl(null)
             return
         }
 
@@ -73,6 +83,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
                     setLocalDb(local)
                     setNamespace(resolvedNamespace)
                     setDb(podDb)
+                    setResolvedPodUrl(podUrl)
                     setShowMigrationPrompt(true)
                     setIsResolvingPod(false)
                     return
@@ -82,6 +93,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
             if (cancelled) return
             setNamespace(resolvedNamespace)
             setDb(podDb)
+            setResolvedPodUrl(podUrl)
             setIsResolvingPod(false)
         })
 
@@ -89,6 +101,52 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
             cancelled = true
         }
     }, [isLoggedIn, webId, session, isLoading])
+
+    const contextValue = useMemo<DatabaseContextValue | null>(() => {
+        if (!db) return null
+        return {
+            db,
+            async savePackingList(list: PackingList) {
+                const result = await db.savePackingList(list)
+                if (isLoggedIn && session && resolvedPodUrl) {
+                    await saveFileToPod({
+                        session,
+                        containerPath: `${resolvedPodUrl}${POD_CONTAINERS.PACKING_LISTS}`,
+                        filename: `${list.id}.json`,
+                        data: list,
+                    })
+                }
+                return result
+            },
+            async loadPackingList(id: string) {
+                return db.getPackingList(id)
+            },
+            async listPackingLists() {
+                return db.getAllPackingLists()
+            },
+            async deletePackingList(id: string) {
+                await db.deletePackingList(id)
+                if (isLoggedIn && session && resolvedPodUrl) {
+                    await deleteFileFromPod(session, `${resolvedPodUrl}${POD_CONTAINERS.PACKING_LISTS}${id}.json`)
+                }
+            },
+            async saveQuestionSet(qs: PackingListQuestionSet) {
+                const result = await db.saveQuestionSet(qs)
+                if (isLoggedIn && session && resolvedPodUrl) {
+                    await saveFileToPod({
+                        session,
+                        containerPath: `${resolvedPodUrl}${POD_CONTAINERS.ROOT}`,
+                        filename: 'packing-list-questions.json',
+                        data: qs,
+                    })
+                }
+                return result
+            },
+            async loadQuestionSet() {
+                return db.getQuestionSet()
+            },
+        }
+    }, [db, isLoggedIn, session, resolvedPodUrl])
 
     if (isLoading || isResolvingPod || !db || !namespace) {
         return null
@@ -118,7 +176,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
     // namespace changes (e.g. login / logout). This ensures every page re-fetches
     // its data from the correct database instead of showing stale state.
     return (
-        <DatabaseContext.Provider value={{ db }}>
+        <DatabaseContext.Provider value={contextValue!}>
             <Fragment key={namespace}>
                 {children}
             </Fragment>

--- a/src/hooks/useHasQuestions.test.ts
+++ b/src/hooks/useHasQuestions.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import type { PackingAppDatabase } from '../services/database'
 import { useHasQuestions } from './useHasQuestions'
 
 vi.mock('../components/DatabaseContext', () => ({
@@ -11,10 +10,10 @@ import { useDatabase } from '../components/DatabaseContext'
 
 const mockUseDatabase = vi.mocked(useDatabase)
 
-function makeDb(overrides: { getQuestionSet?: ReturnType<typeof vi.fn> } = {}) {
+function makeContextValue(overrides: { loadQuestionSet?: ReturnType<typeof vi.fn> } = {}) {
     return {
-        getQuestionSet: overrides.getQuestionSet ?? vi.fn().mockResolvedValue({ questions: [] }),
-    }
+        loadQuestionSet: overrides.loadQuestionSet ?? vi.fn().mockResolvedValue({ questions: [] }),
+    } as ReturnType<typeof useDatabase>
 }
 
 describe('useHasQuestions', () => {
@@ -27,8 +26,7 @@ describe('useHasQuestions', () => {
     })
 
     it('returns false when no questions exist (not_found)', async () => {
-        const db = makeDb({ getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }) })
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue({ loadQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }) }))
 
         const { result } = renderHook(() => useHasQuestions())
 
@@ -36,8 +34,7 @@ describe('useHasQuestions', () => {
     })
 
     it('returns false when document exists but has no questions', async () => {
-        const db = makeDb({ getQuestionSet: vi.fn().mockResolvedValue({ questions: [] }) })
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue({ loadQuestionSet: vi.fn().mockResolvedValue({ questions: [] }) }))
 
         const { result } = renderHook(() => useHasQuestions())
 
@@ -45,8 +42,7 @@ describe('useHasQuestions', () => {
     })
 
     it('returns true when at least one question exists', async () => {
-        const db = makeDb({ getQuestionSet: vi.fn().mockResolvedValue({ questions: [{ id: '1', text: 'Do you need a jacket?' }] }) })
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue({ loadQuestionSet: vi.fn().mockResolvedValue({ questions: [{ id: '1', text: 'Do you need a jacket?' }] }) }))
 
         const { result } = renderHook(() => useHasQuestions())
 
@@ -54,8 +50,7 @@ describe('useHasQuestions', () => {
     })
 
     it('returns false and logs error for unexpected errors', async () => {
-        const db = makeDb({ getQuestionSet: vi.fn().mockRejectedValue(new Error('unexpected')) })
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue({ loadQuestionSet: vi.fn().mockRejectedValue(new Error('unexpected')) }))
 
         const { result } = renderHook(() => useHasQuestions())
 

--- a/src/hooks/useHasQuestions.ts
+++ b/src/hooks/useHasQuestions.ts
@@ -2,18 +2,18 @@ import { useState, useEffect } from 'react'
 import { useDatabase } from '../components/DatabaseContext'
 
 export const useHasQuestions = () => {
-    const { db } = useDatabase()
+    const { loadQuestionSet } = useDatabase()
     const [hasQuestions, setHasQuestions] = useState(false)
 
     useEffect(() => {
-        db.getQuestionSet()
+        loadQuestionSet()
             .then((doc) => setHasQuestions(doc.questions.length > 0))
             .catch((err: unknown) => {
                 const hasName = typeof err === 'object' && err !== null && 'name' in err
                 if (!hasName || (err as { name: string }).name !== 'not_found') console.error(err)
                 setHasQuestions(false)
             })
-    }, [db])
+    }, [loadQuestionSet])
 
     return hasQuestions
 }

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -268,6 +268,18 @@ function makeDb(overrides: Record<string, unknown> = {}) {
     }
 }
 
+function makeContextValue(db: ReturnType<typeof makeDb> | ReturnType<typeof makeDeletionDb>) {
+    return {
+        db: db as unknown as PackingAppDatabase,
+        savePackingList: db.savePackingList,
+        saveQuestionSet: db.saveQuestionSet,
+        loadPackingList: vi.fn().mockResolvedValue(null),
+        listPackingLists: db.getAllPackingLists,
+        deletePackingList: vi.fn().mockResolvedValue(undefined),
+        loadQuestionSet: db.getQuestionSet,
+    } as ReturnType<typeof useDatabase>
+}
+
 function renderCreatePackingList() {
     return render(
         <MemoryRouter>
@@ -292,9 +304,7 @@ describe('CreatePackingList – suggestion card', () => {
             ...pastList,
             items: [{ ...customItem, questionId: 'q1', optionId: 'o1', personId: 'p1' }],
         }
-        mockUseDatabase.mockReturnValue({
-            db: makeDb({ getAllPackingLists: vi.fn().mockResolvedValue([noCustomList]) }),
-        } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(makeDb({ getAllPackingLists: vi.fn().mockResolvedValue([noCustomList]) })))
 
         renderCreatePackingList()
         // Wait for loading to finish, then confirm no suggestion card
@@ -303,14 +313,14 @@ describe('CreatePackingList – suggestion card', () => {
     })
 
     it('shows suggestion card when there are unreviewed custom items', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeDb() } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(makeDb()))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
     })
 
     it('card body is collapsed by default and expands on click', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeDb() } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(makeDb()))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
@@ -325,7 +335,7 @@ describe('CreatePackingList – suggestion card', () => {
     })
 
     it('dismissing the card hides it', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeDb() } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(makeDb()))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
@@ -337,7 +347,7 @@ describe('CreatePackingList – suggestion card', () => {
 
     it('"Skip" calls db.savePackingList with reviewed:true and removes item from card', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
@@ -357,7 +367,7 @@ describe('CreatePackingList – suggestion card', () => {
 
     it('"Add" calls db.saveQuestionSet and db.savePackingList with reviewed:true', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
@@ -386,7 +396,7 @@ describe('CreatePackingList – suggestion card', () => {
 
     it('"Add" sets selected:true for the matching person in personSelections', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
@@ -413,7 +423,7 @@ describe('CreatePackingList – suggestion card', () => {
             return Promise.resolve({ rev: `rev-${saveCallCount + 1}` })
         })
         const db = makeDb({ getAllPackingLists: vi.fn().mockResolvedValue([listWithTwo]), savePackingList })
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
@@ -430,7 +440,7 @@ describe('CreatePackingList – suggestion card', () => {
     })
 
     it('destination select renders with "Always Needed Items" default and question/option entries', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeDb() } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(makeDb()))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
@@ -446,7 +456,7 @@ describe('CreatePackingList – suggestion card', () => {
 
     it('"Add" with default selection adds to alwaysNeededItems', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
@@ -468,7 +478,7 @@ describe('CreatePackingList – suggestion card', () => {
 
     it('"Add" with a question/option selected adds to that option\'s items, not alwaysNeededItems', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
@@ -500,7 +510,7 @@ describe('CreatePackingList – suggestion card', () => {
             return Promise.resolve({ rev: `qs-rev-${qsSaveCount + 1}` })
         })
         const db = makeDb({ getAllPackingLists: vi.fn().mockResolvedValue([listWithTwo]), saveQuestionSet })
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
@@ -524,7 +534,7 @@ describe('CreatePackingList – suggestion card', () => {
         }
         const listWithTwo: PackingList = { ...pastList, items: [customItem, secondItem] }
         const db = makeDb({ getAllPackingLists: vi.fn().mockResolvedValue([listWithTwo]) })
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/past trips you added items/i))
@@ -553,7 +563,15 @@ describe('CreatePackingList - login button', () => {
             login: vi.fn(),
             logout: vi.fn(),
         })
-        mockUseDatabase.mockReturnValue({ db: null as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue({
+            db: null as unknown as PackingAppDatabase,
+            savePackingList: vi.fn(),
+            saveQuestionSet: vi.fn(),
+            loadPackingList: vi.fn(),
+            listPackingLists: vi.fn().mockResolvedValue([]),
+            deletePackingList: vi.fn(),
+            loadQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }),
+        } as ReturnType<typeof useDatabase>)
         mockUseToast.mockReturnValue({ showToast: vi.fn() as (message: string, type: ToastType) => void })
     })
 
@@ -600,10 +618,9 @@ describe('CreatePackingList – pod sync on creation', () => {
         cleanup()
     })
 
-    it('syncs the newly created list to the pod immediately after saving', async () => {
-        mockUseDatabase.mockReturnValue({
-            db: makeDb({ getAllPackingLists: vi.fn().mockResolvedValue([]) }),
-        } as ReturnType<typeof useDatabase>)
+    it('calls savePackingList with the newly created list when logged in', async () => {
+        const db = makeDb({ getAllPackingLists: vi.fn().mockResolvedValue([]) })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/Answer the questions below/i))
@@ -613,11 +630,8 @@ describe('CreatePackingList – pod sync on creation', () => {
         fireEvent.click(screen.getByRole('button', { name: /create packing list/i }))
 
         await waitFor(() => {
-            expect(mockSaveFileToPod).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    containerPath: 'https://timgent.solidcommunity.net/pack-me-up/packing-lists/',
-                    data: expect.objectContaining({ name: 'My New List' }),
-                })
+            expect(db.savePackingList).toHaveBeenCalledWith(
+                expect.objectContaining({ name: 'My New List' })
             )
         })
     })
@@ -632,7 +646,7 @@ describe('CreatePackingList – pod sync on creation', () => {
             logout: vi.fn(),
         })
         const db = makeDb({ getAllPackingLists: vi.fn().mockResolvedValue([]) })
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/Answer the questions below/i))
@@ -785,9 +799,7 @@ describe('CreatePackingList – deletion suggestion card', () => {
 
     it('does not show deletion card when there are no unreviewed deleted items', async () => {
         const noDeleted: PackingList = { ...listWithDeletedItem, deletedItems: [] }
-        mockUseDatabase.mockReturnValue({
-            db: makeDeletionDb({ getAllPackingLists: vi.fn().mockResolvedValue([noDeleted]) }),
-        } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(makeDeletionDb({ getAllPackingLists: vi.fn().mockResolvedValue([noDeleted]) })))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/Answer the questions below/i))
@@ -795,14 +807,14 @@ describe('CreatePackingList – deletion suggestion card', () => {
     })
 
     it('shows deletion card when there are unreviewed deleted items', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeDeletionDb() } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(makeDeletionDb()))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/previously removed/i))
     })
 
     it('deletion card is collapsed by default and expands on click', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeDeletionDb() } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(makeDeletionDb()))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/previously removed/i))
@@ -813,7 +825,7 @@ describe('CreatePackingList – deletion suggestion card', () => {
     })
 
     it('dismissing the deletion card hides it', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeDeletionDb() } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(makeDeletionDb()))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/previously removed/i))
@@ -824,7 +836,7 @@ describe('CreatePackingList – deletion suggestion card', () => {
 
     it('"Keep" marks the deletedItems entry as reviewed:true via db.savePackingList', async () => {
         const db = makeDeletionDb()
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/previously removed/i))
@@ -843,7 +855,7 @@ describe('CreatePackingList – deletion suggestion card', () => {
 
     it('"Remove permanently" removes item from alwaysNeededItems and marks reviewed', async () => {
         const db = makeDeletionDb()
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/previously removed/i))
@@ -878,7 +890,7 @@ describe('CreatePackingList – deletion suggestion card', () => {
             deletedItems: [deletedItem, secondDeleted],
         }
         const db = makeDeletionDb({ getAllPackingLists: vi.fn().mockResolvedValue([listWithTwo]) })
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderCreatePackingList()
         await waitFor(() => screen.getByText(/previously removed/i))

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -9,7 +9,6 @@ import { Button } from '../components/Button'
 import { useToast } from '../components/ToastContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { SolidProviderSelector } from '../components/SolidProviderSelector'
-import { getPrimaryPodUrl, saveFileToPod, POD_CONTAINERS } from '../services/solidPod'
 
 export function deduplicateItems(items: PackingListItem[]): PackingListItem[] {
     const seen = new Set<string>()
@@ -292,9 +291,9 @@ export function CreatePackingList() {
     const [isSuggestionDismissed, setIsSuggestionDismissed] = useState(false)
     const [isDeletionSuggestionDismissed, setIsDeletionSuggestionDismissed] = useState(false)
     const { showToast } = useToast()
-    const { isLoggedIn, login, session } = useSolidPod()
+    const { isLoggedIn, login } = useSolidPod()
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
-    const { db } = useDatabase()
+    const { db, savePackingList, saveQuestionSet, listPackingLists, loadQuestionSet } = useDatabase()
     const navigate = useNavigate()
 
     const { register, handleSubmit, setValue, watch } = useForm<PackingListFormData>({
@@ -314,8 +313,8 @@ export function CreatePackingList() {
             setIsLoading(true)
             try {
                 const [doc, lists] = await Promise.all([
-                    db.getQuestionSet(),
-                    db.getAllPackingLists(),
+                    loadQuestionSet(),
+                    listPackingLists(),
                 ])
                 setQuestionSet(doc)
                 setAllPackingLists(lists)
@@ -335,7 +334,7 @@ export function CreatePackingList() {
             }
         }
         fetchQuestionSet()
-    }, [db, showToast])
+    }, [loadQuestionSet, listPackingLists, showToast])
 
     const suggestions = useMemo(
         () => questionSet ? getUnreviewedCustomItems(allPackingLists, questionSet) : [],
@@ -378,7 +377,7 @@ export function CreatePackingList() {
                 ),
             }
         }
-        const { rev } = await db.saveQuestionSet(updatedQs)
+        const { rev } = await saveQuestionSet(updatedQs)
         setQuestionSet({ ...updatedQs, _rev: rev })
 
         await markReviewed(listId, item)
@@ -395,7 +394,7 @@ export function CreatePackingList() {
             ...list,
             items: list.items.map(i => i.id === item.id ? { ...i, reviewed: true } : i),
         }
-        const { rev } = await db.savePackingList(updatedList)
+        const { rev } = await savePackingList(updatedList)
         setAllPackingLists(prev => prev.map(l => l.id === listId ? { ...updatedList, _rev: rev } : l))
     }
 
@@ -406,7 +405,7 @@ export function CreatePackingList() {
             ...list,
             deletedItems: (list.deletedItems ?? []).map(i => i.id === item.id ? { ...i, reviewed: true } : i),
         }
-        const { rev } = await db.savePackingList(updatedList)
+        const { rev } = await savePackingList(updatedList)
         setAllPackingLists(prev => prev.map(l => l.id === listId ? { ...updatedList, _rev: rev } : l))
     }
 
@@ -439,7 +438,7 @@ export function CreatePackingList() {
                 ),
             }
         }
-        const { rev } = await db.saveQuestionSet(updatedQs)
+        const { rev } = await saveQuestionSet(updatedQs)
         setQuestionSet({ ...updatedQs, _rev: rev })
         await markDeletedReviewed(listId, item)
     }
@@ -511,18 +510,7 @@ export function CreatePackingList() {
             items: deduplicateItems([...questionBasedItems, ...alwaysNeededItems])
         }
         try {
-            await db.savePackingList(packingList)
-            if (isLoggedIn) {
-                const podUrl = await getPrimaryPodUrl(session)
-                if (podUrl) {
-                    await saveFileToPod({
-                        session: session!,
-                        containerPath: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`,
-                        filename: `${packingList.id}.json`,
-                        data: packingList,
-                    })
-                }
-            }
+            await savePackingList(packingList)
             showToast('Packing list created successfully!', 'success')
             // Navigate to the newly created packing list
             navigate(`/view-lists/${packingList.id}`)

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -45,14 +45,12 @@ import type { Session } from '@inrupt/solid-client-authn-browser'
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
-import { getPrimaryPodUrl, loadMultipleFilesFromPod, saveFileToPod, deleteFileFromPod } from '../services/solidPod'
+import { getPrimaryPodUrl, loadMultipleFilesFromPod } from '../services/solidPod'
 
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
 const mockLoadMultipleFilesFromPod = vi.mocked(loadMultipleFilesFromPod)
-const mockSaveFileToPod = vi.mocked(saveFileToPod)
-const mockDeleteFileFromPod = vi.mocked(deleteFileFromPod)
 
 const testPackingList = {
     id: 'list-1',
@@ -72,7 +70,21 @@ function makeDb() {
     return {
         getAllPackingLists: vi.fn().mockResolvedValue([testList]),
         deletePackingList: vi.fn().mockResolvedValue(undefined),
+        savePackingList: vi.fn().mockResolvedValue({ rev: '1' }),
     }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeContextValue(db: any) {
+    return {
+        db: db as unknown as PackingAppDatabase,
+        savePackingList: db.savePackingList ?? vi.fn().mockResolvedValue({ rev: '1' }),
+        deletePackingList: db.deletePackingList,
+        loadPackingList: vi.fn().mockResolvedValue(null),
+        listPackingLists: db.getAllPackingLists,
+        saveQuestionSet: vi.fn().mockResolvedValue({ rev: '1' }),
+        loadQuestionSet: vi.fn().mockResolvedValue({ people: [], questions: [], alwaysNeededItems: [] }),
+    } as ReturnType<typeof useDatabase>
 }
 
 function renderComponent() {
@@ -93,13 +105,12 @@ describe('PackingLists', () => {
             login: vi.fn(),
             logout: vi.fn(),
         })
-        mockUseDatabase.mockReturnValue({
-            db: {
-                getAllPackingLists: vi.fn().mockResolvedValue([testPackingList]),
-                deletePackingList: vi.fn(),
-                savePackingList: vi.fn(),
-            } as unknown as PackingAppDatabase,
-        })
+        const db = {
+            getAllPackingLists: vi.fn().mockResolvedValue([testPackingList]),
+            deletePackingList: vi.fn().mockResolvedValue(undefined),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '1' }),
+        }
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
         localStorage.clear()
     })
 
@@ -141,15 +152,14 @@ describe('PackingLists progress bar minimum width', () => {
             optionId: 'o1',
             packed: i === 0, // only 1 of 130 packed → 1%
         }))
-        mockUseDatabase.mockReturnValue({
-            db: {
-                getAllPackingLists: vi.fn().mockResolvedValue([{
-                    id: 'list-1', name: 'Big List', createdAt: '2026-01-01T00:00:00Z', items,
-                }]),
-                deletePackingList: vi.fn(),
-                savePackingList: vi.fn(),
-            } as unknown as PackingAppDatabase,
-        })
+        const db = {
+            getAllPackingLists: vi.fn().mockResolvedValue([{
+                id: 'list-1', name: 'Big List', createdAt: '2026-01-01T00:00:00Z', items,
+            }]),
+            deletePackingList: vi.fn().mockResolvedValue(undefined),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '1' }),
+        }
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         render(<MemoryRouter><PackingLists /></MemoryRouter>)
 
@@ -171,15 +181,14 @@ describe('PackingLists progress bar minimum width', () => {
             optionId: 'o1',
             packed: false,
         }))
-        mockUseDatabase.mockReturnValue({
-            db: {
-                getAllPackingLists: vi.fn().mockResolvedValue([{
-                    id: 'list-2', name: 'Empty Progress', createdAt: '2026-01-01T00:00:00Z', items,
-                }]),
-                deletePackingList: vi.fn(),
-                savePackingList: vi.fn(),
-            } as unknown as PackingAppDatabase,
-        })
+        const db = {
+            getAllPackingLists: vi.fn().mockResolvedValue([{
+                id: 'list-2', name: 'Empty Progress', createdAt: '2026-01-01T00:00:00Z', items,
+            }]),
+            deletePackingList: vi.fn().mockResolvedValue(undefined),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '1' }),
+        }
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         render(<MemoryRouter><PackingLists /></MemoryRouter>)
 
@@ -205,7 +214,7 @@ describe('PackingLists delete confirmation', () => {
 
     it('does not delete immediately when Delete is clicked', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
 
@@ -218,7 +227,7 @@ describe('PackingLists delete confirmation', () => {
 
     it('shows a confirmation dialog with the list name when Delete is clicked', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
 
@@ -234,7 +243,7 @@ describe('PackingLists delete confirmation', () => {
 
     it('cancels deletion when Cancel is clicked in the dialog', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
 
@@ -254,7 +263,7 @@ describe('PackingLists delete confirmation', () => {
 
     it('deletes the list when confirmed in the dialog', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
 
@@ -286,7 +295,7 @@ describe('PackingLists rename', () => {
 
     it('shows a Rename button on each list card', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
 
@@ -297,7 +306,7 @@ describe('PackingLists rename', () => {
 
     it('opens a rename modal pre-filled with the current list name when Rename is clicked', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
 
@@ -313,7 +322,7 @@ describe('PackingLists rename', () => {
 
     it('calls savePackingList with the new name when Save is clicked', async () => {
         const db = { ...makeDb(), savePackingList: vi.fn().mockResolvedValue({ rev: '2' }) }
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
 
@@ -335,7 +344,7 @@ describe('PackingLists rename', () => {
 
     it('does not call savePackingList when Cancel is clicked in the rename modal', async () => {
         const db = { ...makeDb(), savePackingList: vi.fn().mockResolvedValue({ rev: '2' }) }
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
 
@@ -365,7 +374,7 @@ describe('PackingLists mobile layout', () => {
 
     it('action buttons container wraps on small screens (has flex-wrap class)', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
         renderComponent()
         await screen.findByText(/Summer Holiday/)
         const buttonsContainer = document.querySelector('[data-testid="list-actions"]')
@@ -388,7 +397,7 @@ describe('PackingLists duplicate', () => {
 
     it('shows a Duplicate button on each list card', async () => {
         const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
 
@@ -399,7 +408,7 @@ describe('PackingLists duplicate', () => {
 
     it('calls savePackingList with a new list named "Copy of {name}" when Duplicate is clicked', async () => {
         const db = { ...makeDb(), savePackingList: vi.fn().mockResolvedValue({ rev: '1' }) }
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
 
@@ -439,7 +448,7 @@ describe('PackingLists auto-sync on login', () => {
     })
 
     it('automatically calls loadMultipleFilesFromPod on mount when logged in', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeLoggedInDb() as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(makeLoggedInDb()))
         mockLoadMultipleFilesFromPod.mockResolvedValue({
             data: [{ id: 'pod-list-1', name: 'Pod List', createdAt: '2026-01-01T00:00:00Z', items: [] }],
             result: { success: true, successCount: 1, failCount: 0, totalCount: 1 },
@@ -455,7 +464,7 @@ describe('PackingLists auto-sync on login', () => {
     it('does not show a "no data found" toast when pod has no packing lists on auto-sync', async () => {
         const showToast = vi.fn()
         vi.mocked(useToast).mockReturnValue({ showToast })
-        mockUseDatabase.mockReturnValue({ db: makeLoggedInDb([]) as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(makeLoggedInDb([])))
         mockLoadMultipleFilesFromPod.mockResolvedValue({
             data: [],
             result: { success: true, successCount: 0, failCount: 0, totalCount: 0 },
@@ -499,12 +508,11 @@ describe('PackingLists pod sync on mutation', () => {
             data: [],
             result: { success: true, successCount: 0, failCount: 0, totalCount: 0 },
         })
-        mockSaveFileToPod.mockResolvedValue(undefined)
-        mockDeleteFileFromPod.mockResolvedValue(undefined)
     })
 
-    it('saves renamed list to pod after rename is confirmed', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+    it('calls savePackingList with the renamed list after rename is confirmed', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
         await screen.findByText(/Summer Holiday/)
@@ -515,17 +523,15 @@ describe('PackingLists pod sync on mutation', () => {
         fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
         await waitFor(() => {
-            expect(mockSaveFileToPod).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    filename: 'list-1.json',
-                    data: expect.objectContaining({ id: 'list-1', name: 'Winter Holiday' }),
-                })
+            expect(db.savePackingList).toHaveBeenCalledWith(
+                expect.objectContaining({ id: 'list-1', name: 'Winter Holiday' })
             )
         })
     })
 
-    it('saves duplicated list to pod after duplicate', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+    it('calls savePackingList with the duplicated list after duplicate', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
         await screen.findByText(/Summer Holiday/)
@@ -533,17 +539,15 @@ describe('PackingLists pod sync on mutation', () => {
         fireEvent.click(screen.getByRole('button', { name: /duplicate/i }))
 
         await waitFor(() => {
-            expect(mockSaveFileToPod).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    filename: 'new-uuid.json',
-                    data: expect.objectContaining({ name: 'Copy of Summer Holiday' }),
-                })
+            expect(db.savePackingList).toHaveBeenCalledWith(
+                expect.objectContaining({ name: 'Copy of Summer Holiday', id: 'new-uuid' })
             )
         })
     })
 
-    it('deletes list from pod after delete is confirmed', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+    it('calls deletePackingList with the list id after delete is confirmed', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
         await screen.findByText(/Summer Holiday/)
@@ -553,14 +557,11 @@ describe('PackingLists pod sync on mutation', () => {
         fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
 
         await waitFor(() => {
-            expect(mockDeleteFileFromPod).toHaveBeenCalledWith(
-                loggedInSession,
-                'https://timgent.solidcommunity.net/packing-lists/list-1.json'
-            )
+            expect(db.deletePackingList).toHaveBeenCalledWith('list-1')
         })
     })
 
-    it('does not call saveFileToPod when not logged in', async () => {
+    it('calls savePackingList even when not logged in', async () => {
         mockUseSolidPod.mockReturnValue({
             isLoggedIn: false,
             session: null,
@@ -569,7 +570,8 @@ describe('PackingLists pod sync on mutation', () => {
             login: vi.fn(),
             logout: vi.fn(),
         })
-        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
         await screen.findByText(/Summer Holiday/)
@@ -577,9 +579,10 @@ describe('PackingLists pod sync on mutation', () => {
         fireEvent.click(screen.getByRole('button', { name: /duplicate/i }))
 
         await waitFor(() => {
-            expect(makeDb().savePackingList).toBeDefined()
+            expect(db.savePackingList).toHaveBeenCalledWith(
+                expect.objectContaining({ name: 'Copy of Summer Holiday' })
+            )
         })
-        expect(mockSaveFileToPod).not.toHaveBeenCalled()
     })
 })
 
@@ -605,7 +608,6 @@ describe('PackingLists local-only lists preserved when loading from pod', () => 
             data: [podList],
             result: { success: true, successCount: 1, failCount: 0, totalCount: 1 },
         })
-        mockSaveFileToPod.mockResolvedValue(undefined)
     })
 
     it('shows locally created list that has not yet been synced to pod', async () => {
@@ -623,7 +625,7 @@ describe('PackingLists local-only lists preserved when loading from pod', () => 
                 return { rev: '1' }
             }),
         }
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockUseDatabase.mockReturnValue(makeContextValue(db))
 
         renderComponent()
 

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -6,7 +6,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { Modal } from '../components/Modal'
-import { getPrimaryPodUrl, loadMultipleFilesFromPod, saveFileToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
+import { getPrimaryPodUrl, loadMultipleFilesFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { generateUUID } from '../utils/uuid'
 
@@ -18,7 +18,7 @@ export function PackingLists() {
     const [renameValue, setRenameValue] = useState('')
     const navigate = useNavigate()
     const { isLoggedIn, session } = useSolidPod()
-    const { db } = useDatabase()
+    const { db, savePackingList, deletePackingList } = useDatabase()
     const handlePodError = usePodErrorHandler()
 
     const requestDeletePackingList = (id: string, name: string, event: React.MouseEvent) => {
@@ -38,9 +38,8 @@ export function PackingLists() {
             const list = packingLists.find(l => l.id === listToRename.id)
             if (!list) return
             const updatedList = { ...list, name: renameValue }
-            await db.savePackingList(updatedList)
+            await savePackingList(updatedList)
             setPackingLists(packingLists.map(l => l.id === listToRename.id ? updatedList : l))
-            syncListToPod(updatedList)
         } catch (err) {
             console.error('Error renaming packing list:', err)
         } finally {
@@ -57,9 +56,8 @@ export function PackingLists() {
                 createdAt: new Date().toISOString(),
                 items: list.items.map(item => ({ ...item, id: generateUUID(), packed: false })),
             }
-            await db.savePackingList(newList)
+            await savePackingList(newList)
             setPackingLists([newList, ...packingLists])
-            syncListToPod(newList)
         } catch (err) {
             console.error('Error duplicating packing list:', err)
         }
@@ -69,40 +67,12 @@ export function PackingLists() {
         if (!listToDelete) return
         const { id } = listToDelete
         try {
-            await db.deletePackingList(id)
+            await deletePackingList(id)
             setPackingLists(packingLists.filter(list => list.id !== id))
-            removeListFromPod(id)
         } catch (err) {
             console.error('Error deleting packing list:', err)
         } finally {
             setListToDelete(null)
-        }
-    }
-
-    const syncListToPod = async (list: PackingList) => {
-        if (!isLoggedIn) return
-        try {
-            const podUrl = await getPrimaryPodUrl(session)
-            if (!podUrl) return
-            await saveFileToPod({
-                session: session!,
-                containerPath: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`,
-                filename: `${list.id}.json`,
-                data: list,
-            })
-        } catch (error) {
-            handlePodError(error, POD_ERROR_MESSAGES.SAVE_FAILED)
-        }
-    }
-
-    const removeListFromPod = async (id: string) => {
-        if (!isLoggedIn) return
-        try {
-            const podUrl = await getPrimaryPodUrl(session)
-            if (!podUrl) return
-            await deleteFileFromPod(session!, `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${id}.json`)
-        } catch (error) {
-            handlePodError(error, POD_ERROR_MESSAGES.SAVE_FAILED)
         }
     }
 
@@ -137,7 +107,7 @@ export function PackingLists() {
             // Sync any local-only lists to the pod so they aren't lost on future loads
             const localOnlyLists = existingLists.filter(l => !podListIds.has(l.id))
             for (const localList of localOnlyLists) {
-                await syncListToPod(localList)
+                await savePackingList(localList)
             }
 
             const allLists = await db.getAllPackingLists()


### PR DESCRIPTION
## Summary
This PR refactors database operations to provide a unified interface through the `DatabaseContext`, centralizing Pod synchronization logic and simplifying component dependencies.

## Key Changes

- **DatabaseContext Enhancement**: Added wrapper methods (`savePackingList`, `loadPackingList`, `listPackingLists`, `deletePackingList`, `saveQuestionSet`, `loadQuestionSet`) that handle both local database operations and Pod synchronization when a user is logged in.

- **Pod Sync Centralization**: Moved Pod file operations (`saveFileToPod`, `deleteFileFromPod`) from individual components into the DatabaseContext, eliminating duplicate sync logic across the codebase.

- **Component Simplification**: 
  - `PackingLists`: Removed direct Pod sync calls (`syncListToPod`, `removeListFromPod`) and now uses unified context methods
  - `CreatePackingList`: Removed Pod-related imports and now uses context methods for all data operations
  - `useHasQuestions`: Updated to use `loadQuestionSet` from context instead of direct database access

- **Test Updates**: Updated test files to:
  - Mock the new unified methods in DatabaseContext
  - Create helper functions (`makeContextValue`) to properly construct context values with all required methods
  - Remove direct mocking of `saveFileToPod` and `deleteFileFromPod` from component tests

## Implementation Details

- The context methods use `useMemo` to ensure stable references and proper dependency tracking
- Pod synchronization is conditional on login state (`isLoggedIn && session && resolvedPodUrl`)
- The `resolvedPodUrl` is now tracked in state and passed to sync operations
- All database operations maintain backward compatibility with existing database interface

https://claude.ai/code/session_01Nqut4qyKNGFtFKZYatLNQ3