### PR TITLE
Fix visual bug: orphaned 'for' label and misaligned buttons in deletion suggestion card

### DIFF
--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -250,11 +250,11 @@ function DeletionSuggestionCard({ suggestions, onRemovePermanently, onKeep, onDi
                             <p className="text-sm text-red-700 font-semibold mb-2">From: {listName}</p>
                             <div className="space-y-2">
                                 {items.map(({ listId, item }) => (
-                                    <div key={item.id} className="flex items-center justify-between gap-2 bg-white rounded border border-red-200 px-3 py-2">
-                                        <div>
+                                    <div key={item.id} className="flex items-start justify-between gap-2 bg-white rounded border border-red-200 px-3 py-2">
+                                        <div className="flex flex-col">
                                             <span className="font-medium text-gray-900">{item.itemText}</span>
                                             {item.personName && (
-                                                <span className="ml-2 text-sm text-gray-500">for {item.personName}</span>
+                                                <span className="text-sm text-gray-500">for {item.personName}</span>
                                             )}
                                         </div>
                                         <div className="flex gap-2 flex-shrink-0">


### PR DESCRIPTION
Use flex-col in the item text container so the person name always appears below
the item name rather than inline (which caused 'for' to dangle at the end of the
item name line). Also switch row alignment to items-start so buttons anchor to
the top of tall multi-line rows instead of floating in the middle.