### PR TITLE
Keep session alive with periodic authenticated requests

### DIFF
--- a/src/components/SolidPodContext.test.tsx
+++ b/src/components/SolidPodContext.test.tsx
@@ -217,6 +217,34 @@ describe('SolidPodContext', () => {
         })
     })
 
+    it('periodically calls session.fetch to keep the session alive', async () => {
+        const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+
+        mockSession = makeMockSession(true, 'https://user.example.org/profile/card#me')
+        mockGetDefaultSession.mockReturnValue(mockSession as never)
+
+        render(<Wrapper><Consumer /></Wrapper>)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('true')
+        })
+
+        const keepaliveCall = setIntervalSpy.mock.calls.find(
+            ([, delay]) => delay === 10 * 60 * 1000
+        )
+        expect(keepaliveCall).toBeDefined()
+
+        mockSession.fetch.mockClear()
+        await act(async () => {
+            await (keepaliveCall![0] as () => Promise<void>)()
+        })
+
+        expect(mockSession.fetch).toHaveBeenCalledWith(
+            'https://user.example.org/profile/card#me',
+            { method: 'HEAD' }
+        )
+    })
+
     it('clearSessionExpired sets sessionExpired to false', async () => {
         mockSession = makeMockSession(true, 'https://user.example.org/profile/card#me')
         mockGetDefaultSession.mockReturnValue(mockSession as never)

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -197,6 +197,25 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
   }, [session, session?.info.isLoggedIn, session?.info.webId]);
 
+  // Periodically make an authenticated request so the library uses its refresh
+  // token to renew the access token before it expires, preventing unnecessary
+  // re-logins when the access token silently expires between user actions.
+  useEffect(() => {
+    if (!session?.info.isLoggedIn || !session?.info.webId) {
+      return;
+    }
+
+    const intervalId = setInterval(async () => {
+      try {
+        await session.fetch(session.info.webId!, { method: 'HEAD' });
+      } catch {
+        // Best-effort: session event listeners handle any real auth failures
+      }
+    }, 10 * 60 * 1000);
+
+    return () => clearInterval(intervalId);
+  }, [session, session?.info.isLoggedIn, session?.info.webId]);
+
   const login = async (oidcIssuer: string, returnTo?: string) => {
     const currentLocation = returnTo || window.location.hash.substring(1) || "/";
     const redirectUrl = new URL("/pod-auth-callback.html", window.location.href);


### PR DESCRIPTION
## Summary
Adds automatic session keepalive functionality to prevent unnecessary re-logins when access tokens silently expire between user actions.

## Changes
- **SolidPodContext.tsx**: Added a new `useEffect` hook that periodically makes authenticated HEAD requests to the user's WebID every 10 minutes when logged in. This triggers the session library's refresh token mechanism to renew the access token before expiration, preventing silent auth failures.
- **SolidPodContext.test.tsx**: Added test coverage verifying that the keepalive interval is set up correctly and that it calls `session.fetch` with the expected parameters (HEAD request to user's WebID).

## Implementation Details
- The keepalive request uses a HEAD method to minimize server load
- Errors are silently caught since session event listeners already handle authentication failures
- The interval is properly cleaned up when the component unmounts or when the user logs out
- Only active when user is logged in (`session?.info.isLoggedIn` is true)

https://claude.ai/code/session_01DoAGsHVa7FpyqdtD2HMEmz