### PR TITLE
Fix suggestion-card items not saving to pod or persisting in question set

### DIFF
--- a/e2e/tests/f-sync.spec.ts
+++ b/e2e/tests/f-sync.spec.ts
@@ -156,6 +156,42 @@ test.describe('F – Solid Pod Sync', () => {
     await expect(page.locator(`input[name="${box1Name}"]`)).toBeChecked({ timeout: 5_000 })
   })
 
+  test('F6: custom item added via suggestion card persists in question set after pod sync', async ({ authedPage: page }) => {
+    await runWizardLoggedIn(page)
+    await createList(page, 'Suggestion Save Trip')
+
+    // Add a custom item (questionId = '' marks it as a suggestion candidate)
+    const customItemName = 'super special sunscreen'
+    await page.getByPlaceholder('Add new item...').first().fill(customItemName)
+    await page.getByRole('button', { name: 'Add' }).first().click()
+    await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
+    await expect(page.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 5_000 })
+
+    // Trigger the suggestion card by navigating to create-packing-list
+    await page.goto('/#/create-packing-list')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(/On past trips you added items/)).toBeVisible({ timeout: 8_000 })
+
+    // Expand and accept the suggestion (default destination: Always Needed Items)
+    await page.getByRole('button', { name: /Review suggestions/i }).click()
+    await expect(page.getByText(customItemName)).toBeVisible({ timeout: 3_000 })
+    await page.getByRole('button', { name: 'Add' }).first().click()
+    // Wait for suggestion card to disappear (item marked reviewed, pod save complete)
+    await expect(page.getByText(/On past trips you added items/)).not.toBeVisible({ timeout: 10_000 })
+
+    // Navigate to manage-questions and verify the item survives pod sync
+    await page.goto('/#/manage-questions')
+    await page.waitForLoadState('networkidle')
+    await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
+    await expect(page.getByRole('button', { name: 'Add Item' })).toBeVisible({ timeout: 3_000 })
+
+    // Wait a full pod-poll cycle (5 s) + buffer so the sync fires.
+    // Without the fix the pod would overwrite the local change and the item disappears.
+    await page.waitForTimeout(7_000)
+
+    await expect(page.getByText(customItemName)).toBeVisible({ timeout: 3_000 })
+  })
+
   test('F4: item check state visible from second context after Pod sync', async ({ authedPage: page, browser }) => {
     await runWizardLoggedIn(page)
     await createList(page, 'Check Sync Test')

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -317,7 +317,7 @@ export function CreatePackingList() {
         }
     }, [questionSet, db])
 
-    usePodSync<PackingListQuestionSet>({
+    const { saveToPod: saveQuestionSetToPod } = usePodSync<PackingListQuestionSet>({
         pathConfig: {
             container: POD_CONTAINERS.ROOT,
             filename: 'packing-list-questions.json',
@@ -401,8 +401,16 @@ export function CreatePackingList() {
                 ),
             }
         }
-        const { rev } = await db.saveQuestionSet(updatedQs)
-        setQuestionSet({ ...updatedQs, _rev: rev })
+        // Stamp a lastModified so manage-questions' fallback-to-pod sync resolution
+        // won't overwrite this save with stale pod data.
+        const updatedQsWithTimestamp = { ...updatedQs, lastModified: new Date().toISOString() }
+        const { rev } = await db.saveQuestionSet(updatedQsWithTimestamp)
+        const savedQs = { ...updatedQsWithTimestamp, _rev: rev }
+        setQuestionSet(savedQs)
+
+        // Push to pod so the updated question set is available on any device and
+        // survives the next pod sync in manage-questions.
+        await saveQuestionSetToPod(savedQs)
 
         await markReviewed(listId, item)
     }


### PR DESCRIPTION
handleSaveToQuestionSet was saving the updated question set to local DB
only. When the user navigated to manage-questions, the page's pod-polling
sync (fallback-to-pod strategy) would overwrite the local change because
the question set had no lastModified timestamp — pod always won.

Two-part fix:
- Stamp a lastModified on the updated question set before the local save,
  so conflict resolution has a proper anchor.
- Push the updated question set to the pod immediately after the local
  save (using the existing usePodSync saveToPod), so the pod and local DB
  stay in sync.

Adds e2e test F6 (inside the serial F-sync block to avoid pod-state
interference) that reproduces the bug: creates a custom packing-list
item, accepts it via the suggestion card, navigates to manage-questions,
waits a full pod-poll cycle, and asserts the item is still visible.

https://claude.ai/code/session_01RAokABr8LnypSH3PTcxQV4