### PR TITLE
Add "anyone with the link can edit" sharing mode

### DIFF
--- a/src/components/SharePackingListModal.test.tsx
+++ b/src/components/SharePackingListModal.test.tsx
@@ -6,11 +6,13 @@ import type { AppSession } from '../types/AppSession'
 
 vi.mock('../services/solidPod', () => ({
     grantCollaboratorAccess: vi.fn(),
+    grantPublicAccess: vi.fn(),
 }))
 
-import { grantCollaboratorAccess } from '../services/solidPod'
+import { grantCollaboratorAccess, grantPublicAccess } from '../services/solidPod'
 
 const mockGrantCollaboratorAccess = vi.mocked(grantCollaboratorAccess)
+const mockGrantPublicAccess = vi.mocked(grantPublicAccess)
 
 const mockSession = {
     info: { isLoggedIn: true, webId: 'https://alice.solidcommunity.net/profile/card#me' },
@@ -207,5 +209,84 @@ describe('SharePackingListModal', () => {
 
             expect(screen.queryByText(/ACL not supported/i)).toBeNull()
         })
+    })
+})
+
+describe('SharePackingListModal — anyone with the link mode', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText: vi.fn().mockResolvedValue(undefined) },
+            writable: true,
+        })
+        Object.defineProperty(window, 'location', {
+            value: { origin: 'https://pack-me-up.app', hash: '' },
+            writable: true,
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('renders a tab or button to switch to "anyone with the link" mode', () => {
+        renderModal()
+        expect(screen.getByRole('button', { name: /anyone with the link/i })).toBeTruthy()
+    })
+
+    it('switching to "anyone with the link" mode hides the WebID input', async () => {
+        renderModal()
+        fireEvent.click(screen.getByRole('button', { name: /anyone with the link/i }))
+        expect(screen.queryByPlaceholderText(/profile\/card#me/i)).toBeNull()
+    })
+
+    it('shows a "Share publicly" button in "anyone with the link" mode', async () => {
+        renderModal()
+        fireEvent.click(screen.getByRole('button', { name: /anyone with the link/i }))
+        expect(screen.getByRole('button', { name: /share publicly/i })).toBeTruthy()
+    })
+
+    it('calls grantPublicAccess (not grantCollaboratorAccess) when "Share publicly" is clicked', async () => {
+        mockGrantPublicAccess.mockResolvedValue(undefined)
+        renderModal()
+        fireEvent.click(screen.getByRole('button', { name: /anyone with the link/i }))
+        fireEvent.click(screen.getByRole('button', { name: /share publicly/i }))
+
+        await waitFor(() => expect(mockGrantPublicAccess).toHaveBeenCalledWith(mockSession, defaultProps.fileUrl))
+        expect(mockGrantCollaboratorAccess).not.toHaveBeenCalled()
+    })
+
+    it('shows the generated link after granting public access', async () => {
+        mockGrantPublicAccess.mockResolvedValue(undefined)
+        renderModal()
+        fireEvent.click(screen.getByRole('button', { name: /anyone with the link/i }))
+        fireEvent.click(screen.getByRole('button', { name: /share publicly/i }))
+
+        await waitFor(() => expect(screen.getByRole('textbox', { name: /shareable link/i })).toBeTruthy())
+        const linkInput = screen.getByRole('textbox', { name: /shareable link/i }) as HTMLInputElement
+        expect(linkInput.value).toContain('/view-lists/abc')
+        expect(linkInput.value).toContain('pod=')
+    })
+
+    it('shows an error when grantPublicAccess throws', async () => {
+        mockGrantPublicAccess.mockRejectedValue(new Error('ACL not supported'))
+        renderModal()
+        fireEvent.click(screen.getByRole('button', { name: /anyone with the link/i }))
+        fireEvent.click(screen.getByRole('button', { name: /share publicly/i }))
+
+        await waitFor(() => expect(screen.getByText(/ACL not supported/i)).toBeTruthy())
+    })
+
+    it('"Copy link" copies the link to clipboard in public mode', async () => {
+        mockGrantPublicAccess.mockResolvedValue(undefined)
+        renderModal()
+        fireEvent.click(screen.getByRole('button', { name: /anyone with the link/i }))
+        fireEvent.click(screen.getByRole('button', { name: /share publicly/i }))
+
+        await waitFor(() => expect(screen.getByRole('button', { name: /copy link/i })).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: /copy link/i }))
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('/view-lists/abc'))
     })
 })

--- a/src/components/SharePackingListModal.tsx
+++ b/src/components/SharePackingListModal.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
 import { AppSession } from '../types/AppSession'
-import { grantCollaboratorAccess } from '../services/solidPod'
+import { grantCollaboratorAccess, grantPublicAccess } from '../services/solidPod'
 import { Modal } from './Modal'
 import { Button } from './Button'
 import { Input } from './Input'
+
+type ShareMode = 'person' | 'public'
 
 interface SharePackingListModalProps {
     isOpen: boolean
@@ -22,10 +24,14 @@ export function SharePackingListModal({
     listId,
     sharerPodUrl,
 }: SharePackingListModalProps) {
+    const [shareMode, setShareMode] = useState<ShareMode>('person')
     const [collaboratorWebId, setCollaboratorWebId] = useState('')
     const [isGranting, setIsGranting] = useState(false)
     const [generatedLink, setGeneratedLink] = useState<string | null>(null)
     const [error, setError] = useState<string | null>(null)
+
+    const buildLink = () =>
+        `${window.location.origin}/#/view-lists/${listId}?pod=${encodeURIComponent(sharerPodUrl)}`
 
     const handleShare = async () => {
         if (!collaboratorWebId.trim()) return
@@ -34,8 +40,20 @@ export function SharePackingListModal({
         setError(null)
         try {
             await grantCollaboratorAccess(session, fileUrl, collaboratorWebId.trim())
-            const link = `${window.location.origin}/#/view-lists/${listId}?pod=${encodeURIComponent(sharerPodUrl)}`
-            setGeneratedLink(link)
+            setGeneratedLink(buildLink())
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to share. Please try again.')
+        } finally {
+            setIsGranting(false)
+        }
+    }
+
+    const handleSharePublicly = async () => {
+        setIsGranting(true)
+        setError(null)
+        try {
+            await grantPublicAccess(session, fileUrl)
+            setGeneratedLink(buildLink())
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to share. Please try again.')
         } finally {
@@ -49,34 +67,87 @@ export function SharePackingListModal({
         }
     }
 
+    const handleModeChange = (mode: ShareMode) => {
+        setShareMode(mode)
+        setError(null)
+        setGeneratedLink(null)
+    }
+
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Share packing list">
             <div className="space-y-4">
-                <div>
-                    <Input
-                        label="Collaborator's WebID"
-                        placeholder="https://friend.solidcommunity.net/profile/card#me"
-                        value={collaboratorWebId}
-                        onChange={e => {
-                            setCollaboratorWebId(e.target.value)
-                            setError(null)
-                        }}
-                        disabled={isGranting}
-                    />
+                {/* Mode tabs */}
+                <div className="flex rounded-lg border border-gray-200 overflow-hidden">
+                    <button
+                        type="button"
+                        onClick={() => handleModeChange('person')}
+                        className={`flex-1 py-2 px-3 text-sm font-medium transition-colors ${
+                            shareMode === 'person'
+                                ? 'bg-blue-600 text-white'
+                                : 'bg-white text-gray-600 hover:bg-gray-50'
+                        }`}
+                    >
+                        With a person
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => handleModeChange('public')}
+                        className={`flex-1 py-2 px-3 text-sm font-medium transition-colors ${
+                            shareMode === 'public'
+                                ? 'bg-blue-600 text-white'
+                                : 'bg-white text-gray-600 hover:bg-gray-50'
+                        }`}
+                    >
+                        Anyone with the link
+                    </button>
                 </div>
+
+                {shareMode === 'person' && (
+                    <div>
+                        <Input
+                            label="Collaborator's WebID"
+                            placeholder="https://friend.solidcommunity.net/profile/card#me"
+                            value={collaboratorWebId}
+                            onChange={e => {
+                                setCollaboratorWebId(e.target.value)
+                                setError(null)
+                            }}
+                            disabled={isGranting}
+                        />
+                    </div>
+                )}
+
+                {shareMode === 'public' && !generatedLink && (
+                    <p className="text-sm text-gray-600">
+                        Anyone who follows this link can view and edit this list — no sign-in required to view.
+                    </p>
+                )}
 
                 {error && (
                     <p className="text-sm text-red-600">{error}</p>
                 )}
 
-                <Button
-                    type="button"
-                    variant="primary"
-                    onClick={handleShare}
-                    disabled={isGranting || !collaboratorWebId.trim()}
-                >
-                    {isGranting ? 'Sharing...' : 'Share'}
-                </Button>
+                {shareMode === 'person' && (
+                    <Button
+                        type="button"
+                        variant="primary"
+                        onClick={handleShare}
+                        disabled={isGranting || !collaboratorWebId.trim()}
+                    >
+                        {isGranting ? 'Sharing...' : 'Share'}
+                    </Button>
+                )}
+
+                {shareMode === 'public' && !generatedLink && (
+                    <Button
+                        type="button"
+                        variant="primary"
+                        onClick={handleSharePublicly}
+                        disabled={isGranting}
+                    >
+                        {isGranting ? 'Sharing...' : 'Share publicly'}
+                    </Button>
+                )}
 
                 {generatedLink && (
                     <div className="space-y-2">

--- a/src/hooks/usePodSync.ts
+++ b/src/hooks/usePodSync.ts
@@ -185,7 +185,8 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
    * Load data from the Pod
    */
   const syncFromPod = useCallback(async () => {
-    if (!enabled || !isLoggedIn || isSyncingRef.current) {
+    const isForeignPod = !!pathConfig.podUrl
+    if (!enabled || (!isLoggedIn && !isForeignPod) || isSyncingRef.current) {
       return;
     }
 
@@ -207,7 +208,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
         return;
       }
 
-      const data = await loadRdfFromPod<T>(session!, fileUrl, rdf.deserialize);
+      const data = await loadRdfFromPod<T>(session ?? null, fileUrl, rdf.deserialize);
 
       setLastSync(new Date());
 
@@ -298,7 +299,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
    * Existing callers that pass pollInterval retain their original behaviour.
    */
   useEffect(() => {
-    if (!enabled || !isLoggedIn) {
+    if (!enabled || (!isLoggedIn && !pathConfig.podUrl)) {
       return;
     }
 

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -152,7 +152,7 @@ export function ViewPackingList() {
         },
         rdf: { serialize: packingListToDataset, deserialize: datasetToPackingList },
         pollInterval: 5000, // Poll every 5 seconds for faster sync
-        enabled: isLoggedIn, // Only sync when logged in
+        enabled: isLoggedIn || !!foreignPodUrl, // Allow reading public shared lists without login
         onSyncSuccess: handleSyncSuccess,
         onSyncError: handleViewSyncError,
         onSaveSuccess: handleSaveSuccess,

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -11,6 +11,7 @@ import {
     POD_CONTAINERS,
     deriveWebIdFromPodUrl,
     grantCollaboratorAccess,
+    grantPublicAccess,
     revokeCollaboratorAccess,
     getCollaborators,
 } from './solidPod'
@@ -35,6 +36,7 @@ vi.mock('@inrupt/solid-client', async (importOriginal) => {
             ...actual.universalAccess,
             setAgentAccess: vi.fn(),
             getAgentAccessAll: vi.fn(),
+            setPublicAccess: vi.fn(),
         },
     }
 })
@@ -47,6 +49,7 @@ const mockGetContainedResourceUrlAll = vi.mocked(getContainedResourceUrlAll)
 const mockOverwriteFile = vi.mocked(overwriteFile)
 const mockSetAgentAccess = vi.mocked(universalAccess.setAgentAccess)
 const mockGetAgentAccessAll = vi.mocked(universalAccess.getAgentAccessAll)
+const mockSetPublicAccess = vi.mocked(universalAccess.setPublicAccess)
 
 const mockSession = {
     info: { isLoggedIn: true, webId: 'https://example.com/profile#me' },
@@ -432,6 +435,18 @@ describe('loadRdfFromPod', () => {
             loadRdfFromPod(mockSession, 'https://pod.example.com/test.ttl', () => null)
         ).rejects.toEqual(err)
     })
+
+    it('uses globalThis.fetch when session is null (public access)', async () => {
+        const url = 'https://pod.example.com/public.ttl'
+        const list = makePackingList('pub-id')
+        mockGetSolidDataset.mockResolvedValueOnce(
+            packingListToDataset(list, url) as unknown as SolidDataset & WithServerResourceInfo
+        )
+
+        await loadRdfFromPod(null, url, (_ds, _u) => ({ id: 'pub-id', name: 'Public', createdAt: '', items: [] }))
+
+        expect(mockGetSolidDataset).toHaveBeenCalledWith(url, expect.objectContaining({ fetch: globalThis.fetch }))
+    })
 })
 
 // ─── saveRdfToPod ────────────────────────────────────────────────────────────
@@ -679,6 +694,61 @@ describe('revokeCollaboratorAccess', () => {
 
         await expect(revokeCollaboratorAccess(mockSession, FILE_URL, COLLAB_WEB_ID)).rejects.toThrow(
             'revokeCollaboratorAccess: server does not support access control for this resource'
+        )
+    })
+})
+
+// ─── grantPublicAccess ───────────────────────────────────────────────────────
+
+describe('grantPublicAccess', () => {
+    const FILE_URL = 'https://alice.solidcommunity.net/pack-me-up/packing-lists/abc.ttl'
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('calls setPublicAccess with read, write, and append true', async () => {
+        mockSetPublicAccess.mockResolvedValue({ read: true, write: true, append: true, controlRead: false, controlWrite: false })
+
+        await grantPublicAccess(mockSession, FILE_URL)
+
+        expect(mockSetPublicAccess).toHaveBeenCalledWith(
+            FILE_URL,
+            { read: true, write: true, append: true },
+            { fetch: mockSession.fetch }
+        )
+    })
+
+    it('resolves successfully when setPublicAccess succeeds', async () => {
+        mockSetPublicAccess.mockResolvedValue({ read: true, write: true, append: true, controlRead: false, controlWrite: false })
+
+        await expect(grantPublicAccess(mockSession, FILE_URL)).resolves.toBeUndefined()
+    })
+
+    it('throws AuthenticationError on 401', async () => {
+        mockSetPublicAccess.mockRejectedValue({ statusCode: 401 })
+
+        await expect(grantPublicAccess(mockSession, FILE_URL)).rejects.toThrow(AuthenticationError)
+    })
+
+    it('throws AuthenticationError on 403', async () => {
+        mockSetPublicAccess.mockRejectedValue({ statusCode: 403 })
+
+        await expect(grantPublicAccess(mockSession, FILE_URL)).rejects.toThrow(AuthenticationError)
+    })
+
+    it('re-throws other errors unchanged', async () => {
+        const err = new Error('Network failure')
+        mockSetPublicAccess.mockRejectedValue(err)
+
+        await expect(grantPublicAccess(mockSession, FILE_URL)).rejects.toThrow('Network failure')
+    })
+
+    it('throws a descriptive error when setPublicAccess returns null', async () => {
+        mockSetPublicAccess.mockResolvedValue(null)
+
+        await expect(grantPublicAccess(mockSession, FILE_URL)).rejects.toThrow(
+            'grantPublicAccess: server does not support access control for this resource'
         )
     })
 })

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -1,7 +1,7 @@
 import { AppSession as Session } from '../types/AppSession'
 import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile, solidDatasetAsTurtle, universalAccess } from '@inrupt/solid-client'
 import type { SolidDataset } from '@inrupt/solid-client'
-const { setAgentAccess, getAgentAccessAll } = universalAccess
+const { setAgentAccess, getAgentAccessAll, setPublicAccess } = universalAccess
 import { PackingAppDatabase } from './database'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList } from '../create-packing-list/types'
@@ -140,6 +140,25 @@ export async function grantCollaboratorAccess(
         )
         if (result === null) {
             throw new Error('grantCollaboratorAccess: server does not support access control for this resource')
+        }
+    } catch (error) {
+        if (isAuthenticationError(error)) handlePodError(error)
+        throw error
+    }
+}
+
+export async function grantPublicAccess(
+    session: Session,
+    fileUrl: string
+): Promise<void> {
+    try {
+        const result = await setPublicAccess(
+            fileUrl,
+            { read: true, write: true, append: true },
+            { fetch: session.fetch }
+        )
+        if (result === null) {
+            throw new Error('grantPublicAccess: server does not support access control for this resource')
         }
     } catch (error) {
         if (isAuthenticationError(error)) handlePodError(error)
@@ -349,15 +368,16 @@ export interface SaveRdfToPodOptions<T> {
  * Loads an RDF dataset from a Pod URL and deserializes it via the provided function.
  */
 export async function loadRdfFromPod<T>(
-    session: Session,
+    session: Session | null,
     fileUrl: string,
     deserializer: (dataset: SolidDataset, datasetUrl: string) => T
 ): Promise<T> {
+    const fetchFn = session?.fetch ?? globalThis.fetch
     try {
-        const dataset = await getSolidDataset(fileUrl, { fetch: session.fetch })
+        const dataset = await getSolidDataset(fileUrl, { fetch: fetchFn })
         return deserializer(dataset, fileUrl)
     } catch (error: unknown) {
-        if (isAuthenticationError(error)) handlePodError(error)
+        if (session && isAuthenticationError(error)) handlePodError(error)
         throw error
     }
 }


### PR DESCRIPTION
Adds a second sharing option in the Share modal that grants public
read/write/append ACL on the pod file (via foaf:Agent), so any logged-in
Solid user can access and edit the list via the generated link without
the owner needing to know their WebID in advance.

Also allows unauthenticated users to view publicly-shared lists by
letting usePodSync sync from a foreign pod without an active session
(falls back to native fetch).

https://claude.ai/code/session_01UzXFH9jLquPYLaSPyxLah6