### PR TITLE
Add expandable/collapsible person sections in packing list view

### DIFF
--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -576,3 +576,67 @@ describe('ViewPackingList inline item editing', () => {
         expect(db.savePackingList).not.toHaveBeenCalled()
     })
 })
+
+describe('ViewPackingList expandable person sections', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...multiCategoryPackingList, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDbMultiCategory() as unknown as PackingAppDatabase })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('person sections are expanded by default', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        expect(screen.getByText('Toothbrush')).toBeTruthy()
+        expect(screen.getByText('Nappies')).toBeTruthy()
+    })
+
+    it('clicking person header collapses that person section', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: /collapse alice's list/i }))
+        expect(screen.queryByText('Toothbrush')).toBeNull()
+    })
+
+    it('collapsing one person section does not affect another', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: /collapse alice's list/i }))
+        expect(screen.getByText('Nappies')).toBeTruthy()
+    })
+
+    it('clicking a collapsed person header expands their section', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: /collapse alice's list/i }))
+        fireEvent.click(screen.getByRole('button', { name: /expand alice's list/i }))
+        expect(screen.getByText('Toothbrush')).toBeTruthy()
+    })
+
+    it('add-item input is hidden when person section is collapsed', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        const addInputs = screen.getAllByPlaceholderText('Add new item...')
+        expect(addInputs.length).toBeGreaterThan(0)
+        fireEvent.click(screen.getByRole('button', { name: /collapse alice's list/i }))
+        const remainingInputs = screen.getAllByPlaceholderText('Add new item...')
+        expect(remainingInputs.length).toBeLessThan(addInputs.length)
+    })
+})

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -50,11 +50,19 @@ export function ViewPackingList() {
     const [editingItemId, setEditingItemId] = useState<string | null>(null)
     const [editingItemText, setEditingItemText] = useState<string>('')
     const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
+    const [collapsedPersons, setCollapsedPersons] = useState<Set<string>>(new Set())
 
     const toggleCategory = (key: string) =>
         setCollapsedCategories(prev => {
             const next = new Set(prev)
             if (next.has(key)) { next.delete(key) } else { next.add(key) }
+            return next
+        })
+
+    const togglePerson = (personName: string) =>
+        setCollapsedPersons(prev => {
+            const next = new Set(prev)
+            if (next.has(personName)) { next.delete(personName) } else { next.add(personName) }
             return next
         })
 
@@ -474,10 +482,18 @@ export function ViewPackingList() {
                             return (
                             <div key={personName} className="border border-gray-200 rounded-lg p-4 bg-white shadow-sm">
                                 <h2 className="text-xl font-semibold text-gray-800 mb-4 pb-2 border-b border-gray-200">
-                                    {personName}'s Items
-                                    <span className="ml-2 text-sm font-normal text-gray-500">{stats.packed} / {stats.total}</span>
+                                    <button
+                                        type="button"
+                                        aria-label={`${collapsedPersons.has(personName) ? 'Expand' : 'Collapse'} ${personName}'s list`}
+                                        onClick={() => togglePerson(personName)}
+                                        className="flex items-center gap-2 w-full text-left"
+                                    >
+                                        <span className="text-sm text-gray-400">{collapsedPersons.has(personName) ? '▶' : '▼'}</span>
+                                        <span>{personName}'s Items</span>
+                                        <span className="ml-2 text-sm font-normal text-gray-500">{stats.packed} / {stats.total}</span>
+                                    </button>
                                 </h2>
-                                <div>
+                                {!collapsedPersons.has(personName) && <div>
                                     {groupByCategory(items).map(({ category, items: catItems }) => {
                                         const sectionKey = `${personName}::${category}`
                                         const isCollapsed = collapsedCategories.has(sectionKey)
@@ -598,7 +614,7 @@ export function ViewPackingList() {
                                             </button>
                                         </div>
                                     </div>
-                                </div>
+                                </div>}
                             </div>
                         )})}
                     </div>


### PR DESCRIPTION
Each person's section can be toggled open or closed via their header,
letting users minimise sections for people they aren't currently packing for.

https://claude.ai/code/session_01CXEdHVaCmtkaNSyaB1G8kJ