### PR TITLE
Add global Add Item button with destination picker to edit questions form

### DIFF
--- a/src/edit-questions/add-item-modal.test.tsx
+++ b/src/edit-questions/add-item-modal.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { AddItemModal, AddItemDestination } from './add-item-modal'
+import { Question } from './types'
+
+const mockQuestions: Question[] = [
+    {
+        id: 'q1',
+        text: 'Transport?',
+        options: [
+            { id: 'o1', text: 'Car', items: [], order: 0 },
+            { id: 'o2', text: 'Plane', items: [], order: 1 },
+        ],
+        order: 0,
+        type: 'saved',
+    },
+    {
+        id: 'q2',
+        text: 'Climate?',
+        options: [
+            { id: 'o3', text: 'Hot', items: [], order: 0 },
+        ],
+        order: 1,
+        type: 'saved',
+    },
+]
+
+function renderModal(props: Partial<Parameters<typeof AddItemModal>[0]> = {}) {
+    const defaults = {
+        isOpen: true,
+        onClose: vi.fn(),
+        onConfirm: vi.fn(),
+        questions: mockQuestions,
+    }
+    return render(<AddItemModal {...defaults} {...props} />)
+}
+
+describe('AddItemModal', () => {
+    it('does not render when isOpen is false', () => {
+        renderModal({ isOpen: false })
+        expect(screen.queryByText('Add Item')).toBeNull()
+    })
+
+    it('renders when isOpen is true', () => {
+        renderModal()
+        expect(screen.getByText('Add Item')).toBeTruthy()
+    })
+
+    it('renders "Always Needed Items" as an option', () => {
+        renderModal()
+        expect(screen.getByRole('option', { name: 'Always Needed Items' })).toBeTruthy()
+    })
+
+    it('renders question/option pairs as select options', () => {
+        renderModal()
+        expect(screen.getByRole('option', { name: 'Transport?: Car' })).toBeTruthy()
+        expect(screen.getByRole('option', { name: 'Transport?: Plane' })).toBeTruthy()
+        expect(screen.getByRole('option', { name: 'Climate?: Hot' })).toBeTruthy()
+    })
+
+    it('defaults to "Always Needed Items" selected on open', () => {
+        renderModal()
+        const select = screen.getByRole('combobox')
+        expect((select as HTMLSelectElement).value).toBe('always')
+    })
+
+    it('calls onConfirm with { type: always } when confirmed with default selection', () => {
+        const onConfirm = vi.fn()
+        renderModal({ onConfirm })
+        fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
+        expect(onConfirm).toHaveBeenCalledWith({ type: 'always' })
+    })
+
+    it('calls onConfirm with option destination when an option row is selected', () => {
+        const onConfirm = vi.fn()
+        renderModal({ onConfirm })
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'q1::o2' } })
+        fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
+        expect(onConfirm).toHaveBeenCalledWith({ type: 'option', questionId: 'q1', optionId: 'o2' })
+    })
+
+    it('calls onClose when Cancel is clicked', () => {
+        const onClose = vi.fn()
+        renderModal({ onClose })
+        fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+        expect(onClose).toHaveBeenCalled()
+    })
+
+    it('calls onClose when Confirm is clicked', () => {
+        const onClose = vi.fn()
+        renderModal({ onClose })
+        fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
+        expect(onClose).toHaveBeenCalled()
+    })
+
+    it('resets to "always" when re-opened after changing selection', () => {
+        const { rerender } = renderModal({ isOpen: true })
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'q1::o1' } })
+        expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('q1::o1')
+
+        rerender(
+            <AddItemModal
+                isOpen={false}
+                onClose={vi.fn()}
+                onConfirm={vi.fn()}
+                questions={mockQuestions}
+            />
+        )
+        rerender(
+            <AddItemModal
+                isOpen={true}
+                onClose={vi.fn()}
+                onConfirm={vi.fn()}
+                questions={mockQuestions}
+            />
+        )
+        expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('always')
+    })
+
+    it('shows only "Always Needed Items" when questions array is empty', () => {
+        renderModal({ questions: [] })
+        const options = screen.getAllByRole('option')
+        expect(options).toHaveLength(1)
+        expect(options[0].textContent).toBe('Always Needed Items')
+    })
+})

--- a/src/edit-questions/add-item-modal.test.tsx
+++ b/src/edit-questions/add-item-modal.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import React from 'react'
-import { AddItemModal, AddItemDestination } from './add-item-modal'
+import { AddItemModal } from './add-item-modal'
 import { Question } from './types'
 
 const mockQuestions: Question[] = [

--- a/src/edit-questions/add-item-modal.test.tsx
+++ b/src/edit-questions/add-item-modal.test.tsx
@@ -47,81 +47,42 @@ describe('AddItemModal', () => {
         expect(screen.getByText('Add Item')).toBeTruthy()
     })
 
-    it('renders "Always Needed Items" as an option', () => {
+    it('renders "Always Needed Items" as a button', () => {
         renderModal()
-        expect(screen.getByRole('option', { name: 'Always Needed Items' })).toBeTruthy()
+        expect(screen.getByRole('button', { name: 'Always Needed Items' })).toBeTruthy()
     })
 
-    it('renders question/option pairs as select options', () => {
+    it('renders question/option pairs as buttons', () => {
         renderModal()
-        expect(screen.getByRole('option', { name: 'Transport?: Car' })).toBeTruthy()
-        expect(screen.getByRole('option', { name: 'Transport?: Plane' })).toBeTruthy()
-        expect(screen.getByRole('option', { name: 'Climate?: Hot' })).toBeTruthy()
+        expect(screen.getByRole('button', { name: /Car/ })).toBeTruthy()
+        expect(screen.getByRole('button', { name: /Plane/ })).toBeTruthy()
+        expect(screen.getByRole('button', { name: /Hot/ })).toBeTruthy()
     })
 
-    it('defaults to "Always Needed Items" selected on open', () => {
-        renderModal()
-        const select = screen.getByRole('combobox')
-        expect((select as HTMLSelectElement).value).toBe('always')
-    })
-
-    it('calls onConfirm with { type: always } when confirmed with default selection', () => {
+    it('calls onConfirm with { type: always } when "Always Needed Items" clicked', () => {
         const onConfirm = vi.fn()
         renderModal({ onConfirm })
-        fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
+        fireEvent.click(screen.getByRole('button', { name: 'Always Needed Items' }))
         expect(onConfirm).toHaveBeenCalledWith({ type: 'always' })
     })
 
-    it('calls onConfirm with option destination when an option row is selected', () => {
+    it('calls onConfirm with option destination when an option button clicked', () => {
         const onConfirm = vi.fn()
         renderModal({ onConfirm })
-        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'q1::o2' } })
-        fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
+        fireEvent.click(screen.getByRole('button', { name: /Plane/ }))
         expect(onConfirm).toHaveBeenCalledWith({ type: 'option', questionId: 'q1', optionId: 'o2' })
     })
 
-    it('calls onClose when Cancel is clicked', () => {
+    it('calls onClose when a destination button is clicked', () => {
         const onClose = vi.fn()
         renderModal({ onClose })
-        fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+        fireEvent.click(screen.getByRole('button', { name: 'Always Needed Items' }))
         expect(onClose).toHaveBeenCalled()
     })
 
-    it('calls onClose when Confirm is clicked', () => {
-        const onClose = vi.fn()
-        renderModal({ onClose })
-        fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
-        expect(onClose).toHaveBeenCalled()
-    })
-
-    it('resets to "always" when re-opened after changing selection', () => {
-        const { rerender } = renderModal({ isOpen: true })
-        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'q1::o1' } })
-        expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('q1::o1')
-
-        rerender(
-            <AddItemModal
-                isOpen={false}
-                onClose={vi.fn()}
-                onConfirm={vi.fn()}
-                questions={mockQuestions}
-            />
-        )
-        rerender(
-            <AddItemModal
-                isOpen={true}
-                onClose={vi.fn()}
-                onConfirm={vi.fn()}
-                questions={mockQuestions}
-            />
-        )
-        expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('always')
-    })
-
-    it('shows only "Always Needed Items" when questions array is empty', () => {
+    it('shows only "Always Needed Items" button when questions array is empty', () => {
         renderModal({ questions: [] })
-        const options = screen.getAllByRole('option')
-        expect(options).toHaveLength(1)
-        expect(options[0].textContent).toBe('Always Needed Items')
+        expect(screen.getByRole('button', { name: 'Always Needed Items' })).toBeTruthy()
+        expect(screen.queryByRole('button', { name: /Car|Plane|Hot/ })).toBeNull()
     })
 })

--- a/src/edit-questions/add-item-modal.tsx
+++ b/src/edit-questions/add-item-modal.tsx
@@ -1,6 +1,4 @@
-import { useState, useEffect } from 'react'
 import { Modal } from '../components/Modal'
-import { Button } from '../components/Button'
 import { Question } from './types'
 
 export type AddItemDestination =
@@ -15,55 +13,40 @@ interface AddItemModalProps {
 }
 
 export function AddItemModal({ isOpen, onClose, questions, onConfirm }: AddItemModalProps) {
-    const [selectedValue, setSelectedValue] = useState('always')
-
-    useEffect(() => {
-        if (isOpen) setSelectedValue('always')
-    }, [isOpen])
-
-    function handleConfirm() {
-        let destination: AddItemDestination
-        if (selectedValue === 'always') {
-            destination = { type: 'always' }
-        } else {
-            const [questionId, optionId] = selectedValue.split('::')
-            destination = { type: 'option', questionId, optionId }
-        }
+    function pick(destination: AddItemDestination) {
         onConfirm(destination)
         onClose()
     }
 
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Add Item">
-            <div className="space-y-4">
-                <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                        Add to
-                    </label>
-                    <select
-                        value={selectedValue}
-                        onChange={(e) => setSelectedValue(e.target.value)}
-                        className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-                    >
-                        <option value="always">Always Needed Items</option>
-                        {questions.flatMap((q) =>
-                            q.options.map((o) => (
-                                <option key={`${q.id}::${o.id}`} value={`${q.id}::${o.id}`}>
-                                    {q.text}: {o.text}
-                                </option>
-                            ))
-                        )}
-                    </select>
-                </div>
-                <div className="flex gap-3 justify-end pt-2">
-                    <Button type="button" variant="secondary" onClick={onClose}>
-                        Cancel
-                    </Button>
-                    <Button type="button" onClick={handleConfirm}>
-                        Confirm
-                    </Button>
-                </div>
+            <div className="space-y-1 max-h-72 overflow-y-auto -mx-2">
+                <DestButton onClick={() => pick({ type: 'always' })}>
+                    Always Needed Items
+                </DestButton>
+                {questions.flatMap((q) =>
+                    q.options.map((o) => (
+                        <DestButton
+                            key={`${q.id}::${o.id}`}
+                            onClick={() => pick({ type: 'option', questionId: q.id, optionId: o.id })}
+                        >
+                            <span className="text-gray-500">{q.text}:</span> {o.text}
+                        </DestButton>
+                    ))
+                )}
             </div>
         </Modal>
+    )
+}
+
+function DestButton({ onClick, children }: { onClick: () => void; children: React.ReactNode }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="w-full text-left px-3 py-2 rounded-md text-sm text-gray-800 hover:bg-gray-100 active:bg-gray-200 transition-colors"
+        >
+            {children}
+        </button>
     )
 }

--- a/src/edit-questions/add-item-modal.tsx
+++ b/src/edit-questions/add-item-modal.tsx
@@ -1,0 +1,69 @@
+import { useState, useEffect } from 'react'
+import { Modal } from '../components/Modal'
+import { Button } from '../components/Button'
+import { Question } from './types'
+
+export type AddItemDestination =
+    | { type: 'always' }
+    | { type: 'option'; questionId: string; optionId: string }
+
+interface AddItemModalProps {
+    isOpen: boolean
+    onClose: () => void
+    questions: Question[]
+    onConfirm: (destination: AddItemDestination) => void
+}
+
+export function AddItemModal({ isOpen, onClose, questions, onConfirm }: AddItemModalProps) {
+    const [selectedValue, setSelectedValue] = useState('always')
+
+    useEffect(() => {
+        if (isOpen) setSelectedValue('always')
+    }, [isOpen])
+
+    function handleConfirm() {
+        let destination: AddItemDestination
+        if (selectedValue === 'always') {
+            destination = { type: 'always' }
+        } else {
+            const [questionId, optionId] = selectedValue.split('::')
+            destination = { type: 'option', questionId, optionId }
+        }
+        onConfirm(destination)
+        onClose()
+    }
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title="Add Item">
+            <div className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Add to
+                    </label>
+                    <select
+                        value={selectedValue}
+                        onChange={(e) => setSelectedValue(e.target.value)}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    >
+                        <option value="always">Always Needed Items</option>
+                        {questions.flatMap((q) =>
+                            q.options.map((o) => (
+                                <option key={`${q.id}::${o.id}`} value={`${q.id}::${o.id}`}>
+                                    {q.text}: {o.text}
+                                </option>
+                            ))
+                        )}
+                    </select>
+                </div>
+                <div className="flex gap-3 justify-end pt-2">
+                    <Button type="button" variant="secondary" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleConfirm}>
+                        Confirm
+                    </Button>
+                </div>
+            </div>
+        </Modal>
+    )
+}

--- a/src/edit-questions/add-item-modal.tsx
+++ b/src/edit-questions/add-item-modal.tsx
@@ -1,4 +1,3 @@
-import { Modal } from '../components/Modal'
 import { Question } from './types'
 
 export type AddItemDestination =
@@ -13,29 +12,51 @@ interface AddItemModalProps {
 }
 
 export function AddItemModal({ isOpen, onClose, questions, onConfirm }: AddItemModalProps) {
+    if (!isOpen) return null
+
     function pick(destination: AddItemDestination) {
         onConfirm(destination)
         onClose()
     }
 
     return (
-        <Modal isOpen={isOpen} onClose={onClose} title="Add Item">
-            <div className="space-y-1 max-h-72 overflow-y-auto -mx-2">
-                <DestButton onClick={() => pick({ type: 'always' })}>
-                    Always Needed Items
-                </DestButton>
-                {questions.flatMap((q) =>
-                    q.options.map((o) => (
-                        <DestButton
-                            key={`${q.id}::${o.id}`}
-                            onClick={() => pick({ type: 'option', questionId: q.id, optionId: o.id })}
-                        >
-                            <span className="text-gray-500">{q.text}:</span> {o.text}
-                        </DestButton>
-                    ))
-                )}
+        <div className="fixed inset-0 z-50 flex items-stretch sm:items-center sm:justify-center sm:p-8">
+            <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={onClose} />
+            <div
+                role="dialog"
+                aria-modal="true"
+                className="relative flex flex-col w-full bg-white shadow-xl sm:rounded-lg sm:max-w-lg sm:h-[calc(100vh-8rem)]"
+            >
+                <div className="flex items-center justify-between px-4 py-4 border-b border-gray-200 sm:px-6">
+                    <h3 className="text-lg font-semibold text-gray-900">Add Item</h3>
+                    <button
+                        type="button"
+                        className="rounded-md text-gray-400 hover:text-gray-500 focus:outline-none"
+                        onClick={onClose}
+                    >
+                        <span className="sr-only">Close</span>
+                        <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+                <div className="flex-1 overflow-y-auto px-2 py-2 space-y-1">
+                    <DestButton onClick={() => pick({ type: 'always' })}>
+                        Always Needed Items
+                    </DestButton>
+                    {questions.flatMap((q) =>
+                        q.options.map((o) => (
+                            <DestButton
+                                key={`${q.id}::${o.id}`}
+                                onClick={() => pick({ type: 'option', questionId: q.id, optionId: o.id })}
+                            >
+                                <span className="text-gray-500">{q.text}:</span> {o.text}
+                            </DestButton>
+                        ))
+                    )}
+                </div>
             </div>
-        </Modal>
+        </div>
     )
 }
 

--- a/src/edit-questions/always-needed-items-section.test.tsx
+++ b/src/edit-questions/always-needed-items-section.test.tsx
@@ -7,7 +7,7 @@ import { PackingListQuestionSet, Person } from './types'
 
 const mockPeople: Person[] = [{ id: '1', name: 'Me' }]
 
-function Wrapper({ defaultValues }: { defaultValues?: Partial<PackingListQuestionSet> }) {
+function Wrapper({ defaultValues, triggerAddItem }: { defaultValues?: Partial<PackingListQuestionSet>; triggerAddItem?: number }) {
     const { control, register, watch, setValue } = useForm<PackingListQuestionSet>({
         defaultValues: {
             questions: [],
@@ -23,6 +23,7 @@ function Wrapper({ defaultValues }: { defaultValues?: Partial<PackingListQuestio
             watch={watch}
             setValue={setValue}
             people={mockPeople}
+            triggerAddItem={triggerAddItem}
         />
     )
 }
@@ -48,5 +49,16 @@ describe('AlwaysNeededItemsSection', () => {
         const header = screen.getByRole('button', { name: /always needed items/i })
         fireEvent.click(header)
         expect(screen.getByText('Add Item')).toBeTruthy()
+    })
+
+    it('expands and appends an item when triggerAddItem increments from 0 to 1', () => {
+        const { rerender } = render(<Wrapper triggerAddItem={0} />)
+        // Collapsed — no Add Item button visible
+        expect(screen.queryByRole('button', { name: /^add item$/i })).toBeNull()
+
+        rerender(<Wrapper triggerAddItem={1} />)
+
+        // Should expand and show the Add Item button
+        expect(screen.getByRole('button', { name: /^add item$/i })).toBeTruthy()
     })
 })

--- a/src/edit-questions/always-needed-items-section.tsx
+++ b/src/edit-questions/always-needed-items-section.tsx
@@ -29,6 +29,8 @@ export function AlwaysNeededItemsSection({ control, register, watch, setValue, p
     const allItemNames = () => allItems.map((item) => item.text);
     const selectRefs = useRef<(HTMLDivElement | null)[]>([]);
     const shouldFocusRef = useRef(false);
+    const [newItemIndex, setNewItemIndex] = useState<number | null>(null);
+    const newItemTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
         if (triggerAddItem !== undefined && triggerAddItem > 0) {
@@ -41,13 +43,13 @@ export function AlwaysNeededItemsSection({ control, register, watch, setValue, p
     useEffect(() => {
         // Only focus/scroll if Add Item was triggered
         if (shouldFocusRef.current) {
-            if (selectRefs.current[itemFields.length - 1]) {
-                const input = selectRefs.current[itemFields.length - 1]?.querySelector('input');
-                if (input) {
-                    input.focus();
-                }
-            }
-            selectRefs.current[itemFields.length - 1]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            const idx = itemFields.length - 1;
+            const el = selectRefs.current[idx];
+            el?.querySelector('input')?.focus();
+            el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            setNewItemIndex(idx);
+            if (newItemTimerRef.current) clearTimeout(newItemTimerRef.current);
+            newItemTimerRef.current = setTimeout(() => setNewItemIndex(null), 1500);
             shouldFocusRef.current = false;
         }
     }, [itemFields.length]);
@@ -76,7 +78,7 @@ export function AlwaysNeededItemsSection({ control, register, watch, setValue, p
             {isExpanded && (
                 <div className="space-y-3">
                 {itemFields.map((_item: Item, itemIndex: number) => (
-                    <div key={itemIndex} className="flex items-start gap-2 sm:gap-3">
+                    <div key={itemIndex} className={`flex items-start gap-2 sm:gap-3 rounded-md ${itemIndex === newItemIndex ? 'ring-2 ring-primary-300' : ''}`}>
                         <div className="flex-1" ref={el => { selectRefs.current[itemIndex] = el; }}>
                             <ItemPeopleSection
                                 control={control}

--- a/src/edit-questions/always-needed-items-section.tsx
+++ b/src/edit-questions/always-needed-items-section.tsx
@@ -28,28 +28,24 @@ export function AlwaysNeededItemsSection({ control, register, watch, setValue, p
     ).filter(Boolean))] as Item[];
     const allItemNames = () => allItems.map((item) => item.text);
     const selectRefs = useRef<(HTMLDivElement | null)[]>([]);
-    const shouldFocusRef = useRef(false);
+    const expectedNewLengthRef = useRef<number | null>(null);
     const [newItemIndex, setNewItemIndex] = useState<number | null>(null);
-    const newItemTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
         if (triggerAddItem !== undefined && triggerAddItem > 0) {
             setIsExpanded(true);
-            shouldFocusRef.current = true;
+            expectedNewLengthRef.current = itemFields.length + 1;
             appendItem({ text: "", personSelections: [] });
         }
     }, [triggerAddItem]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
-        // Only focus/scroll if Add Item was triggered
-        if (shouldFocusRef.current) {
+        if (expectedNewLengthRef.current === itemFields.length) {
+            expectedNewLengthRef.current = null;
             const idx = itemFields.length - 1;
             selectRefs.current[idx]?.querySelector('input')?.focus();
-            setTimeout(() => selectRefs.current[idx]?.scrollIntoView({ behavior: 'smooth', block: 'center' }), 50);
+            selectRefs.current[idx]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
             setNewItemIndex(idx);
-            if (newItemTimerRef.current) clearTimeout(newItemTimerRef.current);
-            newItemTimerRef.current = setTimeout(() => setNewItemIndex(null), 1500);
-            shouldFocusRef.current = false;
         }
     }, [itemFields.length]);
 
@@ -113,7 +109,7 @@ export function AlwaysNeededItemsSection({ control, register, watch, setValue, p
                 <Button
                     type="button"
                     onClick={() => {
-                        shouldFocusRef.current = true;
+                        expectedNewLengthRef.current = itemFields.length + 1;
                         appendItem({ text: "", personSelections: [] });
                     }}
                     variant="ghost"

--- a/src/edit-questions/always-needed-items-section.tsx
+++ b/src/edit-questions/always-needed-items-section.tsx
@@ -46,7 +46,7 @@ export function AlwaysNeededItemsSection({ control, register, watch, setValue, p
             const idx = itemFields.length - 1;
             const el = selectRefs.current[idx];
             el?.querySelector('input')?.focus();
-            el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            requestAnimationFrame(() => el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }));
             setNewItemIndex(idx);
             if (newItemTimerRef.current) clearTimeout(newItemTimerRef.current);
             newItemTimerRef.current = setTimeout(() => setNewItemIndex(null), 1500);

--- a/src/edit-questions/always-needed-items-section.tsx
+++ b/src/edit-questions/always-needed-items-section.tsx
@@ -17,7 +17,6 @@ interface AlwaysNeededItemsSectionProps {
 
 export function AlwaysNeededItemsSection({ control, register, watch, setValue, people, triggerAddItem }: AlwaysNeededItemsSectionProps) {
     const [isExpanded, setIsExpanded] = useState(false);
-    const containerRef = useRef<HTMLDivElement>(null);
 
     const { fields: itemFields, append: appendItem } = useFieldArray({
         control,
@@ -48,13 +47,13 @@ export function AlwaysNeededItemsSection({ control, register, watch, setValue, p
                     input.focus();
                 }
             }
-            containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            selectRefs.current[itemFields.length - 1]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
             shouldFocusRef.current = false;
         }
     }, [itemFields.length]);
 
     return (
-        <div ref={containerRef} className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6">
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6">
             <button
                 type="button"
                 onClick={() => setIsExpanded(!isExpanded)}

--- a/src/edit-questions/always-needed-items-section.tsx
+++ b/src/edit-questions/always-needed-items-section.tsx
@@ -44,9 +44,8 @@ export function AlwaysNeededItemsSection({ control, register, watch, setValue, p
         // Only focus/scroll if Add Item was triggered
         if (shouldFocusRef.current) {
             const idx = itemFields.length - 1;
-            const el = selectRefs.current[idx];
-            el?.querySelector('input')?.focus();
-            requestAnimationFrame(() => el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }));
+            selectRefs.current[idx]?.querySelector('input')?.focus();
+            setTimeout(() => selectRefs.current[idx]?.scrollIntoView({ behavior: 'smooth', block: 'center' }), 50);
             setNewItemIndex(idx);
             if (newItemTimerRef.current) clearTimeout(newItemTimerRef.current);
             newItemTimerRef.current = setTimeout(() => setNewItemIndex(null), 1500);

--- a/src/edit-questions/always-needed-items-section.tsx
+++ b/src/edit-questions/always-needed-items-section.tsx
@@ -12,10 +12,12 @@ interface AlwaysNeededItemsSectionProps {
     watch: UseFormWatch<PackingListQuestionSet>;
     setValue: UseFormSetValue<PackingListQuestionSet>;
     people: Person[];
+    triggerAddItem?: number;
 }
 
-export function AlwaysNeededItemsSection({ control, register, watch, setValue, people }: AlwaysNeededItemsSectionProps) {
+export function AlwaysNeededItemsSection({ control, register, watch, setValue, people, triggerAddItem }: AlwaysNeededItemsSectionProps) {
     const [isExpanded, setIsExpanded] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
 
     const { fields: itemFields, append: appendItem } = useFieldArray({
         control,
@@ -30,7 +32,15 @@ export function AlwaysNeededItemsSection({ control, register, watch, setValue, p
     const shouldFocusRef = useRef(false);
 
     useEffect(() => {
-        // Only focus if the user clicked "Add Item" button
+        if (triggerAddItem !== undefined && triggerAddItem > 0) {
+            setIsExpanded(true);
+            shouldFocusRef.current = true;
+            appendItem({ text: "", personSelections: [] });
+        }
+    }, [triggerAddItem]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        // Only focus/scroll if Add Item was triggered
         if (shouldFocusRef.current) {
             if (selectRefs.current[itemFields.length - 1]) {
                 const input = selectRefs.current[itemFields.length - 1]?.querySelector('input');
@@ -38,12 +48,13 @@ export function AlwaysNeededItemsSection({ control, register, watch, setValue, p
                     input.focus();
                 }
             }
+            containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
             shouldFocusRef.current = false;
         }
     }, [itemFields.length]);
 
     return (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6">
+        <div ref={containerRef} className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6">
             <button
                 type="button"
                 onClick={() => setIsExpanded(!isExpanded)}

--- a/src/edit-questions/option-section.tsx
+++ b/src/edit-questions/option-section.tsx
@@ -16,10 +16,12 @@ interface OptionSectionProps {
     setValue: UseFormSetValue<PackingListQuestionSet>;
     removeOption: () => void;
     people: Person[];
+    triggerAddItem?: number;
 }
 
-export function OptionSection({ control, questionIndex, optionIndex, register, watch, setValue, removeOption, people }: OptionSectionProps) {
+export function OptionSection({ control, questionIndex, optionIndex, register, watch, setValue, removeOption, people, triggerAddItem }: OptionSectionProps) {
     const [isExpanded, setIsExpanded] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
     const { fields: itemFields, append: appendItem } = useFieldArray({
         control,
         name: `questions.${questionIndex}.options.${optionIndex}.items`
@@ -32,7 +34,15 @@ export function OptionSection({ control, questionIndex, optionIndex, register, w
     const shouldFocusRef = useRef(false);
 
     useEffect(() => {
-        // Only focus if the user clicked "Add Item" button
+        if (triggerAddItem !== undefined && triggerAddItem > 0) {
+            setIsExpanded(true);
+            shouldFocusRef.current = true;
+            appendItem({ text: "", personSelections: [] });
+        }
+    }, [triggerAddItem]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        // Only focus/scroll if Add Item was triggered
         if (shouldFocusRef.current) {
             if (selectRefs.current[itemFields.length - 1]) {
                 const input = selectRefs.current[itemFields.length - 1]?.querySelector('input');
@@ -40,12 +50,13 @@ export function OptionSection({ control, questionIndex, optionIndex, register, w
                     input.focus();
                 }
             }
+            containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
             shouldFocusRef.current = false;
         }
     }, [itemFields.length]);
 
     return (
-        <div className="bg-gray-50 rounded-lg p-4">
+        <div ref={containerRef} className="bg-gray-50 rounded-lg p-4">
             <div className={`flex items-start gap-2 sm:gap-4 ${isExpanded ? 'mb-4' : ''}`}>
                 <button
                     type="button"

--- a/src/edit-questions/option-section.tsx
+++ b/src/edit-questions/option-section.tsx
@@ -21,7 +21,6 @@ interface OptionSectionProps {
 
 export function OptionSection({ control, questionIndex, optionIndex, register, watch, setValue, removeOption, people, triggerAddItem }: OptionSectionProps) {
     const [isExpanded, setIsExpanded] = useState(false);
-    const containerRef = useRef<HTMLDivElement>(null);
     const { fields: itemFields, append: appendItem } = useFieldArray({
         control,
         name: `questions.${questionIndex}.options.${optionIndex}.items`
@@ -50,13 +49,13 @@ export function OptionSection({ control, questionIndex, optionIndex, register, w
                     input.focus();
                 }
             }
-            containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            selectRefs.current[itemFields.length - 1]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
             shouldFocusRef.current = false;
         }
     }, [itemFields.length]);
 
     return (
-        <div ref={containerRef} className="bg-gray-50 rounded-lg p-4">
+        <div className="bg-gray-50 rounded-lg p-4">
             <div className={`flex items-start gap-2 sm:gap-4 ${isExpanded ? 'mb-4' : ''}`}>
                 <button
                     type="button"

--- a/src/edit-questions/option-section.tsx
+++ b/src/edit-questions/option-section.tsx
@@ -31,6 +31,8 @@ export function OptionSection({ control, questionIndex, optionIndex, register, w
     const allItemNames = () => allItems.map((item) => item.text);
     const selectRefs = useRef<(HTMLDivElement | null)[]>([]);
     const shouldFocusRef = useRef(false);
+    const [newItemIndex, setNewItemIndex] = useState<number | null>(null);
+    const newItemTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
         if (triggerAddItem !== undefined && triggerAddItem > 0) {
@@ -43,13 +45,13 @@ export function OptionSection({ control, questionIndex, optionIndex, register, w
     useEffect(() => {
         // Only focus/scroll if Add Item was triggered
         if (shouldFocusRef.current) {
-            if (selectRefs.current[itemFields.length - 1]) {
-                const input = selectRefs.current[itemFields.length - 1]?.querySelector('input');
-                if (input) {
-                    input.focus();
-                }
-            }
-            selectRefs.current[itemFields.length - 1]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            const idx = itemFields.length - 1;
+            const el = selectRefs.current[idx];
+            el?.querySelector('input')?.focus();
+            el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            setNewItemIndex(idx);
+            if (newItemTimerRef.current) clearTimeout(newItemTimerRef.current);
+            newItemTimerRef.current = setTimeout(() => setNewItemIndex(null), 1500);
             shouldFocusRef.current = false;
         }
     }, [itemFields.length]);
@@ -89,7 +91,7 @@ export function OptionSection({ control, questionIndex, optionIndex, register, w
             {isExpanded && <div className="ml-0 sm:ml-4 space-y-3">
                 <div className="text-sm font-medium text-gray-700 mb-2">Items:</div>
                 {itemFields.map((_item: Item, itemIndex: number) => (
-                    <div key={itemIndex} className="flex items-start gap-2 sm:gap-3">
+                    <div key={itemIndex} className={`flex items-start gap-2 sm:gap-3 rounded-md ${itemIndex === newItemIndex ? 'ring-2 ring-primary-300' : ''}`}>
                         <div className="flex-1" ref={el => { selectRefs.current[itemIndex] = el; }}>
                             <ItemPeopleSection
                                 control={control}

--- a/src/edit-questions/option-section.tsx
+++ b/src/edit-questions/option-section.tsx
@@ -30,28 +30,24 @@ export function OptionSection({ control, questionIndex, optionIndex, register, w
     ).filter(Boolean))] as Item[];
     const allItemNames = () => allItems.map((item) => item.text);
     const selectRefs = useRef<(HTMLDivElement | null)[]>([]);
-    const shouldFocusRef = useRef(false);
+    const expectedNewLengthRef = useRef<number | null>(null);
     const [newItemIndex, setNewItemIndex] = useState<number | null>(null);
-    const newItemTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
         if (triggerAddItem !== undefined && triggerAddItem > 0) {
             setIsExpanded(true);
-            shouldFocusRef.current = true;
+            expectedNewLengthRef.current = itemFields.length + 1;
             appendItem({ text: "", personSelections: [] });
         }
     }, [triggerAddItem]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
-        // Only focus/scroll if Add Item was triggered
-        if (shouldFocusRef.current) {
+        if (expectedNewLengthRef.current === itemFields.length) {
+            expectedNewLengthRef.current = null;
             const idx = itemFields.length - 1;
             selectRefs.current[idx]?.querySelector('input')?.focus();
-            setTimeout(() => selectRefs.current[idx]?.scrollIntoView({ behavior: 'smooth', block: 'center' }), 50);
+            selectRefs.current[idx]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
             setNewItemIndex(idx);
-            if (newItemTimerRef.current) clearTimeout(newItemTimerRef.current);
-            newItemTimerRef.current = setTimeout(() => setNewItemIndex(null), 1500);
-            shouldFocusRef.current = false;
         }
     }, [itemFields.length]);
 
@@ -127,7 +123,7 @@ export function OptionSection({ control, questionIndex, optionIndex, register, w
                 <Button
                     type="button"
                     onClick={() => {
-                        shouldFocusRef.current = true;
+                        expectedNewLengthRef.current = itemFields.length + 1;
                         appendItem({ text: "", personSelections: [] });
                     }}
                     variant="ghost"

--- a/src/edit-questions/option-section.tsx
+++ b/src/edit-questions/option-section.tsx
@@ -46,9 +46,8 @@ export function OptionSection({ control, questionIndex, optionIndex, register, w
         // Only focus/scroll if Add Item was triggered
         if (shouldFocusRef.current) {
             const idx = itemFields.length - 1;
-            const el = selectRefs.current[idx];
-            el?.querySelector('input')?.focus();
-            requestAnimationFrame(() => el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }));
+            selectRefs.current[idx]?.querySelector('input')?.focus();
+            setTimeout(() => selectRefs.current[idx]?.scrollIntoView({ behavior: 'smooth', block: 'center' }), 50);
             setNewItemIndex(idx);
             if (newItemTimerRef.current) clearTimeout(newItemTimerRef.current);
             newItemTimerRef.current = setTimeout(() => setNewItemIndex(null), 1500);

--- a/src/edit-questions/option-section.tsx
+++ b/src/edit-questions/option-section.tsx
@@ -48,7 +48,7 @@ export function OptionSection({ control, questionIndex, optionIndex, register, w
             const idx = itemFields.length - 1;
             const el = selectRefs.current[idx];
             el?.querySelector('input')?.focus();
-            el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            requestAnimationFrame(() => el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }));
             setNewItemIndex(idx);
             if (newItemTimerRef.current) clearTimeout(newItemTimerRef.current);
             newItemTimerRef.current = setTimeout(() => setNewItemIndex(null), 1500);

--- a/src/edit-questions/question-section.tsx
+++ b/src/edit-questions/question-section.tsx
@@ -17,9 +17,11 @@ interface QuestionSectionProps {
     moveUp?: () => void;
     moveDown?: () => void;
     forceCollapsed?: boolean | null;
+    triggerAddItemForOptionIndex?: number;
+    triggerAddItemVersion?: number;
 }
 
-export function QuestionSection({ questionIndex, control, register, watch, setValue, removeQuestion, people, moveUp, moveDown, forceCollapsed }: QuestionSectionProps) {
+export function QuestionSection({ questionIndex, control, register, watch, setValue, removeQuestion, people, moveUp, moveDown, forceCollapsed, triggerAddItemForOptionIndex, triggerAddItemVersion }: QuestionSectionProps) {
     const [isExpanded, setIsExpanded] = useState(true);
 
     // Sync with forceCollapsed when it changes
@@ -28,6 +30,13 @@ export function QuestionSection({ questionIndex, control, register, watch, setVa
             setIsExpanded(!forceCollapsed);
         }
     }, [forceCollapsed]);
+
+    // Expand when a child option is targeted for item addition
+    useEffect(() => {
+        if (triggerAddItemForOptionIndex !== undefined && triggerAddItemVersion !== undefined && triggerAddItemVersion > 0) {
+            setIsExpanded(true);
+        }
+    }, [triggerAddItemVersion, triggerAddItemForOptionIndex]);
     const { fields: optionFields, append: appendOption, remove: removeOption } = useFieldArray({
         control,
         name: `questions.${questionIndex}.options` as const
@@ -139,6 +148,11 @@ export function QuestionSection({ questionIndex, control, register, watch, setVa
                                 setValue={setValue}
                                 removeOption={() => removeOption(optionIndex)}
                                 people={people}
+                                triggerAddItem={
+                                    triggerAddItemForOptionIndex === optionIndex
+                                        ? triggerAddItemVersion
+                                        : undefined
+                                }
                             />
                         ))}
                         <div className="mt-4">

--- a/src/pages/edit-questions-form.test.tsx
+++ b/src/pages/edit-questions-form.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { EditQuestionsForm } from './edit-questions-form'
@@ -127,5 +127,44 @@ describe('EditQuestionsForm', () => {
         await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull())
         expect(screen.queryByRole('button', { name: /JSON Editor/i })).toBeNull()
         expect(screen.queryByText('(Advanced)')).toBeNull()
+    })
+
+    it('renders "Add Item" button(s)', async () => {
+        render(
+            <MemoryRouter>
+                <EditQuestionsForm />
+            </MemoryRouter>
+        )
+
+        await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull())
+        const addItemButtons = screen.getAllByRole('button', { name: /^add item$/i })
+        expect(addItemButtons.length).toBeGreaterThan(0)
+    })
+
+    it('clicking "Add Item" opens the destination modal', async () => {
+        render(
+            <MemoryRouter>
+                <EditQuestionsForm />
+            </MemoryRouter>
+        )
+
+        await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull())
+        fireEvent.click(screen.getAllByRole('button', { name: /^add item$/i })[0])
+        expect(screen.getByRole('dialog')).toBeTruthy()
+        expect(screen.getAllByText('Add Item').length).toBeGreaterThan(0)
+    })
+
+    it('clicking Cancel in the Add Item modal closes it', async () => {
+        render(
+            <MemoryRouter>
+                <EditQuestionsForm />
+            </MemoryRouter>
+        )
+
+        await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull())
+        fireEvent.click(screen.getAllByRole('button', { name: /^add item$/i })[0])
+        expect(screen.getByRole('dialog')).toBeTruthy()
+        fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+        expect(screen.queryByRole('dialog')).toBeNull()
     })
 })

--- a/src/pages/edit-questions-form.test.tsx
+++ b/src/pages/edit-questions-form.test.tsx
@@ -137,7 +137,7 @@ describe('EditQuestionsForm', () => {
         )
 
         await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull())
-        const addItemButtons = screen.getAllByRole('button', { name: /^add item$/i })
+        const addItemButtons = screen.getAllByRole('button', { name: /^add item\.\.\.$/i })
         expect(addItemButtons.length).toBeGreaterThan(0)
     })
 
@@ -149,7 +149,7 @@ describe('EditQuestionsForm', () => {
         )
 
         await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull())
-        fireEvent.click(screen.getAllByRole('button', { name: /^add item$/i })[0])
+        fireEvent.click(screen.getAllByRole('button', { name: /^add item\.\.\.$/i })[0])
         expect(screen.getByRole('dialog')).toBeTruthy()
         expect(screen.getAllByText('Add Item').length).toBeGreaterThan(0)
     })
@@ -162,7 +162,7 @@ describe('EditQuestionsForm', () => {
         )
 
         await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull())
-        fireEvent.click(screen.getAllByRole('button', { name: /^add item$/i })[0])
+        fireEvent.click(screen.getAllByRole('button', { name: /^add item\.\.\.$/i })[0])
         expect(screen.getByRole('dialog')).toBeTruthy()
         fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
         expect(screen.queryByRole('dialog')).toBeNull()

--- a/src/pages/edit-questions-form.test.tsx
+++ b/src/pages/edit-questions-form.test.tsx
@@ -154,7 +154,7 @@ describe('EditQuestionsForm', () => {
         expect(screen.getAllByText('Add Item').length).toBeGreaterThan(0)
     })
 
-    it('clicking Cancel in the Add Item modal closes it', async () => {
+    it('modal can be closed via the X button', async () => {
         render(
             <MemoryRouter>
                 <EditQuestionsForm />
@@ -164,7 +164,7 @@ describe('EditQuestionsForm', () => {
         await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull())
         fireEvent.click(screen.getAllByRole('button', { name: /^add item\.\.\.$/i })[0])
         expect(screen.getByRole('dialog')).toBeTruthy()
-        fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+        fireEvent.click(screen.getByRole('button', { name: /close/i }))
         expect(screen.queryByRole('dialog')).toBeNull()
     })
 })

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { useForm, SubmitHandler, useFieldArray, useWatch } from "react-hook-form"
 import { useDebouncedCallback } from 'use-debounce'
@@ -18,6 +18,7 @@ import { POD_CONTAINERS } from '../services/solidPod'
 import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSerialization'
 import { JsonEditor } from '../edit-questions/json-editor'
 import { validateQuestionSet } from '../edit-questions/validation'
+import { AddItemModal, AddItemDestination } from '../edit-questions/add-item-modal'
 
 export function EditQuestionsForm() {
 
@@ -44,6 +45,12 @@ export function EditQuestionsForm() {
 
   const [currentQuestionSet, setCurrentQuestionSet] = useState<PackingListQuestionSet | null>(null);
   const [allQuestionsCollapsed, setAllQuestionsCollapsed] = useState<boolean | null>(true);
+  const [isAddItemModalOpen, setIsAddItemModalOpen] = useState(false);
+  const [addItemTarget, setAddItemTarget] = useState<{
+    destination: 'always' | { questionIndex: number; optionIndex: number };
+    version: number;
+  } | null>(null);
+  const addItemVersionRef = useRef(0);
 
   console.log("EditQuestionsForm - isLoggedIn:", isLoggedIn);
 
@@ -96,6 +103,24 @@ export function EditQuestionsForm() {
     console.error('Save to Pod error:', error);
     showToast(`Failed to save to Pod: ${error}`, 'error');
   }, [showToast]);
+
+  const handleAddItemConfirm = useCallback((destination: AddItemDestination) => {
+    addItemVersionRef.current += 1;
+    const version = addItemVersionRef.current;
+    if (destination.type === 'always') {
+      setAddItemTarget({ destination: 'always', version });
+    } else {
+      const questions = getValues('questions');
+      const questionIndex = questions.findIndex((q) => q.id === destination.questionId);
+      const optionIndex = questionIndex >= 0
+        ? questions[questionIndex].options.findIndex((o) => o.id === destination.optionId)
+        : -1;
+      if (questionIndex >= 0 && optionIndex >= 0) {
+        setAddItemTarget({ destination: { questionIndex, optionIndex }, version });
+      }
+    }
+    setIsAddItemModalOpen(false);
+  }, [getValues]);
 
   // Set up automatic Pod sync with polling
   const { lastSync, isSyncing, error: syncError, saveToPod } = usePodSync<PackingListQuestionSet>({
@@ -437,6 +462,7 @@ export function EditQuestionsForm() {
             watch={watch}
             setValue={setValue}
             people={people}
+            triggerAddItem={addItemTarget?.destination === 'always' ? addItemTarget.version : undefined}
           />
           {questionFields.length > 0 && (
             <div className="flex justify-end">
@@ -462,6 +488,18 @@ export function EditQuestionsForm() {
               moveUp={questionIndex > 0 ? () => moveQuestion(questionIndex, questionIndex - 1) : undefined}
               moveDown={questionIndex < questionFields.length - 1 ? () => moveQuestion(questionIndex, questionIndex + 1) : undefined}
               forceCollapsed={allQuestionsCollapsed}
+              triggerAddItemForOptionIndex={
+                addItemTarget?.destination !== 'always' &&
+                (addItemTarget?.destination as { questionIndex: number; optionIndex: number })?.questionIndex === questionIndex
+                  ? (addItemTarget.destination as { questionIndex: number; optionIndex: number }).optionIndex
+                  : undefined
+              }
+              triggerAddItemVersion={
+                addItemTarget?.destination !== 'always' &&
+                (addItemTarget?.destination as { questionIndex: number; optionIndex: number })?.questionIndex === questionIndex
+                  ? addItemTarget.version
+                  : undefined
+              }
             />
           ))}
           {/* Add Question button at bottom of form - only visible on large screens */}
@@ -554,6 +592,13 @@ export function EditQuestionsForm() {
             >
               Add Question
             </Button>
+            <Button
+              type="button"
+              onClick={() => setIsAddItemModalOpen(true)}
+              variant="secondary"
+            >
+              Add Item
+            </Button>
             <Button type="button" onClick={() => {
               const defaultData = { questions: [], people: [{ id: crypto.randomUUID(), name: "Me" }], alwaysNeededItems: [] };
               reset(defaultData);
@@ -634,6 +679,13 @@ export function EditQuestionsForm() {
             >
               Add Question
             </Button>
+            <Button
+              type="button"
+              onClick={() => setIsAddItemModalOpen(true)}
+              variant="secondary"
+            >
+              Add Item
+            </Button>
             <Button type="button" onClick={() => {
               const defaultData = { questions: [], people: [{ id: crypto.randomUUID(), name: "Me" }], alwaysNeededItems: [] };
               reset(defaultData);
@@ -644,6 +696,12 @@ export function EditQuestionsForm() {
           </div>
         </div>
       </div>
+      <AddItemModal
+        isOpen={isAddItemModalOpen}
+        onClose={() => setIsAddItemModalOpen(false)}
+        questions={watch('questions') ?? []}
+        onConfirm={handleAddItemConfirm}
+      />
         </>
       ) : (
         <div className="w-full max-w-5xl">

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -597,7 +597,7 @@ export function EditQuestionsForm() {
               onClick={() => setIsAddItemModalOpen(true)}
               variant="secondary"
             >
-              Add Item
+              Add Item...
             </Button>
             <Button type="button" onClick={() => {
               const defaultData = { questions: [], people: [{ id: crypto.randomUUID(), name: "Me" }], alwaysNeededItems: [] };
@@ -684,7 +684,7 @@ export function EditQuestionsForm() {
               onClick={() => setIsAddItemModalOpen(true)}
               variant="secondary"
             >
-              Add Item
+              Add Item...
             </Button>
             <Button type="button" onClick={() => {
               const defaultData = { questions: [], people: [{ id: crypto.randomUUID(), name: "Me" }], alwaysNeededItems: [] };

--- a/src/pages/edit-questions-form.tsx
+++ b/src/pages/edit-questions-form.tsx
@@ -490,14 +490,14 @@ export function EditQuestionsForm() {
               forceCollapsed={allQuestionsCollapsed}
               triggerAddItemForOptionIndex={
                 addItemTarget?.destination !== 'always' &&
-                (addItemTarget?.destination as { questionIndex: number; optionIndex: number })?.questionIndex === questionIndex
-                  ? (addItemTarget.destination as { questionIndex: number; optionIndex: number }).optionIndex
+                (addItemTarget?.destination as { questionIndex: number; optionIndex: number } | undefined)?.questionIndex === questionIndex
+                  ? (addItemTarget?.destination as { questionIndex: number; optionIndex: number } | undefined)?.optionIndex
                   : undefined
               }
               triggerAddItemVersion={
                 addItemTarget?.destination !== 'always' &&
-                (addItemTarget?.destination as { questionIndex: number; optionIndex: number })?.questionIndex === questionIndex
-                  ? addItemTarget.version
+                (addItemTarget?.destination as { questionIndex: number; optionIndex: number } | undefined)?.questionIndex === questionIndex
+                  ? addItemTarget?.version
                   : undefined
               }
             />


### PR DESCRIPTION
Previously, adding an item required scrolling to the right question/option
section, expanding it, then clicking Add Item. The new button opens a modal
listing all destinations (Always Needed Items + all question/option pairs),
then scrolls to and focuses the new item in the target section.

Uses a version-counter prop pattern to trigger append from the form level
into the leaf section components that own their own useFieldArray instances.