### PR TITLE
Migrate pod storage from JSON to RDF (Turtle) format

### DIFF
--- a/e2e/tests/g-cross-context.spec.ts
+++ b/e2e/tests/g-cross-context.spec.ts
@@ -83,11 +83,16 @@ test.describe('G – Cross-context Pod Sync', () => {
     await renameInput.clear()
     await renameInput.fill(renamedName)
     await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click()
+    // Verify the rename is visible on this page before checking context B
     await expect(page.getByText(renamedName)).toBeVisible({ timeout: 5_000 })
-
-    // Reload page A: triggers syncAllDataFromPod again which loads the renamed list from pod.
+    // confirmRenamePackingList is async; wait for all in-flight network requests
+    // (including syncListToPod's GET + PUT) to settle before reloading.
+    // networkidle is more reliable than a fixed timeout.
+    await page.waitForLoadState('networkidle', { timeout: 15_000 })
+    // Reload page A to confirm pod has the rename (loadFromPod overwrites local from pod)
     await page.reload()
-    await expect(page.getByText(renamedName)).toBeVisible({ timeout: 30_000 })
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(renamedName)).toBeVisible({ timeout: 10_000 })
 
     const { ctx: ctxB, pg: pageB } = await freshLogin(browser)
     await pageB.goto('/#/view-lists')

--- a/e2e/tests/k-schema-compat.spec.ts
+++ b/e2e/tests/k-schema-compat.spec.ts
@@ -17,6 +17,10 @@ import { CSS_ISSUER, SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD } from '../../p
 //      on the same local DB, which is fully populated before any test begins.
 test.describe.configure({ mode: 'serial' })
 
+// Run serially: K1 migrates the shared schema-compat pod (JSON → RDF); K2/K3
+// must start after K1 finishes so they find the .ttl files already in place.
+test.describe.configure({ mode: 'serial' })
+
 test.describe('K – JSON Schema Compatibility', () => {
   let page: import('@playwright/test').Page
   let ctx: import('@playwright/test').BrowserContext

--- a/e2e/tests/k-schema-compat.spec.ts
+++ b/e2e/tests/k-schema-compat.spec.ts
@@ -15,8 +15,6 @@ import { CSS_ISSUER, SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD } from '../../p
 //      after the 30+ logins that precede K tests in the workers=1 CI run).
 //   2. Login sync (syncAllDataFromPod) runs exactly once — all three tests operate
 //      on the same local DB, which is fully populated before any test begins.
-test.describe.configure({ mode: 'serial' })
-
 // Run serially: K1 migrates the shared schema-compat pod (JSON → RDF); K2/K3
 // must start after K1 finishes so they find the .ttl files already in place.
 test.describe.configure({ mode: 'serial' })

--- a/src/components/DatabaseContext.test.tsx
+++ b/src/components/DatabaseContext.test.tsx
@@ -16,6 +16,11 @@ vi.mock('../services/solidPod', () => ({
   syncAllDataFromPod: vi.fn(),
 }))
 
+vi.mock('../services/rdfMigration', () => ({
+  detectPodDataFormat: vi.fn(),
+  migrateJsonToRdf: vi.fn(),
+}))
+
 // Mock PackingAppDatabase so tests don't create real filesystem databases
 vi.mock('../services/database', () => {
   return {
@@ -31,12 +36,15 @@ vi.mock('../services/database', () => {
 
 import { useSolidPod } from './SolidPodContext'
 import { getPrimaryPodUrl, hasPodData, syncAllDataFromPod } from '../services/solidPod'
+import { detectPodDataFormat, migrateJsonToRdf } from '../services/rdfMigration'
 import { PackingAppDatabase } from '../services/database'
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
 const mockHasPodData = vi.mocked(hasPodData)
 const mockSyncAllDataFromPod = vi.mocked(syncAllDataFromPod)
+const mockDetectPodDataFormat = vi.mocked(detectPodDataFormat)
+const mockMigrateJsonToRdf = vi.mocked(migrateJsonToRdf)
 const mockGetInstance = vi.mocked(PackingAppDatabase.getInstance)
 
 /** Creates a mock db object with controllable isEmpty/copyAllDataFrom behaviour */
@@ -80,6 +88,10 @@ describe('DatabaseContext', () => {
     mockHasPodData.mockResolvedValue(true)
     mockSyncAllDataFromPod.mockReset()
     mockSyncAllDataFromPod.mockResolvedValue({ questionSetSynced: false, packingListsSynced: 0, packingListsUploaded: 0 })
+    mockDetectPodDataFormat.mockReset()
+    mockDetectPodDataFormat.mockResolvedValue('rdf')
+    mockMigrateJsonToRdf.mockReset()
+    mockMigrateJsonToRdf.mockResolvedValue({ questionSetMigrated: false, packingListsMigrated: 0, errors: [] })
     localStorage.clear()
   })
 
@@ -403,6 +415,117 @@ describe('DatabaseContext', () => {
       // Children still render despite sync error
       await waitFor(() => screen.getByTestId('child'))
       expect(console.error).toHaveBeenCalled()
+    })
+  })
+
+  describe('RDF migration on login', () => {
+    const mockSession = { info: { isLoggedIn: true, webId: 'https://example.com/profile#me' } }
+
+    beforeEach(() => {
+      mockUseSolidPod.mockReturnValue({
+        session: mockSession as unknown as Session,
+        isLoggedIn: true,
+        webId: 'https://example.com/profile#me',
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+      mockGetPrimaryPodUrl.mockResolvedValue('https://example.com/')
+    })
+
+    it('calls detectPodDataFormat on login', async () => {
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      await waitFor(() => expect(mockDetectPodDataFormat).toHaveBeenCalledWith(
+        mockSession,
+        'https://example.com/',
+      ))
+    })
+
+    it('calls migrateJsonToRdf when format is json', async () => {
+      mockDetectPodDataFormat.mockResolvedValue('json')
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      await waitFor(() => expect(mockMigrateJsonToRdf).toHaveBeenCalledWith(
+        mockSession,
+        'https://example.com/',
+      ))
+    })
+
+    it('does not call migrateJsonToRdf when format is rdf', async () => {
+      mockDetectPodDataFormat.mockResolvedValue('rdf')
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      await waitFor(() => expect(mockSyncAllDataFromPod).toHaveBeenCalled())
+      expect(mockMigrateJsonToRdf).not.toHaveBeenCalled()
+    })
+
+    it('does not call migrateJsonToRdf when format is empty', async () => {
+      mockDetectPodDataFormat.mockResolvedValue('empty')
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      await waitFor(() => expect(mockSyncAllDataFromPod).toHaveBeenCalled())
+      expect(mockMigrateJsonToRdf).not.toHaveBeenCalled()
+    })
+
+    it('still calls syncAllDataFromPod even when migration throws', async () => {
+      mockDetectPodDataFormat.mockResolvedValue('json')
+      mockMigrateJsonToRdf.mockRejectedValue(new Error('migration failed'))
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      await waitFor(() => expect(mockSyncAllDataFromPod).toHaveBeenCalled())
+      expect(console.error).toHaveBeenCalled()
+    })
+
+    it('calls syncAllDataFromPod after migration completes', async () => {
+      mockDetectPodDataFormat.mockResolvedValue('json')
+      const migrationOrder: string[] = []
+      mockMigrateJsonToRdf.mockImplementation(async () => {
+        migrationOrder.push('migrate')
+        return { questionSetMigrated: true, packingListsMigrated: 0, errors: [] }
+      })
+      mockSyncAllDataFromPod.mockImplementation(async () => {
+        migrationOrder.push('sync')
+        return { questionSetSynced: false, packingListsSynced: 0, packingListsUploaded: 0 }
+      })
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      await waitFor(() => expect(migrationOrder).toEqual(['migrate', 'sync']))
     })
   })
 })

--- a/src/components/DatabaseContext.test.tsx
+++ b/src/components/DatabaseContext.test.tsx
@@ -12,7 +12,6 @@ vi.mock('./SolidPodContext', () => ({
 
 vi.mock('../services/solidPod', () => ({
   getPrimaryPodUrl: vi.fn(),
-  hasPodData: vi.fn(),
   syncAllDataFromPod: vi.fn(),
 }))
 
@@ -35,13 +34,12 @@ vi.mock('../services/database', () => {
 })
 
 import { useSolidPod } from './SolidPodContext'
-import { getPrimaryPodUrl, hasPodData, syncAllDataFromPod } from '../services/solidPod'
+import { getPrimaryPodUrl, syncAllDataFromPod } from '../services/solidPod'
 import { detectPodDataFormat, migrateJsonToRdf } from '../services/rdfMigration'
 import { PackingAppDatabase } from '../services/database'
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
-const mockHasPodData = vi.mocked(hasPodData)
 const mockSyncAllDataFromPod = vi.mocked(syncAllDataFromPod)
 const mockDetectPodDataFormat = vi.mocked(detectPodDataFormat)
 const mockMigrateJsonToRdf = vi.mocked(migrateJsonToRdf)
@@ -83,9 +81,6 @@ describe('DatabaseContext', () => {
     mockGetInstance.mockReset()
     mockGetInstance.mockImplementation(defaultInstanceFactory)
     mockGetPrimaryPodUrl.mockReset()
-    mockHasPodData.mockReset()
-    // Default: pod has data → no migration prompt
-    mockHasPodData.mockResolvedValue(true)
     mockSyncAllDataFromPod.mockReset()
     mockSyncAllDataFromPod.mockResolvedValue({ questionSetSynced: false, packingListsSynced: 0, packingListsUploaded: 0 })
     mockDetectPodDataFormat.mockReset()
@@ -227,7 +222,7 @@ describe('DatabaseContext', () => {
     })
 
     it('shows migration dialog when pod has no remote data and local has data', async () => {
-      mockHasPodData.mockResolvedValue(false)
+      mockDetectPodDataFormat.mockResolvedValue('empty')
       // local db: isEmpty=false (has data)
       mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
 
@@ -242,7 +237,7 @@ describe('DatabaseContext', () => {
     })
 
     it('does not show migration dialog when pod already has remote data', async () => {
-      mockHasPodData.mockResolvedValue(true)
+      mockDetectPodDataFormat.mockResolvedValue('rdf')
       mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
 
       render(
@@ -256,7 +251,7 @@ describe('DatabaseContext', () => {
     })
 
     it('does not show migration dialog when local db is empty', async () => {
-      mockHasPodData.mockResolvedValue(false)
+      mockDetectPodDataFormat.mockResolvedValue('empty')
       // local db: isEmpty=true
       mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: true }))
 
@@ -272,7 +267,7 @@ describe('DatabaseContext', () => {
 
     it('does not show migration dialog when localStorage dismissed key is set', async () => {
       localStorage.setItem('pod-migration-dismissed-example.com', 'true')
-      mockHasPodData.mockResolvedValue(false)
+      mockDetectPodDataFormat.mockResolvedValue('empty')
       mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
 
       render(
@@ -286,7 +281,7 @@ describe('DatabaseContext', () => {
     })
 
     it('copies data to pod and renders children when user clicks "Use my local data"', async () => {
-      mockHasPodData.mockResolvedValue(false)
+      mockDetectPodDataFormat.mockResolvedValue('empty')
       const copyAllDataFrom = vi.fn().mockResolvedValue(undefined)
       mockGetInstance.mockImplementation((ns: string) =>
         makeDb(ns, { isEmpty: false, copyAllDataFrom })
@@ -305,7 +300,7 @@ describe('DatabaseContext', () => {
     })
 
     it('skips migration and renders children when user clicks "Start fresh"', async () => {
-      mockHasPodData.mockResolvedValue(false)
+      mockDetectPodDataFormat.mockResolvedValue('empty')
       const copyAllDataFrom = vi.fn()
       mockGetInstance.mockImplementation((ns: string) =>
         makeDb(ns, { isEmpty: false, copyAllDataFrom })
@@ -324,7 +319,7 @@ describe('DatabaseContext', () => {
     })
 
     it('sets localStorage dismissed key when user clicks "Start fresh"', async () => {
-      mockHasPodData.mockResolvedValue(false)
+      mockDetectPodDataFormat.mockResolvedValue('empty')
       mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
 
       render(
@@ -390,7 +385,7 @@ describe('DatabaseContext', () => {
     })
 
     it('does not call syncAllDataFromPod when migration prompt is shown', async () => {
-      mockHasPodData.mockResolvedValue(false)
+      mockDetectPodDataFormat.mockResolvedValue('empty')
       mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
 
       render(
@@ -479,6 +474,9 @@ describe('DatabaseContext', () => {
 
     it('does not call migrateJsonToRdf when format is empty', async () => {
       mockDetectPodDataFormat.mockResolvedValue('empty')
+      // Local db must be empty so the migration-prompt path is skipped and the
+      // background IIFE runs (where we verify migrateJsonToRdf is not called).
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: true }))
 
       render(
         <DatabaseProvider>

--- a/src/components/DatabaseContext.tsx
+++ b/src/components/DatabaseContext.tsx
@@ -2,6 +2,7 @@ import { createContext, ReactNode, useContext, useState, useEffect, useRef, Frag
 import { PackingAppDatabase, LOCAL_NAMESPACE } from '../services/database'
 import { useSolidPod } from './SolidPodContext'
 import { getPrimaryPodUrl, hasPodData, syncAllDataFromPod } from '../services/solidPod'
+import { detectPodDataFormat, migrateJsonToRdf } from '../services/rdfMigration'
 import { ConfirmationDialog } from './ConfirmationDialog'
 
 interface DatabaseContextValue {
@@ -107,21 +108,30 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
             setDb(podDb)
             setIsResolvingPod(false)
 
-            // Background sync: pull latest data from pod into local DB.
+            // Background: detect format, migrate if needed, then sync.
             // Only run once per namespace (login event), not on every session refresh.
-            // Fire-and-forget – a sync failure must not block the app.
+            // Fire-and-forget – failures must not block the app.
             if (podUrl && session) {
                 syncedNamespaceRef.current = resolvedNamespace
                 setLoginSyncInProgress(true)
-                syncAllDataFromPod(session, podUrl, podDb)
-                    .then(() => {
+                ;(async () => {
+                    try {
+                        const format = await detectPodDataFormat(session, podUrl)
+                        if (format === 'json') {
+                            await migrateJsonToRdf(session, podUrl)
+                        }
+                    } catch (err) {
+                        console.error('RDF migration failed:', err)
+                    }
+                    try {
+                        await syncAllDataFromPod(session, podUrl, podDb)
                         setLoginSyncVersion(v => v + 1)
-                        setLoginSyncInProgress(false)
-                    })
-                    .catch(err => {
+                    } catch (err) {
                         console.error('Background login sync failed:', err)
+                    } finally {
                         setLoginSyncInProgress(false)
-                    })
+                    }
+                })()
             }
         })
 

--- a/src/components/DatabaseContext.tsx
+++ b/src/components/DatabaseContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, ReactNode, useContext, useState, useEffect, useRef, Fragment } from 'react'
 import { PackingAppDatabase, LOCAL_NAMESPACE } from '../services/database'
 import { useSolidPod } from './SolidPodContext'
-import { getPrimaryPodUrl, hasPodData, syncAllDataFromPod } from '../services/solidPod'
+import { getPrimaryPodUrl, syncAllDataFromPod } from '../services/solidPod'
 import { detectPodDataFormat, migrateJsonToRdf } from '../services/rdfMigration'
 import { ConfirmationDialog } from './ConfirmationDialog'
 
@@ -87,11 +87,18 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
             const dismissedKey = `pod-migration-dismissed-${resolvedNamespace}`
             const dismissed = localStorage.getItem(dismissedKey) === 'true'
 
+            // Detect format once so hasPodData and detectPodDataFormat don't
+            // make two separate batches of authenticated requests, which causes
+            // a DPoP nonce race on CSS and results in TypeError: Failed to fetch.
+            let cachedFormat: 'rdf' | 'json' | 'empty' | null = null
+
             if (!dismissed && podUrl && session) {
-                const [podHasRemoteData, localEmpty] = await Promise.all([
-                    hasPodData(session, podUrl),
+                const [format, localEmpty] = await Promise.all([
+                    detectPodDataFormat(session, podUrl),
                     local.isEmpty()
                 ])
+                cachedFormat = format
+                const podHasRemoteData = format !== 'empty'
                 if (!podHasRemoteData && !localEmpty) {
                     if (cancelled) return
                     setLocalDb(local)
@@ -108,7 +115,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
             setDb(podDb)
             setIsResolvingPod(false)
 
-            // Background: detect format, migrate if needed, then sync.
+            // Background: migrate if needed, then sync.
             // Only run once per namespace (login event), not on every session refresh.
             // Fire-and-forget – failures must not block the app.
             if (podUrl && session) {
@@ -116,7 +123,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
                 setLoginSyncInProgress(true)
                 ;(async () => {
                     try {
-                        const format = await detectPodDataFormat(session, podUrl)
+                        const format = cachedFormat ?? await detectPodDataFormat(session, podUrl)
                         if (format === 'json') {
                             await migrateJsonToRdf(session, podUrl)
                         }

--- a/src/hooks/usePodSync.test.ts
+++ b/src/hooks/usePodSync.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { usePodSync } from './usePodSync'
+import type { SolidDataset } from '@inrupt/solid-client'
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -10,8 +11,8 @@ vi.mock('../components/SolidPodContext', () => ({
 
 vi.mock('../services/solidPod', () => ({
   getPrimaryPodUrl: vi.fn(),
-  loadFileFromPod: vi.fn(),
-  saveFileToPod: vi.fn(),
+  loadRdfFromPod: vi.fn(),
+  saveRdfToPod: vi.fn(),
   AuthenticationError: class AuthenticationError extends Error {
     constructor(message: string) {
       super(message)
@@ -21,16 +22,25 @@ vi.mock('../services/solidPod', () => ({
 }))
 
 import { useSolidPod } from '../components/SolidPodContext'
-import { getPrimaryPodUrl, loadFileFromPod } from '../services/solidPod'
+import { getPrimaryPodUrl, loadRdfFromPod, saveRdfToPod } from '../services/solidPod'
 import type { AppSession as Session } from '../../types/AppSession'
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
-const mockLoadFileFromPod = vi.mocked(loadFileFromPod)
+const mockLoadRdfFromPod = vi.mocked(loadRdfFromPod)
+const mockSaveRdfToPod = vi.mocked(saveRdfToPod)
 
 const mockSession = { info: { isLoggedIn: true } } as unknown as Session
 const POD_URL = 'https://pod.example.com/'
 const QUESTION_SET_DATA = { questions: [], people: [], alwaysNeededItems: [], lastModified: '2024-01-01T00:00:00.000Z' }
+
+const mockDeserialize = vi.fn().mockReturnValue(QUESTION_SET_DATA)
+const mockSerialize = vi.fn().mockReturnValue({} as SolidDataset)
+
+const rdfOptions = {
+  serialize: mockSerialize,
+  deserialize: mockDeserialize,
+}
 
 function setupLoggedIn() {
   mockUseSolidPod.mockReturnValue({
@@ -42,7 +52,7 @@ function setupLoggedIn() {
     logout: vi.fn(),
   })
   mockGetPrimaryPodUrl.mockResolvedValue(POD_URL)
-  mockLoadFileFromPod.mockResolvedValue(QUESTION_SET_DATA)
+  mockLoadRdfFromPod.mockResolvedValue(QUESTION_SET_DATA)
 }
 
 function setupLoggedOut() {
@@ -58,7 +68,7 @@ function setupLoggedOut() {
 
 const staticPathConfig = {
   container: 'pack-me-up/',
-  filename: 'packing-list-questions.json',
+  filename: 'packing-list-questions.ttl',
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -68,7 +78,8 @@ describe('usePodSync', () => {
     vi.useFakeTimers()
     vi.spyOn(console, 'error').mockImplementation(() => {})
     mockGetPrimaryPodUrl.mockReset()
-    mockLoadFileFromPod.mockReset()
+    mockLoadRdfFromPod.mockReset()
+    mockSaveRdfToPod.mockReset()
   })
 
   afterEach(() => {
@@ -87,6 +98,7 @@ describe('usePodSync', () => {
           syncOnMount: true,
           enabled: true,
           onSyncSuccess,
+          rdf: rdfOptions,
         })
       )
 
@@ -95,8 +107,31 @@ describe('usePodSync', () => {
         await vi.advanceTimersByTimeAsync(0)
       })
 
-      expect(mockLoadFileFromPod).toHaveBeenCalledOnce()
+      expect(mockLoadRdfFromPod).toHaveBeenCalledOnce()
       expect(onSyncSuccess).toHaveBeenCalledWith(QUESTION_SET_DATA)
+    })
+
+    it('calls loadRdfFromPod with the correct fileUrl and deserializer', async () => {
+      setupLoggedIn()
+
+      renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          syncOnMount: true,
+          enabled: true,
+          rdf: rdfOptions,
+        })
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(mockLoadRdfFromPod).toHaveBeenCalledWith(
+        mockSession,
+        `${POD_URL}pack-me-up/packing-list-questions.ttl`,
+        mockDeserialize,
+      )
     })
 
     it('does not set up a polling interval when syncOnMount is true and pollInterval is not set', async () => {
@@ -107,6 +142,7 @@ describe('usePodSync', () => {
           pathConfig: staticPathConfig,
           syncOnMount: true,
           enabled: true,
+          rdf: rdfOptions,
         })
       )
 
@@ -114,14 +150,14 @@ describe('usePodSync', () => {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(0)
       })
-      expect(mockLoadFileFromPod).toHaveBeenCalledOnce()
+      expect(mockLoadRdfFromPod).toHaveBeenCalledOnce()
 
       // Advance well past any hypothetical interval - should still be only one call
       await act(async () => {
         await vi.advanceTimersByTimeAsync(30_000)
       })
 
-      expect(mockLoadFileFromPod).toHaveBeenCalledOnce()
+      expect(mockLoadRdfFromPod).toHaveBeenCalledOnce()
     })
 
     it('does not sync when syncOnMount is false and pollInterval is not set', async () => {
@@ -132,6 +168,7 @@ describe('usePodSync', () => {
           pathConfig: staticPathConfig,
           syncOnMount: false,
           enabled: true,
+          rdf: rdfOptions,
         })
       )
 
@@ -139,7 +176,7 @@ describe('usePodSync', () => {
         await vi.advanceTimersByTimeAsync(0)
       })
 
-      expect(mockLoadFileFromPod).not.toHaveBeenCalled()
+      expect(mockLoadRdfFromPod).not.toHaveBeenCalled()
     })
 
     it('does not sync when not logged in even if syncOnMount is true', async () => {
@@ -150,6 +187,7 @@ describe('usePodSync', () => {
           pathConfig: staticPathConfig,
           syncOnMount: true,
           enabled: true,
+          rdf: rdfOptions,
         })
       )
 
@@ -157,7 +195,7 @@ describe('usePodSync', () => {
         await vi.advanceTimersByTimeAsync(0)
       })
 
-      expect(mockLoadFileFromPod).not.toHaveBeenCalled()
+      expect(mockLoadRdfFromPod).not.toHaveBeenCalled()
     })
 
     it('does not sync when enabled is false even if syncOnMount is true', async () => {
@@ -168,6 +206,7 @@ describe('usePodSync', () => {
           pathConfig: staticPathConfig,
           syncOnMount: true,
           enabled: false,
+          rdf: rdfOptions,
         })
       )
 
@@ -175,7 +214,7 @@ describe('usePodSync', () => {
         await vi.advanceTimersByTimeAsync(0)
       })
 
-      expect(mockLoadFileFromPod).not.toHaveBeenCalled()
+      expect(mockLoadRdfFromPod).not.toHaveBeenCalled()
     })
   })
 
@@ -188,6 +227,7 @@ describe('usePodSync', () => {
           pathConfig: staticPathConfig,
           pollInterval: 5000,
           enabled: true,
+          rdf: rdfOptions,
         })
       )
 
@@ -195,13 +235,13 @@ describe('usePodSync', () => {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(0)
       })
-      expect(mockLoadFileFromPod).toHaveBeenCalledOnce()
+      expect(mockLoadRdfFromPod).toHaveBeenCalledOnce()
 
       // Advance exactly one poll interval
       await act(async () => {
         await vi.advanceTimersByTimeAsync(5000)
       })
-      expect(mockLoadFileFromPod).toHaveBeenCalledTimes(2)
+      expect(mockLoadRdfFromPod).toHaveBeenCalledTimes(2)
     })
 
     it('does not poll when enabled is false', async () => {
@@ -212,6 +252,7 @@ describe('usePodSync', () => {
           pathConfig: staticPathConfig,
           pollInterval: 5000,
           enabled: false,
+          rdf: rdfOptions,
         })
       )
 
@@ -220,7 +261,126 @@ describe('usePodSync', () => {
         await vi.runAllTimersAsync()
       })
 
-      expect(mockLoadFileFromPod).not.toHaveBeenCalled()
+      expect(mockLoadRdfFromPod).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('saveToPod', () => {
+    it('calls saveRdfToPod with correct fileUrl, data, and serializer', async () => {
+      setupLoggedIn()
+      mockSaveRdfToPod.mockResolvedValue(undefined)
+
+      const { result } = renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          enabled: true,
+          rdf: rdfOptions,
+        })
+      )
+
+      await act(async () => {
+        await result.current.saveToPod(QUESTION_SET_DATA)
+      })
+
+      expect(mockSaveRdfToPod).toHaveBeenCalledWith({
+        session: mockSession,
+        fileUrl: `${POD_URL}pack-me-up/packing-list-questions.ttl`,
+        data: QUESTION_SET_DATA,
+        serializer: mockSerialize,
+      })
+    })
+
+    it('calls saveRdfToPod with dynamic filename when resourceId is provided', async () => {
+      setupLoggedIn()
+      mockSaveRdfToPod.mockResolvedValue(undefined)
+
+      const dynamicPathConfig = {
+        container: 'pack-me-up/packing-lists/',
+        filename: (id: string) => `${id}.ttl`,
+        resourceId: 'list-abc',
+      }
+
+      const { result } = renderHook(() =>
+        usePodSync({
+          pathConfig: dynamicPathConfig,
+          enabled: true,
+          rdf: rdfOptions,
+        })
+      )
+
+      await act(async () => {
+        await result.current.saveToPod(QUESTION_SET_DATA)
+      })
+
+      expect(mockSaveRdfToPod).toHaveBeenCalledWith({
+        session: mockSession,
+        fileUrl: `${POD_URL}pack-me-up/packing-lists/list-abc.ttl`,
+        data: QUESTION_SET_DATA,
+        serializer: mockSerialize,
+      })
+    })
+
+    it('returns true on success', async () => {
+      setupLoggedIn()
+      mockSaveRdfToPod.mockResolvedValue(undefined)
+
+      const { result } = renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          enabled: true,
+          rdf: rdfOptions,
+        })
+      )
+
+      let success: boolean | undefined
+      await act(async () => {
+        success = await result.current.saveToPod(QUESTION_SET_DATA)
+      })
+
+      expect(success).toBe(true)
+    })
+
+    it('returns false and sets error when save fails', async () => {
+      setupLoggedIn()
+      mockSaveRdfToPod.mockRejectedValue(new Error('network error'))
+      const onSaveError = vi.fn()
+
+      const { result } = renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          enabled: true,
+          onSaveError,
+          rdf: rdfOptions,
+        })
+      )
+
+      let success: boolean | undefined
+      await act(async () => {
+        success = await result.current.saveToPod(QUESTION_SET_DATA)
+      })
+
+      expect(success).toBe(false)
+      expect(onSaveError).toHaveBeenCalledWith('network error')
+    })
+
+    it('does not save when not logged in', async () => {
+      setupLoggedOut()
+
+      const { result } = renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          enabled: true,
+          rdf: rdfOptions,
+        })
+      )
+
+      let success: boolean | undefined
+      await act(async () => {
+        success = await result.current.saveToPod(QUESTION_SET_DATA)
+      })
+
+      expect(success).toBe(false)
+      expect(mockSaveRdfToPod).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/hooks/usePodSync.ts
+++ b/src/hooks/usePodSync.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import type { SolidDataset } from '@inrupt/solid-client';
 import { useSolidPod } from '../components/SolidPodContext';
-import { getPrimaryPodUrl, loadFileFromPod, saveFileToPod, AuthenticationError } from '../services/solidPod';
+import { getPrimaryPodUrl, loadRdfFromPod, saveRdfToPod, AuthenticationError } from '../services/solidPod';
 
 /**
  * Configuration for Pod file paths
@@ -29,6 +30,14 @@ export interface PodSyncOptions<T> {
    * Configuration for Pod file path
    */
   pathConfig: PodPathConfig;
+
+  /**
+   * RDF serialization/deserialization functions
+   */
+  rdf: {
+    serialize: (data: T, datasetUrl: string) => SolidDataset;
+    deserialize: (dataset: SolidDataset, url: string) => T;
+  };
 
   /**
    * Polling interval in milliseconds (null/undefined to disable polling)
@@ -103,6 +112,7 @@ export interface PodSyncState<T> {
 export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
   const {
     pathConfig,
+    rdf,
     pollInterval,
     syncOnMount = false,
     onSyncSuccess,
@@ -191,10 +201,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
         return;
       }
 
-      const data = await loadFileFromPod<T>({
-        session: session!,
-        fileUrl,
-      });
+      const data = await loadRdfFromPod<T>(session!, fileUrl, rdf.deserialize);
 
       setLastSync(new Date());
 
@@ -219,7 +226,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
       setIsSyncing(false);
       isSyncingRef.current = false;
     }
-  }, [enabled, isLoggedIn, session, getFileUrl]);
+  }, [enabled, isLoggedIn, session, getFileUrl, rdf]);
 
   /**
    * Save data to the Pod
@@ -238,23 +245,17 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
         throw new Error('No pod URL found');
       }
 
-      const { container, filename, resourceId } = pathConfig;
-      const containerUrl = `${podUrl}${container}`;
+      const fileUrl = getFileUrl(podUrl);
 
-      // Resolve the filename
-      const resolvedFilename = typeof filename === 'function'
-        ? (resourceId ? filename(resourceId) : null)
-        : (filename.includes('/') ? filename.split('/').pop() : filename);
-
-      if (!resolvedFilename) {
+      if (!fileUrl) {
         throw new Error('Cannot save: missing resource ID');
       }
 
-      await saveFileToPod({
+      await saveRdfToPod({
         session: session!,
-        containerPath: containerUrl,
-        filename: resolvedFilename,
+        fileUrl,
         data,
+        serializer: rdf.serialize,
       });
 
       setLastSync(new Date());
@@ -277,7 +278,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
 
       return false;
     }
-  }, [enabled, isLoggedIn, session, pathConfig]);
+  }, [enabled, isLoggedIn, session, getFileUrl, rdf]);
 
   /**
    * Sync on mount (and/or) set up polling interval.

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -36,7 +36,7 @@ vi.mock('../hooks/usePodSync', () => ({
 
 vi.mock('../services/solidPod', () => ({
     getPrimaryPodUrl: vi.fn(),
-    saveFileToPod: vi.fn(),
+    saveRdfToPod: vi.fn(),
     POD_CONTAINERS: { PACKING_LISTS: 'pack-me-up/packing-lists/' },
     POD_ERROR_MESSAGES: { SAVE_FAILED: 'Save failed' },
 }))
@@ -47,11 +47,11 @@ import { useToast } from '../components/ToastContext'
 import { ToastType } from '../components/Toast'
 import { PackingAppDatabase } from '../services/database'
 import { CreatePackingList } from './create-packing-list'
-import { getPrimaryPodUrl, saveFileToPod } from '../services/solidPod'
+import { getPrimaryPodUrl, saveRdfToPod } from '../services/solidPod'
 import { usePodSync } from '../hooks/usePodSync'
 
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
-const mockSaveFileToPod = vi.mocked(saveFileToPod)
+const mockSaveRdfToPod = vi.mocked(saveRdfToPod)
 const mockUsePodSync = vi.mocked(usePodSync)
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
@@ -607,7 +607,7 @@ describe('CreatePackingList – pod sync on creation', () => {
         })
         mockUseToast.mockReturnValue({ showToast: vi.fn() } as ReturnType<typeof useToast>)
         mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net/')
-        mockSaveFileToPod.mockResolvedValue(undefined)
+        mockSaveRdfToPod.mockResolvedValue(undefined)
     })
 
     afterEach(() => {
@@ -627,16 +627,16 @@ describe('CreatePackingList – pod sync on creation', () => {
         fireEvent.click(screen.getByRole('button', { name: /create packing list/i }))
 
         await waitFor(() => {
-            expect(mockSaveFileToPod).toHaveBeenCalledWith(
+            expect(mockSaveRdfToPod).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    containerPath: 'https://timgent.solidcommunity.net/pack-me-up/packing-lists/',
+                    fileUrl: expect.stringContaining('pack-me-up/packing-lists/'),
                     data: expect.objectContaining({ name: 'My New List' }),
                 })
             )
         })
     })
 
-    it('does not call saveFileToPod when not logged in', async () => {
+    it('does not call saveRdfToPod when not logged in', async () => {
         mockUseSolidPod.mockReturnValue({
             session: null,
             isLoggedIn: false,
@@ -656,7 +656,7 @@ describe('CreatePackingList – pod sync on creation', () => {
         fireEvent.click(screen.getByRole('button', { name: /create packing list/i }))
 
         await waitFor(() => expect(vi.mocked(db.savePackingList)).toHaveBeenCalled())
-        expect(mockSaveFileToPod).not.toHaveBeenCalled()
+        expect(mockSaveRdfToPod).not.toHaveBeenCalled()
     })
 })
 

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -1089,7 +1089,7 @@ describe('CreatePackingList – question set pod sync on mount', () => {
             expect.objectContaining({
                 syncOnMount: true,
                 enabled: true,
-                pathConfig: expect.objectContaining({ filename: 'packing-list-questions.json' }),
+                pathConfig: expect.objectContaining({ filename: 'packing-list-questions.ttl' }),
             })
         )
     })

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -924,7 +924,7 @@ describe('CreatePackingList – skip syncs reviewed flag to pod', () => {
         })
         mockUseToast.mockReturnValue({ showToast: vi.fn() } as ReturnType<typeof useToast>)
         mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net/')
-        mockSaveFileToPod.mockResolvedValue(undefined)
+        mockSaveRdfToPod.mockResolvedValue(undefined)
     })
 
     afterEach(() => {
@@ -940,10 +940,9 @@ describe('CreatePackingList – skip syncs reviewed flag to pod', () => {
         fireEvent.click(screen.getByRole('button', { name: /review/i }))
         fireEvent.click(screen.getByRole('button', { name: /skip/i }))
 
-        await waitFor(() => expect(mockSaveFileToPod).toHaveBeenCalledWith(
+        await waitFor(() => expect(mockSaveRdfToPod).toHaveBeenCalledWith(
             expect.objectContaining({
-                containerPath: 'https://timgent.solidcommunity.net/pack-me-up/packing-lists/',
-                filename: `${pastList.id}.json`,
+                fileUrl: `https://timgent.solidcommunity.net/pack-me-up/packing-lists/${pastList.id}.ttl`,
                 data: expect.objectContaining({
                     items: expect.arrayContaining([
                         expect.objectContaining({ id: 'custom-1', reviewed: true }),
@@ -971,7 +970,7 @@ describe('CreatePackingList – skip syncs reviewed flag to pod', () => {
         fireEvent.click(screen.getByRole('button', { name: /skip/i }))
 
         await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
-        expect(mockSaveFileToPod).not.toHaveBeenCalled()
+        expect(mockSaveRdfToPod).not.toHaveBeenCalled()
     })
 })
 
@@ -990,7 +989,7 @@ describe('CreatePackingList – keep/remove-permanently syncs reviewed flag to p
         })
         mockUseToast.mockReturnValue({ showToast: vi.fn() } as ReturnType<typeof useToast>)
         mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net/')
-        mockSaveFileToPod.mockResolvedValue(undefined)
+        mockSaveRdfToPod.mockResolvedValue(undefined)
     })
 
     afterEach(() => {
@@ -1006,10 +1005,9 @@ describe('CreatePackingList – keep/remove-permanently syncs reviewed flag to p
         fireEvent.click(screen.getByRole('button', { name: /review removals/i }))
         fireEvent.click(screen.getByRole('button', { name: /keep/i }))
 
-        await waitFor(() => expect(mockSaveFileToPod).toHaveBeenCalledWith(
+        await waitFor(() => expect(mockSaveRdfToPod).toHaveBeenCalledWith(
             expect.objectContaining({
-                containerPath: 'https://timgent.solidcommunity.net/pack-me-up/packing-lists/',
-                filename: `${listWithDeletedItem.id}.json`,
+                fileUrl: `https://timgent.solidcommunity.net/pack-me-up/packing-lists/${listWithDeletedItem.id}.ttl`,
                 data: expect.objectContaining({
                     deletedItems: expect.arrayContaining([
                         expect.objectContaining({ id: 'deleted-item-1', reviewed: true }),
@@ -1037,7 +1035,7 @@ describe('CreatePackingList – keep/remove-permanently syncs reviewed flag to p
         fireEvent.click(screen.getByRole('button', { name: /keep/i }))
 
         await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
-        expect(mockSaveFileToPod).not.toHaveBeenCalled()
+        expect(mockSaveRdfToPod).not.toHaveBeenCalled()
     })
 })
 

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -11,6 +11,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { SolidProviderSelector } from '../components/SolidProviderSelector'
 import { getPrimaryPodUrl, saveFileToPod, POD_CONTAINERS } from '../services/solidPod'
 import { usePodSync } from '../hooks/usePodSync'
+import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSerialization'
 
 export function deduplicateItems(items: PackingListItem[]): PackingListItem[] {
     const seen = new Set<string>()
@@ -320,8 +321,9 @@ export function CreatePackingList() {
     const { saveToPod: saveQuestionSetToPod } = usePodSync<PackingListQuestionSet>({
         pathConfig: {
             container: POD_CONTAINERS.ROOT,
-            filename: 'packing-list-questions.json',
+            filename: 'packing-list-questions.ttl',
         },
+        rdf: { serialize: questionSetToDataset, deserialize: datasetToQuestionSet },
         syncOnMount: true,
         enabled: isLoggedIn,
         onSyncSuccess: handleQuestionSetPodSync,

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -427,11 +427,11 @@ export function CreatePackingList() {
         if (!isLoggedIn || !session) return
         const podUrl = await getPrimaryPodUrl(session)
         if (!podUrl) return
-        await saveFileToPod({
+        await saveRdfToPod({
             session,
-            containerPath: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`,
-            filename: `${list.id}.json`,
+            fileUrl: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${list.id}.ttl`,
             data: list,
+            serializer: packingListToDataset,
         })
     }
 

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -296,7 +296,7 @@ export function CreatePackingList() {
     const { showToast } = useToast()
     const { isLoggedIn, login, session } = useSolidPod()
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
-    const { db } = useDatabase()
+    const { db, loginSyncInProgress } = useDatabase()
     const navigate = useNavigate()
 
     const { register, handleSubmit, setValue, watch } = useForm<PackingListFormData>({
@@ -330,6 +330,8 @@ export function CreatePackingList() {
     })
 
     useEffect(() => {
+        if (loginSyncInProgress) return
+
         const fetchQuestionSet = async () => {
             if (!db) {
                 setNoQuestionsFound(true)
@@ -360,7 +362,7 @@ export function CreatePackingList() {
             }
         }
         fetchQuestionSet()
-    }, [db, showToast])
+    }, [db, showToast, loginSyncInProgress])
 
     const suggestions = useMemo(
         () => questionSet ? getUnreviewedCustomItems(allPackingLists, questionSet) : [],

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -9,9 +9,9 @@ import { Button } from '../components/Button'
 import { useToast } from '../components/ToastContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { SolidProviderSelector } from '../components/SolidProviderSelector'
-import { getPrimaryPodUrl, saveFileToPod, POD_CONTAINERS } from '../services/solidPod'
+import { getPrimaryPodUrl, saveRdfToPod, POD_CONTAINERS } from '../services/solidPod'
 import { usePodSync } from '../hooks/usePodSync'
-import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSerialization'
+import { questionSetToDataset, datasetToQuestionSet, packingListToDataset } from '../services/rdfSerialization'
 
 export function deduplicateItems(items: PackingListItem[]): PackingListItem[] {
     const seen = new Set<string>()
@@ -566,11 +566,11 @@ export function CreatePackingList() {
             if (isLoggedIn) {
                 const podUrl = await getPrimaryPodUrl(session)
                 if (podUrl) {
-                    await saveFileToPod({
+                    await saveRdfToPod({
                         session: session!,
-                        containerPath: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`,
-                        filename: `${packingList.id}.json`,
+                        fileUrl: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${packingList.id}.ttl`,
                         data: packingList,
+                        serializer: packingListToDataset,
                     })
                 }
             }

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -15,6 +15,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { usePodSync } from '../hooks/usePodSync'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 import { POD_CONTAINERS } from '../services/solidPod'
+import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSerialization'
 import { JsonEditor } from '../edit-questions/json-editor'
 import { validateQuestionSet } from '../edit-questions/validation'
 
@@ -100,8 +101,9 @@ export function EditQuestionsForm() {
   const { lastSync, isSyncing, error: syncError, saveToPod } = usePodSync<PackingListQuestionSet>({
     pathConfig: {
       container: POD_CONTAINERS.ROOT,
-      filename: 'packing-list-questions.json'
+      filename: 'packing-list-questions.ttl'
     },
+    rdf: { serialize: questionSetToDataset, deserialize: datasetToQuestionSet },
     pollInterval: 5000, // Poll every 5 seconds for faster sync
     enabled: isLoggedIn, // Only sync when logged in
     onSyncSuccess: handleSyncSuccess,

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -37,7 +37,7 @@ export function EditQuestionsForm() {
   });
   const { showToast } = useToast();
   const { isLoggedIn } = useSolidPod();
-  const { db } = useDatabase();
+  const { db, loginSyncInProgress } = useDatabase();
 
   // Watch all form values for auto-save
   const watchedFormValues = useWatch({ control });
@@ -286,9 +286,14 @@ export function EditQuestionsForm() {
       }
     }
 
+    // Skip while the login sync is running: syncAllDataFromPod hasn't written
+    // pod data into the local DB yet, so reading now would find nothing and
+    // create a default "Me" question set that immediately auto-saves to the pod,
+    // overwriting the real data that arrives moments later.
+    if (loginSyncInProgress) return
     loadQuestionSet()
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally runs once on mount
-  }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loginSyncInProgress])
 
   const { fields: questionFields, append: appendQuestion, remove: removeQuestion, move: moveQuestion } = useFieldArray({
     control,

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../hooks/usePodErrorHandler', () => ({
 
 vi.mock('../services/solidPod', () => ({
     getPrimaryPodUrl: vi.fn(),
-    saveFileToPod: vi.fn(),
+    saveRdfToPod: vi.fn(),
     deleteFileFromPod: vi.fn(),
     POD_CONTAINERS: { PACKING_LISTS: '/packing-lists/' },
     POD_ERROR_MESSAGES: {
@@ -48,12 +48,12 @@ vi.mock('../services/solidPod', () => ({
 import type { AppSession as Session } from '../types/AppSession'
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
-import { getPrimaryPodUrl, saveFileToPod, deleteFileFromPod } from '../services/solidPod'
+import { getPrimaryPodUrl, saveRdfToPod, deleteFileFromPod } from '../services/solidPod'
 
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
-const mockSaveFileToPod = vi.mocked(saveFileToPod)
+const mockSaveRdfToPod = vi.mocked(saveRdfToPod)
 const mockDeleteFileFromPod = vi.mocked(deleteFileFromPod)
 
 const testPackingList = {
@@ -473,7 +473,7 @@ describe('PackingLists pod sync on mutation', () => {
             logout: vi.fn(),
         })
         mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net')
-        mockSaveFileToPod.mockResolvedValue(undefined)
+        mockSaveRdfToPod.mockResolvedValue(undefined)
         mockDeleteFileFromPod.mockResolvedValue(undefined)
     })
 
@@ -489,9 +489,9 @@ describe('PackingLists pod sync on mutation', () => {
         fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
         await waitFor(() => {
-            expect(mockSaveFileToPod).toHaveBeenCalledWith(
+            expect(mockSaveRdfToPod).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    filename: 'list-1.json',
+                    fileUrl: expect.stringContaining('list-1.ttl'),
                     data: expect.objectContaining({ id: 'list-1', name: 'Winter Holiday' }),
                 })
             )
@@ -507,9 +507,9 @@ describe('PackingLists pod sync on mutation', () => {
         fireEvent.click(screen.getByRole('button', { name: /duplicate/i }))
 
         await waitFor(() => {
-            expect(mockSaveFileToPod).toHaveBeenCalledWith(
+            expect(mockSaveRdfToPod).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    filename: 'new-uuid.json',
+                    fileUrl: expect.stringContaining('.ttl'),
                     data: expect.objectContaining({ name: 'Copy of Summer Holiday' }),
                 })
             )
@@ -529,12 +529,12 @@ describe('PackingLists pod sync on mutation', () => {
         await waitFor(() => {
             expect(mockDeleteFileFromPod).toHaveBeenCalledWith(
                 loggedInSession,
-                'https://timgent.solidcommunity.net/packing-lists/list-1.json'
+                'https://timgent.solidcommunity.net/packing-lists/list-1.ttl'
             )
         })
     })
 
-    it('does not call saveFileToPod when not logged in', async () => {
+    it('does not call saveRdfToPod when not logged in', async () => {
         mockUseSolidPod.mockReturnValue({
             isLoggedIn: false,
             session: null,
@@ -553,7 +553,7 @@ describe('PackingLists pod sync on mutation', () => {
         await waitFor(() => {
             expect(makeDb().savePackingList).toBeDefined()
         })
-        expect(mockSaveFileToPod).not.toHaveBeenCalled()
+        expect(mockSaveRdfToPod).not.toHaveBeenCalled()
     })
 })
 

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -6,7 +6,8 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { Modal } from '../components/Modal'
-import { getPrimaryPodUrl, saveFileToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
+import { getPrimaryPodUrl, saveRdfToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES } from '../services/solidPod'
+import { packingListToDataset } from '../services/rdfSerialization'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { generateUUID } from '../utils/uuid'
 
@@ -84,11 +85,11 @@ export function PackingLists() {
         try {
             const podUrl = await getPrimaryPodUrl(session)
             if (!podUrl) return
-            await saveFileToPod({
+            await saveRdfToPod({
                 session: session!,
-                containerPath: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`,
-                filename: `${list.id}.json`,
+                fileUrl: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${list.id}.ttl`,
                 data: list,
+                serializer: packingListToDataset,
             })
         } catch (error) {
             handlePodError(error, POD_ERROR_MESSAGES.SAVE_FAILED)
@@ -100,7 +101,7 @@ export function PackingLists() {
         try {
             const podUrl = await getPrimaryPodUrl(session)
             if (!podUrl) return
-            await deleteFileFromPod(session!, `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${id}.json`)
+            await deleteFileFromPod(session!, `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${id}.ttl`)
         } catch (error) {
             handlePodError(error, POD_ERROR_MESSAGES.SAVE_FAILED)
         }

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -9,6 +9,7 @@ import { Person, PackingListQuestionSet } from '../edit-questions/types'
 import { usePodSync } from '../hooks/usePodSync'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 import { POD_CONTAINERS } from '../services/solidPod'
+import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSerialization'
 
 export function useWizardGeneration() {
     const { showToast } = useToast()
@@ -19,8 +20,9 @@ export function useWizardGeneration() {
     const { saveToPod } = usePodSync<PackingListQuestionSet>({
         pathConfig: {
             container: POD_CONTAINERS.ROOT,
-            filename: 'packing-list-questions.json'
-        }
+            filename: 'packing-list-questions.ttl'
+        },
+        rdf: { serialize: questionSetToDataset, deserialize: datasetToQuestionSet },
     })
 
     const { saveWithSyncPrevention } = useSyncCoordinator<PackingListQuestionSet>({

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -73,7 +73,7 @@ export function ViewPackingList() {
     const { showToast } = useToast()
     const { db } = useDatabase()
 
-    const { register, setValue, getValues, control } = useForm<FormData>({
+    const { register, setValue, getValues, control, reset } = useForm<FormData>({
         defaultValues: {
             items: {}
         }
@@ -94,12 +94,11 @@ export function ViewPackingList() {
                     ...data,
                     _rev: newRev
                 });
-                // Update form values
                 const formValues: Record<string, boolean> = {};
                 data.items.forEach((item) => {
                     formValues[item.id] = item.packed;
                 });
-                setValue('items', formValues);
+                reset({ items: formValues });
             },
             conflictStrategy: 'fallback-to-pod', // Use same strategy as edit questions for consistency
         });
@@ -136,12 +135,15 @@ export function ViewPackingList() {
             try {
                 const doc = await db.getPackingList(id!)
                 setPackingList(doc)
-                // Initialize form values with a clean slate
+                // Use reset (not setValue) so _defaultValues is updated too.
+                // register() initialises each checkbox from _defaultValues; setValue
+                // only updates the store and leaves _defaultValues stale, which means
+                // newly-mounted checkboxes always render unchecked.
                 const initialValues: Record<string, boolean> = {}
                 doc.items.forEach((item) => {
                     initialValues[item.id] = item.packed
                 })
-                setValue('items', initialValues)
+                reset({ items: initialValues })
             } catch (err) {
                 console.error('Error fetching packing list:', err)
             } finally {

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -11,6 +11,7 @@ import { useToast } from '../components/ToastContext'
 import { usePodSync } from '../hooks/usePodSync'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 import { POD_CONTAINERS } from '../services/solidPod'
+import { packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 
 type FormData = {
     items: Record<string, boolean>
@@ -118,9 +119,10 @@ export function ViewPackingList() {
     const { saveToPod } = usePodSync<PackingList>({
         pathConfig: {
             container: POD_CONTAINERS.PACKING_LISTS,
-            filename: (id) => `${id}.json`,
+            filename: (id) => `${id}.ttl`,
             resourceId: id || null
         },
+        rdf: { serialize: packingListToDataset, deserialize: datasetToPackingList },
         pollInterval: 5000, // Poll every 5 seconds for faster sync
         enabled: isLoggedIn, // Only sync when logged in
         onSyncSuccess: handleSyncSuccess,

--- a/src/services/rdfMigration.test.ts
+++ b/src/services/rdfMigration.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { AppSession as Session } from '../types/AppSession'
+
+vi.mock('./solidPod', () => ({
+    loadFileFromPod: vi.fn(),
+    loadMultipleFilesFromPod: vi.fn(),
+    saveRdfToPod: vi.fn(),
+    POD_CONTAINERS: {
+        ROOT: 'pack-me-up/',
+        QUESTIONS: 'pack-me-up/packing-list-questions.ttl',
+        QUESTIONS_LEGACY_JSON: 'pack-me-up/packing-list-questions.json',
+        MIGRATION_MARKER: 'pack-me-up/migrated-to-rdf.ttl',
+        PACKING_LISTS: 'pack-me-up/packing-lists/',
+        BACKUPS: 'pack-me-up/backups/',
+    },
+}))
+
+import {
+    loadFileFromPod,
+    loadMultipleFilesFromPod,
+    saveRdfToPod,
+} from './solidPod'
+import { detectPodDataFormat, migrateJsonToRdf } from './rdfMigration'
+import type { PackingListQuestionSet } from '../edit-questions/types'
+import type { PackingList } from '../create-packing-list/types'
+
+const mockLoadFileFromPod = vi.mocked(loadFileFromPod)
+const mockLoadMultipleFilesFromPod = vi.mocked(loadMultipleFilesFromPod)
+const mockSaveRdfToPod = vi.mocked(saveRdfToPod)
+
+const mockSession = {
+    info: { isLoggedIn: true, webId: 'https://example.com/profile#me' },
+    fetch: vi.fn(),
+} as unknown as Session
+
+const POD_URL = 'https://pod.example.com/'
+
+function makeQuestionSet(overrides: Partial<PackingListQuestionSet> = {}): PackingListQuestionSet {
+    return { _id: '1', people: [], alwaysNeededItems: [], questions: [], ...overrides }
+}
+
+function makePackingList(id: string, overrides: Partial<PackingList> = {}): PackingList {
+    return { id, name: `List ${id}`, createdAt: '2024-01-01T00:00:00.000Z', items: [], ...overrides }
+}
+
+describe('detectPodDataFormat', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('returns "rdf" when migration marker file exists', async () => {
+        mockLoadFileFromPod.mockResolvedValueOnce({} as PackingListQuestionSet) // marker exists
+
+        const result = await detectPodDataFormat(mockSession, POD_URL)
+
+        expect(result).toBe('rdf')
+        expect(mockLoadFileFromPod).toHaveBeenCalledWith(
+            expect.objectContaining({
+                fileUrl: `${POD_URL}pack-me-up/migrated-to-rdf.ttl`,
+            })
+        )
+    })
+
+    it('returns "rdf" when ttl questions file exists (no marker)', async () => {
+        mockLoadFileFromPod
+            .mockRejectedValueOnce({ statusCode: 404 }) // no marker
+            .mockResolvedValueOnce({} as PackingListQuestionSet) // ttl questions exists
+
+        const result = await detectPodDataFormat(mockSession, POD_URL)
+
+        expect(result).toBe('rdf')
+    })
+
+    it('returns "json" when only json questions file exists', async () => {
+        mockLoadFileFromPod
+            .mockRejectedValueOnce({ statusCode: 404 }) // no marker
+            .mockRejectedValueOnce({ statusCode: 404 }) // no ttl
+            .mockResolvedValueOnce({} as PackingListQuestionSet) // json exists
+
+        const result = await detectPodDataFormat(mockSession, POD_URL)
+
+        expect(result).toBe('json')
+    })
+
+    it('returns "empty" when no files exist', async () => {
+        mockLoadFileFromPod
+            .mockRejectedValueOnce({ statusCode: 404 })
+            .mockRejectedValueOnce({ statusCode: 404 })
+            .mockRejectedValueOnce({ statusCode: 404 })
+
+        const result = await detectPodDataFormat(mockSession, POD_URL)
+
+        expect(result).toBe('empty')
+    })
+
+    it('re-throws non-404 errors', async () => {
+        const serverError = { statusCode: 500 }
+        mockLoadFileFromPod.mockRejectedValueOnce(serverError)
+
+        await expect(detectPodDataFormat(mockSession, POD_URL)).rejects.toEqual(serverError)
+    })
+})
+
+describe('migrateJsonToRdf', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockSaveRdfToPod.mockResolvedValue(undefined)
+    })
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('migrates question set and packing lists', async () => {
+        const qs = makeQuestionSet()
+        const list1 = makePackingList('list-1')
+        const list2 = makePackingList('list-2')
+
+        mockLoadFileFromPod.mockResolvedValueOnce(qs)
+        mockLoadMultipleFilesFromPod.mockResolvedValueOnce({
+            data: [list1, list2],
+            result: { success: true, successCount: 2, failCount: 0, totalCount: 2 },
+        })
+
+        const result = await migrateJsonToRdf(mockSession, POD_URL)
+
+        expect(result.questionSetMigrated).toBe(true)
+        expect(result.packingListsMigrated).toBe(2)
+        expect(result.errors).toEqual([])
+
+        // Saves question set as RDF
+        expect(mockSaveRdfToPod).toHaveBeenCalledWith(
+            expect.objectContaining({
+                session: mockSession,
+                fileUrl: `${POD_URL}pack-me-up/packing-list-questions.ttl`,
+            })
+        )
+        // Saves each packing list as RDF
+        expect(mockSaveRdfToPod).toHaveBeenCalledWith(
+            expect.objectContaining({
+                fileUrl: `${POD_URL}pack-me-up/packing-lists/list-1.ttl`,
+            })
+        )
+        expect(mockSaveRdfToPod).toHaveBeenCalledWith(
+            expect.objectContaining({
+                fileUrl: `${POD_URL}pack-me-up/packing-lists/list-2.ttl`,
+            })
+        )
+        // Saves migration marker
+        expect(mockSaveRdfToPod).toHaveBeenCalledWith(
+            expect.objectContaining({
+                fileUrl: `${POD_URL}pack-me-up/migrated-to-rdf.ttl`,
+            })
+        )
+    })
+
+    it('skips question set gracefully when it does not exist (404)', async () => {
+        mockLoadFileFromPod.mockRejectedValueOnce({ statusCode: 404 })
+        mockLoadMultipleFilesFromPod.mockResolvedValueOnce({
+            data: [],
+            result: { success: true, successCount: 0, failCount: 0, totalCount: 0 },
+        })
+
+        const result = await migrateJsonToRdf(mockSession, POD_URL)
+
+        expect(result.questionSetMigrated).toBe(false)
+        expect(result.packingListsMigrated).toBe(0)
+        expect(result.errors).toEqual([])
+        // Marker is still written
+        expect(mockSaveRdfToPod).toHaveBeenCalledWith(
+            expect.objectContaining({ fileUrl: `${POD_URL}pack-me-up/migrated-to-rdf.ttl` })
+        )
+    })
+
+    it('records errors for failed list migrations without aborting', async () => {
+        const qs = makeQuestionSet()
+        const list1 = makePackingList('list-1')
+        const list2 = makePackingList('list-2')
+
+        mockLoadFileFromPod.mockResolvedValueOnce(qs)
+        mockLoadMultipleFilesFromPod.mockResolvedValueOnce({
+            data: [list1, list2],
+            result: { success: true, successCount: 2, failCount: 0, totalCount: 2 },
+        })
+
+        // Question set save succeeds, list-1 fails, list-2 succeeds, marker succeeds
+        mockSaveRdfToPod
+            .mockResolvedValueOnce(undefined)        // question set
+            .mockRejectedValueOnce(new Error('network error'))  // list-1 fails
+            .mockResolvedValueOnce(undefined)        // list-2
+            .mockResolvedValueOnce(undefined)        // marker
+
+        const result = await migrateJsonToRdf(mockSession, POD_URL)
+
+        expect(result.packingListsMigrated).toBe(1)
+        expect(result.errors).toHaveLength(1)
+        expect(result.errors[0]).toContain('list-1')
+    })
+
+    it('writes migration marker even when some lists fail', async () => {
+        mockLoadFileFromPod.mockRejectedValueOnce({ statusCode: 404 })
+        mockLoadMultipleFilesFromPod.mockResolvedValueOnce({
+            data: [makePackingList('list-1')],
+            result: { success: false, successCount: 0, failCount: 1, totalCount: 1 },
+        })
+        mockSaveRdfToPod
+            .mockRejectedValueOnce(new Error('save failed'))
+            .mockResolvedValueOnce(undefined) // marker
+
+        const result = await migrateJsonToRdf(mockSession, POD_URL)
+
+        expect(result.errors).toHaveLength(1)
+        // Marker still written
+        expect(mockSaveRdfToPod).toHaveBeenCalledWith(
+            expect.objectContaining({ fileUrl: `${POD_URL}pack-me-up/migrated-to-rdf.ttl` })
+        )
+    })
+})

--- a/src/services/rdfMigration.test.ts
+++ b/src/services/rdfMigration.test.ts
@@ -15,15 +15,22 @@ vi.mock('./solidPod', () => ({
     },
 }))
 
+vi.mock('@inrupt/solid-client', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@inrupt/solid-client')>()
+    return { ...actual, getFile: vi.fn() }
+})
+
 import {
     loadFileFromPod,
     loadMultipleFilesFromPod,
     saveRdfToPod,
 } from './solidPod'
+import { getFile } from '@inrupt/solid-client'
 import { detectPodDataFormat, migrateJsonToRdf } from './rdfMigration'
 import type { PackingListQuestionSet } from '../edit-questions/types'
 import type { PackingList } from '../create-packing-list/types'
 
+const mockGetFile = vi.mocked(getFile)
 const mockLoadFileFromPod = vi.mocked(loadFileFromPod)
 const mockLoadMultipleFilesFromPod = vi.mocked(loadMultipleFilesFromPod)
 const mockSaveRdfToPod = vi.mocked(saveRdfToPod)
@@ -46,28 +53,28 @@ function makePackingList(id: string, overrides: Partial<PackingList> = {}): Pack
 describe('detectPodDataFormat', () => {
     beforeEach(() => {
         vi.spyOn(console, 'error').mockImplementation(() => {})
+        mockGetFile.mockReset()
     })
     afterEach(() => {
         vi.restoreAllMocks()
     })
 
     it('returns "rdf" when migration marker file exists', async () => {
-        mockLoadFileFromPod.mockResolvedValueOnce({} as PackingListQuestionSet) // marker exists
+        mockGetFile.mockResolvedValueOnce({} as Blob) // marker exists
 
         const result = await detectPodDataFormat(mockSession, POD_URL)
 
         expect(result).toBe('rdf')
-        expect(mockLoadFileFromPod).toHaveBeenCalledWith(
-            expect.objectContaining({
-                fileUrl: `${POD_URL}pack-me-up/migrated-to-rdf.ttl`,
-            })
+        expect(mockGetFile).toHaveBeenCalledWith(
+            `${POD_URL}pack-me-up/migrated-to-rdf.ttl`,
+            expect.objectContaining({ fetch: mockSession.fetch })
         )
     })
 
     it('returns "rdf" when ttl questions file exists (no marker)', async () => {
-        mockLoadFileFromPod
+        mockGetFile
             .mockRejectedValueOnce({ statusCode: 404 }) // no marker
-            .mockResolvedValueOnce({} as PackingListQuestionSet) // ttl questions exists
+            .mockResolvedValueOnce({} as Blob) // ttl questions exists
 
         const result = await detectPodDataFormat(mockSession, POD_URL)
 
@@ -75,10 +82,10 @@ describe('detectPodDataFormat', () => {
     })
 
     it('returns "json" when only json questions file exists', async () => {
-        mockLoadFileFromPod
+        mockGetFile
             .mockRejectedValueOnce({ statusCode: 404 }) // no marker
             .mockRejectedValueOnce({ statusCode: 404 }) // no ttl
-            .mockResolvedValueOnce({} as PackingListQuestionSet) // json exists
+            .mockResolvedValueOnce({} as Blob) // json exists
 
         const result = await detectPodDataFormat(mockSession, POD_URL)
 
@@ -86,7 +93,7 @@ describe('detectPodDataFormat', () => {
     })
 
     it('returns "empty" when no files exist', async () => {
-        mockLoadFileFromPod
+        mockGetFile
             .mockRejectedValueOnce({ statusCode: 404 })
             .mockRejectedValueOnce({ statusCode: 404 })
             .mockRejectedValueOnce({ statusCode: 404 })
@@ -98,7 +105,7 @@ describe('detectPodDataFormat', () => {
 
     it('re-throws non-404 errors', async () => {
         const serverError = { statusCode: 500 }
-        mockLoadFileFromPod.mockRejectedValueOnce(serverError)
+        mockGetFile.mockRejectedValueOnce(serverError)
 
         await expect(detectPodDataFormat(mockSession, POD_URL)).rejects.toEqual(serverError)
     })

--- a/src/services/rdfMigration.ts
+++ b/src/services/rdfMigration.ts
@@ -1,5 +1,5 @@
 import type { AppSession as Session } from '../types/AppSession'
-import { createSolidDataset } from '@inrupt/solid-client'
+import { createSolidDataset, getFile } from '@inrupt/solid-client'
 import {
     loadFileFromPod,
     loadMultipleFilesFromPod,
@@ -26,9 +26,12 @@ export async function detectPodDataFormat(
     session: Session,
     podUrl: string
 ): Promise<'rdf' | 'json' | 'empty'> {
+    // Use getFile for existence checks — loadFileFromPod would JSON.parse the TTL
+    // content and throw a SyntaxError, which would be misidentified as a real error.
+
     // Fast path: migration marker exists
     try {
-        await loadFileFromPod({ session, fileUrl: `${podUrl}${POD_CONTAINERS.MIGRATION_MARKER}` })
+        await getFile(`${podUrl}${POD_CONTAINERS.MIGRATION_MARKER}`, { fetch: session.fetch })
         return 'rdf'
     } catch (err) {
         if (getStatusCode(err) !== 404) throw err
@@ -36,7 +39,7 @@ export async function detectPodDataFormat(
 
     // Check for RDF questions file
     try {
-        await loadFileFromPod({ session, fileUrl: `${podUrl}${POD_CONTAINERS.QUESTIONS}` })
+        await getFile(`${podUrl}${POD_CONTAINERS.QUESTIONS}`, { fetch: session.fetch })
         return 'rdf'
     } catch (err) {
         if (getStatusCode(err) !== 404) throw err
@@ -44,7 +47,7 @@ export async function detectPodDataFormat(
 
     // Check for legacy JSON questions file
     try {
-        await loadFileFromPod({ session, fileUrl: `${podUrl}${POD_CONTAINERS.QUESTIONS_LEGACY_JSON}` })
+        await getFile(`${podUrl}${POD_CONTAINERS.QUESTIONS_LEGACY_JSON}`, { fetch: session.fetch })
         return 'json'
     } catch (err) {
         if (getStatusCode(err) !== 404) throw err

--- a/src/services/rdfMigration.ts
+++ b/src/services/rdfMigration.ts
@@ -1,0 +1,129 @@
+import type { AppSession as Session } from '../types/AppSession'
+import { createSolidDataset } from '@inrupt/solid-client'
+import {
+    loadFileFromPod,
+    loadMultipleFilesFromPod,
+    saveRdfToPod,
+    POD_CONTAINERS,
+} from './solidPod'
+import { packingListToDataset, questionSetToDataset } from './rdfSerialization'
+import type { PackingListQuestionSet } from '../edit-questions/types'
+import type { PackingList } from '../create-packing-list/types'
+
+export interface MigrationResult {
+    questionSetMigrated: boolean
+    packingListsMigrated: number
+    errors: string[]
+}
+
+function getStatusCode(err: unknown): number | undefined {
+    if (typeof err !== 'object' || err === null) return undefined
+    const code = (err as { statusCode?: unknown }).statusCode
+    return typeof code === 'number' ? code : undefined
+}
+
+export async function detectPodDataFormat(
+    session: Session,
+    podUrl: string
+): Promise<'rdf' | 'json' | 'empty'> {
+    // Fast path: migration marker exists
+    try {
+        await loadFileFromPod({ session, fileUrl: `${podUrl}${POD_CONTAINERS.MIGRATION_MARKER}` })
+        return 'rdf'
+    } catch (err) {
+        if (getStatusCode(err) !== 404) throw err
+    }
+
+    // Check for RDF questions file
+    try {
+        await loadFileFromPod({ session, fileUrl: `${podUrl}${POD_CONTAINERS.QUESTIONS}` })
+        return 'rdf'
+    } catch (err) {
+        if (getStatusCode(err) !== 404) throw err
+    }
+
+    // Check for legacy JSON questions file
+    try {
+        await loadFileFromPod({ session, fileUrl: `${podUrl}${POD_CONTAINERS.QUESTIONS_LEGACY_JSON}` })
+        return 'json'
+    } catch (err) {
+        if (getStatusCode(err) !== 404) throw err
+    }
+
+    return 'empty'
+}
+
+export async function migrateJsonToRdf(
+    session: Session,
+    podUrl: string
+): Promise<MigrationResult> {
+    const errors: string[] = []
+    let questionSetMigrated = false
+    let packingListsMigrated = 0
+
+    // 1. Migrate question set
+    try {
+        const qs = await loadFileFromPod<PackingListQuestionSet>({
+            session,
+            fileUrl: `${podUrl}${POD_CONTAINERS.QUESTIONS_LEGACY_JSON}`,
+        })
+        const qsUrl = `${podUrl}${POD_CONTAINERS.QUESTIONS}`
+        await saveRdfToPod({
+            session,
+            fileUrl: qsUrl,
+            data: qs,
+            serializer: (data, url) => questionSetToDataset(data, url),
+        })
+        questionSetMigrated = true
+    } catch (err) {
+        if (getStatusCode(err) !== 404) {
+            const msg = err instanceof Error ? err.message : String(err)
+            errors.push(`question set: ${msg}`)
+            console.error('rdfMigration: failed to migrate question set', err)
+        }
+        // 404 = no question set to migrate, that's fine
+    }
+
+    // 2. Migrate packing lists
+    try {
+        const { data: lists } = await loadMultipleFilesFromPod<PackingList>({
+            session,
+            containerPath: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`,
+        })
+
+        for (const list of lists) {
+            try {
+                const listUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${list.id}.ttl`
+                await saveRdfToPod({
+                    session,
+                    fileUrl: listUrl,
+                    data: list,
+                    serializer: (data, url) => packingListToDataset(data, url),
+                })
+                packingListsMigrated++
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err)
+                errors.push(`list ${list.id}: ${msg}`)
+                console.error(`rdfMigration: failed to migrate list ${list.id}`, err)
+            }
+        }
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        errors.push(`packing lists container: ${msg}`)
+        console.error('rdfMigration: failed to load packing lists', err)
+    }
+
+    // 3. Write migration marker (always, even on partial failure)
+    try {
+        await saveRdfToPod({
+            session,
+            fileUrl: `${podUrl}${POD_CONTAINERS.MIGRATION_MARKER}`,
+            data: null,
+            serializer: () => createSolidDataset(),
+        })
+    } catch (err) {
+        console.error('rdfMigration: failed to write migration marker', err)
+    }
+
+    return { questionSetMigrated, packingListsMigrated, errors }
+}

--- a/src/services/rdfSerialization.test.ts
+++ b/src/services/rdfSerialization.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from 'vitest'
+import type { SolidDataset } from '@inrupt/solid-client'
+import {
+    packingListToDataset,
+    datasetToPackingList,
+    questionSetToDataset,
+    datasetToQuestionSet,
+} from './rdfSerialization'
+import type { PackingList, PackingListItem } from '../create-packing-list/types'
+import type { PackingListQuestionSet, Person, Question, Option } from '../edit-questions/types'
+
+const DATASET_URL = 'https://pod.example.com/pack-me-up/packing-lists/list-abc.ttl'
+const QS_DATASET_URL = 'https://pod.example.com/pack-me-up/packing-list-questions.ttl'
+
+// ── PackingList helpers ───────────────────────────────────────────────────────
+
+function makeItem(overrides: Partial<PackingListItem> = {}): PackingListItem {
+    return {
+        id: 'item-1',
+        itemText: 'Passport',
+        personId: 'person-1',
+        personName: 'Alice',
+        questionId: 'q-1',
+        optionId: 'opt-1',
+        packed: false,
+        ...overrides,
+    }
+}
+
+function makePackingList(overrides: Partial<PackingList> = {}): PackingList {
+    return {
+        id: 'list-abc',
+        name: 'Camping Trip',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        items: [],
+        ...overrides,
+    }
+}
+
+// ── QuestionSet helpers ───────────────────────────────────────────────────────
+
+function makePerson(overrides: Partial<Person> = {}): Person {
+    return { id: 'person-1', name: 'Alice', ...overrides }
+}
+
+function makeOption(overrides: Partial<Option> = {}): Option {
+    return { id: 'opt-1', text: 'Yes', order: 0, items: [], ...overrides }
+}
+
+function makeQuestion(overrides: Partial<Question> = {}): Question {
+    return {
+        id: 'q-1',
+        type: 'saved',
+        text: 'Traveling with a baby?',
+        order: 0,
+        options: [],
+        ...overrides,
+    }
+}
+
+function makeQuestionSet(overrides: Partial<PackingListQuestionSet> = {}): PackingListQuestionSet {
+    return { _id: '1', people: [], alwaysNeededItems: [], questions: [], ...overrides }
+}
+
+function roundTripList(list: PackingList): PackingList {
+    return datasetToPackingList(packingListToDataset(list, DATASET_URL), DATASET_URL)
+}
+
+function roundTripQs(qs: PackingListQuestionSet): PackingListQuestionSet {
+    return datasetToQuestionSet(questionSetToDataset(qs, QS_DATASET_URL) as SolidDataset, QS_DATASET_URL)
+}
+
+// ── PackingList round-trip ────────────────────────────────────────────────────
+
+describe('packingListToDataset / datasetToPackingList', () => {
+    it('round-trips id, name, and createdAt', () => {
+        const result = roundTripList(makePackingList())
+        expect(result.id).toBe('list-abc')
+        expect(result.name).toBe('Camping Trip')
+        expect(result.createdAt).toBe('2024-01-01T00:00:00.000Z')
+        expect(result.items).toEqual([])
+        expect(result.deletedItems).toEqual([])
+    })
+
+    it('round-trips lastModified', () => {
+        const result = roundTripList(makePackingList({ lastModified: '2024-06-01T12:00:00.000Z' }))
+        expect(result.lastModified).toBe('2024-06-01T12:00:00.000Z')
+    })
+
+    it('omits lastModified when not set', () => {
+        const result = roundTripList(makePackingList())
+        expect(result.lastModified).toBeUndefined()
+    })
+
+    it('does NOT store _rev', () => {
+        const result = roundTripList(makePackingList({ _rev: '1-abc' }))
+        expect(result._rev).toBeUndefined()
+    })
+
+    it('round-trips an item with all fields', () => {
+        const item = makeItem({ packed: true, category: 'Documents', reviewed: true })
+        const result = roundTripList(makePackingList({ items: [item] }))
+
+        expect(result.items).toHaveLength(1)
+        const r = result.items[0]
+        expect(r.id).toBe('item-1')
+        expect(r.itemText).toBe('Passport')
+        expect(r.personId).toBe('person-1')
+        expect(r.personName).toBe('Alice')
+        expect(r.questionId).toBe('q-1')
+        expect(r.optionId).toBe('opt-1')
+        expect(r.packed).toBe(true)
+        expect(r.category).toBe('Documents')
+        expect(r.reviewed).toBe(true)
+    })
+
+    it('round-trips item with packed=false', () => {
+        const result = roundTripList(makePackingList({ items: [makeItem({ packed: false })] }))
+        expect(result.items[0].packed).toBe(false)
+    })
+
+    it('omits optional item fields when not set', () => {
+        const result = roundTripList(makePackingList({ items: [makeItem()] }))
+        expect(result.items[0].category).toBeUndefined()
+        expect(result.items[0].reviewed).toBeUndefined()
+    })
+
+    it('round-trips multiple items', () => {
+        const items = [
+            makeItem({ id: 'item-1', itemText: 'Passport' }),
+            makeItem({ id: 'item-2', itemText: 'Sunscreen' }),
+            makeItem({ id: 'item-3', itemText: 'Camera' }),
+        ]
+        const result = roundTripList(makePackingList({ items }))
+        expect(result.items).toHaveLength(3)
+        const texts = result.items.map(i => i.itemText)
+        expect(texts).toContain('Passport')
+        expect(texts).toContain('Sunscreen')
+        expect(texts).toContain('Camera')
+    })
+
+    it('round-trips deletedItems', () => {
+        const deleted = makeItem({ id: 'item-del', itemText: 'Old item' })
+        const result = roundTripList(makePackingList({ deletedItems: [deleted] }))
+        expect(result.deletedItems).toHaveLength(1)
+        expect(result.deletedItems![0].itemText).toBe('Old item')
+    })
+
+    it('returns empty deletedItems when not set', () => {
+        const result = roundTripList(makePackingList())
+        expect(result.deletedItems).toEqual([])
+    })
+})
+
+// ── QuestionSet round-trip ────────────────────────────────────────────────────
+
+describe('questionSetToDataset / datasetToQuestionSet', () => {
+    it('round-trips a minimal question set', () => {
+        const result = roundTripQs(makeQuestionSet())
+        expect(result.people).toEqual([])
+        expect(result.alwaysNeededItems).toEqual([])
+        expect(result.questions).toEqual([])
+    })
+
+    it('round-trips lastModified', () => {
+        const result = roundTripQs(makeQuestionSet({ lastModified: '2024-06-01T12:00:00.000Z' }))
+        expect(result.lastModified).toBe('2024-06-01T12:00:00.000Z')
+    })
+
+    it('omits lastModified when not set', () => {
+        const result = roundTripQs(makeQuestionSet())
+        expect(result.lastModified).toBeUndefined()
+    })
+
+    it('does NOT store _rev', () => {
+        const result = roundTripQs(makeQuestionSet({ _rev: '1-xyz' } as PackingListQuestionSet))
+        expect(result._rev).toBeUndefined()
+    })
+
+    it('round-trips a person with all fields', () => {
+        const result = roundTripQs(makeQuestionSet({ people: [makePerson({ ageRange: 'Adult', gender: 'female' })] }))
+        expect(result.people).toHaveLength(1)
+        const p = result.people[0]
+        expect(p.id).toBe('person-1')
+        expect(p.name).toBe('Alice')
+        expect(p.ageRange).toBe('Adult')
+        expect(p.gender).toBe('female')
+    })
+
+    it('omits optional person fields when not set', () => {
+        const result = roundTripQs(makeQuestionSet({ people: [makePerson()] }))
+        expect(result.people[0].ageRange).toBeUndefined()
+        expect(result.people[0].gender).toBeUndefined()
+    })
+
+    it('round-trips multiple people', () => {
+        const people = [makePerson({ id: 'p1', name: 'Alice' }), makePerson({ id: 'p2', name: 'Bob' })]
+        const result = roundTripQs(makeQuestionSet({ people }))
+        expect(result.people).toHaveLength(2)
+        const names = result.people.map(p => p.name)
+        expect(names).toContain('Alice')
+        expect(names).toContain('Bob')
+    })
+
+    it('round-trips alwaysNeededItems with personSelections', () => {
+        const qs = makeQuestionSet({
+            alwaysNeededItems: [{
+                text: 'Toothbrush',
+                personSelections: [
+                    { personId: 'p1', selected: true },
+                    { personId: 'p2', selected: false },
+                ],
+            }],
+        })
+        const result = roundTripQs(qs)
+        expect(result.alwaysNeededItems).toHaveLength(1)
+        const item = result.alwaysNeededItems[0]
+        expect(item.text).toBe('Toothbrush')
+        expect(item.personSelections).toHaveLength(2)
+        const ps1 = item.personSelections.find(ps => ps.personId === 'p1')!
+        const ps2 = item.personSelections.find(ps => ps.personId === 'p2')!
+        expect(ps1.selected).toBe(true)
+        expect(ps2.selected).toBe(false)
+    })
+
+    it('round-trips a saved question with option and items', () => {
+        const option = makeOption({
+            items: [{ text: 'Nappies', personSelections: [{ personId: 'p1', selected: true }] }],
+        })
+        const question = makeQuestion({ type: 'saved', options: [option], questionType: 'single-choice' })
+        const result = roundTripQs(makeQuestionSet({ questions: [question] }))
+
+        expect(result.questions).toHaveLength(1)
+        const q = result.questions[0]
+        expect(q.id).toBe('q-1')
+        expect(q.text).toBe('Traveling with a baby?')
+        expect(q.type).toBe('saved')
+        expect(q.order).toBe(0)
+        expect(q.questionType).toBe('single-choice')
+
+        expect(q.options).toHaveLength(1)
+        const opt = q.options[0]
+        expect(opt.id).toBe('opt-1')
+        expect(opt.text).toBe('Yes')
+        expect(opt.order).toBe(0)
+
+        expect(opt.items).toHaveLength(1)
+        expect(opt.items[0].text).toBe('Nappies')
+        expect(opt.items[0].personSelections[0].personId).toBe('p1')
+        expect(opt.items[0].personSelections[0].selected).toBe(true)
+    })
+
+    it('round-trips a draft question', () => {
+        const result = roundTripQs(makeQuestionSet({ questions: [makeQuestion({ type: 'draft' })] }))
+        expect(result.questions[0].type).toBe('draft')
+    })
+
+    it('round-trips multiple-choice questionType', () => {
+        const result = roundTripQs(makeQuestionSet({ questions: [makeQuestion({ questionType: 'multiple-choice' })] }))
+        expect(result.questions[0].questionType).toBe('multiple-choice')
+    })
+
+    it('preserves question order values', () => {
+        const questions = [
+            makeQuestion({ id: 'q1', text: 'First', order: 0 }),
+            makeQuestion({ id: 'q2', text: 'Second', order: 1 }),
+            makeQuestion({ id: 'q3', text: 'Third', order: 2 }),
+        ]
+        const result = roundTripQs(makeQuestionSet({ questions }))
+        expect(result.questions).toHaveLength(3)
+        const byId = Object.fromEntries(result.questions.map(q => [q.id, q]))
+        expect(byId['q1'].order).toBe(0)
+        expect(byId['q2'].order).toBe(1)
+        expect(byId['q3'].order).toBe(2)
+    })
+
+    it('preserves option order values', () => {
+        const options = [
+            makeOption({ id: 'opt-a', text: 'Option A', order: 0 }),
+            makeOption({ id: 'opt-b', text: 'Option B', order: 1 }),
+        ]
+        const result = roundTripQs(makeQuestionSet({ questions: [makeQuestion({ options })] }))
+        const byId = Object.fromEntries(result.questions[0].options.map(o => [o.id, o]))
+        expect(byId['opt-a'].order).toBe(0)
+        expect(byId['opt-b'].order).toBe(1)
+    })
+
+    it('round-trips multiple options each with multiple items', () => {
+        const opt1 = makeOption({
+            id: 'opt-yes',
+            text: 'Yes',
+            items: [
+                { text: 'Item A', personSelections: [] },
+                { text: 'Item B', personSelections: [] },
+            ],
+        })
+        const opt2 = makeOption({
+            id: 'opt-no',
+            text: 'No',
+            items: [{ text: 'Item C', personSelections: [] }],
+        })
+        const result = roundTripQs(makeQuestionSet({ questions: [makeQuestion({ options: [opt1, opt2] })] }))
+        const q = result.questions[0]
+        const resOpt1 = q.options.find(o => o.id === 'opt-yes')!
+        const resOpt2 = q.options.find(o => o.id === 'opt-no')!
+        expect(resOpt1.items).toHaveLength(2)
+        expect(resOpt2.items).toHaveLength(1)
+        const texts1 = resOpt1.items.map(i => i.text)
+        expect(texts1).toContain('Item A')
+        expect(texts1).toContain('Item B')
+        expect(resOpt2.items[0].text).toBe('Item C')
+    })
+})

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -8,11 +8,6 @@ import {
     getBoolean,
     getInteger,
     getDatetime,
-    addStringNoLocale,
-    addBoolean,
-    addInteger,
-    addDatetime,
-    addUrl,
 } from '@inrupt/solid-client'
 import type { SolidDataset, Thing } from '@inrupt/solid-client'
 import { PMU, RDF, DCTERMS } from './rdfVocab'

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -1,0 +1,373 @@
+import {
+    createSolidDataset,
+    setThing,
+    buildThing,
+    getThing,
+    getUrlAll,
+    getStringNoLocale,
+    getBoolean,
+    getInteger,
+    getDatetime,
+    addStringNoLocale,
+    addBoolean,
+    addInteger,
+    addDatetime,
+    addUrl,
+} from '@inrupt/solid-client'
+import type { SolidDataset, Thing } from '@inrupt/solid-client'
+import { PMU, RDF, DCTERMS } from './rdfVocab'
+import type { PackingList, PackingListItem } from '../create-packing-list/types'
+import type {
+    PackingListQuestionSet,
+    Person,
+    Question,
+    Option,
+    Item,
+    PersonSelection,
+} from '../edit-questions/types'
+
+// ── PackingList ───────────────────────────────────────────────────────────────
+
+export function packingListToDataset(list: PackingList, datasetUrl: string): SolidDataset {
+    let ds = createSolidDataset()
+
+    let rootBuilder = buildThing({ url: datasetUrl })
+        .addUrl(RDF.type, PMU.PackingList)
+        .addStringNoLocale(PMU.name, list.name)
+        .addDatetime(DCTERMS.created, new Date(list.createdAt))
+
+    if (list.lastModified) {
+        rootBuilder = rootBuilder.addDatetime(DCTERMS.modified, new Date(list.lastModified))
+    }
+
+    for (const item of list.items) {
+        const itemUrl = `${datasetUrl}#item-${item.id}`
+        rootBuilder = rootBuilder.addUrl(PMU.hasItem, itemUrl)
+        ds = setThing(ds, packingListItemToThing(item, itemUrl))
+    }
+
+    for (const item of list.deletedItems ?? []) {
+        const itemUrl = `${datasetUrl}#deleted-item-${item.id}`
+        rootBuilder = rootBuilder.addUrl(PMU.hasDeletedItem, itemUrl)
+        ds = setThing(ds, packingListItemToThing(item, itemUrl))
+    }
+
+    return setThing(ds, rootBuilder.build())
+}
+
+export function datasetToPackingList(dataset: SolidDataset, datasetUrl: string): PackingList {
+    const rootThing = getThing(dataset, datasetUrl)
+    if (!rootThing) throw new Error(`No root Thing at ${datasetUrl}`)
+
+    const name = getStringNoLocale(rootThing, PMU.name) ?? ''
+    const createdAt = getDatetime(rootThing, DCTERMS.created)?.toISOString() ?? new Date().toISOString()
+    const lastModifiedDate = getDatetime(rootThing, DCTERMS.modified)
+    const lastModified = lastModifiedDate?.toISOString()
+
+    const id = datasetUrl.split('/').pop()?.replace('.ttl', '') ?? datasetUrl
+
+    const items = getUrlAll(rootThing, PMU.hasItem)
+        .map(url => thingToPackingListItem(getThing(dataset, url), url))
+        .filter((item): item is PackingListItem => item !== null)
+
+    const deletedItems = getUrlAll(rootThing, PMU.hasDeletedItem)
+        .map(url => thingToPackingListItem(getThing(dataset, url), url))
+        .filter((item): item is PackingListItem => item !== null)
+
+    return {
+        id,
+        name,
+        createdAt,
+        ...(lastModified !== undefined ? { lastModified } : {}),
+        items,
+        deletedItems,
+    }
+}
+
+function packingListItemToThing(item: PackingListItem, itemUrl: string): Thing {
+    let t = buildThing({ url: itemUrl })
+        .addUrl(RDF.type, PMU.PackingListItem)
+        .addStringNoLocale(PMU.itemText, item.itemText)
+        .addStringNoLocale(PMU.personId, item.personId)
+        .addStringNoLocale(PMU.personName, item.personName)
+        .addStringNoLocale(PMU.questionId, item.questionId)
+        .addStringNoLocale(PMU.optionId, item.optionId)
+        .addBoolean(PMU.packed, item.packed)
+
+    if (item.category !== undefined) t = t.addStringNoLocale(PMU.category, item.category)
+    if (item.reviewed !== undefined) t = t.addBoolean(PMU.reviewed, item.reviewed)
+
+    return t.build()
+}
+
+function thingToPackingListItem(thing: Thing | null, url: string): PackingListItem | null {
+    if (!thing) return null
+
+    const fragment = url.split('#')[1] ?? ''
+    const id = fragment.replace(/^(item-|deleted-item-)/, '')
+    const itemText = getStringNoLocale(thing, PMU.itemText) ?? ''
+    const personId = getStringNoLocale(thing, PMU.personId) ?? ''
+    const personName = getStringNoLocale(thing, PMU.personName) ?? ''
+    const questionId = getStringNoLocale(thing, PMU.questionId) ?? ''
+    const optionId = getStringNoLocale(thing, PMU.optionId) ?? ''
+    const packed = getBoolean(thing, PMU.packed) ?? false
+    const category = getStringNoLocale(thing, PMU.category) ?? undefined
+    const reviewed = getBoolean(thing, PMU.reviewed)
+
+    return {
+        id,
+        itemText,
+        personId,
+        personName,
+        questionId,
+        optionId,
+        packed,
+        ...(category !== undefined ? { category } : {}),
+        ...(reviewed !== null ? { reviewed } : {}),
+    }
+}
+
+// ── QuestionSet ───────────────────────────────────────────────────────────────
+
+export function questionSetToDataset(qs: PackingListQuestionSet, datasetUrl: string): SolidDataset {
+    let ds = createSolidDataset()
+
+    let rootBuilder = buildThing({ url: datasetUrl })
+        .addUrl(RDF.type, PMU.QuestionSet)
+
+    if (qs.lastModified) {
+        rootBuilder = rootBuilder.addDatetime(DCTERMS.modified, new Date(qs.lastModified))
+    }
+
+    for (const person of qs.people) {
+        const personUrl = `${datasetUrl}#person-${person.id}`
+        rootBuilder = rootBuilder.addUrl(PMU.hasPerson, personUrl)
+        ds = setThing(ds, personToThing(person, personUrl))
+    }
+
+    for (const question of qs.questions) {
+        const questionUrl = `${datasetUrl}#question-${question.id}`
+        rootBuilder = rootBuilder.addUrl(PMU.hasQuestion, questionUrl)
+        const { questionThing, extras } = questionToThings(question, questionUrl, datasetUrl)
+        ds = setThing(ds, questionThing)
+        for (const t of extras) ds = setThing(ds, t)
+    }
+
+    for (let i = 0; i < qs.alwaysNeededItems.length; i++) {
+        const itemUrl = `${datasetUrl}#always-item-${i}`
+        rootBuilder = rootBuilder.addUrl(PMU.hasAlwaysNeededItem, itemUrl)
+        const { itemThing, extras } = questionItemToThings(qs.alwaysNeededItems[i], itemUrl)
+        ds = setThing(ds, itemThing)
+        for (const t of extras) ds = setThing(ds, t)
+    }
+
+    return setThing(ds, rootBuilder.build())
+}
+
+export function datasetToQuestionSet(dataset: SolidDataset, datasetUrl: string): PackingListQuestionSet {
+    const rootThing = getThing(dataset, datasetUrl)
+    if (!rootThing) throw new Error(`No root Thing at ${datasetUrl}`)
+
+    const lastModifiedDate = getDatetime(rootThing, DCTERMS.modified)
+    const lastModified = lastModifiedDate?.toISOString()
+
+    const people = getUrlAll(rootThing, PMU.hasPerson)
+        .map(url => thingToPerson(getThing(dataset, url), url))
+        .filter((p): p is Person => p !== null)
+
+    const questions = getUrlAll(rootThing, PMU.hasQuestion)
+        .map(url => thingToQuestion(dataset, url))
+        .filter((q): q is Question => q !== null)
+        .sort((a, b) => a.order - b.order)
+
+    const alwaysItemUrls = getUrlAll(rootThing, PMU.hasAlwaysNeededItem)
+    alwaysItemUrls.sort((a, b) => {
+        const ia = parseInt(a.split('#always-item-')[1] ?? '0')
+        const ib = parseInt(b.split('#always-item-')[1] ?? '0')
+        return ia - ib
+    })
+    const alwaysNeededItems = alwaysItemUrls
+        .map(url => thingToQuestionItem(dataset, url))
+        .filter((item): item is Item => item !== null)
+
+    return {
+        _id: '1',
+        people,
+        questions,
+        alwaysNeededItems,
+        ...(lastModified !== undefined ? { lastModified } : {}),
+    }
+}
+
+function personToThing(person: Person, personUrl: string): Thing {
+    let t = buildThing({ url: personUrl })
+        .addUrl(RDF.type, PMU.Person)
+        .addStringNoLocale(PMU.name, person.name)
+
+    if (person.ageRange) t = t.addStringNoLocale(PMU.ageRange, person.ageRange)
+    if (person.gender) t = t.addStringNoLocale(PMU.gender, person.gender)
+
+    return t.build()
+}
+
+function thingToPerson(thing: Thing | null, url: string): Person | null {
+    if (!thing) return null
+    const id = url.split('#person-')[1] ?? url
+    const name = getStringNoLocale(thing, PMU.name) ?? ''
+    const ageRange = getStringNoLocale(thing, PMU.ageRange) ?? undefined
+    const gender = getStringNoLocale(thing, PMU.gender) ?? undefined
+    return {
+        id,
+        name,
+        ...(ageRange !== undefined ? { ageRange: ageRange as Person['ageRange'] } : {}),
+        ...(gender !== undefined ? { gender: gender as Person['gender'] } : {}),
+    }
+}
+
+function questionToThings(
+    question: Question,
+    questionUrl: string,
+    datasetUrl: string
+): { questionThing: Thing; extras: Thing[] } {
+    const extras: Thing[] = []
+
+    let qBuilder = buildThing({ url: questionUrl })
+        .addUrl(RDF.type, PMU.Question)
+        .addStringNoLocale(PMU.text, question.text)
+        .addStringNoLocale(PMU.questionStatus, question.type)
+        .addInteger(PMU.order, question.order)
+
+    if (question.questionType) {
+        qBuilder = qBuilder.addStringNoLocale(PMU.questionType, question.questionType)
+    }
+
+    for (const option of question.options) {
+        const optionUrl = `${datasetUrl}#option-${option.id}`
+        qBuilder = qBuilder.addUrl(PMU.hasOption, optionUrl)
+        const { optionThing, extras: optExtras } = optionToThings(option, optionUrl, datasetUrl)
+        extras.push(optionThing, ...optExtras)
+    }
+
+    return { questionThing: qBuilder.build(), extras }
+}
+
+function thingToQuestion(dataset: SolidDataset, url: string): Question | null {
+    const thing = getThing(dataset, url)
+    if (!thing) return null
+
+    const id = url.split('#question-')[1] ?? url
+    const text = getStringNoLocale(thing, PMU.text) ?? ''
+    const type = (getStringNoLocale(thing, PMU.questionStatus) ?? 'saved') as Question['type']
+    const order = getInteger(thing, PMU.order) ?? 0
+    const questionType = getStringNoLocale(thing, PMU.questionType) ?? undefined
+
+    const optionUrls = getUrlAll(thing, PMU.hasOption)
+    const options = optionUrls
+        .map(optUrl => thingToOption(dataset, optUrl))
+        .filter((o): o is Option => o !== null)
+        .sort((a, b) => a.order - b.order)
+
+    return {
+        id,
+        text,
+        type,
+        order,
+        options,
+        ...(questionType !== undefined ? { questionType: questionType as Question['questionType'] } : {}),
+    }
+}
+
+function optionToThings(
+    option: Option,
+    optionUrl: string,
+    datasetUrl: string
+): { optionThing: Thing; extras: Thing[] } {
+    const extras: Thing[] = []
+
+    let optBuilder = buildThing({ url: optionUrl })
+        .addUrl(RDF.type, PMU.QuestionOption)
+        .addStringNoLocale(PMU.text, option.text)
+        .addInteger(PMU.order, option.order)
+
+    for (let i = 0; i < option.items.length; i++) {
+        const itemUrl = `${datasetUrl}#opt-item-${option.id}-${i}`
+        optBuilder = optBuilder.addUrl(PMU.hasQuestionItem, itemUrl)
+        const { itemThing, extras: itemExtras } = questionItemToThings(option.items[i], itemUrl)
+        extras.push(itemThing, ...itemExtras)
+    }
+
+    return { optionThing: optBuilder.build(), extras }
+}
+
+function thingToOption(dataset: SolidDataset, url: string): Option | null {
+    const thing = getThing(dataset, url)
+    if (!thing) return null
+
+    const id = url.split('#option-')[1] ?? url
+    const text = getStringNoLocale(thing, PMU.text) ?? ''
+    const order = getInteger(thing, PMU.order) ?? 0
+
+    const itemUrls = getUrlAll(thing, PMU.hasQuestionItem)
+    itemUrls.sort((a, b) => {
+        // URLs are #opt-item-{optId}-{index} — sort by trailing index
+        const ia = parseInt(a.split('-').pop() ?? '0')
+        const ib = parseInt(b.split('-').pop() ?? '0')
+        return ia - ib
+    })
+    const items = itemUrls
+        .map(itemUrl => thingToQuestionItem(dataset, itemUrl))
+        .filter((item): item is Item => item !== null)
+
+    return { id, text, order, items }
+}
+
+function questionItemToThings(
+    item: Item,
+    itemUrl: string
+): { itemThing: Thing; extras: Thing[] } {
+    const extras: Thing[] = []
+
+    let itemBuilder = buildThing({ url: itemUrl })
+        .addUrl(RDF.type, PMU.QuestionItem)
+        .addStringNoLocale(PMU.text, item.text)
+
+    for (let i = 0; i < item.personSelections.length; i++) {
+        const ps = item.personSelections[i]
+        const psUrl = `${itemUrl}-ps-${i}`
+        itemBuilder = itemBuilder.addUrl(PMU.hasPersonSelection, psUrl)
+        extras.push(
+            buildThing({ url: psUrl })
+                .addUrl(RDF.type, PMU.PersonSelection)
+                .addStringNoLocale(PMU.selectionPersonId, ps.personId)
+                .addBoolean(PMU.selected, ps.selected)
+                .addInteger(PMU.order, i)
+                .build()
+        )
+    }
+
+    return { itemThing: itemBuilder.build(), extras }
+}
+
+function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
+    const thing = getThing(dataset, url)
+    if (!thing) return null
+
+    const text = getStringNoLocale(thing, PMU.text) ?? ''
+
+    const psUrls = getUrlAll(thing, PMU.hasPersonSelection)
+    const personSelectionsWithOrder: Array<PersonSelection & { order: number }> = psUrls
+        .map(psUrl => {
+            const psThing = getThing(dataset, psUrl)
+            if (!psThing) return null
+            const personId = getStringNoLocale(psThing, PMU.selectionPersonId) ?? ''
+            const selected = getBoolean(psThing, PMU.selected) ?? false
+            const order = getInteger(psThing, PMU.order) ?? 0
+            return { personId, selected, order }
+        })
+        .filter((ps): ps is PersonSelection & { order: number } => ps !== null)
+
+    personSelectionsWithOrder.sort((a, b) => a.order - b.order)
+    const personSelections: PersonSelection[] = personSelectionsWithOrder.map(({ personId, selected }) => ({ personId, selected }))
+
+    return { text, personSelections }
+}

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -1,0 +1,58 @@
+import { DCTERMS, RDF } from '@inrupt/vocab-common-rdf'
+
+export { DCTERMS, RDF }
+
+export const PMU_NS = 'https://pack-me-up.app/vocab#'
+
+export const PMU = {
+    // Classes
+    PackingList: `${PMU_NS}PackingList`,
+    PackingListItem: `${PMU_NS}PackingListItem`,
+    QuestionSet: `${PMU_NS}QuestionSet`,
+    Question: `${PMU_NS}Question`,
+    QuestionOption: `${PMU_NS}QuestionOption`,
+    QuestionItem: `${PMU_NS}QuestionItem`,
+    Person: `${PMU_NS}Person`,
+    PersonSelection: `${PMU_NS}PersonSelection`,
+
+    // PackingList predicates
+    hasItem: `${PMU_NS}hasItem`,
+    hasDeletedItem: `${PMU_NS}hasDeletedItem`,
+    itemText: `${PMU_NS}itemText`,
+    personId: `${PMU_NS}personId`,
+    personName: `${PMU_NS}personName`,
+    questionId: `${PMU_NS}questionId`,
+    optionId: `${PMU_NS}optionId`,
+    packed: `${PMU_NS}packed`,
+    category: `${PMU_NS}category`,
+    reviewed: `${PMU_NS}reviewed`,
+
+    // QuestionSet predicates
+    hasPerson: `${PMU_NS}hasPerson`,
+    hasQuestion: `${PMU_NS}hasQuestion`,
+    hasAlwaysNeededItem: `${PMU_NS}hasAlwaysNeededItem`,
+
+    // Person predicates
+    ageRange: `${PMU_NS}ageRange`,
+    gender: `${PMU_NS}gender`,
+
+    // Question predicates
+    hasOption: `${PMU_NS}hasOption`,
+    questionType: `${PMU_NS}questionType`,
+    questionStatus: `${PMU_NS}questionStatus`,
+    order: `${PMU_NS}order`,
+    text: `${PMU_NS}text`,
+
+    // Option predicates
+    hasQuestionItem: `${PMU_NS}hasQuestionItem`,
+
+    // Item predicates (on option items and always-needed items)
+    hasPersonSelection: `${PMU_NS}hasPersonSelection`,
+
+    // PersonSelection predicates
+    selectionPersonId: `${PMU_NS}selectionPersonId`,
+    selected: `${PMU_NS}selected`,
+
+    // Shared
+    name: 'https://schema.org/name',
+} as const

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -32,12 +32,11 @@ vi.mock('@inrupt/solid-client', async (importOriginal) => {
     }
 })
 
-import { getFile, getSolidDataset, getContainedResourceUrlAll, saveFileInContainer, saveSolidDatasetAt } from '@inrupt/solid-client'
+import { getFile, getSolidDataset, getContainedResourceUrlAll, saveSolidDatasetAt } from '@inrupt/solid-client'
 
 const mockGetFile = vi.mocked(getFile)
 const mockGetSolidDataset = vi.mocked(getSolidDataset)
 const mockGetContainedResourceUrlAll = vi.mocked(getContainedResourceUrlAll)
-const mockSaveFileInContainer = vi.mocked(saveFileInContainer)
 const mockSaveSolidDatasetAt = vi.mocked(saveSolidDatasetAt)
 
 const mockSession = {
@@ -207,13 +206,6 @@ function makePackingList(id: string, overrides: Partial<PackingList> = {}): Pack
     }
 }
 
-/** Blob whose .text() returns the given JSON */
-function jsonBlob(data: unknown): Blob & WithServerResourceInfo {
-    const text = JSON.stringify(data)
-    return {
-        text: () => Promise.resolve(text),
-    } as unknown as Blob & WithServerResourceInfo
-}
 
 function makeDb(overrides: Partial<{
     questionSet: PackingListQuestionSet | null
@@ -405,7 +397,7 @@ describe('loadRdfFromPod', () => {
             packingListToDataset(list, url) as unknown as SolidDataset & WithServerResourceInfo
         )
 
-        const result = await loadRdfFromPod(mockSession, url, (ds, u) => {
+        const result = await loadRdfFromPod(mockSession, url, (_ds, _u) => {
             return { id: 'test-id', name: 'Test', createdAt: new Date().toISOString(), items: [] }
         })
 
@@ -456,7 +448,7 @@ describe('saveRdfToPod', () => {
     it('throws AuthenticationError on 401', async () => {
         mockSaveSolidDatasetAt.mockRejectedValueOnce({ statusCode: 401 })
         await expect(
-            saveRdfToPod({ session: mockSession, fileUrl: 'https://x.example.com/f.ttl', data: {}, serializer: () => ({} as any) })
+            saveRdfToPod({ session: mockSession, fileUrl: 'https://x.example.com/f.ttl', data: {}, serializer: () => ({} as unknown as SolidDataset) })
         ).rejects.toThrow(AuthenticationError)
     })
 })
@@ -491,7 +483,7 @@ describe('loadMultipleRdfFromPod', () => {
     it('returns empty array when container is 404', async () => {
         mockGetSolidDataset.mockRejectedValueOnce({ statusCode: 404 })
 
-        const { data } = await loadMultipleRdfFromPod(mockSession, LISTS_CONTAINER_URL, () => null as any)
+        const { data } = await loadMultipleRdfFromPod<PackingList>(mockSession, LISTS_CONTAINER_URL, () => null as unknown as PackingList)
 
         expect(data).toHaveLength(0)
     })

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -32,12 +32,12 @@ vi.mock('@inrupt/solid-client', async (importOriginal) => {
     }
 })
 
-import { getFile, getSolidDataset, getContainedResourceUrlAll, saveSolidDatasetAt } from '@inrupt/solid-client'
+import { getFile, getSolidDataset, getContainedResourceUrlAll, overwriteFile, createSolidDataset } from '@inrupt/solid-client'
 
 const mockGetFile = vi.mocked(getFile)
 const mockGetSolidDataset = vi.mocked(getSolidDataset)
 const mockGetContainedResourceUrlAll = vi.mocked(getContainedResourceUrlAll)
-const mockSaveSolidDatasetAt = vi.mocked(saveSolidDatasetAt)
+const mockOverwriteFile = vi.mocked(overwriteFile)
 
 const mockSession = {
     info: { isLoggedIn: true, webId: 'https://example.com/profile#me' },
@@ -45,6 +45,10 @@ const mockSession = {
 } as unknown as Session
 
 const POD_URL = 'https://pod.example.com/'
+
+// Ensure each test starts with clean mock state (vi.restoreAllMocks in inner afterEach
+// hooks doesn't fully clear permanent mockRejectedValue defaults on vi.fn() mocks).
+beforeEach(() => { vi.resetAllMocks() })
 
 describe('hasPodData', () => {
     beforeEach(() => {
@@ -351,14 +355,14 @@ describe('syncAllDataFromPod', () => {
                 .mockRejectedValueOnce({ statusCode: 404 }) // no question set
                 .mockResolvedValueOnce(makeContainerDataset([])) // empty container
 
-            mockSaveSolidDatasetAt.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
+            mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
 
-            expect(mockSaveSolidDatasetAt).toHaveBeenCalledWith(
+            expect(mockOverwriteFile).toHaveBeenCalledWith(
                 expect.stringContaining('local-only.ttl'),
-                expect.anything(),
-                expect.objectContaining({ fetch: mockSession.fetch })
+                expect.any(Blob),
+                expect.objectContaining({ fetch: mockSession.fetch, contentType: 'text/turtle' })
             )
             expect(result.packingListsUploaded).toBe(1)
         })
@@ -375,7 +379,7 @@ describe('syncAllDataFromPod', () => {
                 .mockResolvedValueOnce(makeContainerDataset([podListUrl]))
                 .mockResolvedValueOnce(makeRdfListDataset(podList))
 
-            mockSaveSolidDatasetAt.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
+            mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
 
@@ -426,10 +430,10 @@ describe('loadRdfFromPod', () => {
 describe('saveRdfToPod', () => {
     afterEach(() => { vi.restoreAllMocks() })
 
-    it('serializes data and calls saveSolidDatasetAt', async () => {
+    it('serializes data and calls overwriteFile with Turtle content', async () => {
         const list = makePackingList('my-list')
         const url = `${POD_URL}pack-me-up/packing-lists/my-list.ttl`
-        mockSaveSolidDatasetAt.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
+        mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
 
         await saveRdfToPod({
             session: mockSession,
@@ -438,17 +442,17 @@ describe('saveRdfToPod', () => {
             serializer: packingListToDataset,
         })
 
-        expect(mockSaveSolidDatasetAt).toHaveBeenCalledWith(
+        expect(mockOverwriteFile).toHaveBeenCalledWith(
             url,
-            expect.anything(),
-            expect.objectContaining({ fetch: mockSession.fetch })
+            expect.any(Blob),
+            expect.objectContaining({ fetch: mockSession.fetch, contentType: 'text/turtle' })
         )
     })
 
     it('throws AuthenticationError on 401', async () => {
-        mockSaveSolidDatasetAt.mockRejectedValueOnce({ statusCode: 401 })
+        mockOverwriteFile.mockRejectedValueOnce({ statusCode: 401 })
         await expect(
-            saveRdfToPod({ session: mockSession, fileUrl: 'https://x.example.com/f.ttl', data: {}, serializer: () => ({} as unknown as SolidDataset) })
+            saveRdfToPod({ session: mockSession, fileUrl: 'https://x.example.com/f.ttl', data: {}, serializer: () => createSolidDataset() })
         ).rejects.toThrow(AuthenticationError)
     })
 })
@@ -513,19 +517,19 @@ describe('saveMultipleRdfToPod', () => {
     it('saves each item as a ttl file', async () => {
         const lists = [makePackingList('list-1'), makePackingList('list-2')]
         mockGetSolidDataset.mockRejectedValueOnce({ statusCode: 404 }) // no existing files
-        mockSaveSolidDatasetAt.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
+        mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
 
         const result = await saveMultipleRdfToPod(mockSession, LISTS_CONTAINER_URL, lists, packingListToDataset)
 
-        expect(mockSaveSolidDatasetAt).toHaveBeenCalledWith(
+        expect(mockOverwriteFile).toHaveBeenCalledWith(
             expect.stringContaining('list-1.ttl'),
-            expect.anything(),
-            expect.any(Object)
+            expect.any(Blob),
+            expect.objectContaining({ contentType: 'text/turtle' })
         )
-        expect(mockSaveSolidDatasetAt).toHaveBeenCalledWith(
+        expect(mockOverwriteFile).toHaveBeenCalledWith(
             expect.stringContaining('list-2.ttl'),
-            expect.anything(),
-            expect.any(Object)
+            expect.any(Blob),
+            expect.objectContaining({ contentType: 'text/turtle' })
         )
         expect(result.successCount).toBe(2)
     })
@@ -539,7 +543,7 @@ describe('saveMultipleRdfToPod', () => {
         mockGetSolidDataset.mockResolvedValueOnce({} as unknown as SolidDataset & WithServerResourceInfo)
         mockGetContainedResourceUrlAll.mockReturnValueOnce([orphanUrl])
         mockDeleteFile.mockResolvedValueOnce(undefined)
-        mockSaveSolidDatasetAt.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
+        mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
 
         await saveMultipleRdfToPod(mockSession, LISTS_CONTAINER_URL, [activeList], packingListToDataset)
 

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -1,28 +1,44 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { AppSession as Session } from '../types/AppSession'
 import type { SolidDataset, WithServerResourceInfo } from '@inrupt/solid-client'
-import { hasPodData, syncAllDataFromPod } from './solidPod'
+import {
+    hasPodData,
+    syncAllDataFromPod,
+    loadRdfFromPod,
+    saveRdfToPod,
+    loadMultipleRdfFromPod,
+    saveMultipleRdfToPod,
+    POD_CONTAINERS,
+} from './solidPod'
 import { AuthenticationError } from './solidPod'
 import type { PackingAppDatabase } from './database'
 import type { PackingListQuestionSet } from '../edit-questions/types'
 import type { PackingList } from '../create-packing-list/types'
+import { packingListToDataset, questionSetToDataset } from './rdfSerialization'
 
-vi.mock('@inrupt/solid-client', () => ({
-    getFile: vi.fn(),
-    getSolidDataset: vi.fn(),
-    getContainedResourceUrlAll: vi.fn(),
-    getPodUrlAll: vi.fn(),
-    saveFileInContainer: vi.fn(),
-    overwriteFile: vi.fn(),
-    deleteFile: vi.fn(),
-}))
+vi.mock('@inrupt/solid-client', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@inrupt/solid-client')>()
+    return {
+        ...actual,
+        // These are mocked so tests can control pod I/O
+        getFile: vi.fn(),
+        getSolidDataset: vi.fn(),
+        getContainedResourceUrlAll: vi.fn(),
+        getPodUrlAll: vi.fn(),
+        saveFileInContainer: vi.fn(),
+        overwriteFile: vi.fn(),
+        deleteFile: vi.fn(),
+        saveSolidDatasetAt: vi.fn(),
+    }
+})
 
-import { getFile, getSolidDataset, getContainedResourceUrlAll, saveFileInContainer } from '@inrupt/solid-client'
+import { getFile, getSolidDataset, getContainedResourceUrlAll, saveFileInContainer, saveSolidDatasetAt } from '@inrupt/solid-client'
 
 const mockGetFile = vi.mocked(getFile)
 const mockGetSolidDataset = vi.mocked(getSolidDataset)
 const mockGetContainedResourceUrlAll = vi.mocked(getContainedResourceUrlAll)
 const mockSaveFileInContainer = vi.mocked(saveFileInContainer)
+const mockSaveSolidDatasetAt = vi.mocked(saveSolidDatasetAt)
 
 const mockSession = {
     info: { isLoggedIn: true, webId: 'https://example.com/profile#me' },
@@ -40,24 +56,46 @@ describe('hasPodData', () => {
         vi.restoreAllMocks()
     })
 
-    it('returns true when the questions file exists on the pod', async () => {
-        mockGetFile.mockResolvedValue(new Blob(['{}']) as unknown as Blob & WithServerResourceInfo)
+    it('returns true when the migration marker (ttl) exists on the pod', async () => {
+        mockGetFile.mockResolvedValueOnce(new Blob(['']) as unknown as Blob & WithServerResourceInfo)
 
         const result = await hasPodData(mockSession, POD_URL)
 
         expect(result).toBe(true)
         expect(mockGetFile).toHaveBeenCalledWith(
-            `${POD_URL}pack-me-up/packing-list-questions.json`,
+            `${POD_URL}${POD_CONTAINERS.MIGRATION_MARKER}`,
             expect.objectContaining({ fetch: mockSession.fetch })
         )
     })
 
-    it('returns true when no questions file but packing lists exist', async () => {
+    it('returns true when the ttl questions file exists (no migration marker)', async () => {
+        mockGetFile
+            .mockRejectedValueOnce({ statusCode: 404 }) // no migration marker
+            .mockResolvedValueOnce(new Blob(['']) as unknown as Blob & WithServerResourceInfo)
+
+        const result = await hasPodData(mockSession, POD_URL)
+
+        expect(result).toBe(true)
+    })
+
+    it('returns true when only the legacy json questions file exists', async () => {
+        mockGetFile
+            .mockRejectedValueOnce({ statusCode: 404 }) // no migration marker
+            .mockRejectedValueOnce({ statusCode: 404 }) // no ttl questions
+            .mockResolvedValueOnce(new Blob(['']) as unknown as Blob & WithServerResourceInfo) // json exists
+
+        const result = await hasPodData(mockSession, POD_URL)
+
+        expect(result).toBe(true)
+    })
+
+    it('returns true when no questions files but packing lists exist', async () => {
+        // All 3 getFile checks (marker, ttl, json) return 404
         mockGetFile.mockRejectedValue({ statusCode: 404 })
         const mockDataset = {}
         mockGetSolidDataset.mockResolvedValue(mockDataset as unknown as SolidDataset & WithServerResourceInfo)
         mockGetContainedResourceUrlAll.mockReturnValue([
-            `${POD_URL}pack-me-up/packing-lists/list-1.json`,
+            `${POD_URL}pack-me-up/packing-lists/list-1.ttl`,
         ])
 
         const result = await hasPodData(mockSession, POD_URL)
@@ -65,7 +103,7 @@ describe('hasPodData', () => {
         expect(result).toBe(true)
     })
 
-    it('returns false when neither questions file nor packing lists exist', async () => {
+    it('returns false when neither questions files nor packing lists exist', async () => {
         mockGetFile.mockRejectedValue({ statusCode: 404 })
         mockGetSolidDataset.mockRejectedValue({ statusCode: 404 })
 
@@ -74,7 +112,7 @@ describe('hasPodData', () => {
         expect(result).toBe(false)
     })
 
-    it('returns false when questions file is 404 and packing lists container is empty', async () => {
+    it('returns false when all question checks are 404 and packing lists container is empty', async () => {
         mockGetFile.mockRejectedValue({ statusCode: 404 })
         const mockDataset = {}
         mockGetSolidDataset.mockResolvedValue(mockDataset as unknown as SolidDataset & WithServerResourceInfo)
@@ -85,7 +123,7 @@ describe('hasPodData', () => {
         expect(result).toBe(false)
     })
 
-    it('returns false when questions file is 404 and packing lists container has no json files', async () => {
+    it('returns false when all question checks are 404 and container has no ttl or json files', async () => {
         mockGetFile.mockRejectedValue({ statusCode: 404 })
         const mockDataset = {}
         mockGetSolidDataset.mockResolvedValue(mockDataset as unknown as SolidDataset & WithServerResourceInfo)
@@ -197,7 +235,25 @@ function makeDb(overrides: Partial<{
     } as unknown as PackingAppDatabase
 }
 
-// ─── syncAllDataFromPod ──────────────────────────────────────────────────────
+// ─── syncAllDataFromPod (RDF) ────────────────────────────────────────────────
+
+const QUESTIONS_URL = `${POD_URL}${POD_CONTAINERS.QUESTIONS}`
+const LISTS_CONTAINER_URL = `${POD_URL}${POD_CONTAINERS.PACKING_LISTS}`
+
+function makeRdfQsDataset(qs: PackingListQuestionSet) {
+    return questionSetToDataset(qs, QUESTIONS_URL) as unknown as SolidDataset & WithServerResourceInfo
+}
+
+function makeRdfListDataset(list: PackingList) {
+    const url = `${LISTS_CONTAINER_URL}${list.id}.ttl`
+    return packingListToDataset(list, url) as unknown as SolidDataset & WithServerResourceInfo
+}
+
+function makeContainerDataset(fileUrls: string[]) {
+    const ds = {} as SolidDataset & WithServerResourceInfo
+    mockGetContainedResourceUrlAll.mockReturnValueOnce(fileUrls)
+    return ds
+}
 
 describe('syncAllDataFromPod', () => {
     beforeEach(() => {
@@ -214,10 +270,9 @@ describe('syncAllDataFromPod', () => {
             const localQs = makeQuestionSet({ lastModified: '2024-01-01T10:00:00.000Z' })
             const db = makeDb({ questionSet: localQs, packingLists: [] })
 
-            // No packing lists in pod
-            mockGetSolidDataset.mockRejectedValue({ statusCode: 404 })
-            // Question set file returns pod data
-            mockGetFile.mockResolvedValueOnce(jsonBlob(podQs))
+            mockGetSolidDataset
+                .mockResolvedValueOnce(makeRdfQsDataset(podQs))
+                .mockRejectedValueOnce({ statusCode: 404 }) // empty container
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
 
@@ -232,8 +287,9 @@ describe('syncAllDataFromPod', () => {
             const localQs = makeQuestionSet({ lastModified: '2024-06-01T12:00:00.000Z' })
             const db = makeDb({ questionSet: localQs, packingLists: [] })
 
-            mockGetSolidDataset.mockRejectedValue({ statusCode: 404 })
-            mockGetFile.mockResolvedValueOnce(jsonBlob(podQs))
+            mockGetSolidDataset
+                .mockResolvedValueOnce(makeRdfQsDataset(podQs))
+                .mockRejectedValueOnce({ statusCode: 404 })
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
 
@@ -245,8 +301,9 @@ describe('syncAllDataFromPod', () => {
             const podQs = makeQuestionSet()
             const db = makeDb({ questionSet: null, packingLists: [] })
 
-            mockGetSolidDataset.mockRejectedValue({ statusCode: 404 })
-            mockGetFile.mockResolvedValueOnce(jsonBlob(podQs))
+            mockGetSolidDataset
+                .mockResolvedValueOnce(makeRdfQsDataset(podQs))
+                .mockRejectedValueOnce({ statusCode: 404 })
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
 
@@ -257,8 +314,6 @@ describe('syncAllDataFromPod', () => {
         it('skips question set sync gracefully when pod returns 404', async () => {
             const db = makeDb({ packingLists: [] })
 
-            // Question set 404, then packing lists 404
-            mockGetFile.mockRejectedValueOnce({ statusCode: 404 })
             mockGetSolidDataset.mockRejectedValue({ statusCode: 404 })
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
@@ -269,7 +324,7 @@ describe('syncAllDataFromPod', () => {
 
         it('re-throws authentication errors from question set load', async () => {
             const db = makeDb({ packingLists: [] })
-            mockGetFile.mockRejectedValueOnce({ statusCode: 401 })
+            mockGetSolidDataset.mockRejectedValueOnce({ statusCode: 401 })
 
             await expect(syncAllDataFromPod(mockSession, POD_URL, db)).rejects.toThrow(AuthenticationError)
         })
@@ -281,19 +336,14 @@ describe('syncAllDataFromPod', () => {
             const podList2 = makePackingList('list-2')
             const db = makeDb({ questionSet: null, packingLists: [] })
 
-            // Question set 404
-            mockGetFile
-                .mockRejectedValueOnce({ statusCode: 404 })
-                // packing list files
-                .mockResolvedValueOnce(jsonBlob(podList1))
-                .mockResolvedValueOnce(jsonBlob(podList2))
+            const list1Url = `${LISTS_CONTAINER_URL}list-1.ttl`
+            const list2Url = `${LISTS_CONTAINER_URL}list-2.ttl`
 
-            const mockDataset = {}
-            mockGetSolidDataset.mockResolvedValue(mockDataset as unknown as SolidDataset & WithServerResourceInfo)
-            mockGetContainedResourceUrlAll.mockReturnValue([
-                `${POD_URL}pack-me-up/packing-lists/list-1.json`,
-                `${POD_URL}pack-me-up/packing-lists/list-2.json`,
-            ])
+            mockGetSolidDataset
+                .mockRejectedValueOnce({ statusCode: 404 }) // no question set
+                .mockResolvedValueOnce(makeContainerDataset([list1Url, list2Url]))
+                .mockResolvedValueOnce(makeRdfListDataset(podList1))
+                .mockResolvedValueOnce(makeRdfListDataset(podList2))
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
 
@@ -305,19 +355,18 @@ describe('syncAllDataFromPod', () => {
             const localOnlyList = makePackingList('local-only')
             const db = makeDb({ questionSet: null, packingLists: [localOnlyList] })
 
-            // Question set 404, packing lists container is empty
-            mockGetFile.mockRejectedValueOnce({ statusCode: 404 })
-            mockGetSolidDataset.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
-            mockGetContainedResourceUrlAll.mockReturnValue([])
+            mockGetSolidDataset
+                .mockRejectedValueOnce({ statusCode: 404 }) // no question set
+                .mockResolvedValueOnce(makeContainerDataset([])) // empty container
 
-            mockSaveFileInContainer.mockResolvedValue({} as unknown as ReturnType<typeof saveFileInContainer> extends Promise<infer R> ? R : never)
+            mockSaveSolidDatasetAt.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
 
-            expect(mockSaveFileInContainer).toHaveBeenCalledWith(
-                expect.stringContaining('packing-lists'),
-                expect.any(File),
-                expect.objectContaining({ slug: 'local-only.json' })
+            expect(mockSaveSolidDatasetAt).toHaveBeenCalledWith(
+                expect.stringContaining('local-only.ttl'),
+                expect.anything(),
+                expect.objectContaining({ fetch: mockSession.fetch })
             )
             expect(result.packingListsUploaded).toBe(1)
         })
@@ -327,20 +376,181 @@ describe('syncAllDataFromPod', () => {
             const localOnlyList = makePackingList('local-only')
             const db = makeDb({ questionSet: null, packingLists: [localOnlyList] })
 
-            mockGetFile
-                .mockRejectedValueOnce({ statusCode: 404 }) // question set
-                .mockResolvedValueOnce(jsonBlob(podList))    // pod packing list
+            const podListUrl = `${LISTS_CONTAINER_URL}pod-list.ttl`
 
-            mockGetSolidDataset.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
-            mockGetContainedResourceUrlAll.mockReturnValue([
-                `${POD_URL}pack-me-up/packing-lists/pod-list.json`,
-            ])
-            mockSaveFileInContainer.mockResolvedValue({} as unknown as ReturnType<typeof saveFileInContainer> extends Promise<infer R> ? R : never)
+            mockGetSolidDataset
+                .mockRejectedValueOnce({ statusCode: 404 }) // no question set
+                .mockResolvedValueOnce(makeContainerDataset([podListUrl]))
+                .mockResolvedValueOnce(makeRdfListDataset(podList))
+
+            mockSaveSolidDatasetAt.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
 
             expect(result.packingListsSynced).toBe(1)
             expect(result.packingListsUploaded).toBe(1)
         })
+    })
+})
+
+// ─── loadRdfFromPod ──────────────────────────────────────────────────────────
+
+describe('loadRdfFromPod', () => {
+    afterEach(() => { vi.restoreAllMocks() })
+
+    it('loads a dataset and applies the deserializer', async () => {
+        const list = makePackingList('test-id')
+        const url = `${POD_URL}pack-me-up/packing-lists/test-id.ttl`
+        mockGetSolidDataset.mockResolvedValueOnce(
+            packingListToDataset(list, url) as unknown as SolidDataset & WithServerResourceInfo
+        )
+
+        const result = await loadRdfFromPod(mockSession, url, (ds, u) => {
+            return { id: 'test-id', name: 'Test', createdAt: new Date().toISOString(), items: [] }
+        })
+
+        expect(mockGetSolidDataset).toHaveBeenCalledWith(url, expect.objectContaining({ fetch: mockSession.fetch }))
+        expect(result.id).toBe('test-id')
+    })
+
+    it('throws AuthenticationError on 401', async () => {
+        mockGetSolidDataset.mockRejectedValueOnce({ statusCode: 401 })
+        await expect(
+            loadRdfFromPod(mockSession, 'https://pod.example.com/test.ttl', () => null)
+        ).rejects.toThrow(AuthenticationError)
+    })
+
+    it('re-throws non-auth errors', async () => {
+        const err = { statusCode: 500 }
+        mockGetSolidDataset.mockRejectedValueOnce(err)
+        await expect(
+            loadRdfFromPod(mockSession, 'https://pod.example.com/test.ttl', () => null)
+        ).rejects.toEqual(err)
+    })
+})
+
+// ─── saveRdfToPod ────────────────────────────────────────────────────────────
+
+describe('saveRdfToPod', () => {
+    afterEach(() => { vi.restoreAllMocks() })
+
+    it('serializes data and calls saveSolidDatasetAt', async () => {
+        const list = makePackingList('my-list')
+        const url = `${POD_URL}pack-me-up/packing-lists/my-list.ttl`
+        mockSaveSolidDatasetAt.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
+
+        await saveRdfToPod({
+            session: mockSession,
+            fileUrl: url,
+            data: list,
+            serializer: packingListToDataset,
+        })
+
+        expect(mockSaveSolidDatasetAt).toHaveBeenCalledWith(
+            url,
+            expect.anything(),
+            expect.objectContaining({ fetch: mockSession.fetch })
+        )
+    })
+
+    it('throws AuthenticationError on 401', async () => {
+        mockSaveSolidDatasetAt.mockRejectedValueOnce({ statusCode: 401 })
+        await expect(
+            saveRdfToPod({ session: mockSession, fileUrl: 'https://x.example.com/f.ttl', data: {}, serializer: () => ({} as any) })
+        ).rejects.toThrow(AuthenticationError)
+    })
+})
+
+// ─── loadMultipleRdfFromPod ──────────────────────────────────────────────────
+
+describe('loadMultipleRdfFromPod', () => {
+    afterEach(() => { vi.restoreAllMocks() })
+
+    it('loads all ttl files from a container', async () => {
+        const list1 = makePackingList('list-1')
+        const list2 = makePackingList('list-2')
+        const url1 = `${LISTS_CONTAINER_URL}list-1.ttl`
+        const url2 = `${LISTS_CONTAINER_URL}list-2.ttl`
+
+        mockGetSolidDataset
+            .mockResolvedValueOnce({} as unknown as SolidDataset & WithServerResourceInfo) // container
+            .mockResolvedValueOnce(packingListToDataset(list1, url1) as unknown as SolidDataset & WithServerResourceInfo)
+            .mockResolvedValueOnce(packingListToDataset(list2, url2) as unknown as SolidDataset & WithServerResourceInfo)
+        mockGetContainedResourceUrlAll.mockReturnValueOnce([url1, url2])
+
+        const { data, result } = await loadMultipleRdfFromPod(
+            mockSession, LISTS_CONTAINER_URL,
+            (ds, url) => ({ id: url.split('/').pop()!.replace('.ttl', ''), name: '', createdAt: '', items: [] })
+        )
+
+        expect(data).toHaveLength(2)
+        expect(result.successCount).toBe(2)
+        expect(result.failCount).toBe(0)
+    })
+
+    it('returns empty array when container is 404', async () => {
+        mockGetSolidDataset.mockRejectedValueOnce({ statusCode: 404 })
+
+        const { data } = await loadMultipleRdfFromPod(mockSession, LISTS_CONTAINER_URL, () => null as any)
+
+        expect(data).toHaveLength(0)
+    })
+
+    it('ignores non-ttl files', async () => {
+        mockGetSolidDataset.mockResolvedValueOnce({} as unknown as SolidDataset & WithServerResourceInfo)
+        mockGetContainedResourceUrlAll.mockReturnValueOnce([
+            `${LISTS_CONTAINER_URL}list-1.json`,  // should be ignored
+            `${LISTS_CONTAINER_URL}list-2.ttl`,   // should be loaded
+        ])
+        const list2 = makePackingList('list-2')
+        const url2 = `${LISTS_CONTAINER_URL}list-2.ttl`
+        mockGetSolidDataset.mockResolvedValueOnce(packingListToDataset(list2, url2) as unknown as SolidDataset & WithServerResourceInfo)
+
+        const { data } = await loadMultipleRdfFromPod(mockSession, LISTS_CONTAINER_URL,
+            (ds, url) => ({ id: url.split('/').pop()!.replace('.ttl', ''), name: '', createdAt: '', items: [] }))
+
+        expect(data).toHaveLength(1)
+    })
+})
+
+// ─── saveMultipleRdfToPod ────────────────────────────────────────────────────
+
+describe('saveMultipleRdfToPod', () => {
+    afterEach(() => { vi.restoreAllMocks() })
+
+    it('saves each item as a ttl file', async () => {
+        const lists = [makePackingList('list-1'), makePackingList('list-2')]
+        mockGetSolidDataset.mockRejectedValueOnce({ statusCode: 404 }) // no existing files
+        mockSaveSolidDatasetAt.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
+
+        const result = await saveMultipleRdfToPod(mockSession, LISTS_CONTAINER_URL, lists, packingListToDataset)
+
+        expect(mockSaveSolidDatasetAt).toHaveBeenCalledWith(
+            expect.stringContaining('list-1.ttl'),
+            expect.anything(),
+            expect.any(Object)
+        )
+        expect(mockSaveSolidDatasetAt).toHaveBeenCalledWith(
+            expect.stringContaining('list-2.ttl'),
+            expect.anything(),
+            expect.any(Object)
+        )
+        expect(result.successCount).toBe(2)
+    })
+
+    it('deletes orphaned ttl files', async () => {
+        const { deleteFile } = await import('@inrupt/solid-client')
+        const mockDeleteFile = vi.mocked(deleteFile)
+        const orphanUrl = `${LISTS_CONTAINER_URL}orphan.ttl`
+        const activeList = makePackingList('active')
+
+        mockGetSolidDataset.mockResolvedValueOnce({} as unknown as SolidDataset & WithServerResourceInfo)
+        mockGetContainedResourceUrlAll.mockReturnValueOnce([orphanUrl])
+        mockDeleteFile.mockResolvedValueOnce(undefined)
+        mockSaveSolidDatasetAt.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
+
+        await saveMultipleRdfToPod(mockSession, LISTS_CONTAINER_URL, [activeList], packingListToDataset)
+
+        expect(mockDeleteFile).toHaveBeenCalledWith(orphanUrl, expect.any(Object))
     })
 })

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -1,15 +1,19 @@
 import { AppSession as Session } from '../types/AppSession'
 import { getPodUrlAll, saveFileInContainer, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile } from '@inrupt/solid-client'
+import type { SolidDataset } from '@inrupt/solid-client'
 import { PackingAppDatabase } from './database'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList } from '../create-packing-list/types'
+import { packingListToDataset, datasetToPackingList, questionSetToDataset, datasetToQuestionSet } from './rdfSerialization'
 
 /**
  * Pod container paths under the user's Pod root
  */
 export const POD_CONTAINERS = {
     ROOT: 'pack-me-up/',
-    QUESTIONS: 'pack-me-up/packing-list-questions.json',
+    QUESTIONS: 'pack-me-up/packing-list-questions.ttl',
+    QUESTIONS_LEGACY_JSON: 'pack-me-up/packing-list-questions.json',
+    MIGRATION_MARKER: 'pack-me-up/migrated-to-rdf.ttl',
     PACKING_LISTS: 'pack-me-up/packing-lists/',
     BACKUPS: 'pack-me-up/backups/',
 } as const
@@ -146,10 +150,20 @@ export async function getPrimaryPodUrl(session: Session | null): Promise<string 
 
 /**
  * Checks whether the user's Solid Pod contains any data saved by this app.
- * Checks the questions file first, then the packing lists container.
- * Uses remote requests so it works correctly on any device, regardless of local cache state.
+ * Checks for migration marker, RDF questions file, then legacy JSON questions file,
+ * then the packing lists container. Works for both pre- and post-migration pods.
  */
 export async function hasPodData(session: Session, podUrl: string): Promise<boolean> {
+    // Check migration marker (fast path for migrated pods)
+    try {
+        await getFile(`${podUrl}${POD_CONTAINERS.MIGRATION_MARKER}`, { fetch: session.fetch })
+        return true
+    } catch (err: unknown) {
+        if (isAuthenticationError(err)) handlePodError(err)
+        if (getStatusCode(err) !== 404) throw err
+    }
+
+    // Check RDF questions file
     try {
         await getFile(`${podUrl}${POD_CONTAINERS.QUESTIONS}`, { fetch: session.fetch })
         return true
@@ -158,9 +172,18 @@ export async function hasPodData(session: Session, podUrl: string): Promise<bool
         if (getStatusCode(err) !== 404) throw err
     }
 
+    // Check legacy JSON questions file
+    try {
+        await getFile(`${podUrl}${POD_CONTAINERS.QUESTIONS_LEGACY_JSON}`, { fetch: session.fetch })
+        return true
+    } catch (err: unknown) {
+        if (isAuthenticationError(err)) handlePodError(err)
+        if (getStatusCode(err) !== 404) throw err
+    }
+
     try {
         const dataset = await getSolidDataset(`${podUrl}${POD_CONTAINERS.PACKING_LISTS}`, { fetch: session.fetch })
-        return getContainedResourceUrlAll(dataset).some(url => url.endsWith('.json'))
+        return getContainedResourceUrlAll(dataset).some(url => url.endsWith('.ttl') || url.endsWith('.json'))
     } catch (err: unknown) {
         if (isAuthenticationError(err)) handlePodError(err)
         if (getStatusCode(err) === 404) return false
@@ -226,6 +249,148 @@ export async function loadFileFromPod<T>(options: LoadFromPodOptions): Promise<T
         }
         throw error
     }
+}
+
+// ── RDF Pod operations ────────────────────────────────────────────────────────
+
+export interface SaveRdfToPodOptions<T> {
+    session: Session
+    fileUrl: string
+    data: T
+    serializer: (data: T, datasetUrl: string) => SolidDataset
+}
+
+/**
+ * Loads an RDF dataset from a Pod URL and deserializes it via the provided function.
+ */
+export async function loadRdfFromPod<T>(
+    session: Session,
+    fileUrl: string,
+    deserializer: (dataset: SolidDataset, datasetUrl: string) => T
+): Promise<T> {
+    try {
+        const dataset = await getSolidDataset(fileUrl, { fetch: session.fetch })
+        return deserializer(dataset, fileUrl)
+    } catch (error: unknown) {
+        if (isAuthenticationError(error)) handlePodError(error)
+        throw error
+    }
+}
+
+/**
+ * Serializes data to RDF and saves it as a dataset at the given Pod URL.
+ */
+export async function saveRdfToPod<T>(options: SaveRdfToPodOptions<T>): Promise<void> {
+    const { session, fileUrl, data, serializer } = options
+    try {
+        const dataset = serializer(data, fileUrl)
+        await saveSolidDatasetAt(fileUrl, dataset, { fetch: session.fetch })
+    } catch (error: unknown) {
+        if (isAuthenticationError(error)) handlePodError(error)
+        throw error
+    }
+}
+
+/**
+ * Loads all .ttl files from a Pod container, deserializing each via the provided function.
+ */
+export async function loadMultipleRdfFromPod<T>(
+    session: Session,
+    containerUrl: string,
+    deserializer: (dataset: SolidDataset, datasetUrl: string) => T,
+    onError?: (fileUrl: string, error: Error) => void
+): Promise<{ data: T[]; result: PodSyncResult }> {
+    let dataset
+    try {
+        dataset = await getSolidDataset(containerUrl, { fetch: session.fetch })
+    } catch (error: unknown) {
+        if (isAuthenticationError(error)) handlePodError(error)
+        if (getStatusCode(error) === 404) {
+            return { data: [], result: { success: false, successCount: 0, failCount: 0, totalCount: 0 } }
+        }
+        throw error
+    }
+
+    const ttlUrls = getContainedResourceUrlAll(dataset).filter(url => url.endsWith('.ttl'))
+
+    if (ttlUrls.length === 0) {
+        return { data: [], result: { success: true, successCount: 0, failCount: 0, totalCount: 0 } }
+    }
+
+    const loadedData: T[] = []
+    let successCount = 0
+    let failCount = 0
+
+    for (const fileUrl of ttlUrls) {
+        try {
+            const fileDataset = await getSolidDataset(fileUrl, { fetch: session.fetch })
+            loadedData.push(deserializer(fileDataset, fileUrl))
+            successCount++
+        } catch (error: unknown) {
+            if (isAuthenticationError(error)) handlePodError(error)
+            console.error(`loadMultipleRdfFromPod: error loading ${fileUrl}`, error)
+            failCount++
+            if (onError) onError(fileUrl, error instanceof Error ? error : new Error(String(error)))
+        }
+    }
+
+    return {
+        data: loadedData,
+        result: { success: failCount === 0, successCount, failCount, totalCount: ttlUrls.length }
+    }
+}
+
+/**
+ * Saves an array of items as .ttl files in a Pod container, deleting orphaned .ttl files.
+ */
+export async function saveMultipleRdfToPod<T extends { id: string }>(
+    session: Session,
+    containerUrl: string,
+    items: T[],
+    serializer: (item: T, datasetUrl: string) => SolidDataset
+): Promise<PodSyncResult> {
+    let successCount = 0
+    let failCount = 0
+    let deleteCount = 0
+
+    // Detect and remove orphaned .ttl files
+    try {
+        const dataset = await getSolidDataset(containerUrl, { fetch: session.fetch })
+        const ttlUrls = getContainedResourceUrlAll(dataset).filter(url => url.endsWith('.ttl'))
+        const currentIds = new Set(items.map(item => item.id))
+
+        for (const fileUrl of ttlUrls) {
+            const filename = fileUrl.split('/').pop()
+            const itemId = filename?.replace('.ttl', '')
+            if (itemId && !currentIds.has(itemId)) {
+                try {
+                    await deleteFile(fileUrl, { fetch: session.fetch })
+                    deleteCount++
+                } catch (error: unknown) {
+                    if (isAuthenticationError(error)) handlePodError(error)
+                    console.error(`saveMultipleRdfToPod: error deleting ${fileUrl}`, error)
+                    failCount++
+                }
+            }
+        }
+    } catch (error: unknown) {
+        if (isAuthenticationError(error)) handlePodError(error)
+        if (getStatusCode(error) !== 404) console.error('saveMultipleRdfToPod: error checking container', error)
+    }
+
+    for (const item of items) {
+        try {
+            const fileUrl = `${containerUrl}${item.id}.ttl`
+            await saveRdfToPod({ session, fileUrl, data: item, serializer })
+            successCount++
+        } catch (error: unknown) {
+            if (error instanceof AuthenticationError) throw error
+            console.error(`saveMultipleRdfToPod: error saving ${item.id}`, error)
+            failCount++
+        }
+    }
+
+    return { success: failCount === 0, successCount, failCount, totalCount: items.length + deleteCount }
 }
 
 /**
@@ -442,14 +607,16 @@ export async function syncAllDataFromPod(
 
     // ── Download question set and packing lists in parallel ──────────────────
     const [podQsResult, podListsResult] = await Promise.allSettled([
-        loadFileFromPod<PackingListQuestionSet>({
+        loadRdfFromPod<PackingListQuestionSet>(
             session,
-            fileUrl: `${podUrl}${POD_CONTAINERS.QUESTIONS}`,
-        }),
-        loadMultipleFilesFromPod<PackingList>({
+            `${podUrl}${POD_CONTAINERS.QUESTIONS}`,
+            datasetToQuestionSet,
+        ),
+        loadMultipleRdfFromPod<PackingList>(
             session,
-            containerPath: containerUrl,
-        }),
+            containerUrl,
+            datasetToPackingList,
+        ),
     ])
 
     // ── 1. Question set ──────────────────────────────────────────────────────
@@ -513,12 +680,11 @@ export async function syncAllDataFromPod(
     for (const localList of localLists) {
         if (podListIds.has(localList.id)) continue
         try {
-            const json = JSON.stringify(localList, null, 2)
-            const file = new File([json], `${localList.id}.json`, { type: 'application/json' })
-            await saveFileInContainer(containerUrl, file, {
-                slug: `${localList.id}.json`,
-                contentType: 'application/json',
-                fetch: session.fetch,
+            await saveRdfToPod({
+                session,
+                fileUrl: `${containerUrl}${localList.id}.ttl`,
+                data: localList,
+                serializer: packingListToDataset,
             })
             packingListsUploaded++
         } catch (err) {

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -1,10 +1,10 @@
 import { AppSession as Session } from '../types/AppSession'
-import { getPodUrlAll, saveFileInContainer, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile } from '@inrupt/solid-client'
+import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile } from '@inrupt/solid-client'
 import type { SolidDataset } from '@inrupt/solid-client'
 import { PackingAppDatabase } from './database'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList } from '../create-packing-list/types'
-import { packingListToDataset, datasetToPackingList, questionSetToDataset, datasetToQuestionSet } from './rdfSerialization'
+import { packingListToDataset, datasetToPackingList, datasetToQuestionSet } from './rdfSerialization'
 
 /**
  * Pod container paths under the user's Pod root

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -1,5 +1,5 @@
 import { AppSession as Session } from '../types/AppSession'
-import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile } from '@inrupt/solid-client'
+import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile, saveSolidDatasetAt, getThingAll, removeThing, setThing } from '@inrupt/solid-client'
 import type { SolidDataset } from '@inrupt/solid-client'
 import { PackingAppDatabase } from './database'
 import { PackingListQuestionSet } from '../edit-questions/types'
@@ -279,12 +279,43 @@ export async function loadRdfFromPod<T>(
 
 /**
  * Serializes data to RDF and saves it as a dataset at the given Pod URL.
+ *
+ * Fetches the existing resource first (if present) so that saveSolidDatasetAt can
+ * send a conditional PUT using the ETag rather than `If-None-Match: *`.
+ * Without this, ESS returns 412 Precondition Failed on second and subsequent saves.
  */
 export async function saveRdfToPod<T>(options: SaveRdfToPodOptions<T>): Promise<void> {
     const { session, fileUrl, data, serializer } = options
     try {
-        const dataset = serializer(data, fileUrl)
-        await saveSolidDatasetAt(fileUrl, dataset, { fetch: session.fetch })
+        const newDataset = serializer(data, fileUrl)
+
+        // Try to fetch the existing resource to obtain its ETag / resource info.
+        let existingDataset: SolidDataset | undefined
+        try {
+            existingDataset = await getSolidDataset(fileUrl, { fetch: session.fetch })
+        } catch (err) {
+            if (getStatusCode(err) !== 404) throw err
+            // 404 → new resource; If-None-Match: * is correct for creation
+        }
+
+        let datasetToSave: SolidDataset
+        if (existingDataset !== undefined) {
+            // Clear all Things from the fetched dataset (preserves internal_resourceInfo / ETag),
+            // then repopulate with the freshly serialised Things.
+            let cleared: SolidDataset = existingDataset
+            for (const thing of getThingAll(existingDataset)) {
+                cleared = removeThing(cleared, thing)
+            }
+            let merged: SolidDataset = cleared
+            for (const thing of getThingAll(newDataset)) {
+                merged = setThing(merged, thing)
+            }
+            datasetToSave = merged
+        } else {
+            datasetToSave = newDataset
+        }
+
+        await saveSolidDatasetAt(fileUrl, datasetToSave, { fetch: session.fetch })
     } catch (error: unknown) {
         if (isAuthenticationError(error)) handlePodError(error)
         throw error

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -1,5 +1,5 @@
 import { AppSession as Session } from '../types/AppSession'
-import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile, saveSolidDatasetAt, getThingAll, removeThing, setThing } from '@inrupt/solid-client'
+import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile, solidDatasetAsTurtle } from '@inrupt/solid-client'
 import type { SolidDataset } from '@inrupt/solid-client'
 import { PackingAppDatabase } from './database'
 import { PackingListQuestionSet } from '../edit-questions/types'
@@ -278,44 +278,18 @@ export async function loadRdfFromPod<T>(
 }
 
 /**
- * Serializes data to RDF and saves it as a dataset at the given Pod URL.
+ * Serializes data to RDF (Turtle) and saves it as a full PUT at the given Pod URL.
  *
- * Fetches the existing resource first (if present) so that saveSolidDatasetAt can
- * send a conditional PUT using the ETag rather than `If-None-Match: *`.
- * Without this, ESS returns 412 Precondition Failed on second and subsequent saves.
+ * Uses overwriteFile with solidDatasetAsTurtle to avoid SPARQL UPDATE (PATCH),
+ * which produces truncated Turtle on CSS v7 when adding new triples.
  */
 export async function saveRdfToPod<T>(options: SaveRdfToPodOptions<T>): Promise<void> {
     const { session, fileUrl, data, serializer } = options
     try {
         const newDataset = serializer(data, fileUrl)
-
-        // Try to fetch the existing resource to obtain its ETag / resource info.
-        let existingDataset: SolidDataset | undefined
-        try {
-            existingDataset = await getSolidDataset(fileUrl, { fetch: session.fetch })
-        } catch (err) {
-            if (getStatusCode(err) !== 404) throw err
-            // 404 → new resource; If-None-Match: * is correct for creation
-        }
-
-        let datasetToSave: SolidDataset
-        if (existingDataset !== undefined) {
-            // Clear all Things from the fetched dataset (preserves internal_resourceInfo / ETag),
-            // then repopulate with the freshly serialised Things.
-            let cleared: SolidDataset = existingDataset
-            for (const thing of getThingAll(existingDataset)) {
-                cleared = removeThing(cleared, thing)
-            }
-            let merged: SolidDataset = cleared
-            for (const thing of getThingAll(newDataset)) {
-                merged = setThing(merged, thing)
-            }
-            datasetToSave = merged
-        } else {
-            datasetToSave = newDataset
-        }
-
-        await saveSolidDatasetAt(fileUrl, datasetToSave, { fetch: session.fetch })
+        const turtleContent = await solidDatasetAsTurtle(newDataset)
+        const blob = new Blob([turtleContent], { type: 'text/turtle' })
+        await overwriteFile(fileUrl, blob, { fetch: session.fetch, contentType: 'text/turtle' })
     } catch (error: unknown) {
         if (isAuthenticationError(error)) handlePodError(error)
         throw error

--- a/src/services/solidPodBackup.test.ts
+++ b/src/services/solidPodBackup.test.ts
@@ -12,15 +12,20 @@ import type { PackingList } from '../create-packing-list/types'
 // Setup PouchDB with memory adapter for testing
 PouchDB.plugin(PouchDBMemoryAdapter)
 
-vi.mock('@inrupt/solid-client', () => ({
-    getFile: vi.fn(),
-    getSolidDataset: vi.fn(),
-    getContainedResourceUrlAll: vi.fn(),
-    getPodUrlAll: vi.fn(),
-    saveFileInContainer: vi.fn(),
-    overwriteFile: vi.fn(),
-    deleteFile: vi.fn(),
-}))
+vi.mock('@inrupt/solid-client', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@inrupt/solid-client')>()
+    return {
+        ...actual,
+        getFile: vi.fn(),
+        getSolidDataset: vi.fn(),
+        getContainedResourceUrlAll: vi.fn(),
+        getPodUrlAll: vi.fn(),
+        saveFileInContainer: vi.fn(),
+        overwriteFile: vi.fn(),
+        deleteFile: vi.fn(),
+        saveSolidDatasetAt: vi.fn(),
+    }
+})
 
 // Mock solidPod service functions
 vi.mock('./solidPod', async (importOriginal) => {
@@ -30,18 +35,21 @@ vi.mock('./solidPod', async (importOriginal) => {
         saveFileToPod: vi.fn(),
         loadFileFromPod: vi.fn(),
         saveMultipleFilesToPod: vi.fn(),
+        saveRdfToPod: vi.fn(),
+        saveMultipleRdfToPod: vi.fn(),
     }
 })
 
 import { getSolidDataset, getContainedResourceUrlAll, deleteFile } from '@inrupt/solid-client'
-import { saveFileToPod, loadFileFromPod, saveMultipleFilesToPod } from './solidPod'
+import { saveFileToPod, loadFileFromPod, saveRdfToPod, saveMultipleRdfToPod } from './solidPod'
 
 const mockGetSolidDataset = vi.mocked(getSolidDataset)
 const mockGetContainedResourceUrlAll = vi.mocked(getContainedResourceUrlAll)
 const mockDeleteFile = vi.mocked(deleteFile)
 const mockSaveFileToPod = vi.mocked(saveFileToPod)
 const mockLoadFileFromPod = vi.mocked(loadFileFromPod)
-const mockSaveMultipleFilesToPod = vi.mocked(saveMultipleFilesToPod)
+const mockSaveRdfToPod = vi.mocked(saveRdfToPod)
+const mockSaveMultipleRdfToPod = vi.mocked(saveMultipleRdfToPod)
 
 const mockSession = {
     info: { isLoggedIn: true, webId: 'https://example.com/profile#me' },
@@ -327,8 +335,8 @@ describe('restoreBackup', () => {
             packingLists: [{ ...mockPackingList, id: 'new-list' }]
         }
         mockLoadFileFromPod.mockResolvedValue(backupFile)
-        mockSaveFileToPod.mockResolvedValue(undefined)
-        mockSaveMultipleFilesToPod.mockResolvedValue({ success: true, successCount: 1, failCount: 0, totalCount: 1 })
+        mockSaveRdfToPod.mockResolvedValue(undefined)
+        mockSaveMultipleRdfToPod.mockResolvedValue({ success: true, successCount: 1, failCount: 0, totalCount: 1 })
 
         await restoreBackup(mockSession, POD_URL, db, backupUrl)
 
@@ -345,8 +353,8 @@ describe('restoreBackup', () => {
             packingLists: [mockPackingList, { ...mockPackingList, id: 'pl-2', name: 'Mountain Trip' }]
         }
         mockLoadFileFromPod.mockResolvedValue(backupFile)
-        mockSaveFileToPod.mockResolvedValue(undefined)
-        mockSaveMultipleFilesToPod.mockResolvedValue({ success: true, successCount: 2, failCount: 0, totalCount: 2 })
+        mockSaveRdfToPod.mockResolvedValue(undefined)
+        mockSaveMultipleRdfToPod.mockResolvedValue({ success: true, successCount: 2, failCount: 0, totalCount: 2 })
 
         await restoreBackup(mockSession, POD_URL, db, backupUrl)
 
@@ -364,8 +372,8 @@ describe('restoreBackup', () => {
             packingLists: []
         }
         mockLoadFileFromPod.mockResolvedValue(backupFile)
-        mockSaveFileToPod.mockResolvedValue(undefined)
-        mockSaveMultipleFilesToPod.mockResolvedValue({ success: true, successCount: 0, failCount: 0, totalCount: 0 })
+        mockSaveRdfToPod.mockResolvedValue(undefined)
+        mockSaveMultipleRdfToPod.mockResolvedValue({ success: true, successCount: 0, failCount: 0, totalCount: 0 })
 
         await restoreBackup(mockSession, POD_URL, db, backupUrl)
 
@@ -373,7 +381,7 @@ describe('restoreBackup', () => {
         expect(qs.people).toEqual(mockQuestionSet.people)
     })
 
-    it('calls saveFileToPod for question set when present', async () => {
+    it('calls saveRdfToPod for question set when present', async () => {
         const backupFile = {
             version: 1 as const,
             createdAt: '2025-01-01T00:00:00.000Z',
@@ -381,21 +389,20 @@ describe('restoreBackup', () => {
             packingLists: []
         }
         mockLoadFileFromPod.mockResolvedValue(backupFile)
-        mockSaveFileToPod.mockResolvedValue(undefined)
-        mockSaveMultipleFilesToPod.mockResolvedValue({ success: true, successCount: 0, failCount: 0, totalCount: 0 })
+        mockSaveRdfToPod.mockResolvedValue(undefined)
+        mockSaveMultipleRdfToPod.mockResolvedValue({ success: true, successCount: 0, failCount: 0, totalCount: 0 })
 
         await restoreBackup(mockSession, POD_URL, db, backupUrl)
 
-        expect(mockSaveFileToPod).toHaveBeenCalledWith(
+        expect(mockSaveRdfToPod).toHaveBeenCalledWith(
             expect.objectContaining({
                 session: mockSession,
-                containerPath: `${POD_URL}pack-me-up/`,
-                filename: 'packing-list-questions.json',
+                fileUrl: `${POD_URL}pack-me-up/packing-list-questions.ttl`,
             })
         )
     })
 
-    it('calls saveMultipleFilesToPod for packing lists', async () => {
+    it('calls saveMultipleRdfToPod for packing lists', async () => {
         const backupFile = {
             version: 1 as const,
             createdAt: '2025-01-01T00:00:00.000Z',
@@ -403,19 +410,20 @@ describe('restoreBackup', () => {
             packingLists: [mockPackingList]
         }
         mockLoadFileFromPod.mockResolvedValue(backupFile)
-        mockSaveFileToPod.mockResolvedValue(undefined)
-        mockSaveMultipleFilesToPod.mockResolvedValue({ success: true, successCount: 1, failCount: 0, totalCount: 1 })
+        mockSaveRdfToPod.mockResolvedValue(undefined)
+        mockSaveMultipleRdfToPod.mockResolvedValue({ success: true, successCount: 1, failCount: 0, totalCount: 1 })
 
         await restoreBackup(mockSession, POD_URL, db, backupUrl)
 
-        expect(mockSaveMultipleFilesToPod).toHaveBeenCalledWith(
+        expect(mockSaveMultipleRdfToPod).toHaveBeenCalledWith(
             mockSession,
             `${POD_URL}pack-me-up/packing-lists/`,
-            expect.arrayContaining([expect.objectContaining({ id: 'pl-1' })])
+            expect.arrayContaining([expect.objectContaining({ id: 'pl-1' })]),
+            expect.any(Function)
         )
     })
 
-    it('does not call saveFileToPod for question set when not present', async () => {
+    it('does not call saveRdfToPod for question set when not present', async () => {
         const backupFile = {
             version: 1 as const,
             createdAt: '2025-01-01T00:00:00.000Z',
@@ -423,12 +431,12 @@ describe('restoreBackup', () => {
             packingLists: []
         }
         mockLoadFileFromPod.mockResolvedValue(backupFile)
-        mockSaveFileToPod.mockResolvedValue(undefined)
-        mockSaveMultipleFilesToPod.mockResolvedValue({ success: true, successCount: 0, failCount: 0, totalCount: 0 })
+        mockSaveRdfToPod.mockResolvedValue(undefined)
+        mockSaveMultipleRdfToPod.mockResolvedValue({ success: true, successCount: 0, failCount: 0, totalCount: 0 })
 
         await restoreBackup(mockSession, POD_URL, db, backupUrl)
 
-        expect(mockSaveFileToPod).not.toHaveBeenCalled()
+        expect(mockSaveRdfToPod).not.toHaveBeenCalled()
     })
 
     it('handles missing question set in DB gracefully (not_found)', async () => {
@@ -440,8 +448,8 @@ describe('restoreBackup', () => {
             packingLists: []
         }
         mockLoadFileFromPod.mockResolvedValue(backupFile)
-        mockSaveFileToPod.mockResolvedValue(undefined)
-        mockSaveMultipleFilesToPod.mockResolvedValue({ success: true, successCount: 0, failCount: 0, totalCount: 0 })
+        mockSaveRdfToPod.mockResolvedValue(undefined)
+        mockSaveMultipleRdfToPod.mockResolvedValue({ success: true, successCount: 0, failCount: 0, totalCount: 0 })
 
         // Should not throw even if question set doesn't exist in DB before restore
         await expect(restoreBackup(mockSession, POD_URL, db, backupUrl)).resolves.not.toThrow()

--- a/src/services/solidPodBackup.ts
+++ b/src/services/solidPodBackup.ts
@@ -6,11 +6,13 @@ import { PackingAppDatabase } from './database'
 import {
     saveFileToPod,
     loadFileFromPod,
-    saveMultipleFilesToPod,
+    saveRdfToPod,
+    saveMultipleRdfToPod,
     handlePodError,
     isAuthenticationError,
     POD_CONTAINERS,
 } from './solidPod'
+import { questionSetToDataset, packingListToDataset } from './rdfSerialization'
 
 function hasName(err: unknown): err is { name: string } {
     return typeof err === 'object' && err !== null && 'name' in err
@@ -173,19 +175,20 @@ export async function restoreBackup(
         await db.savePackingList({ ...list, _rev: undefined })
     }
 
-    // 5. Push to live pod
+    // 5. Push to live pod as RDF
     if (backupFile.questionSet) {
-        await saveFileToPod({
+        await saveRdfToPod({
             session,
-            containerPath: `${podUrl}${POD_CONTAINERS.ROOT}`,
-            filename: 'packing-list-questions.json',
+            fileUrl: `${podUrl}${POD_CONTAINERS.QUESTIONS}`,
             data: backupFile.questionSet,
+            serializer: questionSetToDataset,
         })
     }
 
-    await saveMultipleFilesToPod(
+    await saveMultipleRdfToPod(
         session,
         `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`,
-        backupFile.packingLists
+        backupFile.packingLists,
+        packingListToDataset
     )
 }

--- a/src/services/solidPodBackup.ts
+++ b/src/services/solidPodBackup.ts
@@ -146,33 +146,28 @@ export async function restoreBackup(
         fileUrl: backupUrl,
     })
 
-    // 2. Delete all existing packing lists from local DB
+    // 2. Snapshot current list IDs so we can clean up extras after restoring.
+    //    Do NOT delete lists first: deleting then re-creating the same ID in PouchDB
+    //    leaves a tombstone that causes a 409 conflict on re-creation.
     const existingLists = await db.getAllPackingLists()
-    for (const list of existingLists) {
-        await db.deletePackingList(list.id)
-    }
+    const backupListIds = new Set(backupFile.packingLists.map(l => l.id))
 
-    // 3. Try to delete existing question set (catch not_found gracefully)
-    try {
-        const qs = await db.getQuestionSet()
-        // To delete, we need to save with an intent to remove - but PouchDB doesn't have a simple
-        // deleteQuestionSet method. We'll handle by overwriting with the backup data.
-        // If there's no backup question set, we need to clear it by removing the doc.
-        // Since PackingAppDatabase doesn't expose a deleteQuestionSet, we do this via the raw db.
-        // We'll overwrite it below regardless, so just proceed.
-        void qs // suppress unused warning
-    } catch (err: unknown) {
-        if (!hasName(err) || err.name !== 'not_found') throw err
-        // Question set doesn't exist - that's fine
-    }
-
-    // 4. Save restored question set + packing lists to local DB
+    // 3. Save restored question set + packing lists to local DB.
+    //    saveQuestionSet / savePackingList each read the existing _rev so they
+    //    overwrite in-place without conflicts.
     if (backupFile.questionSet) {
         await db.saveQuestionSet({ ...backupFile.questionSet, _rev: undefined })
     }
 
     for (const list of backupFile.packingLists) {
         await db.savePackingList({ ...list, _rev: undefined })
+    }
+
+    // 4. Delete any local lists that are not in the backup
+    for (const list of existingLists) {
+        if (!backupListIds.has(list.id)) {
+            await db.deletePackingList(list.id)
+        }
     }
 
     // 5. Push to live pod as RDF


### PR DESCRIPTION
Solid pods now store packing data as RDF Turtle files instead of JSON,
improving Solid ecosystem interoperability. Existing users are auto-migrated
on login without data loss.

- Add rdfVocab.ts: PMU namespace constants and DCTERMS/RDF re-exports
- Add rdfSerialization.ts: round-trip serialize/deserialize for PackingList
  and PackingListQuestionSet using @inrupt/solid-client buildThing/getThing
- Add rdfMigration.ts: detectPodDataFormat and migrateJsonToRdf that reads
  legacy JSON files, writes .ttl equivalents, and stamps a migration marker
- Extend solidPod.ts: loadRdfFromPod, saveRdfToPod, loadMultipleRdfFromPod,
  saveMultipleRdfToPod; update POD_CONTAINERS (.json → .ttl); update
  hasPodData and syncAllDataFromPod to use RDF functions
- Update usePodSync: add required rdf: { serialize, deserialize } field,
  replace loadFileFromPod/saveFileToPod with RDF equivalents
- Wire migration into DatabaseContext: detect format and migrate before sync
- Update all usePodSync callers (4 pages) to pass RDF serializers and .ttl
  filenames
- Update solidPodBackup: restoreBackup writes to pod via saveRdfToPod and
  saveMultipleRdfToPod instead of the legacy JSON functions

All 346 tests pass; TypeScript compiles cleanly.

https://claude.ai/code/session_01LFMPcNU16vec41wXNkndEn