### PR TITLE
Improve data sync architecture: login sync, create-packing-list sync, remove duplicate pod load

### DIFF
--- a/src/components/DatabaseContext.test.tsx
+++ b/src/components/DatabaseContext.test.tsx
@@ -13,6 +13,7 @@ vi.mock('./SolidPodContext', () => ({
 vi.mock('../services/solidPod', () => ({
   getPrimaryPodUrl: vi.fn(),
   hasPodData: vi.fn(),
+  syncAllDataFromPod: vi.fn(),
 }))
 
 // Mock PackingAppDatabase so tests don't create real filesystem databases
@@ -29,12 +30,13 @@ vi.mock('../services/database', () => {
 })
 
 import { useSolidPod } from './SolidPodContext'
-import { getPrimaryPodUrl, hasPodData } from '../services/solidPod'
+import { getPrimaryPodUrl, hasPodData, syncAllDataFromPod } from '../services/solidPod'
 import { PackingAppDatabase } from '../services/database'
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
 const mockHasPodData = vi.mocked(hasPodData)
+const mockSyncAllDataFromPod = vi.mocked(syncAllDataFromPod)
 const mockGetInstance = vi.mocked(PackingAppDatabase.getInstance)
 
 /** Creates a mock db object with controllable isEmpty/copyAllDataFrom behaviour */
@@ -76,6 +78,8 @@ describe('DatabaseContext', () => {
     mockHasPodData.mockReset()
     // Default: pod has data → no migration prompt
     mockHasPodData.mockResolvedValue(true)
+    mockSyncAllDataFromPod.mockReset()
+    mockSyncAllDataFromPod.mockResolvedValue({ questionSetSynced: false, packingListsSynced: 0, packingListsUploaded: 0 })
     localStorage.clear()
   })
 
@@ -320,6 +324,85 @@ describe('DatabaseContext', () => {
       await waitFor(() => screen.getByText('Start fresh'))
       fireEvent.click(screen.getByText('Start fresh'))
       expect(localStorage.getItem('pod-migration-dismissed-example.com')).toBe('true')
+    })
+  })
+
+  describe('login sync', () => {
+    const mockSession = { info: { isLoggedIn: true, webId: 'https://example.com/profile#me' } }
+
+    beforeEach(() => {
+      mockUseSolidPod.mockReturnValue({
+        session: mockSession as unknown as Session,
+        isLoggedIn: true,
+        webId: 'https://example.com/profile#me',
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+      mockGetPrimaryPodUrl.mockResolvedValue('https://example.com/')
+    })
+
+    it('calls syncAllDataFromPod after pod namespace is established', async () => {
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      expect(mockSyncAllDataFromPod).toHaveBeenCalledWith(
+        mockSession,
+        'https://example.com/',
+        expect.anything()
+      )
+    })
+
+    it('does not call syncAllDataFromPod when not logged in', async () => {
+      mockUseSolidPod.mockReturnValue({
+        session: null,
+        isLoggedIn: false,
+        webId: undefined,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      expect(mockSyncAllDataFromPod).not.toHaveBeenCalled()
+    })
+
+    it('does not call syncAllDataFromPod when migration prompt is shown', async () => {
+      mockHasPodData.mockResolvedValue(false)
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByText(/you have local data/i))
+      expect(mockSyncAllDataFromPod).not.toHaveBeenCalled()
+    })
+
+    it('does not crash when syncAllDataFromPod throws', async () => {
+      mockSyncAllDataFromPod.mockRejectedValue(new Error('Network error'))
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      // Children still render despite sync error
+      await waitFor(() => screen.getByTestId('child'))
+      expect(console.error).toHaveBeenCalled()
     })
   })
 })

--- a/src/components/DatabaseContext.tsx
+++ b/src/components/DatabaseContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, ReactNode, useContext, useState, useEffect, Fragment } from 'react'
 import { PackingAppDatabase, LOCAL_NAMESPACE } from '../services/database'
 import { useSolidPod } from './SolidPodContext'
-import { getPrimaryPodUrl, hasPodData } from '../services/solidPod'
+import { getPrimaryPodUrl, hasPodData, syncAllDataFromPod } from '../services/solidPod'
 import { ConfirmationDialog } from './ConfirmationDialog'
 
 interface DatabaseContextValue {
@@ -83,6 +83,14 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
             setNamespace(resolvedNamespace)
             setDb(podDb)
             setIsResolvingPod(false)
+
+            // Background sync: pull latest data from pod into local DB.
+            // Fire-and-forget – a sync failure must not block the app.
+            if (podUrl && session) {
+                syncAllDataFromPod(session, podUrl, podDb).catch(err => {
+                    console.error('Background login sync failed:', err)
+                })
+            }
         })
 
         return () => {

--- a/src/hooks/usePodSync.test.ts
+++ b/src/hooks/usePodSync.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { usePodSync } from './usePodSync'
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../components/SolidPodContext', () => ({
+  useSolidPod: vi.fn(),
+}))
+
+vi.mock('../services/solidPod', () => ({
+  getPrimaryPodUrl: vi.fn(),
+  loadFileFromPod: vi.fn(),
+  saveFileToPod: vi.fn(),
+  AuthenticationError: class AuthenticationError extends Error {
+    constructor(message: string) {
+      super(message)
+      this.name = 'AuthenticationError'
+    }
+  },
+}))
+
+import { useSolidPod } from '../components/SolidPodContext'
+import { getPrimaryPodUrl, loadFileFromPod } from '../services/solidPod'
+import type { Session } from '@inrupt/solid-client-authn-browser'
+
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
+const mockLoadFileFromPod = vi.mocked(loadFileFromPod)
+
+const mockSession = { info: { isLoggedIn: true } } as unknown as Session
+const POD_URL = 'https://pod.example.com/'
+const QUESTION_SET_DATA = { questions: [], people: [], alwaysNeededItems: [], lastModified: '2024-01-01T00:00:00.000Z' }
+
+function setupLoggedIn() {
+  mockUseSolidPod.mockReturnValue({
+    session: mockSession,
+    isLoggedIn: true,
+    webId: 'https://example.com/profile#me',
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+  })
+  mockGetPrimaryPodUrl.mockResolvedValue(POD_URL)
+  mockLoadFileFromPod.mockResolvedValue(QUESTION_SET_DATA)
+}
+
+function setupLoggedOut() {
+  mockUseSolidPod.mockReturnValue({
+    session: null,
+    isLoggedIn: false,
+    webId: undefined,
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+  })
+}
+
+const staticPathConfig = {
+  container: 'pack-me-up/',
+  filename: 'packing-list-questions.json',
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('usePodSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockGetPrimaryPodUrl.mockReset()
+    mockLoadFileFromPod.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  describe('syncOnMount (without polling)', () => {
+    it('syncs once on mount when syncOnMount is true and pollInterval is not set', async () => {
+      setupLoggedIn()
+      const onSyncSuccess = vi.fn()
+
+      renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          syncOnMount: true,
+          enabled: true,
+          onSyncSuccess,
+        })
+      )
+
+      // Let the async syncFromPod call resolve
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(mockLoadFileFromPod).toHaveBeenCalledOnce()
+      expect(onSyncSuccess).toHaveBeenCalledWith(QUESTION_SET_DATA)
+    })
+
+    it('does not set up a polling interval when syncOnMount is true and pollInterval is not set', async () => {
+      setupLoggedIn()
+
+      renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          syncOnMount: true,
+          enabled: true,
+        })
+      )
+
+      // Initial sync
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      expect(mockLoadFileFromPod).toHaveBeenCalledOnce()
+
+      // Advance well past any hypothetical interval - should still be only one call
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000)
+      })
+
+      expect(mockLoadFileFromPod).toHaveBeenCalledOnce()
+    })
+
+    it('does not sync when syncOnMount is false and pollInterval is not set', async () => {
+      setupLoggedIn()
+
+      renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          syncOnMount: false,
+          enabled: true,
+        })
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(mockLoadFileFromPod).not.toHaveBeenCalled()
+    })
+
+    it('does not sync when not logged in even if syncOnMount is true', async () => {
+      setupLoggedOut()
+
+      renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          syncOnMount: true,
+          enabled: true,
+        })
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(mockLoadFileFromPod).not.toHaveBeenCalled()
+    })
+
+    it('does not sync when enabled is false even if syncOnMount is true', async () => {
+      setupLoggedIn()
+
+      renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          syncOnMount: true,
+          enabled: false,
+        })
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(mockLoadFileFromPod).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('polling (existing behaviour preserved)', () => {
+    it('syncs on mount and polls at the given interval when pollInterval is set', async () => {
+      setupLoggedIn()
+
+      renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          pollInterval: 5000,
+          enabled: true,
+        })
+      )
+
+      // Initial sync on mount (run microtasks / promise callbacks)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      expect(mockLoadFileFromPod).toHaveBeenCalledOnce()
+
+      // Advance exactly one poll interval
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
+      expect(mockLoadFileFromPod).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not poll when enabled is false', async () => {
+      setupLoggedIn()
+
+      renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          pollInterval: 5000,
+          enabled: false,
+        })
+      )
+
+      await act(async () => {
+        vi.advanceTimersByTime(10_000)
+        await vi.runAllTimersAsync()
+      })
+
+      expect(mockLoadFileFromPod).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/hooks/usePodSync.ts
+++ b/src/hooks/usePodSync.ts
@@ -31,9 +31,15 @@ export interface PodSyncOptions<T> {
   pathConfig: PodPathConfig;
 
   /**
-   * Polling interval in milliseconds (null to disable polling)
+   * Polling interval in milliseconds (null/undefined to disable polling)
    */
   pollInterval?: number;
+
+  /**
+   * Sync once on mount even when pollInterval is not set.
+   * Default: false (no breaking change for existing callers that rely on pollInterval).
+   */
+  syncOnMount?: boolean;
 
   /**
    * Callback when sync from Pod succeeds
@@ -97,7 +103,8 @@ export interface PodSyncState<T> {
 export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
   const {
     pathConfig,
-    pollInterval = 10000, // Default: poll every 10 seconds
+    pollInterval,
+    syncOnMount = false,
     onSyncSuccess,
     onSyncError,
     onSaveSuccess,
@@ -262,10 +269,16 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
   }, [enabled, isLoggedIn, session, pathConfig, onSaveSuccess, onSaveError]);
 
   /**
-   * Set up polling interval
+   * Sync on mount (and/or) set up polling interval.
+   *
+   * - syncOnMount: true  → performs one sync immediately on mount (no polling)
+   * - pollInterval: N    → performs one sync immediately on mount AND polls every N ms
+   * - both false/unset   → no automatic sync
+   *
+   * Existing callers that pass pollInterval retain their original behaviour.
    */
   useEffect(() => {
-    if (!enabled || !isLoggedIn || !pollInterval) {
+    if (!enabled || !isLoggedIn) {
       return;
     }
 
@@ -276,8 +289,14 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
       return;
     }
 
-    // Do an initial sync when the hook mounts or login state changes
-    syncFromPod();
+    // Do an initial sync when syncOnMount is true OR polling is configured
+    if (syncOnMount || pollInterval) {
+      syncFromPod();
+    }
+
+    if (!pollInterval) {
+      return;
+    }
 
     // Set up the polling interval
     const interval = setInterval(() => {
@@ -291,7 +310,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
     // pathConfigKey is a stable string representation of pathConfig to avoid object reference issues
     // The interval only needs to restart when the actual config values change
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, isLoggedIn, pollInterval, pathConfigKey]);
+  }, [enabled, isLoggedIn, syncOnMount, pollInterval, pathConfigKey]);
 
   return {
     lastSync,

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, cleanup, act } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { deduplicateItems, getUnreviewedCustomItems, getUnreviewedDeletedItems } from './create-packing-list'
@@ -24,6 +24,16 @@ vi.mock('../hooks/useHasQuestions', () => ({
     useHasQuestions: vi.fn(),
 }))
 
+vi.mock('../hooks/usePodSync', () => ({
+    usePodSync: vi.fn().mockReturnValue({
+        lastSync: null,
+        isSyncing: false,
+        error: null,
+        saveToPod: vi.fn(),
+        syncFromPod: vi.fn(),
+    }),
+}))
+
 vi.mock('../services/solidPod', () => ({
     getPrimaryPodUrl: vi.fn(),
     saveFileToPod: vi.fn(),
@@ -38,9 +48,11 @@ import { ToastType } from '../components/Toast'
 import { PackingAppDatabase } from '../services/database'
 import { CreatePackingList } from './create-packing-list'
 import { getPrimaryPodUrl, saveFileToPod } from '../services/solidPod'
+import { usePodSync } from '../hooks/usePodSync'
 
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
 const mockSaveFileToPod = vi.mocked(saveFileToPod)
+const mockUsePodSync = vi.mocked(usePodSync)
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockUseDatabase = vi.mocked(useDatabase)
@@ -890,5 +902,139 @@ describe('CreatePackingList – deletion suggestion card', () => {
         fireEvent.click(screen.getByRole('button', { name: /keep/i }))
 
         await waitFor(() => expect(screen.queryByText(/previously removed/i)).toBeNull())
+    })
+})
+
+// ─── CreatePackingList – question set pod sync on mount ───────────────────────
+
+describe('CreatePackingList – question set pod sync on mount', () => {
+    const localQuestionSet: PackingListQuestionSet = {
+        ...testQuestionSet,
+        lastModified: '2024-01-01T10:00:00.000Z',
+    }
+
+    function makeSyncDb(overrides: Record<string, unknown> = {}) {
+        return {
+            getQuestionSet: vi.fn().mockResolvedValue(localQuestionSet),
+            getAllPackingLists: vi.fn().mockResolvedValue([]),
+            saveQuestionSet: vi.fn().mockResolvedValue({ rev: 'rev-synced' }),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+            ...overrides,
+        }
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUsePodSync.mockReturnValue({
+            lastSync: null,
+            isSyncing: false,
+            error: null,
+            saveToPod: vi.fn(),
+            syncFromPod: vi.fn(),
+        })
+        mockUseToast.mockReturnValue({ showToast: vi.fn() } as ReturnType<typeof useToast>)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('calls usePodSync with syncOnMount:true for the question set when logged in', async () => {
+        mockUseSolidPod.mockReturnValue({
+            session: null, isLoggedIn: true, webId: 'https://example.com/profile#me',
+            isLoading: false, login: vi.fn(), logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeSyncDb() } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+
+        expect(mockUsePodSync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                syncOnMount: true,
+                enabled: true,
+                pathConfig: expect.objectContaining({ filename: 'packing-list-questions.json' }),
+            })
+        )
+    })
+
+    it('does not enable usePodSync for question set when not logged in', async () => {
+        mockUseSolidPod.mockReturnValue({
+            session: null, isLoggedIn: false, webId: undefined,
+            isLoading: false, login: vi.fn(), logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeSyncDb() } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+
+        expect(mockUsePodSync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                syncOnMount: true,
+                enabled: false,
+            })
+        )
+    })
+
+    it('updates the displayed question set when pod data is newer', async () => {
+        mockUseSolidPod.mockReturnValue({
+            session: null, isLoggedIn: true, webId: 'https://example.com/profile#me',
+            isLoading: false, login: vi.fn(), logout: vi.fn(),
+        })
+        const db = makeSyncDb()
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+
+        // Capture the onSyncSuccess callback
+        let capturedOnSyncSuccess: ((data: PackingListQuestionSet) => void) | undefined
+        mockUsePodSync.mockImplementation((opts) => {
+            capturedOnSyncSuccess = opts.onSyncSuccess as (data: PackingListQuestionSet) => void
+            return { lastSync: null, isSyncing: false, error: null, saveToPod: vi.fn(), syncFromPod: vi.fn() }
+        })
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+
+        // Simulate pod returning a newer question set with an extra person
+        const newerPodQs: PackingListQuestionSet = {
+            ...testQuestionSet,
+            lastModified: '2024-06-01T12:00:00.000Z',
+            people: [{ id: 'p1', name: 'Alice' }, { id: 'p2', name: 'Bob' }],
+        }
+        await act(async () => {
+            capturedOnSyncSuccess!(newerPodQs)
+        })
+
+        await waitFor(() => expect(db.saveQuestionSet).toHaveBeenCalledWith(
+            expect.objectContaining({ lastModified: newerPodQs.lastModified })
+        ))
+    })
+
+    it('does not overwrite local question set when pod data is older', async () => {
+        mockUseSolidPod.mockReturnValue({
+            session: null, isLoggedIn: true, webId: 'https://example.com/profile#me',
+            isLoading: false, login: vi.fn(), logout: vi.fn(),
+        })
+        const db = makeSyncDb()
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+
+        let capturedOnSyncSuccess: ((data: PackingListQuestionSet) => void) | undefined
+        mockUsePodSync.mockImplementation((opts) => {
+            capturedOnSyncSuccess = opts.onSyncSuccess as (data: PackingListQuestionSet) => void
+            return { lastSync: null, isSyncing: false, error: null, saveToPod: vi.fn(), syncFromPod: vi.fn() }
+        })
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+
+        // Simulate pod returning an OLDER question set
+        const olderPodQs: PackingListQuestionSet = {
+            ...testQuestionSet,
+            lastModified: '2023-01-01T00:00:00.000Z',
+        }
+        await act(async () => {
+            capturedOnSyncSuccess!(olderPodQs)
+        })
+
+        expect(db.saveQuestionSet).not.toHaveBeenCalled()
     })
 })

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useCallback } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { Link, useNavigate } from 'react-router-dom'
 import { PackingListQuestionSet } from '../edit-questions/types'
@@ -10,6 +10,7 @@ import { useToast } from '../components/ToastContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { SolidProviderSelector } from '../components/SolidProviderSelector'
 import { getPrimaryPodUrl, saveFileToPod, POD_CONTAINERS } from '../services/solidPod'
+import { usePodSync } from '../hooks/usePodSync'
 
 export function deduplicateItems(items: PackingListItem[]): PackingListItem[] {
     const seen = new Set<string>()
@@ -302,6 +303,28 @@ export function CreatePackingList() {
             name: '',
             questionAnswers: []
         }
+    })
+
+    // Sync question set from pod once on page load so the list is created from
+    // the most up-to-date question set, even if another device updated it since login.
+    const handleQuestionSetPodSync = useCallback((podData: PackingListQuestionSet) => {
+        const podTime = podData.lastModified ? new Date(podData.lastModified).getTime() : 0
+        const localTime = questionSet?.lastModified ? new Date(questionSet.lastModified).getTime() : 0
+        if (!questionSet || podTime > localTime) {
+            db.saveQuestionSet(podData).then(({ rev }) => {
+                setQuestionSet({ ...podData, _rev: rev })
+            }).catch(err => console.error('Failed to save synced question set:', err))
+        }
+    }, [questionSet, db])
+
+    usePodSync<PackingListQuestionSet>({
+        pathConfig: {
+            container: POD_CONTAINERS.ROOT,
+            filename: 'packing-list-questions.json',
+        },
+        syncOnMount: true,
+        enabled: isLoggedIn,
+        onSyncSuccess: handleQuestionSetPodSync,
     })
 
     useEffect(() => {

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -27,9 +27,7 @@ vi.mock('../hooks/usePodErrorHandler', () => ({
 
 vi.mock('../services/solidPod', () => ({
     getPrimaryPodUrl: vi.fn(),
-    saveMultipleFilesToPod: vi.fn(),
     saveFileToPod: vi.fn(),
-    loadMultipleFilesFromPod: vi.fn(),
     deleteFileFromPod: vi.fn(),
     POD_CONTAINERS: { PACKING_LISTS: '/packing-lists/' },
     POD_ERROR_MESSAGES: {
@@ -44,13 +42,11 @@ vi.mock('../services/solidPod', () => ({
 import type { Session } from '@inrupt/solid-client-authn-browser'
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
-import { useToast } from '../components/ToastContext'
-import { getPrimaryPodUrl, loadMultipleFilesFromPod, saveFileToPod, deleteFileFromPod } from '../services/solidPod'
+import { getPrimaryPodUrl, saveFileToPod, deleteFileFromPod } from '../services/solidPod'
 
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
-const mockLoadMultipleFilesFromPod = vi.mocked(loadMultipleFilesFromPod)
 const mockSaveFileToPod = vi.mocked(saveFileToPod)
 const mockDeleteFileFromPod = vi.mocked(deleteFileFromPod)
 
@@ -415,64 +411,6 @@ describe('PackingLists duplicate', () => {
     })
 })
 
-describe('PackingLists auto-sync on login', () => {
-    const loggedInSession = { fetch: vi.fn() } as unknown as Session
-
-    function makeLoggedInDb(lists = [{ id: 'pod-list-1', name: 'Pod List', createdAt: '2026-01-01T00:00:00Z', items: [] }]) {
-        return {
-            getAllPackingLists: vi.fn().mockResolvedValue(lists),
-            deletePackingList: vi.fn().mockResolvedValue(undefined),
-            savePackingList: vi.fn().mockResolvedValue({ rev: '1' }),
-        }
-    }
-
-    beforeEach(() => {
-        mockUseSolidPod.mockReturnValue({
-            isLoggedIn: true,
-            session: loggedInSession,
-            webId: 'https://timgent.solidcommunity.net/profile/card#me',
-            isLoading: false,
-            login: vi.fn(),
-            logout: vi.fn(),
-        })
-        mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net')
-    })
-
-    it('automatically calls loadMultipleFilesFromPod on mount when logged in', async () => {
-        mockUseDatabase.mockReturnValue({ db: makeLoggedInDb() as unknown as PackingAppDatabase })
-        mockLoadMultipleFilesFromPod.mockResolvedValue({
-            data: [{ id: 'pod-list-1', name: 'Pod List', createdAt: '2026-01-01T00:00:00Z', items: [] }],
-            result: { success: true, successCount: 1, failCount: 0, totalCount: 1 },
-        })
-
-        renderComponent()
-
-        await waitFor(() => {
-            expect(mockLoadMultipleFilesFromPod).toHaveBeenCalled()
-        })
-    })
-
-    it('does not show a "no data found" toast when pod has no packing lists on auto-sync', async () => {
-        const showToast = vi.fn()
-        vi.mocked(useToast).mockReturnValue({ showToast })
-        mockUseDatabase.mockReturnValue({ db: makeLoggedInDb([]) as unknown as PackingAppDatabase })
-        mockLoadMultipleFilesFromPod.mockResolvedValue({
-            data: [],
-            result: { success: true, successCount: 0, failCount: 0, totalCount: 0 },
-        })
-
-        renderComponent()
-
-        await waitFor(() => {
-            expect(mockLoadMultipleFilesFromPod).toHaveBeenCalled()
-        })
-        expect(showToast).not.toHaveBeenCalledWith(
-            expect.stringContaining('No packing lists found'),
-            expect.anything()
-        )
-    })
-})
-
 describe('PackingLists pod sync on mutation', () => {
     const loggedInSession = { fetch: vi.fn() } as unknown as Session
 
@@ -495,10 +433,6 @@ describe('PackingLists pod sync on mutation', () => {
             logout: vi.fn(),
         })
         mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net')
-        mockLoadMultipleFilesFromPod.mockResolvedValue({
-            data: [],
-            result: { success: true, successCount: 0, failCount: 0, totalCount: 0 },
-        })
         mockSaveFileToPod.mockResolvedValue(undefined)
         mockDeleteFileFromPod.mockResolvedValue(undefined)
     })
@@ -583,53 +517,3 @@ describe('PackingLists pod sync on mutation', () => {
     })
 })
 
-describe('PackingLists local-only lists preserved when loading from pod', () => {
-    const loggedInSession = { fetch: vi.fn() } as unknown as Session
-
-    const podList = { id: 'pod-list-1', name: 'Old Pod List', createdAt: '2026-01-01T00:00:00Z', items: [] }
-    const localOnlyList = { id: 'local-only-1', name: 'Newly Created List', createdAt: '2026-02-01T00:00:00Z', items: [] }
-
-    beforeEach(() => {
-        vi.clearAllMocks()
-        mockUseSolidPod.mockReturnValue({
-            isLoggedIn: true,
-            session: loggedInSession,
-            webId: 'https://timgent.solidcommunity.net/profile/card#me',
-            isLoading: false,
-            login: vi.fn(),
-            logout: vi.fn(),
-        })
-        mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net')
-        // Pod has only the old list (local-only-1 was never synced)
-        mockLoadMultipleFilesFromPod.mockResolvedValue({
-            data: [podList],
-            result: { success: true, successCount: 1, failCount: 0, totalCount: 1 },
-        })
-        mockSaveFileToPod.mockResolvedValue(undefined)
-    })
-
-    it('shows locally created list that has not yet been synced to pod', async () => {
-        // Simulate a real DB: starts with both lists, and deletePackingList actually removes from state
-        const dbState = new Map([
-            [podList.id, podList],
-            [localOnlyList.id, localOnlyList],
-        ])
-
-        const db = {
-            getAllPackingLists: vi.fn().mockImplementation(async () => Array.from(dbState.values())),
-            deletePackingList: vi.fn().mockImplementation(async (id: string) => { dbState.delete(id) }),
-            savePackingList: vi.fn().mockImplementation(async (list: typeof podList) => {
-                dbState.set(list.id, list)
-                return { rev: '1' }
-            }),
-        }
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
-
-        renderComponent()
-
-        await waitFor(() => {
-            expect(screen.getByText(/Old Pod List/)).toBeTruthy()
-            expect(screen.getByText(/Newly Created List/)).toBeTruthy()
-        })
-    })
-})

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -6,7 +6,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { Modal } from '../components/Modal'
-import { getPrimaryPodUrl, loadMultipleFilesFromPod, saveFileToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
+import { getPrimaryPodUrl, saveFileToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { generateUUID } from '../utils/uuid'
 
@@ -105,57 +105,6 @@ export function PackingLists() {
             handlePodError(error, POD_ERROR_MESSAGES.SAVE_FAILED)
         }
     }
-
-    const loadFromPod = async () => {
-        const podUrl = await getPrimaryPodUrl(session)
-        if (!podUrl) return null
-
-        try {
-            const containerUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`
-            const { data: loadedLists, result } = await loadMultipleFilesFromPod<PackingList>({
-                session: session!,
-                containerPath: containerUrl
-            })
-
-            if (result.totalCount === 0) return result
-
-            const existingLists = await db.getAllPackingLists()
-            const podListIds = new Set(loadedLists.map(l => l.id))
-
-            // Only delete local lists that are also in the pod (they'll be replaced with the pod version).
-            // Local-only lists (not yet synced) are preserved and synced up to the pod.
-            for (const existingList of existingLists) {
-                if (podListIds.has(existingList.id)) {
-                    await db.deletePackingList(existingList.id)
-                }
-            }
-            for (const list of loadedLists) {
-                delete list._rev
-                await db.savePackingList(list)
-            }
-
-            // Sync any local-only lists to the pod so they aren't lost on future loads
-            const localOnlyLists = existingLists.filter(l => !podListIds.has(l.id))
-            for (const localList of localOnlyLists) {
-                await syncListToPod(localList)
-            }
-
-            const allLists = await db.getAllPackingLists()
-            setPackingLists(allLists)
-
-            return result
-        } catch (error) {
-            handlePodError(error, POD_ERROR_MESSAGES.LOAD_FAILED)
-            return null
-        }
-    }
-
-    useEffect(() => {
-        if (isLoggedIn) {
-            loadFromPod()
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isLoggedIn])
 
     useEffect(() => {
         const fetchPackingLists = async () => {

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { Session } from '@inrupt/solid-client-authn-browser'
 import type { SolidDataset, WithServerResourceInfo } from '@inrupt/solid-client'
-import { hasPodData } from './solidPod'
+import { hasPodData, syncAllDataFromPod } from './solidPod'
 import { AuthenticationError } from './solidPod'
+import type { PackingAppDatabase } from './database'
+import type { PackingListQuestionSet } from '../edit-questions/types'
+import type { PackingList } from '../create-packing-list/types'
 
 vi.mock('@inrupt/solid-client', () => ({
     getFile: vi.fn(),
@@ -14,11 +17,12 @@ vi.mock('@inrupt/solid-client', () => ({
     deleteFile: vi.fn(),
 }))
 
-import { getFile, getSolidDataset, getContainedResourceUrlAll } from '@inrupt/solid-client'
+import { getFile, getSolidDataset, getContainedResourceUrlAll, saveFileInContainer } from '@inrupt/solid-client'
 
 const mockGetFile = vi.mocked(getFile)
 const mockGetSolidDataset = vi.mocked(getSolidDataset)
 const mockGetContainedResourceUrlAll = vi.mocked(getContainedResourceUrlAll)
+const mockSaveFileInContainer = vi.mocked(saveFileInContainer)
 
 const mockSession = {
     info: { isLoggedIn: true, webId: 'https://example.com/profile#me' },
@@ -138,5 +142,205 @@ describe('hasPodData', () => {
         mockGetSolidDataset.mockRejectedValue(unexpectedError)
 
         await expect(hasPodData(mockSession, POD_URL)).rejects.toEqual(unexpectedError)
+    })
+})
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeQuestionSet(overrides: Partial<PackingListQuestionSet> = {}): PackingListQuestionSet {
+    return {
+        _id: '1',
+        people: [],
+        alwaysNeededItems: [],
+        questions: [],
+        lastModified: '2024-01-01T10:00:00.000Z',
+        ...overrides,
+    }
+}
+
+function makePackingList(id: string, overrides: Partial<PackingList> = {}): PackingList {
+    return {
+        id,
+        name: `List ${id}`,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        items: [],
+        lastModified: '2024-01-01T10:00:00.000Z',
+        ...overrides,
+    }
+}
+
+/** Blob whose .text() returns the given JSON */
+function jsonBlob(data: unknown): Blob & WithServerResourceInfo {
+    const text = JSON.stringify(data)
+    return {
+        text: () => Promise.resolve(text),
+    } as unknown as Blob & WithServerResourceInfo
+}
+
+function makeDb(overrides: Partial<{
+    questionSet: PackingListQuestionSet | null
+    packingLists: PackingList[]
+}> = {}): PackingAppDatabase {
+    const questionSet = overrides.questionSet !== undefined ? overrides.questionSet : null
+    const packingLists = overrides.packingLists ?? []
+
+    return {
+        getQuestionSet: vi.fn().mockImplementation(() =>
+            questionSet
+                ? Promise.resolve(questionSet)
+                : Promise.reject({ name: 'not_found' })
+        ),
+        saveQuestionSet: vi.fn().mockResolvedValue({ rev: 'rev-1' }),
+        getAllPackingLists: vi.fn().mockResolvedValue(packingLists),
+        savePackingList: vi.fn().mockResolvedValue({ rev: 'rev-pl' }),
+        deletePackingList: vi.fn().mockResolvedValue(undefined),
+    } as unknown as PackingAppDatabase
+}
+
+// ─── syncAllDataFromPod ──────────────────────────────────────────────────────
+
+describe('syncAllDataFromPod', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    describe('question set sync', () => {
+        it('saves pod question set to local DB when pod is newer', async () => {
+            const podQs = makeQuestionSet({ lastModified: '2024-06-01T12:00:00.000Z' })
+            const localQs = makeQuestionSet({ lastModified: '2024-01-01T10:00:00.000Z' })
+            const db = makeDb({ questionSet: localQs, packingLists: [] })
+
+            // No packing lists in pod
+            mockGetSolidDataset.mockRejectedValue({ statusCode: 404 })
+            // Question set file returns pod data
+            mockGetFile.mockResolvedValueOnce(jsonBlob(podQs))
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(db.saveQuestionSet).toHaveBeenCalledWith(expect.objectContaining({
+                lastModified: podQs.lastModified,
+            }))
+            expect(result.questionSetSynced).toBe(true)
+        })
+
+        it('does not overwrite local question set when local is newer', async () => {
+            const podQs = makeQuestionSet({ lastModified: '2024-01-01T10:00:00.000Z' })
+            const localQs = makeQuestionSet({ lastModified: '2024-06-01T12:00:00.000Z' })
+            const db = makeDb({ questionSet: localQs, packingLists: [] })
+
+            mockGetSolidDataset.mockRejectedValue({ statusCode: 404 })
+            mockGetFile.mockResolvedValueOnce(jsonBlob(podQs))
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(db.saveQuestionSet).not.toHaveBeenCalled()
+            expect(result.questionSetSynced).toBe(false)
+        })
+
+        it('saves pod question set when no local copy exists', async () => {
+            const podQs = makeQuestionSet()
+            const db = makeDb({ questionSet: null, packingLists: [] })
+
+            mockGetSolidDataset.mockRejectedValue({ statusCode: 404 })
+            mockGetFile.mockResolvedValueOnce(jsonBlob(podQs))
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(db.saveQuestionSet).toHaveBeenCalled()
+            expect(result.questionSetSynced).toBe(true)
+        })
+
+        it('skips question set sync gracefully when pod returns 404', async () => {
+            const db = makeDb({ packingLists: [] })
+
+            // Question set 404, then packing lists 404
+            mockGetFile.mockRejectedValueOnce({ statusCode: 404 })
+            mockGetSolidDataset.mockRejectedValue({ statusCode: 404 })
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(db.saveQuestionSet).not.toHaveBeenCalled()
+            expect(result.questionSetSynced).toBe(false)
+        })
+
+        it('re-throws authentication errors from question set load', async () => {
+            const db = makeDb({ packingLists: [] })
+            mockGetFile.mockRejectedValueOnce({ statusCode: 401 })
+
+            await expect(syncAllDataFromPod(mockSession, POD_URL, db)).rejects.toThrow(AuthenticationError)
+        })
+    })
+
+    describe('packing lists sync', () => {
+        it('saves all pod packing lists to local DB', async () => {
+            const podList1 = makePackingList('list-1')
+            const podList2 = makePackingList('list-2')
+            const db = makeDb({ questionSet: null, packingLists: [] })
+
+            // Question set 404
+            mockGetFile
+                .mockRejectedValueOnce({ statusCode: 404 })
+                // packing list files
+                .mockResolvedValueOnce(jsonBlob(podList1))
+                .mockResolvedValueOnce(jsonBlob(podList2))
+
+            const mockDataset = {}
+            mockGetSolidDataset.mockResolvedValue(mockDataset as unknown as SolidDataset & WithServerResourceInfo)
+            mockGetContainedResourceUrlAll.mockReturnValue([
+                `${POD_URL}pack-me-up/packing-lists/list-1.json`,
+                `${POD_URL}pack-me-up/packing-lists/list-2.json`,
+            ])
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(db.savePackingList).toHaveBeenCalledTimes(2)
+            expect(result.packingListsSynced).toBe(2)
+        })
+
+        it('uploads local-only packing lists to pod', async () => {
+            const localOnlyList = makePackingList('local-only')
+            const db = makeDb({ questionSet: null, packingLists: [localOnlyList] })
+
+            // Question set 404, packing lists container is empty
+            mockGetFile.mockRejectedValueOnce({ statusCode: 404 })
+            mockGetSolidDataset.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
+            mockGetContainedResourceUrlAll.mockReturnValue([])
+
+            mockSaveFileInContainer.mockResolvedValue({} as unknown as ReturnType<typeof saveFileInContainer> extends Promise<infer R> ? R : never)
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(mockSaveFileInContainer).toHaveBeenCalledWith(
+                expect.stringContaining('packing-lists'),
+                expect.any(File),
+                expect.objectContaining({ slug: 'local-only.json' })
+            )
+            expect(result.packingListsUploaded).toBe(1)
+        })
+
+        it('returns correct counts when both pod and local lists exist', async () => {
+            const podList = makePackingList('pod-list')
+            const localOnlyList = makePackingList('local-only')
+            const db = makeDb({ questionSet: null, packingLists: [localOnlyList] })
+
+            mockGetFile
+                .mockRejectedValueOnce({ statusCode: 404 }) // question set
+                .mockResolvedValueOnce(jsonBlob(podList))    // pod packing list
+
+            mockGetSolidDataset.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
+            mockGetContainedResourceUrlAll.mockReturnValue([
+                `${POD_URL}pack-me-up/packing-lists/pod-list.json`,
+            ])
+            mockSaveFileInContainer.mockResolvedValue({} as unknown as ReturnType<typeof saveFileInContainer> extends Promise<infer R> ? R : never)
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(result.packingListsSynced).toBe(1)
+            expect(result.packingListsUploaded).toBe(1)
+        })
     })
 })

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -1,5 +1,8 @@
 import { Session } from '@inrupt/solid-client-authn-browser'
 import { getPodUrlAll, saveFileInContainer, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile } from '@inrupt/solid-client'
+import { PackingAppDatabase } from './database'
+import { PackingListQuestionSet } from '../edit-questions/types'
+import { PackingList } from '../create-packing-list/types'
 
 /**
  * Pod container paths under the user's Pod root
@@ -394,4 +397,111 @@ export async function loadMultipleFilesFromPod<T>(
             totalCount: jsonFileUrls.length
         }
     }
+}
+
+/**
+ * Result of a full sync from Pod to local DB
+ */
+export interface SyncAllResult {
+    /** true if the pod question set was newer than local and was saved */
+    questionSetSynced: boolean
+    /** number of packing lists downloaded from pod and saved locally */
+    packingListsSynced: number
+    /** number of local-only packing lists uploaded to pod */
+    packingListsUploaded: number
+}
+
+/**
+ * Performs a full one-way sync from the Solid Pod into the local database.
+ *
+ * - Question set: pod wins if it is newer than the local copy (fallback-to-pod
+ *   strategy). If no local copy exists, the pod data is always saved.
+ * - Packing lists: all lists present on the pod are saved locally (pod wins for
+ *   any conflicting IDs). Local-only lists (not yet on the pod) are uploaded so
+ *   data is never lost.
+ *
+ * 404 responses are treated as "no data" and handled gracefully.
+ * Authentication errors (401/403) are re-thrown immediately.
+ * Other non-critical errors are logged and skipped so one failure does not
+ * prevent the rest of the sync from completing.
+ */
+export async function syncAllDataFromPod(
+    session: Session,
+    podUrl: string,
+    db: PackingAppDatabase
+): Promise<SyncAllResult> {
+    let questionSetSynced = false
+    let packingListsSynced = 0
+    let packingListsUploaded = 0
+
+    // ── 1. Question set ──────────────────────────────────────────────────────
+    try {
+        const podQs = await loadFileFromPod<PackingListQuestionSet>({
+            session,
+            fileUrl: `${podUrl}${POD_CONTAINERS.QUESTIONS}`,
+        })
+
+        let localQs: PackingListQuestionSet | null = null
+        try {
+            localQs = await db.getQuestionSet()
+        } catch {
+            // not_found is expected for a fresh login
+        }
+
+        const podTime = podQs.lastModified ? new Date(podQs.lastModified).getTime() : 0
+        const localTime = localQs?.lastModified ? new Date(localQs.lastModified).getTime() : 0
+
+        // Fallback-to-pod: save when there is no local copy OR pod is newer
+        if (!localQs || podTime > localTime) {
+            await db.saveQuestionSet({ ...podQs, _rev: undefined })
+            questionSetSynced = true
+        }
+    } catch (err: unknown) {
+        if (err instanceof AuthenticationError) throw err
+        const status = getStatusCode(err)
+        if (status !== 404) {
+            console.error('syncAllDataFromPod: error syncing question set', err)
+        }
+        // 404 = no question set on pod yet → silently skip
+    }
+
+    // ── 2. Packing lists ─────────────────────────────────────────────────────
+    const containerUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`
+
+    const { data: podLists } = await loadMultipleFilesFromPod<PackingList>({
+        session,
+        containerPath: containerUrl,
+    })
+
+    const podListIds = new Set(podLists.map((l) => l.id))
+
+    // Save all pod lists to local DB (pod wins for conflicting IDs)
+    for (const podList of podLists) {
+        try {
+            await db.savePackingList({ ...podList, _rev: undefined })
+            packingListsSynced++
+        } catch (err) {
+            console.error(`syncAllDataFromPod: error saving packing list ${podList.id}`, err)
+        }
+    }
+
+    // Upload any local-only lists to the pod so they are not lost
+    const localLists = await db.getAllPackingLists()
+    for (const localList of localLists) {
+        if (podListIds.has(localList.id)) continue
+        try {
+            await saveFileToPod({
+                session,
+                containerPath: containerUrl,
+                filename: `${localList.id}.json`,
+                data: localList,
+            })
+            packingListsUploaded++
+        } catch (err) {
+            if (err instanceof AuthenticationError) throw err
+            console.error(`syncAllDataFromPod: error uploading local list ${localList.id}`, err)
+        }
+    }
+
+    return { questionSetSynced, packingListsSynced, packingListsUploaded }
 }


### PR DESCRIPTION
- Add syncAllDataFromPod service function that syncs question set and all
  packing lists from pod to local DB in one shot, uploading local-only
  lists back to the pod
- Call syncAllDataFromPod as a background fire-and-forget in DatabaseContext
  after pod namespace is established, so all data is fresh immediately after
  login without any page needing special on-login logic
- Add syncOnMount option to usePodSync so callers can request a one-shot
  sync on page load without polling (backward-compatible; existing callers
  with pollInterval are unaffected)
- Use usePodSync with syncOnMount: true in create-packing-list so the
  question set is always up to date when generating a new list
- Remove loadFromPod function and its isLoggedIn-triggered useEffect from
  packing-lists.tsx; the login sync in DatabaseContext now covers this

https://claude.ai/code/session_01XyJNwPgwVTj8sNxPFWHmvq