### PR TITLE
Fix button shrinking in packing list by adding shrink-0 class

### DIFF
--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -592,7 +592,7 @@ export function ViewPackingList() {
                                             <button
                                                 type="button"
                                                 onClick={() => handleAddItem(personName)}
-                                                className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
+                                                className="shrink-0 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
                                             >
                                                 Add
                                             </button>


### PR DESCRIPTION
## Summary
Added the `shrink-0` Tailwind CSS class to the "Add" button in the packing list view to prevent it from shrinking when space is constrained.

## Changes
- Added `shrink-0` utility class to the "Add Item" button in the person's packing list section
- This ensures the button maintains its intended size and doesn't compress in flex layouts with limited space

## Details
The button is part of a flex container where other elements may expand. Without `shrink-0`, the button could be squeezed smaller than intended. This class prevents that unwanted behavior while maintaining all other styling (colors, padding, hover effects, etc.).

https://claude.ai/code/session_01Q5fPuc9uRSCKvM1ALAFE6m