### PR TITLE
Add JSON schema compatibility E2E tests (K suite)

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,5 +1,5 @@
 import { test as base, BrowserContext, Page } from '@playwright/test'
-import { AUTH_STATE_FILE, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD } from '../playwright.config'
+import { AUTH_STATE_FILE, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD, SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD } from '../playwright.config'
 import { loginToCss } from './helpers/login'
 
 type MyFixtures = {
@@ -9,6 +9,8 @@ type MyFixtures = {
   authedPage: Page
   /** A fresh context with a pre-loaded auth state */
   authedContext: BrowserContext
+  /** A page logged in as the schema-compat account (pod pre-seeded with v1 JSON fixtures) */
+  schemaCompatPage: Page
 }
 
 export const test = base.extend<MyFixtures>({
@@ -41,6 +43,15 @@ export const test = base.extend<MyFixtures>({
     await page.goto('/')
     await page.getByRole('button', { name: 'Logout' }).first().waitFor({ state: 'visible', timeout: 30_000 })
     await use(page)
+  },
+
+  schemaCompatPage: async ({ browser }, use) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    await page.goto('/')
+    await loginToCss(page, CSS_ISSUER, SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD)
+    await use(page)
+    await context.close()
   },
 })
 

--- a/e2e/fixtures/v1-packing-list.json
+++ b/e2e/fixtures/v1-packing-list.json
@@ -1,0 +1,31 @@
+{
+  "id": "v1-list-schema-compat",
+  "name": "Schema Compat Test Trip",
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "lastModified": "2024-01-01T00:00:00.000Z",
+  "items": [
+    {
+      "id": "sc-item-1",
+      "itemText": "Pyjamas",
+      "personId": "sc-person-1",
+      "personName": "Alice",
+      "questionId": "sc-q-1",
+      "optionId": "sc-opt-yes",
+      "packed": false,
+      "category": "Clothes",
+      "reviewed": false
+    },
+    {
+      "id": "sc-item-2",
+      "itemText": "Passport",
+      "personId": "sc-person-1",
+      "personName": "Alice",
+      "questionId": "",
+      "optionId": "",
+      "packed": false,
+      "category": "Travel Documents",
+      "reviewed": false
+    }
+  ],
+  "deletedItems": []
+}

--- a/e2e/fixtures/v1-question-set.json
+++ b/e2e/fixtures/v1-question-set.json
@@ -1,0 +1,49 @@
+{
+  "people": [
+    {
+      "id": "sc-person-1",
+      "name": "Alice",
+      "ageRange": "Adult",
+      "gender": "female"
+    }
+  ],
+  "alwaysNeededItems": [
+    {
+      "text": "Passport",
+      "personSelections": [
+        { "personId": "sc-person-1", "selected": true }
+      ]
+    }
+  ],
+  "questions": [
+    {
+      "id": "sc-q-1",
+      "type": "saved",
+      "text": "Will you be staying overnight?",
+      "questionType": "single-choice",
+      "order": 0,
+      "options": [
+        {
+          "id": "sc-opt-yes",
+          "text": "Yes",
+          "order": 0,
+          "items": [
+            {
+              "text": "Pyjamas",
+              "personSelections": [
+                { "personId": "sc-person-1", "selected": true }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "sc-opt-no",
+          "text": "No",
+          "order": 1,
+          "items": []
+        }
+      ]
+    }
+  ],
+  "lastModified": "2024-01-01T00:00:00.000Z"
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -5,10 +5,14 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import { createCssAccount } from './helpers/css-api'
 import { loginToCss } from './helpers/login'
+import { loginToExistingCssAccount, createCssClientCredentials, getCssBearerToken, seedPodWithJsonFixtures } from './helpers/pod-seed'
 import {
   CSS_PORT, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD, TEST_POD_NAME,
-  AUTH_STATE_FILE, CSS_PID_FILE, APP_URL
+  AUTH_STATE_FILE, CSS_PID_FILE, APP_URL,
+  SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD, SCHEMA_COMPAT_POD_NAME,
 } from '../playwright.config'
+import v1QuestionSet from './fixtures/v1-question-set.json' with { type: 'json' }
+import v1PackingList from './fixtures/v1-packing-list.json' with { type: 'json' }
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const localChromium = process.env.CHROMIUM_PATH ?? '/opt/pw-browsers/chromium-1194/chrome-linux/chrome'
@@ -42,9 +46,24 @@ export default async function globalSetup() {
   await waitForUrl(`http://localhost:${CSS_PORT}/.account/`)
   console.log('[setup] CSS ready')
 
-  // 2. Create test account
+  // 2. Create test accounts
   await createCssAccount(CSS_PORT, TEST_EMAIL, TEST_PASSWORD, TEST_POD_NAME)
   console.log(`[setup] Test account created: ${TEST_EMAIL}`)
+
+  await createCssAccount(CSS_PORT, SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD, SCHEMA_COMPAT_POD_NAME)
+  console.log(`[setup] Schema-compat account created: ${SCHEMA_COMPAT_EMAIL}`)
+
+  // 2a. Seed schema-compat pod with v1 JSON fixtures (server-side, no browser needed)
+  const accountToken = await loginToExistingCssAccount(CSS_PORT, SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD)
+  const webId = `http://localhost:${CSS_PORT}/${SCHEMA_COMPAT_POD_NAME}/profile/card#me`
+  const { id: clientId, secret: clientSecret } = await createCssClientCredentials(CSS_PORT, accountToken, webId)
+  const podUrl = `http://localhost:${CSS_PORT}/${SCHEMA_COMPAT_POD_NAME}/`
+  const bearerToken = await getCssBearerToken(CSS_PORT, clientId, clientSecret, webId)
+  await seedPodWithJsonFixtures(podUrl, bearerToken, {
+    questionSet: v1QuestionSet,
+    packingLists: [v1PackingList],
+  })
+  console.log('[setup] Schema-compat pod seeded with v1 JSON fixtures')
 
   // 3. Wait for app
   console.log('[setup] Waiting for app...')

--- a/e2e/helpers/pod-seed.ts
+++ b/e2e/helpers/pod-seed.ts
@@ -1,0 +1,141 @@
+import type { PackingListQuestionSet } from '../../src/edit-questions/types'
+import type { PackingList } from '../../src/create-packing-list/types'
+
+/**
+ * Log in to an existing CSS account and return the CSS-Account-Token.
+ */
+export async function loginToExistingCssAccount(
+  port: number,
+  email: string,
+  password: string,
+): Promise<string> {
+  const base = `http://localhost:${port}`
+  const res = await fetch(`${base}/.account/login/password/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+  if (!res.ok) {
+    throw new Error(`CSS login failed: ${res.status} ${await res.text()}`)
+  }
+  const data = await res.json() as Record<string, unknown>
+  return data.authorization as string
+}
+
+/**
+ * Create OAuth client credentials for a CSS account.
+ * Returns { id, secret } suitable for the client_credentials grant.
+ *
+ * CSS v7 controls structure: controls.account.clientCredentials is the POST URL.
+ */
+export async function createCssClientCredentials(
+  port: number,
+  accountToken: string,
+  webId: string,
+): Promise<{ id: string; secret: string }> {
+  const base = `http://localhost:${port}`
+
+  const controlsRes = await fetch(`${base}/.account/`, {
+    headers: { Authorization: `CSS-Account-Token ${accountToken}` },
+  })
+  if (!controlsRes.ok) {
+    throw new Error(`CSS controls fetch failed: ${controlsRes.status} ${await controlsRes.text()}`)
+  }
+  const controlsData = await controlsRes.json() as { controls: { account: { clientCredentials: string } } }
+  const credentialsUrl = controlsData.controls?.account?.clientCredentials
+  if (!credentialsUrl) {
+    throw new Error('Could not find controls.account.clientCredentials URL in CSS controls response')
+  }
+
+  const credRes = await fetch(credentialsUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `CSS-Account-Token ${accountToken}`,
+    },
+    body: JSON.stringify({ name: 'pod-seed-client', webId }),
+  })
+  if (!credRes.ok) {
+    throw new Error(`CSS client credentials creation failed: ${credRes.status} ${await credRes.text()}`)
+  }
+  const credData = await credRes.json() as Record<string, unknown>
+  return { id: credData.id as string, secret: credData.secret as string }
+}
+
+/**
+ * Exchange CSS client credentials for a Bearer access token via the
+ * OAuth client_credentials grant.
+ */
+export async function getCssBearerToken(
+  port: number,
+  clientId: string,
+  clientSecret: string,
+  webId: string,
+): Promise<string> {
+  const base = `http://localhost:${port}`
+
+  const oidcRes = await fetch(`${base}/.well-known/openid-configuration`)
+  if (!oidcRes.ok) {
+    throw new Error(`OIDC config fetch failed: ${oidcRes.status}`)
+  }
+  const oidcData = await oidcRes.json() as Record<string, unknown>
+  const tokenEndpoint = oidcData.token_endpoint as string
+
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+  const tokenRes = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${credentials}`,
+    },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      webid: webId,
+      scope: 'webid',
+    }).toString(),
+  })
+  if (!tokenRes.ok) {
+    throw new Error(`CSS token exchange failed: ${tokenRes.status} ${await tokenRes.text()}`)
+  }
+  const tokenData = await tokenRes.json() as Record<string, unknown>
+  return tokenData.access_token as string
+}
+
+/**
+ * Write v1 JSON fixtures directly to a CSS pod via authenticated HTTP PUT.
+ * CSS creates intermediate LDP containers automatically on PUT.
+ */
+export async function seedPodWithJsonFixtures(
+  podUrl: string,
+  bearerToken: string,
+  fixtures: { questionSet: PackingListQuestionSet; packingLists: PackingList[] },
+): Promise<void> {
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${bearerToken}`,
+  }
+
+  // Question set
+  const qsUrl = `${podUrl}pack-me-up/packing-list-questions.json`
+  const qsRes = await fetch(qsUrl, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify(fixtures.questionSet, null, 2),
+  })
+  if (!qsRes.ok) {
+    throw new Error(`Failed to seed question set: ${qsRes.status} ${await qsRes.text()}`)
+  }
+
+  // Packing lists
+  for (const list of fixtures.packingLists) {
+    const listUrl = `${podUrl}pack-me-up/packing-lists/${list.id}.json`
+    const listRes = await fetch(listUrl, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify(list, null, 2),
+    })
+    if (!listRes.ok) {
+      throw new Error(`Failed to seed packing list ${list.id}: ${listRes.status} ${await listRes.text()}`)
+    }
+  }
+}

--- a/e2e/tests/k-schema-compat.spec.ts
+++ b/e2e/tests/k-schema-compat.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * K – JSON Schema Compatibility
+ *
+ * Guards against regressions in the JSON data read path during the planned
+ * migration to RDF storage. The schema-compat pod is pre-seeded in globalSetup
+ * with committed v1 JSON fixtures (e2e/fixtures/). If any field rename or
+ * structural change breaks the read path, one of these tests will fail.
+ */
+import { test, expect } from '../fixtures'
+
+test.describe('K – JSON Schema Compatibility', () => {
+  test('K1: question set page loads people and questions from v1 JSON', async ({ schemaCompatPage: page }) => {
+    await page.goto('/#/manage-questions')
+    await page.waitForLoadState('networkidle')
+
+    // Expand People section (collapsed by default)
+    await page.getByRole('button', { name: /People/i }).first().click()
+    await expect(page.getByRole('button', { name: 'Add Person' })).toBeVisible({ timeout: 5_000 })
+
+    // "Alice" from the fixture should be in the name input (pattern from f-sync tests)
+    const personInputs = page.locator('input[placeholder="Enter person name"]')
+    await expect(personInputs.first()).toHaveValue('Alice', { timeout: 20_000 })
+
+    // The question from the fixture should be in the question text input
+    const questionInputs = page.locator('input[placeholder="Enter your question"]')
+    await expect(questionInputs.first()).toHaveValue('Will you be staying overnight?', { timeout: 10_000 })
+  })
+
+  test('K2: individual packing list loads items from v1 JSON', async ({ schemaCompatPage: page }) => {
+    await page.goto('/#/view-lists')
+
+    // Wait for pod sync to complete before checking list presence
+    await page.waitForSelector('text=Loading packing lists...', { state: 'hidden', timeout: 60_000 })
+
+    // The pre-seeded list should be visible
+    await expect(page.getByText('Schema Compat Test Trip')).toBeVisible({ timeout: 10_000 })
+
+    // Navigate into the list
+    await page.getByText('Schema Compat Test Trip').click()
+    await page.waitForURL(/#\/view-lists\//, { timeout: 8_000 })
+
+    // Items from the fixture should be visible
+    await expect(page.getByText('Pyjamas')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('Passport')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('K3: new packing list can be created when question set is loaded from v1 JSON', async ({ schemaCompatPage: page }) => {
+    // Wait for sync to complete via view-lists (same pattern as K2) before navigating to create.
+    // Use the nav link for subsequent navigation (hash change, no full page reload/OIDC re-auth).
+    await page.goto('/#/view-lists')
+    await page.waitForSelector('text=Loading packing lists...', { state: 'hidden', timeout: 60_000 })
+
+    await page.getByRole('link', { name: 'Create List' }).click()
+    await page.waitForURL(/#\/create-packing-list/, { timeout: 5_000 })
+
+    // The question from the fixture should appear as a form question
+    await expect(page.getByText('Will you be staying overnight?')).toBeVisible({ timeout: 10_000 })
+
+    // Fill in a name and create the list
+    await page.getByPlaceholder('Enter a name for your packing list').fill('K3 New List')
+    await page.getByRole('button', { name: 'Create Packing List' }).click()
+
+    // Should navigate to the new list's view page
+    await page.waitForURL(/#\/view-lists\//, { timeout: 8_000 })
+    await expect(page.getByText('K3 New List')).toBeVisible()
+  })
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,9 @@ export const TEST_EMAIL = 'test@example.com'
 export const TEST_PASSWORD = 'test1234'
 export const TEST_POD_NAME = 'testuser'
 export const AUTH_STATE_FILE = path.join(__dirname, 'e2e/.auth/user.json')
+export const SCHEMA_COMPAT_EMAIL = 'schema-compat@example.com'
+export const SCHEMA_COMPAT_PASSWORD = 'test1234'
+export const SCHEMA_COMPAT_POD_NAME = 'schemacompat'
 export const CSS_PID_FILE = path.join(__dirname, '.e2e-css-pid')
 export const APP_URL = 'http://localhost:4173'
 


### PR DESCRIPTION
Pre-seeds a dedicated Solid pod (schema-compat account) with committed v1 JSON
fixtures in globalSetup, then verifies the app correctly loads and renders that
data via three Playwright tests:
- K1: question set page shows people and questions from v1 JSON
- K2: individual packing list page renders v1 items correctly
- K3: new packing list can still be created against a v1 question set

Provides a regression guard for the JSON read path during a planned migration
to RDF storage — any breaking field rename or structural change will cause these
tests to fail.

https://claude.ai/code/session_01SYHeHAcxHq1avDU2dDytrF