### PR TITLE
Add collaborative packing list sharing via Solid ACL

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -10,6 +10,7 @@ import {
   CSS_PORT, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD, TEST_POD_NAME,
   AUTH_STATE_FILE, CSS_PID_FILE, APP_URL,
   SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD, SCHEMA_COMPAT_POD_NAME,
+  COLLAB_EMAIL, COLLAB_PASSWORD, COLLAB_POD_NAME,
 } from '../playwright.config'
 import v1QuestionSet from './fixtures/v1-question-set.json' with { type: 'json' }
 import v1PackingList from './fixtures/v1-packing-list.json' with { type: 'json' }
@@ -52,6 +53,9 @@ export default async function globalSetup() {
 
   await createCssAccount(CSS_PORT, SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD, SCHEMA_COMPAT_POD_NAME)
   console.log(`[setup] Schema-compat account created: ${SCHEMA_COMPAT_EMAIL}`)
+
+  await createCssAccount(CSS_PORT, COLLAB_EMAIL, COLLAB_PASSWORD, COLLAB_POD_NAME)
+  console.log(`[setup] Collab account created: ${COLLAB_EMAIL}`)
 
   // 2a. Seed schema-compat pod with v1 JSON fixtures (server-side, no browser needed)
   const accountToken = await loginToExistingCssAccount(CSS_PORT, SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD)

--- a/e2e/tests/l-sharing.spec.ts
+++ b/e2e/tests/l-sharing.spec.ts
@@ -40,10 +40,14 @@ test.describe('L – Sharing a packing list', () => {
         await firstCheckbox.click()
         await expect(pageA.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
         await expect(pageA.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
-        // Uncheck to leave items in clean state for the collaboration test
+        // Uncheck to leave items in clean state for the collaboration test.
+        // Must toggle "Show Packed" first: after checking, the item is hidden (showPacked=false),
+        // so re-evaluating the locator would find a *different* checkbox without the toggle.
+        await pageA.getByRole('button', { name: /show packed/i }).click()
         await firstCheckbox.click()
         await expect(pageA.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
         await expect(pageA.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
+        await pageA.getByRole('button', { name: /hide packed/i }).click()
     })
 
     test.afterAll(async () => {
@@ -58,9 +62,9 @@ test.describe('L – Sharing a packing list', () => {
         await pageA.getByRole('button', { name: 'Share' }).click()
         await expect(pageA.getByText('Share packing list')).toBeVisible({ timeout: 5_000 })
 
-        // Enter User B's pod URL then submit via the dialog's Share button (not the toolbar one)
-        const collabPodUrl = `http://localhost:${CSS_PORT}/${COLLAB_POD_NAME}/`
-        await pageA.getByPlaceholder(/pod url/i).fill(collabPodUrl)
+        // Enter User B's WebID then submit via the dialog's Share button (not the toolbar one)
+        const collabWebId = `http://localhost:${CSS_PORT}/${COLLAB_POD_NAME}/profile/card#me`
+        await pageA.getByPlaceholder(/profile\/card#me/i).fill(collabWebId)
         await pageA.getByRole('dialog').getByRole('button', { name: 'Share' }).click()
 
         // Wait for the generated link (ACL request may take a moment)
@@ -126,8 +130,10 @@ test.describe('L – Sharing a packing list', () => {
             // Confirm no pod-write error was surfaced (error toast = ACL or network failure)
             await expect(pageB.getByText(/Failed to save to Pod/i)).not.toBeVisible()
 
-            // User A polls every 5s — give 3 full cycles (15s) for propagation
-            await expect(pageA.locator('input[type="checkbox"]:checked').first()).toBeVisible({ timeout: 20_000 })
+            // User A polls every 5s — give 3 full cycles (15s) for propagation.
+            // With showPacked=false (default), checked items are removed from the DOM,
+            // so we verify sync via the "N packed items hidden" banner instead.
+            await expect(pageA.getByText(/packed.*hidden/i)).toBeVisible({ timeout: 20_000 })
         } finally {
             await ctxB.close()
         }

--- a/e2e/tests/l-sharing.spec.ts
+++ b/e2e/tests/l-sharing.spec.ts
@@ -51,8 +51,8 @@ test.describe('L – Sharing a packing list', () => {
     })
 
     test('L1: User A shares a list; shareable link contains expected params', async () => {
-        // Share button visible for own list (only shown when ownPodUrl is resolved)
-        await expect(pageA.getByRole('button', { name: 'Share' })).toBeVisible({ timeout: 10_000 })
+        // Share button visible immediately for own list (pod URL derived from webId synchronously)
+        await expect(pageA.getByRole('button', { name: 'Share' })).toBeVisible({ timeout: 5_000 })
 
         // Open share modal
         await pageA.getByRole('button', { name: 'Share' }).click()
@@ -123,8 +123,11 @@ test.describe('L – Sharing a packing list', () => {
             await expect(pageB.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
             await expect(pageB.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
 
-            // User A polls every 5s — checked state should propagate within 12s
-            await expect(pageA.locator('input[type="checkbox"]:checked').first()).toBeVisible({ timeout: 12_000 })
+            // Confirm no pod-write error was surfaced (error toast = ACL or network failure)
+            await expect(pageB.getByText(/Failed to save to Pod/i)).not.toBeVisible()
+
+            // User A polls every 5s — give 3 full cycles (15s) for propagation
+            await expect(pageA.locator('input[type="checkbox"]:checked').first()).toBeVisible({ timeout: 20_000 })
         } finally {
             await ctxB.close()
         }

--- a/e2e/tests/l-sharing.spec.ts
+++ b/e2e/tests/l-sharing.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '../fixtures'
+import { fillPersonRequiredFields } from '../helpers/wizard'
+import { loginToCss } from '../helpers/login'
+import { CSS_ISSUER, CSS_PORT, TEST_EMAIL, TEST_PASSWORD, COLLAB_EMAIL, COLLAB_PASSWORD, COLLAB_POD_NAME } from '../../playwright.config'
+
+// L tests use two pod users. Serial mode gives exclusive pod access.
+test.describe.configure({ mode: 'serial' })
+
+test.describe('L – Sharing a packing list', () => {
+    let pageA: import('@playwright/test').Page
+    let ctxA: import('@playwright/test').BrowserContext
+    let shareLink: string
+    const listName = `Shared Trip ${Date.now()}`
+
+    test.beforeAll(async ({ browser }) => {
+        // User A: log in, run wizard, create a packing list
+        ctxA = await browser.newContext()
+        pageA = await ctxA.newPage()
+        await pageA.goto('/')
+        await loginToCss(pageA, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD)
+
+        await pageA.goto('/#/wizard')
+        await fillPersonRequiredFields(pageA)
+        await pageA.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+        try { await pageA.getByRole('button', { name: 'Yes, Override' }).click({ timeout: 3_000 }) } catch { /* ok */ }
+        await expect(pageA.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 15_000 })
+        await pageA.getByRole('button', { name: /Create My First Packing List/i }).click()
+        try { await pageA.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 }) } catch { /* ok */ }
+        await pageA.waitForURL(/#\/create-packing-list/, { timeout: 10_000 })
+
+        // Create list
+        await pageA.getByPlaceholder('Enter a name for your packing list').waitFor({ timeout: 15_000 })
+        await pageA.getByPlaceholder('Enter a name for your packing list').fill(listName)
+        await pageA.getByRole('button', { name: 'Create Packing List' }).click()
+        await pageA.waitForURL(/#\/view-lists\//, { timeout: 10_000 })
+
+        // Sync to pod: check an item, wait for green indicator cycle
+        const firstCheckbox = pageA.locator('input[type="checkbox"]').first()
+        await firstCheckbox.waitFor({ timeout: 10_000 })
+        await firstCheckbox.click()
+        await expect(pageA.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
+        await expect(pageA.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
+        // Uncheck to leave items in clean state
+        await firstCheckbox.click()
+        await expect(pageA.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
+        await expect(pageA.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
+    })
+
+    test.afterAll(async () => {
+        await ctxA.close()
+    })
+
+    test('L1: User A shares a list and the shareable link contains the expected params', async () => {
+        // Share button should be visible for own list
+        await expect(pageA.getByRole('button', { name: /^share$/i })).toBeVisible({ timeout: 5_000 })
+
+        // Open share modal
+        await pageA.getByRole('button', { name: /^share$/i }).click()
+        await expect(pageA.getByText('Share packing list')).toBeVisible({ timeout: 5_000 })
+
+        // Enter User B's pod URL
+        const collabPodUrl = `http://localhost:${CSS_PORT}/${COLLAB_POD_NAME}/`
+        await pageA.getByPlaceholder(/pod url/i).fill(collabPodUrl)
+        await pageA.getByRole('button', { name: /^share$/i }).click()
+
+        // Wait for the link to appear
+        await expect(pageA.getByRole('textbox', { name: /shareable link/i })).toBeVisible({ timeout: 15_000 })
+
+        const linkInput = pageA.getByRole('textbox', { name: /shareable link/i })
+        shareLink = await linkInput.inputValue()
+
+        expect(shareLink).toContain('/view-lists/')
+        expect(shareLink).toContain('pod=')
+        expect(shareLink).toContain(encodeURIComponent(`http://localhost:${CSS_PORT}/testuser/`))
+
+        // Close modal
+        await pageA.keyboard.press('Escape')
+
+        // "Shared list" badge should NOT be on User A's own view
+        expect(await pageA.getByText('Shared list').count()).toBe(0)
+    })
+
+    test('L2: User B opens the shared link and sees the "Shared list" badge', async ({ browser }) => {
+        // User B: log in as collab user and navigate to the shared link
+        const ctxB = await browser.newContext()
+        const pageB = await ctxB.newPage()
+
+        try {
+            await pageB.goto('/')
+            await loginToCss(pageB, CSS_ISSUER, COLLAB_EMAIL, COLLAB_PASSWORD)
+
+            // Strip the origin from the shareLink to get the hash path
+            const hashPart = shareLink.replace(/^https?:\/\/[^#]+/, '')
+            await pageB.goto(hashPart)
+
+            // "Shared list" badge must be visible
+            await expect(pageB.getByText('Shared list')).toBeVisible({ timeout: 30_000 })
+
+            // List name should match what User A created
+            await expect(pageB.getByText(listName)).toBeVisible({ timeout: 15_000 })
+
+            // Share button must NOT be visible on a shared list
+            expect(await pageB.getByRole('button', { name: /^share$/i }).count()).toBe(0)
+        } finally {
+            await ctxB.close()
+        }
+    })
+
+    test('L3: User B checks an item; User A sees the change within one poll cycle', async ({ browser }) => {
+        const ctxB = await browser.newContext()
+        const pageB = await ctxB.newPage()
+
+        try {
+            await pageB.goto('/')
+            await loginToCss(pageB, CSS_ISSUER, COLLAB_EMAIL, COLLAB_PASSWORD)
+
+            const hashPart = shareLink.replace(/^https?:\/\/[^#]+/, '')
+            await pageB.goto(hashPart)
+
+            // Wait for list to load on shared view
+            await expect(pageB.getByText('Shared list')).toBeVisible({ timeout: 30_000 })
+
+            // User B checks the first item
+            const firstCheckbox = pageB.locator('input[type="checkbox"]').first()
+            await firstCheckbox.waitFor({ timeout: 10_000 })
+            await firstCheckbox.click()
+
+            // Wait for save indicator to complete on User B's side
+            await expect(pageB.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
+            await expect(pageB.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
+
+            // User A's page should reflect the checked item within 10s (one poll cycle)
+            await expect(pageA.locator('input[type="checkbox"]:checked').first()).toBeVisible({ timeout: 10_000 })
+        } finally {
+            await ctxB.close()
+        }
+    })
+})

--- a/e2e/tests/l-sharing.spec.ts
+++ b/e2e/tests/l-sharing.spec.ts
@@ -40,7 +40,7 @@ test.describe('L – Sharing a packing list', () => {
         await firstCheckbox.click()
         await expect(pageA.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
         await expect(pageA.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
-        // Uncheck to leave items in clean state
+        // Uncheck to leave items in clean state for the collaboration test
         await firstCheckbox.click()
         await expect(pageA.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
         await expect(pageA.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
@@ -50,24 +50,22 @@ test.describe('L – Sharing a packing list', () => {
         await ctxA.close()
     })
 
-    test('L1: User A shares a list and the shareable link contains the expected params', async () => {
-        // Share button should be visible for own list
-        await expect(pageA.getByRole('button', { name: /^share$/i })).toBeVisible({ timeout: 5_000 })
+    test('L1: User A shares a list; shareable link contains expected params', async () => {
+        // Share button visible for own list (only shown when ownPodUrl is resolved)
+        await expect(pageA.getByRole('button', { name: 'Share' })).toBeVisible({ timeout: 10_000 })
 
         // Open share modal
-        await pageA.getByRole('button', { name: /^share$/i }).click()
+        await pageA.getByRole('button', { name: 'Share' }).click()
         await expect(pageA.getByText('Share packing list')).toBeVisible({ timeout: 5_000 })
 
-        // Enter User B's pod URL
+        // Enter User B's pod URL then submit via the dialog's Share button (not the toolbar one)
         const collabPodUrl = `http://localhost:${CSS_PORT}/${COLLAB_POD_NAME}/`
         await pageA.getByPlaceholder(/pod url/i).fill(collabPodUrl)
-        await pageA.getByRole('button', { name: /^share$/i }).click()
+        await pageA.getByRole('dialog').getByRole('button', { name: 'Share' }).click()
 
-        // Wait for the link to appear
+        // Wait for the generated link (ACL request may take a moment)
         await expect(pageA.getByRole('textbox', { name: /shareable link/i })).toBeVisible({ timeout: 15_000 })
-
-        const linkInput = pageA.getByRole('textbox', { name: /shareable link/i })
-        shareLink = await linkInput.inputValue()
+        shareLink = await pageA.getByRole('textbox', { name: /shareable link/i }).inputValue()
 
         expect(shareLink).toContain('/view-lists/')
         expect(shareLink).toContain('pod=')
@@ -76,12 +74,11 @@ test.describe('L – Sharing a packing list', () => {
         // Close modal
         await pageA.keyboard.press('Escape')
 
-        // "Shared list" badge should NOT be on User A's own view
-        expect(await pageA.getByText('Shared list').count()).toBe(0)
+        // "Shared list" badge must NOT appear on User A's own view
+        await expect(pageA.getByText('Shared list')).not.toBeVisible()
     })
 
-    test('L2: User B opens the shared link and sees the "Shared list" badge', async ({ browser }) => {
-        // User B: log in as collab user and navigate to the shared link
+    test('L2: User B opens the shared link; sees "Shared list" badge and list contents', async ({ browser }) => {
         const ctxB = await browser.newContext()
         const pageB = await ctxB.newPage()
 
@@ -89,18 +86,17 @@ test.describe('L – Sharing a packing list', () => {
             await pageB.goto('/')
             await loginToCss(pageB, CSS_ISSUER, COLLAB_EMAIL, COLLAB_PASSWORD)
 
-            // Strip the origin from the shareLink to get the hash path
-            const hashPart = shareLink.replace(/^https?:\/\/[^#]+/, '')
-            await pageB.goto(hashPart)
+            // Navigate directly to the full shareable URL
+            await pageB.goto(shareLink)
 
             // "Shared list" badge must be visible
             await expect(pageB.getByText('Shared list')).toBeVisible({ timeout: 30_000 })
 
-            // List name should match what User A created
+            // List name must match what User A created
             await expect(pageB.getByText(listName)).toBeVisible({ timeout: 15_000 })
 
             // Share button must NOT be visible on a shared list
-            expect(await pageB.getByRole('button', { name: /^share$/i }).count()).toBe(0)
+            await expect(pageB.getByRole('button', { name: 'Share' })).not.toBeVisible()
         } finally {
             await ctxB.close()
         }
@@ -114,10 +110,8 @@ test.describe('L – Sharing a packing list', () => {
             await pageB.goto('/')
             await loginToCss(pageB, CSS_ISSUER, COLLAB_EMAIL, COLLAB_PASSWORD)
 
-            const hashPart = shareLink.replace(/^https?:\/\/[^#]+/, '')
-            await pageB.goto(hashPart)
-
-            // Wait for list to load on shared view
+            // Navigate to the shared list
+            await pageB.goto(shareLink)
             await expect(pageB.getByText('Shared list')).toBeVisible({ timeout: 30_000 })
 
             // User B checks the first item
@@ -125,12 +119,12 @@ test.describe('L – Sharing a packing list', () => {
             await firstCheckbox.waitFor({ timeout: 10_000 })
             await firstCheckbox.click()
 
-            // Wait for save indicator to complete on User B's side
+            // Wait for User B's save to reach the pod (green "Saved" indicator cycle)
             await expect(pageB.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
             await expect(pageB.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
 
-            // User A's page should reflect the checked item within 10s (one poll cycle)
-            await expect(pageA.locator('input[type="checkbox"]:checked').first()).toBeVisible({ timeout: 10_000 })
+            // User A polls every 5s — checked state should propagate within 12s
+            await expect(pageA.locator('input[type="checkbox"]:checked').first()).toBeVisible({ timeout: 12_000 })
         } finally {
             await ctxB.close()
         }

--- a/e2e/tests/l-sharing.spec.ts
+++ b/e2e/tests/l-sharing.spec.ts
@@ -51,8 +51,8 @@ test.describe('L – Sharing a packing list', () => {
     })
 
     test('L1: User A shares a list; shareable link contains expected params', async () => {
-        // Share button visible immediately for own list (pod URL derived from webId synchronously)
-        await expect(pageA.getByRole('button', { name: 'Share' })).toBeVisible({ timeout: 5_000 })
+        // Share button renders immediately, enabled once pod URL resolves (~1 network round-trip)
+        await expect(pageA.getByRole('button', { name: 'Share' })).toBeEnabled({ timeout: 10_000 })
 
         // Open share modal
         await pageA.getByRole('button', { name: 'Share' }).click()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,9 @@ export const AUTH_STATE_FILE = path.join(__dirname, 'e2e/.auth/user.json')
 export const SCHEMA_COMPAT_EMAIL = 'schema-compat@example.com'
 export const SCHEMA_COMPAT_PASSWORD = 'test1234'
 export const SCHEMA_COMPAT_POD_NAME = 'schemacompat'
+export const COLLAB_EMAIL = 'collab@example.com'
+export const COLLAB_PASSWORD = 'test1234'
+export const COLLAB_POD_NAME = 'collabuser'
 export const CSS_PID_FILE = path.join(__dirname, '.e2e-css-pid')
 export const APP_URL = 'http://localhost:4173'
 

--- a/src/components/SharePackingListModal.test.tsx
+++ b/src/components/SharePackingListModal.test.tsx
@@ -6,13 +6,11 @@ import type { AppSession } from '../types/AppSession'
 
 vi.mock('../services/solidPod', () => ({
     grantCollaboratorAccess: vi.fn(),
-    deriveWebIdFromPodUrl: vi.fn((url: string) => `${url.replace(/\/$/, '')}/profile/card#me`),
 }))
 
-import { grantCollaboratorAccess, deriveWebIdFromPodUrl } from '../services/solidPod'
+import { grantCollaboratorAccess } from '../services/solidPod'
 
 const mockGrantCollaboratorAccess = vi.mocked(grantCollaboratorAccess)
-const mockDeriveWebIdFromPodUrl = vi.mocked(deriveWebIdFromPodUrl)
 
 const mockSession = {
     info: { isLoggedIn: true, webId: 'https://alice.solidcommunity.net/profile/card#me' },
@@ -23,7 +21,7 @@ const defaultProps = {
     isOpen: true,
     onClose: vi.fn(),
     session: mockSession,
-    fileUrl: 'https://alice.solidcommunity.net/pack-me-up/packing-lists/abc.json',
+    fileUrl: 'https://alice.solidcommunity.net/pack-me-up/packing-lists/abc.ttl',
     listId: 'abc',
     sharerPodUrl: 'https://alice.solidcommunity.net/',
 }
@@ -60,9 +58,9 @@ describe('SharePackingListModal', () => {
             expect(screen.queryByText('Share packing list')).toBeNull()
         })
 
-        it('renders a pod URL input', () => {
+        it('renders a WebID input', () => {
             renderModal()
-            expect(screen.getByPlaceholderText(/pod url/i)).toBeTruthy()
+            expect(screen.getByPlaceholderText(/profile\/card#me/i)).toBeTruthy()
         })
 
         it('renders a Share button', () => {
@@ -72,30 +70,36 @@ describe('SharePackingListModal', () => {
     })
 
     describe('granting access', () => {
-        it('does not call grantCollaboratorAccess when pod URL input is empty', async () => {
+        it('does not call grantCollaboratorAccess when WebID input is empty', async () => {
             renderModal()
             fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
             expect(mockGrantCollaboratorAccess).not.toHaveBeenCalled()
         })
 
-        it('calls deriveWebIdFromPodUrl with the entered pod URL', async () => {
+        it('calls grantCollaboratorAccess with the entered WebID directly', async () => {
             mockGrantCollaboratorAccess.mockResolvedValue(undefined)
             renderModal()
 
-            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
-                target: { value: 'https://bob.solidcommunity.net/' },
+            fireEvent.change(screen.getByPlaceholderText(/profile\/card#me/i), {
+                target: { value: 'https://bob.solidcommunity.net/profile/card#me' },
             })
             fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
 
-            await waitFor(() => expect(mockDeriveWebIdFromPodUrl).toHaveBeenCalledWith('https://bob.solidcommunity.net/'))
+            await waitFor(() =>
+                expect(mockGrantCollaboratorAccess).toHaveBeenCalledWith(
+                    mockSession,
+                    defaultProps.fileUrl,
+                    'https://bob.solidcommunity.net/profile/card#me'
+                )
+            )
         })
 
-        it('calls grantCollaboratorAccess with session, fileUrl, and derived WebID', async () => {
+        it('trims whitespace from the WebID before calling grantCollaboratorAccess', async () => {
             mockGrantCollaboratorAccess.mockResolvedValue(undefined)
             renderModal()
 
-            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
-                target: { value: 'https://bob.solidcommunity.net/' },
+            fireEvent.change(screen.getByPlaceholderText(/profile\/card#me/i), {
+                target: { value: '  https://bob.solidcommunity.net/profile/card#me  ' },
             })
             fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
 
@@ -112,8 +116,8 @@ describe('SharePackingListModal', () => {
             mockGrantCollaboratorAccess.mockResolvedValue(undefined)
             renderModal()
 
-            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
-                target: { value: 'https://bob.solidcommunity.net/' },
+            fireEvent.change(screen.getByPlaceholderText(/profile\/card#me/i), {
+                target: { value: 'https://bob.solidcommunity.net/profile/card#me' },
             })
             fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
 
@@ -128,8 +132,8 @@ describe('SharePackingListModal', () => {
             mockGrantCollaboratorAccess.mockResolvedValue(undefined)
             renderModal()
 
-            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
-                target: { value: 'https://bob.solidcommunity.net/' },
+            fireEvent.change(screen.getByPlaceholderText(/profile\/card#me/i), {
+                target: { value: 'https://bob.solidcommunity.net/profile/card#me' },
             })
             fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
 
@@ -141,8 +145,8 @@ describe('SharePackingListModal', () => {
             mockGrantCollaboratorAccess.mockReturnValue(new Promise(res => { resolveGrant = res }))
             renderModal()
 
-            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
-                target: { value: 'https://bob.solidcommunity.net/' },
+            fireEvent.change(screen.getByPlaceholderText(/profile\/card#me/i), {
+                target: { value: 'https://bob.solidcommunity.net/profile/card#me' },
             })
             fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
 
@@ -159,8 +163,8 @@ describe('SharePackingListModal', () => {
             mockGrantCollaboratorAccess.mockResolvedValue(undefined)
             renderModal()
 
-            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
-                target: { value: 'https://bob.solidcommunity.net/' },
+            fireEvent.change(screen.getByPlaceholderText(/profile\/card#me/i), {
+                target: { value: 'https://bob.solidcommunity.net/profile/card#me' },
             })
             fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
 
@@ -178,27 +182,27 @@ describe('SharePackingListModal', () => {
             mockGrantCollaboratorAccess.mockRejectedValue(new Error('ACL not supported'))
             renderModal()
 
-            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
-                target: { value: 'https://bob.solidcommunity.net/' },
+            fireEvent.change(screen.getByPlaceholderText(/profile\/card#me/i), {
+                target: { value: 'https://bob.solidcommunity.net/profile/card#me' },
             })
             fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
 
             await waitFor(() => expect(screen.getByText(/ACL not supported/i)).toBeTruthy())
         })
 
-        it('clears error message when pod URL input changes', async () => {
+        it('clears error message when WebID input changes', async () => {
             mockGrantCollaboratorAccess.mockRejectedValue(new Error('ACL not supported'))
             renderModal()
 
-            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
-                target: { value: 'https://bob.solidcommunity.net/' },
+            fireEvent.change(screen.getByPlaceholderText(/profile\/card#me/i), {
+                target: { value: 'https://bob.solidcommunity.net/profile/card#me' },
             })
             fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
 
             await waitFor(() => expect(screen.getByText(/ACL not supported/i)).toBeTruthy())
 
-            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
-                target: { value: 'https://carol.solidcommunity.net/' },
+            fireEvent.change(screen.getByPlaceholderText(/profile\/card#me/i), {
+                target: { value: 'https://carol.solidcommunity.net/profile/card#me' },
             })
 
             expect(screen.queryByText(/ACL not supported/i)).toBeNull()

--- a/src/components/SharePackingListModal.test.tsx
+++ b/src/components/SharePackingListModal.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { SharePackingListModal } from './SharePackingListModal'
+import type { AppSession } from '../types/AppSession'
+
+vi.mock('../services/solidPod', () => ({
+    grantCollaboratorAccess: vi.fn(),
+    deriveWebIdFromPodUrl: vi.fn((url: string) => `${url.replace(/\/$/, '')}/profile/card#me`),
+}))
+
+import { grantCollaboratorAccess, deriveWebIdFromPodUrl } from '../services/solidPod'
+
+const mockGrantCollaboratorAccess = vi.mocked(grantCollaboratorAccess)
+const mockDeriveWebIdFromPodUrl = vi.mocked(deriveWebIdFromPodUrl)
+
+const mockSession = {
+    info: { isLoggedIn: true, webId: 'https://alice.solidcommunity.net/profile/card#me' },
+    fetch: vi.fn(),
+} as unknown as AppSession
+
+const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    session: mockSession,
+    fileUrl: 'https://alice.solidcommunity.net/pack-me-up/packing-lists/abc.json',
+    listId: 'abc',
+    sharerPodUrl: 'https://alice.solidcommunity.net/',
+}
+
+function renderModal(props = {}) {
+    return render(<SharePackingListModal {...defaultProps} {...props} />)
+}
+
+describe('SharePackingListModal', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText: vi.fn().mockResolvedValue(undefined) },
+            writable: true,
+        })
+        Object.defineProperty(window, 'location', {
+            value: { origin: 'https://pack-me-up.app', hash: '' },
+            writable: true,
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    describe('rendering', () => {
+        it('renders when isOpen is true', () => {
+            renderModal()
+            expect(screen.getByText('Share packing list')).toBeTruthy()
+        })
+
+        it('does not render when isOpen is false', () => {
+            renderModal({ isOpen: false })
+            expect(screen.queryByText('Share packing list')).toBeNull()
+        })
+
+        it('renders a pod URL input', () => {
+            renderModal()
+            expect(screen.getByPlaceholderText(/pod url/i)).toBeTruthy()
+        })
+
+        it('renders a Share button', () => {
+            renderModal()
+            expect(screen.getByRole('button', { name: /^share$/i })).toBeTruthy()
+        })
+    })
+
+    describe('granting access', () => {
+        it('does not call grantCollaboratorAccess when pod URL input is empty', async () => {
+            renderModal()
+            fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
+            expect(mockGrantCollaboratorAccess).not.toHaveBeenCalled()
+        })
+
+        it('calls deriveWebIdFromPodUrl with the entered pod URL', async () => {
+            mockGrantCollaboratorAccess.mockResolvedValue(undefined)
+            renderModal()
+
+            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
+                target: { value: 'https://bob.solidcommunity.net/' },
+            })
+            fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
+
+            await waitFor(() => expect(mockDeriveWebIdFromPodUrl).toHaveBeenCalledWith('https://bob.solidcommunity.net/'))
+        })
+
+        it('calls grantCollaboratorAccess with session, fileUrl, and derived WebID', async () => {
+            mockGrantCollaboratorAccess.mockResolvedValue(undefined)
+            renderModal()
+
+            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
+                target: { value: 'https://bob.solidcommunity.net/' },
+            })
+            fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
+
+            await waitFor(() =>
+                expect(mockGrantCollaboratorAccess).toHaveBeenCalledWith(
+                    mockSession,
+                    defaultProps.fileUrl,
+                    'https://bob.solidcommunity.net/profile/card#me'
+                )
+            )
+        })
+
+        it('shows the generated link after successful grant', async () => {
+            mockGrantCollaboratorAccess.mockResolvedValue(undefined)
+            renderModal()
+
+            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
+                target: { value: 'https://bob.solidcommunity.net/' },
+            })
+            fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
+
+            await waitFor(() => expect(screen.getByRole('textbox', { name: /shareable link/i })).toBeTruthy())
+            const linkInput = screen.getByRole('textbox', { name: /shareable link/i }) as HTMLInputElement
+            expect(linkInput.value).toContain('/view-lists/abc')
+            expect(linkInput.value).toContain('pod=')
+            expect(linkInput.value).toContain(encodeURIComponent('https://alice.solidcommunity.net/'))
+        })
+
+        it('shows a "Copy link" button after successful grant', async () => {
+            mockGrantCollaboratorAccess.mockResolvedValue(undefined)
+            renderModal()
+
+            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
+                target: { value: 'https://bob.solidcommunity.net/' },
+            })
+            fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
+
+            await waitFor(() => expect(screen.getByRole('button', { name: /copy link/i })).toBeTruthy())
+        })
+
+        it('Share button is disabled while grant is in progress', async () => {
+            let resolveGrant: () => void
+            mockGrantCollaboratorAccess.mockReturnValue(new Promise(res => { resolveGrant = res }))
+            renderModal()
+
+            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
+                target: { value: 'https://bob.solidcommunity.net/' },
+            })
+            fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
+
+            const sharingBtn = screen.getByRole('button', { name: /sharing/i })
+            expect(sharingBtn).toBeTruthy()
+            expect((sharingBtn as HTMLButtonElement).disabled).toBe(true)
+
+            resolveGrant!()
+        })
+    })
+
+    describe('clipboard', () => {
+        it('clicking "Copy link" calls navigator.clipboard.writeText with the link', async () => {
+            mockGrantCollaboratorAccess.mockResolvedValue(undefined)
+            renderModal()
+
+            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
+                target: { value: 'https://bob.solidcommunity.net/' },
+            })
+            fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
+
+            await waitFor(() => expect(screen.getByRole('button', { name: /copy link/i })).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /copy link/i }))
+
+            expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+                expect.stringContaining('/view-lists/abc')
+            )
+        })
+    })
+
+    describe('error handling', () => {
+        it('shows an error message when grantCollaboratorAccess throws', async () => {
+            mockGrantCollaboratorAccess.mockRejectedValue(new Error('ACL not supported'))
+            renderModal()
+
+            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
+                target: { value: 'https://bob.solidcommunity.net/' },
+            })
+            fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
+
+            await waitFor(() => expect(screen.getByText(/ACL not supported/i)).toBeTruthy())
+        })
+
+        it('clears error message when pod URL input changes', async () => {
+            mockGrantCollaboratorAccess.mockRejectedValue(new Error('ACL not supported'))
+            renderModal()
+
+            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
+                target: { value: 'https://bob.solidcommunity.net/' },
+            })
+            fireEvent.click(screen.getByRole('button', { name: /^share$/i }))
+
+            await waitFor(() => expect(screen.getByText(/ACL not supported/i)).toBeTruthy())
+
+            fireEvent.change(screen.getByPlaceholderText(/pod url/i), {
+                target: { value: 'https://carol.solidcommunity.net/' },
+            })
+
+            expect(screen.queryByText(/ACL not supported/i)).toBeNull()
+        })
+    })
+})

--- a/src/components/SharePackingListModal.tsx
+++ b/src/components/SharePackingListModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { AppSession } from '../types/AppSession'
-import { grantCollaboratorAccess, deriveWebIdFromPodUrl } from '../services/solidPod'
+import { grantCollaboratorAccess } from '../services/solidPod'
 import { Modal } from './Modal'
 import { Button } from './Button'
 import { Input } from './Input'
@@ -22,19 +22,18 @@ export function SharePackingListModal({
     listId,
     sharerPodUrl,
 }: SharePackingListModalProps) {
-    const [collaboratorPodUrl, setCollaboratorPodUrl] = useState('')
+    const [collaboratorWebId, setCollaboratorWebId] = useState('')
     const [isGranting, setIsGranting] = useState(false)
     const [generatedLink, setGeneratedLink] = useState<string | null>(null)
     const [error, setError] = useState<string | null>(null)
 
     const handleShare = async () => {
-        if (!collaboratorPodUrl.trim()) return
+        if (!collaboratorWebId.trim()) return
 
         setIsGranting(true)
         setError(null)
         try {
-            const webId = deriveWebIdFromPodUrl(collaboratorPodUrl)
-            await grantCollaboratorAccess(session, fileUrl, webId)
+            await grantCollaboratorAccess(session, fileUrl, collaboratorWebId.trim())
             const link = `${window.location.origin}/#/view-lists/${listId}?pod=${encodeURIComponent(sharerPodUrl)}`
             setGeneratedLink(link)
         } catch (err) {
@@ -55,11 +54,11 @@ export function SharePackingListModal({
             <div className="space-y-4">
                 <div>
                     <Input
-                        label="Collaborator's pod URL"
-                        placeholder="Pod URL (e.g. https://friend.solidcommunity.net/)"
-                        value={collaboratorPodUrl}
+                        label="Collaborator's WebID"
+                        placeholder="https://friend.solidcommunity.net/profile/card#me"
+                        value={collaboratorWebId}
                         onChange={e => {
-                            setCollaboratorPodUrl(e.target.value)
+                            setCollaboratorWebId(e.target.value)
                             setError(null)
                         }}
                         disabled={isGranting}
@@ -74,7 +73,7 @@ export function SharePackingListModal({
                     type="button"
                     variant="primary"
                     onClick={handleShare}
-                    disabled={isGranting || !collaboratorPodUrl.trim()}
+                    disabled={isGranting || !collaboratorWebId.trim()}
                 >
                     {isGranting ? 'Sharing...' : 'Share'}
                 </Button>

--- a/src/components/SharePackingListModal.tsx
+++ b/src/components/SharePackingListModal.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react'
+import { AppSession } from '../types/AppSession'
+import { grantCollaboratorAccess, deriveWebIdFromPodUrl } from '../services/solidPod'
+import { Modal } from './Modal'
+import { Button } from './Button'
+import { Input } from './Input'
+
+interface SharePackingListModalProps {
+    isOpen: boolean
+    onClose: () => void
+    session: AppSession
+    fileUrl: string
+    listId: string
+    sharerPodUrl: string
+}
+
+export function SharePackingListModal({
+    isOpen,
+    onClose,
+    session,
+    fileUrl,
+    listId,
+    sharerPodUrl,
+}: SharePackingListModalProps) {
+    const [collaboratorPodUrl, setCollaboratorPodUrl] = useState('')
+    const [isGranting, setIsGranting] = useState(false)
+    const [generatedLink, setGeneratedLink] = useState<string | null>(null)
+    const [error, setError] = useState<string | null>(null)
+
+    const handleShare = async () => {
+        if (!collaboratorPodUrl.trim()) return
+
+        setIsGranting(true)
+        setError(null)
+        try {
+            const webId = deriveWebIdFromPodUrl(collaboratorPodUrl)
+            await grantCollaboratorAccess(session, fileUrl, webId)
+            const link = `${window.location.origin}/#/view-lists/${listId}?pod=${encodeURIComponent(sharerPodUrl)}`
+            setGeneratedLink(link)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to share. Please try again.')
+        } finally {
+            setIsGranting(false)
+        }
+    }
+
+    const handleCopy = () => {
+        if (generatedLink) {
+            navigator.clipboard.writeText(generatedLink)
+        }
+    }
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title="Share packing list">
+            <div className="space-y-4">
+                <div>
+                    <Input
+                        label="Collaborator's pod URL"
+                        placeholder="Pod URL (e.g. https://friend.solidcommunity.net/)"
+                        value={collaboratorPodUrl}
+                        onChange={e => {
+                            setCollaboratorPodUrl(e.target.value)
+                            setError(null)
+                        }}
+                        disabled={isGranting}
+                    />
+                </div>
+
+                {error && (
+                    <p className="text-sm text-red-600">{error}</p>
+                )}
+
+                <Button
+                    type="button"
+                    variant="primary"
+                    onClick={handleShare}
+                    disabled={isGranting || !collaboratorPodUrl.trim()}
+                >
+                    {isGranting ? 'Sharing...' : 'Share'}
+                </Button>
+
+                {generatedLink && (
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-gray-700">
+                            Shareable link
+                            <input
+                                aria-label="Shareable link"
+                                type="text"
+                                readOnly
+                                value={generatedLink}
+                                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 bg-gray-50"
+                            />
+                        </label>
+                        <Button type="button" variant="secondary" onClick={handleCopy}>
+                            Copy link
+                        </Button>
+                    </div>
+                )}
+            </div>
+        </Modal>
+    )
+}

--- a/src/hooks/usePodSync.test.ts
+++ b/src/hooks/usePodSync.test.ts
@@ -384,6 +384,55 @@ describe('usePodSync', () => {
     })
   })
 
+  describe('404 error handling', () => {
+    it('silently swallows 404 on own pod (file not yet created)', async () => {
+      setupLoggedIn()
+      mockLoadRdfFromPod.mockRejectedValue(Object.assign(new Error('Not Found'), { statusCode: 404 }))
+      const onSyncError = vi.fn()
+
+      const { result } = renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,  // no podUrl = own pod
+          syncOnMount: true,
+          enabled: true,
+          onSyncError,
+          rdf: rdfOptions,
+        })
+      )
+
+      await act(async () => {
+        await result.current.syncFromPod()
+      })
+
+      expect(onSyncError).not.toHaveBeenCalled()
+    })
+
+    it('reports 404 on a foreign pod as a real error', async () => {
+      setupLoggedIn()
+      mockLoadRdfFromPod.mockRejectedValue(Object.assign(new Error('Not Found'), { statusCode: 404 }))
+      const onSyncError = vi.fn()
+
+      const { result } = renderHook(() =>
+        usePodSync({
+          pathConfig: {
+            ...staticPathConfig,
+            podUrl: 'https://alice.solidcommunity.net/',  // foreign pod
+          },
+          syncOnMount: true,
+          enabled: true,
+          onSyncError,
+          rdf: rdfOptions,
+        })
+      )
+
+      await act(async () => {
+        await result.current.syncFromPod()
+      })
+
+      expect(onSyncError).toHaveBeenCalledWith(expect.stringContaining('Not Found'))
+    })
+  })
+
   describe('podUrl override in pathConfig', () => {
     const FOREIGN_POD_URL = 'https://alice.solidcommunity.net/'
 

--- a/src/hooks/usePodSync.test.ts
+++ b/src/hooks/usePodSync.test.ts
@@ -394,10 +394,11 @@ describe('usePodSync', () => {
         usePodSync({
           pathConfig: {
             container: 'pack-me-up/packing-lists/',
-            filename: (id) => `${id}.json`,
+            filename: (id) => `${id}.ttl`,
             resourceId: 'list-abc',
             podUrl: FOREIGN_POD_URL,
           },
+          rdf: rdfOptions,
           enabled: true,
         })
       )
@@ -407,27 +408,25 @@ describe('usePodSync', () => {
       })
 
       expect(mockGetPrimaryPodUrl).not.toHaveBeenCalled()
-      expect(mockLoadFileFromPod).toHaveBeenCalledWith(
-        expect.objectContaining({
-          fileUrl: `${FOREIGN_POD_URL}pack-me-up/packing-lists/list-abc.json`,
-        })
+      expect(mockLoadRdfFromPod).toHaveBeenCalledWith(
+        mockSession,
+        `${FOREIGN_POD_URL}pack-me-up/packing-lists/list-abc.ttl`,
+        expect.any(Function)
       )
     })
 
     it('saveToPod uses pathConfig.podUrl instead of getPrimaryPodUrl when provided', async () => {
       setupLoggedIn()
-      const mockSaveFileToPod = vi.fn().mockResolvedValue(undefined)
-      const { saveFileToPod } = await import('../services/solidPod')
-      vi.mocked(saveFileToPod).mockImplementation(mockSaveFileToPod)
 
       const { result } = renderHook(() =>
         usePodSync({
           pathConfig: {
             container: 'pack-me-up/packing-lists/',
-            filename: (id) => `${id}.json`,
+            filename: (id) => `${id}.ttl`,
             resourceId: 'list-abc',
             podUrl: FOREIGN_POD_URL,
           },
+          rdf: rdfOptions,
           enabled: true,
         })
       )
@@ -437,9 +436,9 @@ describe('usePodSync', () => {
       })
 
       expect(mockGetPrimaryPodUrl).not.toHaveBeenCalled()
-      expect(mockSaveFileToPod).toHaveBeenCalledWith(
+      expect(mockSaveRdfToPod).toHaveBeenCalledWith(
         expect.objectContaining({
-          containerPath: `${FOREIGN_POD_URL}pack-me-up/packing-lists/`,
+          fileUrl: `${FOREIGN_POD_URL}pack-me-up/packing-lists/list-abc.ttl`,
         })
       )
     })

--- a/src/hooks/usePodSync.test.ts
+++ b/src/hooks/usePodSync.test.ts
@@ -383,4 +383,82 @@ describe('usePodSync', () => {
       expect(mockSaveRdfToPod).not.toHaveBeenCalled()
     })
   })
+
+  describe('podUrl override in pathConfig', () => {
+    const FOREIGN_POD_URL = 'https://alice.solidcommunity.net/'
+
+    it('syncFromPod uses pathConfig.podUrl instead of getPrimaryPodUrl when provided', async () => {
+      setupLoggedIn()
+
+      const { result } = renderHook(() =>
+        usePodSync({
+          pathConfig: {
+            container: 'pack-me-up/packing-lists/',
+            filename: (id) => `${id}.json`,
+            resourceId: 'list-abc',
+            podUrl: FOREIGN_POD_URL,
+          },
+          enabled: true,
+        })
+      )
+
+      await act(async () => {
+        await result.current.syncFromPod()
+      })
+
+      expect(mockGetPrimaryPodUrl).not.toHaveBeenCalled()
+      expect(mockLoadFileFromPod).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileUrl: `${FOREIGN_POD_URL}pack-me-up/packing-lists/list-abc.json`,
+        })
+      )
+    })
+
+    it('saveToPod uses pathConfig.podUrl instead of getPrimaryPodUrl when provided', async () => {
+      setupLoggedIn()
+      const mockSaveFileToPod = vi.fn().mockResolvedValue(undefined)
+      const { saveFileToPod } = await import('../services/solidPod')
+      vi.mocked(saveFileToPod).mockImplementation(mockSaveFileToPod)
+
+      const { result } = renderHook(() =>
+        usePodSync({
+          pathConfig: {
+            container: 'pack-me-up/packing-lists/',
+            filename: (id) => `${id}.json`,
+            resourceId: 'list-abc',
+            podUrl: FOREIGN_POD_URL,
+          },
+          enabled: true,
+        })
+      )
+
+      await act(async () => {
+        await result.current.saveToPod({ id: 'list-abc', name: 'Test' })
+      })
+
+      expect(mockGetPrimaryPodUrl).not.toHaveBeenCalled()
+      expect(mockSaveFileToPod).toHaveBeenCalledWith(
+        expect.objectContaining({
+          containerPath: `${FOREIGN_POD_URL}pack-me-up/packing-lists/`,
+        })
+      )
+    })
+
+    it('falls back to getPrimaryPodUrl when pathConfig.podUrl is absent', async () => {
+      setupLoggedIn()
+
+      const { result } = renderHook(() =>
+        usePodSync({
+          pathConfig: staticPathConfig,
+          enabled: true,
+        })
+      )
+
+      await act(async () => {
+        await result.current.syncFromPod()
+      })
+
+      expect(mockGetPrimaryPodUrl).toHaveBeenCalled()
+    })
+  })
 })

--- a/src/hooks/usePodSync.ts
+++ b/src/hooks/usePodSync.ts
@@ -215,9 +215,11 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
         onSyncSuccessRef.current(data);
       }
     } catch (err: unknown) {
-      // 404 errors are expected when file doesn't exist yet - not a real error
       const statusCode = typeof err === 'object' && err !== null ? (err as { statusCode?: number }).statusCode : undefined
-      if (statusCode !== 404) {
+      // 404 on own pod = file not yet created (expected) → silent
+      // 404 on foreign pod (pathConfig.podUrl set) = file missing or access denied → report
+      const isSilentMiss = statusCode === 404 && !pathConfig.podUrl
+      if (!isSilentMiss) {
         // Authentication errors use their own message
         const errorMessage = err instanceof AuthenticationError
           ? err.message

--- a/src/hooks/usePodSync.ts
+++ b/src/hooks/usePodSync.ts
@@ -23,6 +23,12 @@ export interface PodPathConfig {
    * Optional resource ID (required when filename is a function)
    */
   resourceId?: string | null;
+
+  /**
+   * Override the pod URL — bypasses getPrimaryPodUrl when set.
+   * Use this to sync with a foreign user's pod (e.g. a shared list).
+   */
+  podUrl?: string;
 }
 
 export interface PodSyncOptions<T> {
@@ -144,11 +150,11 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
   // Create a stable key for pathConfig to use in useEffect dependencies
   // This prevents the interval from restarting when pathConfig object reference changes
   const pathConfigKey = useMemo(() => {
-    const { container, filename, resourceId } = pathConfig;
+    const { container, filename, resourceId, podUrl } = pathConfig;
     const filenameKey = typeof filename === 'function' ? 'function' : filename;
-    return `${container}:${filenameKey}:${resourceId || ''}`;
+    return `${container}:${filenameKey}:${resourceId || ''}:${podUrl || ''}`;
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pathConfig.container, pathConfig.filename, pathConfig.resourceId]);
+  }, [pathConfig.container, pathConfig.filename, pathConfig.resourceId, pathConfig.podUrl]);
 
   /**
    * Resolve the full file URL from the path configuration
@@ -188,7 +194,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
     setError(null);
 
     try {
-      const podUrl = await getPrimaryPodUrl(session);
+      const podUrl = pathConfig.podUrl ?? await getPrimaryPodUrl(session);
 
       if (!podUrl) {
         throw new Error('No pod URL found');
@@ -239,7 +245,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
     setError(null);
 
     try {
-      const podUrl = await getPrimaryPodUrl(session);
+      const podUrl = pathConfig.podUrl ?? await getPrimaryPodUrl(session);
 
       if (!podUrl) {
         throw new Error('No pod URL found');

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { ViewPackingList } from './view-packing-list'
@@ -13,8 +13,9 @@ vi.mock('../components/SolidPodContext', () => ({
     useSolidPod: vi.fn(),
 }))
 
+const mockShowToast = vi.fn()
 vi.mock('../components/ToastContext', () => ({
-    useToast: vi.fn(() => ({ showToast: vi.fn() })),
+    useToast: vi.fn(() => ({ showToast: mockShowToast })),
 }))
 
 vi.mock('../hooks/usePodSync', () => ({
@@ -34,7 +35,6 @@ vi.mock('../services/solidPod', () => ({
     POD_CONTAINERS: { PACKING_LISTS: 'pack-me-up/packing-lists/' },
     getPrimaryPodUrl: vi.fn().mockResolvedValue('https://own.solidcommunity.net/'),
     grantCollaboratorAccess: vi.fn(),
-    deriveWebIdFromPodUrl: vi.fn((url: string) => `${url.replace(/\/$/, '')}/profile/card#me`),
 }))
 
 vi.mock('../components/SharePackingListModal', () => ({
@@ -757,5 +757,32 @@ describe('ViewPackingList foreign pod (?pod= param)', () => {
 
         // Loading text should remain visible since we're waiting for pod poll
         await waitFor(() => expect(screen.getByText(/loading/i)).toBeTruthy())
+    })
+
+    it('stops loading and shows a toast when foreign pod sync fails before data is loaded', async () => {
+        const dbWithNotFound = {
+            ...makeDb(),
+            getPackingList: vi.fn().mockRejectedValue({ name: 'not_found' }),
+        }
+        mockUseDatabase.mockReturnValue({ db: dbWithNotFound as unknown as PackingAppDatabase })
+        mockShowToast.mockClear()
+
+        renderWithForeignPod(FOREIGN_POD_URL)
+
+        // Wait until the component is in the loading state (DB not_found processed)
+        await waitFor(() => expect(screen.getByText(/loading/i)).toBeTruthy())
+
+        // Simulate the pod sync failing (e.g. 403 Forbidden - ACL not set)
+        const onSyncError = mockUsePodSync.mock.calls[mockUsePodSync.mock.calls.length - 1][0].onSyncError as (e: string) => void
+        act(() => onSyncError('403 Forbidden'))
+
+        // Loading spinner should disappear
+        await waitFor(() => expect(screen.queryByText(/loading packing list/i)).toBeNull())
+
+        // Toast should have been shown
+        expect(mockShowToast).toHaveBeenCalledWith(
+            expect.stringContaining('Could not load shared list'),
+            'error'
+        )
     })
 })

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -33,7 +33,6 @@ import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 vi.mock('../services/solidPod', () => ({
     POD_CONTAINERS: { PACKING_LISTS: 'pack-me-up/packing-lists/' },
     getPrimaryPodUrl: vi.fn().mockResolvedValue('https://own.solidcommunity.net/'),
-    derivePodUrlFromWebId: vi.fn((webId: string) => webId.replace('/profile/card#me', '/')),
     grantCollaboratorAccess: vi.fn(),
     deriveWebIdFromPodUrl: vi.fn((url: string) => `${url.replace(/\/$/, '')}/profile/card#me`),
 }))

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -33,6 +33,7 @@ import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 vi.mock('../services/solidPod', () => ({
     POD_CONTAINERS: { PACKING_LISTS: 'pack-me-up/packing-lists/' },
     getPrimaryPodUrl: vi.fn().mockResolvedValue('https://own.solidcommunity.net/'),
+    derivePodUrlFromWebId: vi.fn((webId: string) => webId.replace('/profile/card#me', '/')),
     grantCollaboratorAccess: vi.fn(),
     deriveWebIdFromPodUrl: vi.fn((url: string) => `${url.replace(/\/$/, '')}/profile/card#me`),
 }))

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -30,6 +30,17 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { usePodSync } from '../hooks/usePodSync'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 
+vi.mock('../services/solidPod', () => ({
+    POD_CONTAINERS: { PACKING_LISTS: 'pack-me-up/packing-lists/' },
+    getPrimaryPodUrl: vi.fn().mockResolvedValue('https://own.solidcommunity.net/'),
+    grantCollaboratorAccess: vi.fn(),
+    deriveWebIdFromPodUrl: vi.fn((url: string) => `${url.replace(/\/$/, '')}/profile/card#me`),
+}))
+
+vi.mock('../components/SharePackingListModal', () => ({
+    SharePackingListModal: vi.fn(() => null),
+}))
+
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockUsePodSync = vi.mocked(usePodSync)
@@ -638,5 +649,113 @@ describe('ViewPackingList expandable person sections', () => {
         fireEvent.click(screen.getByRole('button', { name: /collapse alice's list/i }))
         const remainingInputs = screen.getAllByPlaceholderText('Add new item...')
         expect(remainingInputs.length).toBeLessThan(addInputs.length)
+    })
+})
+
+// ─── Foreign pod (?pod= query param) ────────────────────────────────────────
+
+const FOREIGN_POD_URL = 'https://alice.solidcommunity.net/'
+
+function renderWithForeignPod(podParam?: string) {
+    const path = podParam
+        ? `/view-list/test-list-1?pod=${encodeURIComponent(podParam)}`
+        : '/view-list/test-list-1'
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <Routes>
+                <Route path="/view-list/:id" element={<ViewPackingList />} />
+            </Routes>
+        </MemoryRouter>
+    )
+}
+
+describe('ViewPackingList foreign pod (?pod= param)', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: { info: { isLoggedIn: true, webId: 'https://own.solidcommunity.net/profile/card#me' }, fetch: vi.fn() },
+            webId: 'https://own.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('passes pathConfig.podUrl to usePodSync when ?pod= param is present', async () => {
+        renderWithForeignPod(FOREIGN_POD_URL)
+
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+
+        expect(mockUsePodSync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                pathConfig: expect.objectContaining({ podUrl: FOREIGN_POD_URL }),
+            })
+        )
+    })
+
+    it('does not pass pathConfig.podUrl to usePodSync when ?pod= param is absent', async () => {
+        renderWithForeignPod()
+
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+
+        const lastCall = mockUsePodSync.mock.calls[mockUsePodSync.mock.calls.length - 1][0]
+        expect(lastCall.pathConfig.podUrl).toBeUndefined()
+    })
+
+    it('shows "Shared list" badge when ?pod= param is present', async () => {
+        renderWithForeignPod(FOREIGN_POD_URL)
+
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+
+        expect(screen.getByText('Shared list')).toBeTruthy()
+    })
+
+    it('does not show "Shared list" badge when ?pod= param is absent', async () => {
+        renderWithForeignPod()
+
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+
+        expect(screen.queryByText('Shared list')).toBeNull()
+    })
+
+    it('does not show Share button when ?pod= param is present', async () => {
+        renderWithForeignPod(FOREIGN_POD_URL)
+
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+
+        expect(screen.queryByRole('button', { name: /^share$/i })).toBeNull()
+    })
+
+    it('shows Share button when logged in and no ?pod= param', async () => {
+        renderWithForeignPod()
+
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+
+        await waitFor(() => expect(screen.getByRole('button', { name: /^share$/i })).toBeTruthy())
+    })
+
+    it('keeps loading state when getPackingList throws not_found on a foreign pod', async () => {
+        const dbWithNotFound = {
+            ...makeDb(),
+            getPackingList: vi.fn().mockRejectedValue({ name: 'not_found' }),
+        }
+        mockUseDatabase.mockReturnValue({ db: dbWithNotFound as unknown as PackingAppDatabase })
+
+        renderWithForeignPod(FOREIGN_POD_URL)
+
+        // Loading text should remain visible since we're waiting for pod poll
+        await waitFor(() => expect(screen.getByText(/loading/i)).toBeTruthy())
     })
 })

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useDebouncedCallback } from 'use-debounce'
 import { PackingList, PackingListItem } from '../create-packing-list/types'
@@ -49,6 +49,10 @@ export function ViewPackingList() {
     const [isLoading, setIsLoading] = useState(true)
     const [shareModalOpen, setShareModalOpen] = useState(false)
     const [ownPodUrl, setOwnPodUrl] = useState<string | null>(null)
+    // Tracks whether initial data has been loaded (local DB or pod).
+    // Used to surface a real error to the user instead of hanging on "Loading…"
+    // when a foreign-pod fetch fails.
+    const hasLoadedRef = useRef(false)
     const [showPacked, setShowPacked] = useState(false)
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
     const [newItemInputs, setNewItemInputs] = useState<Record<string, string>>({})
@@ -101,6 +105,7 @@ export function ViewPackingList() {
                 return await db.savePackingList(data);
             },
             updateFormAndState: (data, newRev) => {
+                hasLoadedRef.current = true;
                 setIsLoading(false);
                 setPackingList({
                     ...data,
@@ -114,6 +119,17 @@ export function ViewPackingList() {
             },
             conflictStrategy: 'fallback-to-pod', // Use same strategy as edit questions for consistency
         });
+
+    // When viewing a shared (foreign) pod list and the initial pod fetch fails,
+    // stop the infinite loading spinner and surface the error as a toast.
+    const handleViewSyncError = useCallback((error: string) => {
+        handleSyncError(error)
+        if (foreignPodUrl && !hasLoadedRef.current) {
+            hasLoadedRef.current = true
+            setIsLoading(false)
+            showToast(`Could not load shared list: ${error}`, 'error')
+        }
+    }, [handleSyncError, foreignPodUrl, showToast])
 
     // Callback when save to Pod succeeds
     const handleSaveSuccess = useCallback(() => {
@@ -138,7 +154,7 @@ export function ViewPackingList() {
         pollInterval: 5000, // Poll every 5 seconds for faster sync
         enabled: isLoggedIn, // Only sync when logged in
         onSyncSuccess: handleSyncSuccess,
-        onSyncError: handleSyncError,
+        onSyncError: handleViewSyncError,
         onSaveSuccess: handleSaveSuccess,
         onSaveError: handleSaveError,
     });
@@ -157,6 +173,7 @@ export function ViewPackingList() {
                     initialValues[item.id] = item.packed
                 })
                 reset({ items: initialValues })
+                hasLoadedRef.current = true
                 setIsLoading(false)
             } catch (err) {
                 const isNotFound = typeof err === 'object' && err !== null && (err as { name?: string }).name === 'not_found'

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -10,7 +10,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
 import { usePodSync } from '../hooks/usePodSync'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
-import { POD_CONTAINERS, getPrimaryPodUrl } from '../services/solidPod'
+import { POD_CONTAINERS, derivePodUrlFromWebId } from '../services/solidPod'
 import { packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { SharePackingListModal } from '../components/SharePackingListModal'
 
@@ -48,7 +48,6 @@ export function ViewPackingList() {
     const [packingList, setPackingList] = useState<PackingList | null>(null)
     const [isLoading, setIsLoading] = useState(true)
     const [shareModalOpen, setShareModalOpen] = useState(false)
-    const [ownPodUrl, setOwnPodUrl] = useState<string | null>(null)
     const [showPacked, setShowPacked] = useState(false)
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
     const [newItemInputs, setNewItemInputs] = useState<Record<string, string>>({})
@@ -74,15 +73,12 @@ export function ViewPackingList() {
 
     const handleCheckAll = (items: PackingListItem[]) =>
         items.forEach(item => setValue(`items.${item.id}`, true))
-    const { isLoggedIn, session } = useSolidPod()
+    const { isLoggedIn, session, webId } = useSolidPod()
     const { showToast } = useToast()
     const { db } = useDatabase()
 
-    useEffect(() => {
-        if (isLoggedIn && session && !foreignPodUrl) {
-            getPrimaryPodUrl(session).then(url => setOwnPodUrl(url ?? null))
-        }
-    }, [isLoggedIn, session, foreignPodUrl])
+    // Derive pod URL from webId synchronously — no network round-trip needed
+    const ownPodUrl = (!foreignPodUrl && webId) ? derivePodUrlFromWebId(webId) : null
 
     const { register, setValue, getValues, control, reset } = useForm<FormData>({
         defaultValues: {

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -10,7 +10,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
 import { usePodSync } from '../hooks/usePodSync'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
-import { POD_CONTAINERS, derivePodUrlFromWebId } from '../services/solidPod'
+import { POD_CONTAINERS, getPrimaryPodUrl } from '../services/solidPod'
 import { packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { SharePackingListModal } from '../components/SharePackingListModal'
 
@@ -48,6 +48,7 @@ export function ViewPackingList() {
     const [packingList, setPackingList] = useState<PackingList | null>(null)
     const [isLoading, setIsLoading] = useState(true)
     const [shareModalOpen, setShareModalOpen] = useState(false)
+    const [ownPodUrl, setOwnPodUrl] = useState<string | null>(null)
     const [showPacked, setShowPacked] = useState(false)
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
     const [newItemInputs, setNewItemInputs] = useState<Record<string, string>>({})
@@ -73,12 +74,15 @@ export function ViewPackingList() {
 
     const handleCheckAll = (items: PackingListItem[]) =>
         items.forEach(item => setValue(`items.${item.id}`, true))
-    const { isLoggedIn, session, webId } = useSolidPod()
+    const { isLoggedIn, session } = useSolidPod()
     const { showToast } = useToast()
     const { db } = useDatabase()
 
-    // Derive pod URL from webId synchronously — no network round-trip needed
-    const ownPodUrl = (!foreignPodUrl && webId) ? derivePodUrlFromWebId(webId) : null
+    useEffect(() => {
+        if (isLoggedIn && session && !foreignPodUrl) {
+            getPrimaryPodUrl(session).then(url => setOwnPodUrl(url ?? null))
+        }
+    }, [isLoggedIn, session, foreignPodUrl])
 
     const { register, setValue, getValues, control, reset } = useForm<FormData>({
         defaultValues: {
@@ -464,11 +468,12 @@ export function ViewPackingList() {
                                 >
                                     {showPacked ? 'Hide Packed' : 'Show Packed'}
                                 </Button>
-                                {isLoggedIn && !foreignPodUrl && ownPodUrl && (
+                                {isLoggedIn && !foreignPodUrl && (
                                     <Button
                                         type="button"
                                         variant="secondary"
                                         onClick={() => setShareModalOpen(true)}
+                                        disabled={!ownPodUrl}
                                     >
                                         Share
                                     </Button>

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -671,7 +671,7 @@ export function ViewPackingList() {
                 isOpen={shareModalOpen}
                 onClose={() => setShareModalOpen(false)}
                 session={session}
-                fileUrl={`${ownPodUrl}${POD_CONTAINERS.PACKING_LISTS}${id}.json`}
+                fileUrl={`${ownPodUrl}${POD_CONTAINERS.PACKING_LISTS}${id}.ttl`}
                 listId={id}
                 sharerPodUrl={ownPodUrl}
             />

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useDebouncedCallback } from 'use-debounce'
 import { PackingList, PackingListItem } from '../create-packing-list/types'
 import { useDatabase } from '../components/DatabaseContext'
@@ -10,8 +10,9 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
 import { usePodSync } from '../hooks/usePodSync'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
-import { POD_CONTAINERS } from '../services/solidPod'
+import { POD_CONTAINERS, getPrimaryPodUrl } from '../services/solidPod'
 import { packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
+import { SharePackingListModal } from '../components/SharePackingListModal'
 
 type FormData = {
     items: Record<string, boolean>
@@ -42,8 +43,12 @@ function groupByCategory(items: PackingListItem[]) {
 export function ViewPackingList() {
     const { id } = useParams<{ id: string }>()
     const navigate = useNavigate()
+    const [searchParams] = useSearchParams()
+    const foreignPodUrl = searchParams.get('pod') ?? undefined
     const [packingList, setPackingList] = useState<PackingList | null>(null)
     const [isLoading, setIsLoading] = useState(true)
+    const [shareModalOpen, setShareModalOpen] = useState(false)
+    const [ownPodUrl, setOwnPodUrl] = useState<string | null>(null)
     const [showPacked, setShowPacked] = useState(false)
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
     const [newItemInputs, setNewItemInputs] = useState<Record<string, string>>({})
@@ -69,9 +74,15 @@ export function ViewPackingList() {
 
     const handleCheckAll = (items: PackingListItem[]) =>
         items.forEach(item => setValue(`items.${item.id}`, true))
-    const { isLoggedIn } = useSolidPod()
+    const { isLoggedIn, session } = useSolidPod()
     const { showToast } = useToast()
     const { db } = useDatabase()
+
+    useEffect(() => {
+        if (isLoggedIn && session && !foreignPodUrl) {
+            getPrimaryPodUrl(session).then(url => setOwnPodUrl(url ?? null))
+        }
+    }, [isLoggedIn, session, foreignPodUrl])
 
     const { register, setValue, getValues, control, reset } = useForm<FormData>({
         defaultValues: {
@@ -90,6 +101,7 @@ export function ViewPackingList() {
                 return await db.savePackingList(data);
             },
             updateFormAndState: (data, newRev) => {
+                setIsLoading(false);
                 setPackingList({
                     ...data,
                     _rev: newRev
@@ -119,7 +131,8 @@ export function ViewPackingList() {
         pathConfig: {
             container: POD_CONTAINERS.PACKING_LISTS,
             filename: (id) => `${id}.ttl`,
-            resourceId: id || null
+            resourceId: id || null,
+            podUrl: foreignPodUrl,
         },
         rdf: { serialize: packingListToDataset, deserialize: datasetToPackingList },
         pollInterval: 5000, // Poll every 5 seconds for faster sync
@@ -144,15 +157,20 @@ export function ViewPackingList() {
                     initialValues[item.id] = item.packed
                 })
                 reset({ items: initialValues })
-            } catch (err) {
-                console.error('Error fetching packing list:', err)
-            } finally {
                 setIsLoading(false)
+            } catch (err) {
+                const isNotFound = typeof err === 'object' && err !== null && (err as { name?: string }).name === 'not_found'
+                if (isNotFound && foreignPodUrl) {
+                    // Leave isLoading=true — the first pod poll will hydrate via handleSyncSuccess
+                } else {
+                    console.error('Error fetching packing list:', err)
+                    setIsLoading(false)
+                }
             }
         }
 
         fetchPackingList()
-    }, [db, id, setValue])
+    }, [db, id, setValue, foreignPodUrl])
 
     const handleItemChange = useDebouncedCallback(async () => {
         if (!packingList) {
@@ -412,6 +430,11 @@ export function ViewPackingList() {
                         <div className="flex flex-wrap items-center justify-between gap-3">
                             <div className="flex items-center gap-3">
                                 <h1 className="text-xl font-bold text-gray-900">{packingList.name}</h1>
+                                {foreignPodUrl && (
+                                    <span className="text-xs font-medium text-blue-700 bg-blue-100 border border-blue-200 rounded-full px-2 py-0.5">
+                                        Shared list
+                                    </span>
+                                )}
                                 <span className="text-sm text-gray-600 font-medium">
                                     {packedCount} / {totalCount} packed ({percentComplete}%)
                                 </span>
@@ -445,6 +468,15 @@ export function ViewPackingList() {
                                 >
                                     {showPacked ? 'Hide Packed' : 'Show Packed'}
                                 </Button>
+                                {isLoggedIn && !foreignPodUrl && ownPodUrl && (
+                                    <Button
+                                        type="button"
+                                        variant="secondary"
+                                        onClick={() => setShareModalOpen(true)}
+                                    >
+                                        Share
+                                    </Button>
+                                )}
                                 <Button
                                     type="button"
                                     variant="secondary"
@@ -634,6 +666,16 @@ export function ViewPackingList() {
             confirmText="Remove"
             confirmVariant="danger"
         />
+        {session && ownPodUrl && id && (
+            <SharePackingListModal
+                isOpen={shareModalOpen}
+                onClose={() => setShareModalOpen(false)}
+                session={session}
+                fileUrl={`${ownPodUrl}${POD_CONTAINERS.PACKING_LISTS}${id}.json`}
+                listId={id}
+                sharerPodUrl={ownPodUrl}
+            />
+        )}
         </>
     )
 }

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -9,6 +9,10 @@ import {
     loadMultipleRdfFromPod,
     saveMultipleRdfToPod,
     POD_CONTAINERS,
+    deriveWebIdFromPodUrl,
+    grantCollaboratorAccess,
+    revokeCollaboratorAccess,
+    getCollaborators,
 } from './solidPod'
 import { AuthenticationError } from './solidPod'
 import type { PackingAppDatabase } from './database'
@@ -20,24 +24,29 @@ vi.mock('@inrupt/solid-client', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@inrupt/solid-client')>()
     return {
         ...actual,
-        // These are mocked so tests can control pod I/O
         getFile: vi.fn(),
         getSolidDataset: vi.fn(),
         getContainedResourceUrlAll: vi.fn(),
         getPodUrlAll: vi.fn(),
-        saveFileInContainer: vi.fn(),
         overwriteFile: vi.fn(),
         deleteFile: vi.fn(),
         saveSolidDatasetAt: vi.fn(),
+        universalAccess: {
+            ...actual.universalAccess,
+            setAgentAccess: vi.fn(),
+            getAgentAccessAll: vi.fn(),
+        },
     }
 })
 
-import { getFile, getSolidDataset, getContainedResourceUrlAll, overwriteFile, createSolidDataset } from '@inrupt/solid-client'
+import { getFile, getSolidDataset, getContainedResourceUrlAll, overwriteFile, createSolidDataset, universalAccess } from '@inrupt/solid-client'
 
 const mockGetFile = vi.mocked(getFile)
 const mockGetSolidDataset = vi.mocked(getSolidDataset)
 const mockGetContainedResourceUrlAll = vi.mocked(getContainedResourceUrlAll)
 const mockOverwriteFile = vi.mocked(overwriteFile)
+const mockSetAgentAccess = vi.mocked(universalAccess.setAgentAccess)
+const mockGetAgentAccessAll = vi.mocked(universalAccess.getAgentAccessAll)
 
 const mockSession = {
     info: { isLoggedIn: true, webId: 'https://example.com/profile#me' },
@@ -548,5 +557,204 @@ describe('saveMultipleRdfToPod', () => {
         await saveMultipleRdfToPod(mockSession, LISTS_CONTAINER_URL, [activeList], packingListToDataset)
 
         expect(mockDeleteFile).toHaveBeenCalledWith(orphanUrl, expect.any(Object))
+    })
+})
+
+// ─── deriveWebIdFromPodUrl ───────────────────────────────────────────────────
+
+describe('deriveWebIdFromPodUrl', () => {
+    it('appends /profile/card#me to a pod URL with trailing slash', () => {
+        expect(deriveWebIdFromPodUrl('https://alice.solidcommunity.net/')).toBe(
+            'https://alice.solidcommunity.net/profile/card#me'
+        )
+    })
+
+    it('appends /profile/card#me to a pod URL without trailing slash', () => {
+        expect(deriveWebIdFromPodUrl('https://alice.solidcommunity.net')).toBe(
+            'https://alice.solidcommunity.net/profile/card#me'
+        )
+    })
+
+    it('works for pod URLs with a path segment', () => {
+        expect(deriveWebIdFromPodUrl('http://localhost:4001/alice/')).toBe(
+            'http://localhost:4001/alice/profile/card#me'
+        )
+    })
+})
+
+// ─── grantCollaboratorAccess ─────────────────────────────────────────────────
+
+describe('grantCollaboratorAccess', () => {
+    const FILE_URL = 'https://alice.solidcommunity.net/pack-me-up/packing-lists/abc.json'
+    const COLLAB_WEB_ID = 'https://bob.solidcommunity.net/profile/card#me'
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('calls setAgentAccess with read, write, and append true', async () => {
+        mockSetAgentAccess.mockResolvedValue({ read: true, write: true, append: true, controlRead: false, controlWrite: false })
+
+        await grantCollaboratorAccess(mockSession, FILE_URL, COLLAB_WEB_ID)
+
+        expect(mockSetAgentAccess).toHaveBeenCalledWith(
+            FILE_URL,
+            COLLAB_WEB_ID,
+            { read: true, write: true, append: true },
+            { fetch: mockSession.fetch }
+        )
+    })
+
+    it('resolves successfully when setAgentAccess succeeds', async () => {
+        mockSetAgentAccess.mockResolvedValue({ read: true, write: true, append: true, controlRead: false, controlWrite: false })
+
+        await expect(grantCollaboratorAccess(mockSession, FILE_URL, COLLAB_WEB_ID)).resolves.toBeUndefined()
+    })
+
+    it('throws AuthenticationError on 401', async () => {
+        mockSetAgentAccess.mockRejectedValue({ statusCode: 401 })
+
+        await expect(grantCollaboratorAccess(mockSession, FILE_URL, COLLAB_WEB_ID)).rejects.toThrow(AuthenticationError)
+    })
+
+    it('throws AuthenticationError on 403', async () => {
+        mockSetAgentAccess.mockRejectedValue({ statusCode: 403 })
+
+        await expect(grantCollaboratorAccess(mockSession, FILE_URL, COLLAB_WEB_ID)).rejects.toThrow(AuthenticationError)
+    })
+
+    it('re-throws other errors unchanged', async () => {
+        const err = new Error('Network failure')
+        mockSetAgentAccess.mockRejectedValue(err)
+
+        await expect(grantCollaboratorAccess(mockSession, FILE_URL, COLLAB_WEB_ID)).rejects.toThrow('Network failure')
+    })
+
+    it('throws a descriptive error when setAgentAccess returns null', async () => {
+        mockSetAgentAccess.mockResolvedValue(null)
+
+        await expect(grantCollaboratorAccess(mockSession, FILE_URL, COLLAB_WEB_ID)).rejects.toThrow(
+            'grantCollaboratorAccess: server does not support access control for this resource'
+        )
+    })
+})
+
+// ─── revokeCollaboratorAccess ────────────────────────────────────────────────
+
+describe('revokeCollaboratorAccess', () => {
+    const FILE_URL = 'https://alice.solidcommunity.net/pack-me-up/packing-lists/abc.json'
+    const COLLAB_WEB_ID = 'https://bob.solidcommunity.net/profile/card#me'
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('calls setAgentAccess with all modes false', async () => {
+        mockSetAgentAccess.mockResolvedValue({ read: false, write: false, append: false, controlRead: false, controlWrite: false })
+
+        await revokeCollaboratorAccess(mockSession, FILE_URL, COLLAB_WEB_ID)
+
+        expect(mockSetAgentAccess).toHaveBeenCalledWith(
+            FILE_URL,
+            COLLAB_WEB_ID,
+            { read: false, write: false, append: false, controlRead: false, controlWrite: false },
+            { fetch: mockSession.fetch }
+        )
+    })
+
+    it('throws AuthenticationError on 401', async () => {
+        mockSetAgentAccess.mockRejectedValue({ statusCode: 401 })
+
+        await expect(revokeCollaboratorAccess(mockSession, FILE_URL, COLLAB_WEB_ID)).rejects.toThrow(AuthenticationError)
+    })
+
+    it('throws AuthenticationError on 403', async () => {
+        mockSetAgentAccess.mockRejectedValue({ statusCode: 403 })
+
+        await expect(revokeCollaboratorAccess(mockSession, FILE_URL, COLLAB_WEB_ID)).rejects.toThrow(AuthenticationError)
+    })
+
+    it('throws a descriptive error when setAgentAccess returns null', async () => {
+        mockSetAgentAccess.mockResolvedValue(null)
+
+        await expect(revokeCollaboratorAccess(mockSession, FILE_URL, COLLAB_WEB_ID)).rejects.toThrow(
+            'revokeCollaboratorAccess: server does not support access control for this resource'
+        )
+    })
+})
+
+// ─── getCollaborators ────────────────────────────────────────────────────────
+
+describe('getCollaborators', () => {
+    const FILE_URL = 'https://alice.solidcommunity.net/pack-me-up/packing-lists/abc.json'
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('returns empty array when getAgentAccessAll returns null', async () => {
+        mockGetAgentAccessAll.mockResolvedValue(null)
+
+        const result = await getCollaborators(mockSession, FILE_URL)
+
+        expect(result).toEqual([])
+    })
+
+    it('returns empty array when getAgentAccessAll returns empty object', async () => {
+        mockGetAgentAccessAll.mockResolvedValue({})
+
+        const result = await getCollaborators(mockSession, FILE_URL)
+
+        expect(result).toEqual([])
+    })
+
+    it('returns WebIDs of agents with read access', async () => {
+        mockGetAgentAccessAll.mockResolvedValue({
+            'https://bob.solidcommunity.net/profile/card#me': { read: true, write: true, append: true, controlRead: false, controlWrite: false },
+        })
+
+        const result = await getCollaborators(mockSession, FILE_URL)
+
+        expect(result).toEqual(['https://bob.solidcommunity.net/profile/card#me'])
+    })
+
+    it('excludes agents without read access', async () => {
+        mockGetAgentAccessAll.mockResolvedValue({
+            'https://bob.solidcommunity.net/profile/card#me': { read: false, write: false, append: false, controlRead: false, controlWrite: false },
+        })
+
+        const result = await getCollaborators(mockSession, FILE_URL)
+
+        expect(result).toEqual([])
+    })
+
+    it('excludes the session owner webId', async () => {
+        mockGetAgentAccessAll.mockResolvedValue({
+            [mockSession.info.webId!]: { read: true, write: true, append: true, controlRead: false, controlWrite: false },
+            'https://bob.solidcommunity.net/profile/card#me': { read: true, write: false, append: false, controlRead: false, controlWrite: false },
+        })
+
+        const result = await getCollaborators(mockSession, FILE_URL)
+
+        expect(result).toEqual(['https://bob.solidcommunity.net/profile/card#me'])
+    })
+
+    it('throws AuthenticationError on 401', async () => {
+        mockGetAgentAccessAll.mockRejectedValue({ statusCode: 401 })
+
+        await expect(getCollaborators(mockSession, FILE_URL)).rejects.toThrow(AuthenticationError)
+    })
+
+    it('throws AuthenticationError on 403', async () => {
+        mockGetAgentAccessAll.mockRejectedValue({ statusCode: 403 })
+
+        await expect(getCollaborators(mockSession, FILE_URL)).rejects.toThrow(AuthenticationError)
+    })
+
+    it('re-throws other errors unchanged', async () => {
+        const err = new Error('Network failure')
+        mockGetAgentAccessAll.mockRejectedValue(err)
+
+        await expect(getCollaborators(mockSession, FILE_URL)).rejects.toThrow('Network failure')
     })
 })

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -108,6 +108,24 @@ export function deriveWebIdFromPodUrl(podUrl: string): string {
     return `${base}/profile/card#me`
 }
 
+export function derivePodUrlFromWebId(webId: string): string | null {
+    try {
+        const url = new URL(webId)
+        url.hash = ''
+        const path = url.pathname
+        if (path.endsWith('/profile/card')) {
+            url.pathname = path.slice(0, -'profile/card'.length)
+            return url.toString()
+        }
+        const firstSegment = path.split('/').find(s => s.length > 0)
+        if (firstSegment) {
+            url.pathname = '/' + firstSegment + '/'
+            return url.toString()
+        }
+    } catch { /* ignore URL parse errors */ }
+    return null
+}
+
 export async function grantCollaboratorAccess(
     session: Session,
     fileUrl: string,

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -1,6 +1,7 @@
 import { AppSession as Session } from '../types/AppSession'
-import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile, solidDatasetAsTurtle } from '@inrupt/solid-client'
+import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile, solidDatasetAsTurtle, universalAccess } from '@inrupt/solid-client'
 import type { SolidDataset } from '@inrupt/solid-client'
+const { setAgentAccess, getAgentAccessAll } = universalAccess
 import { PackingAppDatabase } from './database'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList } from '../create-packing-list/types'
@@ -100,6 +101,72 @@ export function handlePodError(error: unknown): never {
         throw new AuthenticationError(POD_ERROR_MESSAGES.SESSION_EXPIRED, error)
     }
     throw error
+}
+
+export function deriveWebIdFromPodUrl(podUrl: string): string {
+    const base = podUrl.replace(/\/+$/, '')
+    return `${base}/profile/card#me`
+}
+
+export async function grantCollaboratorAccess(
+    session: Session,
+    fileUrl: string,
+    collaboratorWebId: string
+): Promise<void> {
+    try {
+        const result = await setAgentAccess(
+            fileUrl,
+            collaboratorWebId,
+            { read: true, write: true, append: true },
+            { fetch: session.fetch }
+        )
+        if (result === null) {
+            throw new Error('grantCollaboratorAccess: server does not support access control for this resource')
+        }
+    } catch (error) {
+        if (isAuthenticationError(error)) handlePodError(error)
+        throw error
+    }
+}
+
+export async function revokeCollaboratorAccess(
+    session: Session,
+    fileUrl: string,
+    collaboratorWebId: string
+): Promise<void> {
+    try {
+        const result = await setAgentAccess(
+            fileUrl,
+            collaboratorWebId,
+            { read: false, write: false, append: false, controlRead: false, controlWrite: false },
+            { fetch: session.fetch }
+        )
+        if (result === null) {
+            throw new Error('revokeCollaboratorAccess: server does not support access control for this resource')
+        }
+    } catch (error) {
+        if (isAuthenticationError(error)) handlePodError(error)
+        throw error
+    }
+}
+
+export async function getCollaborators(
+    session: Session,
+    fileUrl: string
+): Promise<string[]> {
+    try {
+        const accessMap = await getAgentAccessAll(fileUrl, { fetch: session.fetch })
+        if (!accessMap) return []
+        return Object.entries(accessMap)
+            .filter(([webId, modes]) =>
+                webId !== session.info.webId &&
+                modes.read === true
+            )
+            .map(([webId]) => webId)
+    } catch (error) {
+        if (isAuthenticationError(error)) handlePodError(error)
+        throw error
+    }
 }
 
 function getStatusCode(err: unknown): number | undefined {


### PR DESCRIPTION
- Add ACL utility functions (deriveWebIdFromPodUrl, grantCollaboratorAccess,
  revokeCollaboratorAccess, getCollaborators) to solidPod.ts using
  @inrupt/solid-client's setAgentAccess/getAgentAccessAll
- Extend PodPathConfig with optional podUrl override so usePodSync can
  sync with a foreign user's pod instead of the logged-in user's pod
- Add ?pod= query param support to /view-lists/:id: reads foreign pod,
  shows "Shared list" badge, hides Share button on foreign views
- Add SharePackingListModal: enter collaborator pod URL, grant ACL access,
  display copy-able shareable link
- Add E2E test suite (l-sharing.spec.ts) covering share flow, badge
  visibility, and cross-user item sync; add collab CSS test account