### PR TITLE
Add New List button to View Lists page (closes #137)

### DIFF
--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -9,6 +9,12 @@ vi.mock('../utils/uuid', () => ({
     generateUUID: vi.fn(() => 'new-uuid'),
 }))
 
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react-router-dom')>()
+    return { ...actual, useNavigate: () => mockNavigate }
+})
+
 vi.mock('../components/DatabaseContext', () => ({
     useDatabase: vi.fn(),
 }))
@@ -408,6 +414,40 @@ describe('PackingLists duplicate', () => {
                 expect.objectContaining({ name: 'Copy of Summer Holiday', id: 'new-uuid' })
             )
         })
+    })
+})
+
+describe('PackingLists new list button', () => {
+    beforeEach(() => {
+        mockNavigate.mockClear()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn().mockResolvedValue([testList]),
+                deletePackingList: vi.fn(),
+                savePackingList: vi.fn(),
+            } as unknown as PackingAppDatabase,
+        })
+    })
+
+    it('renders a New List button', async () => {
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+        expect(screen.getByRole('button', { name: /new list/i })).toBeTruthy()
+    })
+
+    it('navigates to /create-packing-list when New List is clicked', async () => {
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+        fireEvent.click(screen.getByRole('button', { name: /new list/i }))
+        expect(mockNavigate).toHaveBeenCalledWith('/create-packing-list')
     })
 })
 

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -127,11 +127,12 @@ export function PackingLists() {
 
     return (
         <div className="max-w-4xl mx-auto py-8 px-4">
-            <div className="mb-8">
+            <div className="mb-8 flex justify-between items-start">
                 <div className="mb-2">
                     <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
                     <p className="mt-2 text-lg text-gray-700 font-medium">View all your created packing lists.</p>
                 </div>
+                <Button variant="primary" onClick={() => navigate('/create-packing-list')}>➕ New List</Button>
             </div>
 
             {packingLists.length === 0 ? (


### PR DESCRIPTION
Adds a primary "New List" button to the header of the packing lists page so users can navigate directly to the create-packing-list flow without returning to the landing page.

https://claude.ai/code/session_01DJWwhoKR15zDNyHmuTUp59