### PR TITLE
Fix visual layout of deletion suggestion card items

### DIFF
--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -250,14 +250,14 @@ function DeletionSuggestionCard({ suggestions, onRemovePermanently, onKeep, onDi
                             <p className="text-sm text-red-700 font-semibold mb-2">From: {listName}</p>
                             <div className="space-y-2">
                                 {items.map(({ listId, item }) => (
-                                    <div key={item.id} className="flex items-start justify-between gap-2 bg-white rounded border border-red-200 px-3 py-2">
-                                        <div className="flex flex-col">
+                                    <div key={item.id} className="flex flex-col gap-2 bg-white rounded border border-red-200 px-3 py-2">
+                                        <div>
                                             <span className="font-medium text-gray-900">{item.itemText}</span>
                                             {item.personName && (
-                                                <span className="text-sm text-gray-500">for {item.personName}</span>
+                                                <span className="ml-2 text-sm text-gray-500">for {item.personName}</span>
                                             )}
                                         </div>
-                                        <div className="flex gap-2 flex-shrink-0">
+                                        <div className="flex gap-2">
                                             <Button
                                                 type="button"
                                                 variant="primary"


### PR DESCRIPTION
## Summary

- Switches item rows in the deletion suggestion card from a side-by-side flex layout to a stacked column layout (text above, buttons below)
- The previous horizontal layout left only ~65px for item text (the "Remove permanently" + "Keep" buttons consumed ~75% of the row width), causing item names and "for [name]" labels to wrap awkwardly across multiple lines
- With the column layout, item text gets the full card width and renders cleanly on one or two lines

## Test plan

- [ ] Open the deletion suggestion card (trigger it by having previously removed items still in a question set)
- [ ] Verify each item row shows the item name and "for [name]" label cleanly, followed by the two action buttons on the line below
- [ ] Check on a narrow mobile viewport that long item names (e.g. "Warm waterproof jacket") wrap gracefully without the "for [name]" label splitting across lines

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1NL4ccGA1CTSyBZWWJA5q)_