### PR TITLE
Fix issue #145: sync question set to pod after wizard completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,3 +4,11 @@
 
 Use TDD (red-green-refactor) when implementing new features.
 Run tests: `npm test`
+
+## Data Access
+
+Never call `db.*` (local PouchDB) and pod storage functions directly in the same place. Use the established intermediate layers:
+
+- **Write** (local + pod together): `useSyncCoordinator.saveWithSyncPrevention(data, saveToPod)` — stamps a `lastModified` timestamp, saves locally first, then best-effort pod push with sync-loop prevention.
+- **Pod path config**: use `usePodSync` to get `saveToPod` / `syncFromPod` for a given resource path.
+- **Login sync** (pod → local on login): handled automatically by `DatabaseContext` via `syncAllDataFromPod` — no per-page code needed.

--- a/src/pages/useWizardGeneration.test.ts
+++ b/src/pages/useWizardGeneration.test.ts
@@ -10,6 +10,11 @@ vi.mock('../components/ToastContext', () => ({
     useToast: vi.fn(() => ({ showToast: vi.fn() })),
 }))
 
+const mockSaveToPod = vi.fn().mockResolvedValue(true)
+vi.mock('../hooks/usePodSync', () => ({
+    usePodSync: vi.fn(() => ({ saveToPod: mockSaveToPod })),
+}))
+
 import { useDatabase } from '../components/DatabaseContext'
 import type { PackingAppDatabase } from '../services/database'
 
@@ -17,7 +22,7 @@ const mockUseDatabase = vi.mocked(useDatabase)
 
 function makeDb() {
     return {
-        saveQuestionSet: vi.fn().mockResolvedValue(undefined),
+        saveQuestionSet: vi.fn().mockResolvedValue({ rev: 'rev-1' }),
     }
 }
 
@@ -25,10 +30,11 @@ describe('useWizardGeneration', () => {
     beforeEach(() => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        mockSaveToPod.mockClear()
     })
 
     it('passes gender from form data through to the saved question set people', async () => {
-        const saveQuestionSet = vi.fn().mockResolvedValue(undefined)
+        const saveQuestionSet = vi.fn().mockResolvedValue({ rev: 'rev-1' })
         mockUseDatabase.mockReturnValue({
             db: { saveQuestionSet } as unknown as PackingAppDatabase,
         })
@@ -53,10 +59,8 @@ describe('useWizardGeneration', () => {
     })
 
     it('omits gender from people when not provided in form data', async () => {
-        const saveQuestionSet = vi.fn().mockResolvedValue(undefined)
-        mockUseDatabase.mockReturnValue({
-            db: { saveQuestionSet } as unknown as PackingAppDatabase,
-        })
+        const saveQuestionSet = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+        mockUseDatabase.mockReturnValue({ db: { saveQuestionSet } as unknown as PackingAppDatabase })
 
         const { result } = renderHook(() => useWizardGeneration())
 
@@ -68,5 +72,25 @@ describe('useWizardGeneration', () => {
 
         const savedData = saveQuestionSet.mock.calls[0][0]
         expect(savedData.people[0].gender).toBeUndefined()
+    })
+
+    it('syncs the question set to the pod after saving locally', async () => {
+        const saveQuestionSet = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+        mockUseDatabase.mockReturnValue({
+            db: { saveQuestionSet } as unknown as PackingAppDatabase,
+        })
+
+        const { result } = renderHook(() => useWizardGeneration())
+
+        await act(async () => {
+            await result.current.generateAndSave({
+                people: [{ name: 'Alice', ageRange: 'Adult' }],
+            })
+        })
+
+        expect(mockSaveToPod).toHaveBeenCalledOnce()
+        const podData = mockSaveToPod.mock.calls[0][0]
+        expect(podData.people[0].name).toBe('Alice')
+        expect(podData._rev).toBe('rev-1')
     })
 })

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -5,13 +5,22 @@ import { createExampleData } from '../edit-questions/example-data'
 import { QUESTION_SET_ID } from '../constants'
 import { WizardFormData } from './wizard-types'
 import { generateUUID } from '../utils/uuid'
-import { Person } from '../edit-questions/types'
+import { Person, PackingListQuestionSet } from '../edit-questions/types'
+import { usePodSync } from '../hooks/usePodSync'
+import { POD_CONTAINERS } from '../services/solidPod'
 
 export function useWizardGeneration() {
     const { showToast } = useToast()
     const { db } = useDatabase()
     const [isLoading, setIsLoading] = useState(false)
     const [isSuccess, setIsSuccess] = useState(false)
+
+    const { saveToPod } = usePodSync<PackingListQuestionSet>({
+        pathConfig: {
+            container: POD_CONTAINERS.ROOT,
+            filename: 'packing-list-questions.json'
+        }
+    })
 
     const generateQuestionSet = (data: WizardFormData) => {
         const people: Person[] = data.people.map(p => ({
@@ -28,11 +37,15 @@ export function useWizardGeneration() {
         setIsSuccess(false)
         try {
             const questionSet = generateQuestionSet(data)
-
-            await db.saveQuestionSet({
+            const questionSetWithId = {
                 _id: QUESTION_SET_ID,
                 ...questionSet
-            })
+            }
+
+            const { rev } = await db.saveQuestionSet(questionSetWithId)
+
+            // Best-effort: push to pod if user is logged in
+            await saveToPod({ ...questionSetWithId, _rev: rev })
 
             showToast('Packing list questions generated successfully!', 'success')
             setIsSuccess(true)

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -7,6 +7,7 @@ import { WizardFormData } from './wizard-types'
 import { generateUUID } from '../utils/uuid'
 import { Person, PackingListQuestionSet } from '../edit-questions/types'
 import { usePodSync } from '../hooks/usePodSync'
+import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 import { POD_CONTAINERS } from '../services/solidPod'
 
 export function useWizardGeneration() {
@@ -20,6 +21,12 @@ export function useWizardGeneration() {
             container: POD_CONTAINERS.ROOT,
             filename: 'packing-list-questions.json'
         }
+    })
+
+    const { saveWithSyncPrevention } = useSyncCoordinator<PackingListQuestionSet>({
+        currentData: null,
+        saveToLocalDb: (data) => db.saveQuestionSet(data),
+        updateFormAndState: () => {},
     })
 
     const generateQuestionSet = (data: WizardFormData) => {
@@ -37,15 +44,11 @@ export function useWizardGeneration() {
         setIsSuccess(false)
         try {
             const questionSet = generateQuestionSet(data)
-            const questionSetWithId = {
-                _id: QUESTION_SET_ID,
-                ...questionSet
-            }
 
-            const { rev } = await db.saveQuestionSet(questionSetWithId)
-
-            // Best-effort: push to pod if user is logged in
-            await saveToPod({ ...questionSetWithId, _rev: rev })
+            await saveWithSyncPrevention(
+                { _id: QUESTION_SET_ID, ...questionSet },
+                saveToPod
+            )
 
             showToast('Packing list questions generated successfully!', 'success')
             setIsSuccess(true)


### PR DESCRIPTION
After saving the question set locally, call saveToPod (best-effort) so
that the data is immediately pushed to the user's Solid Pod when logged in.
Previously the wizard only wrote to local PouchDB with no pod push.

https://claude.ai/code/session_01Wrx7pKiUo1eYC6zwAwukoP