### PR TITLE
Show pod owner's name instead of raw URL in shared pod banner

### DIFF
--- a/src/components/ForeignPodLayout.tsx
+++ b/src/components/ForeignPodLayout.tsx
@@ -47,14 +47,15 @@ export function ForeignPodLayout() {
                     list = { contexts: [], lastModified: new Date().toISOString() }
                 }
 
-                const alreadyStored = list.contexts.some(c => c.podUrl === foreignPodUrl)
-                if (alreadyStored) return
+                const existing = list.contexts.find(c => c.podUrl === foreignPodUrl)
+                if (existing && (existing.label || !name)) return
 
-                const newContext = name
-                    ? { podUrl: foreignPodUrl, addedAt: new Date().toISOString(), label: name }
-                    : { podUrl: foreignPodUrl, addedAt: new Date().toISOString() }
                 const updated: SharedWithMeList = {
-                    contexts: [...list.contexts, newContext],
+                    contexts: existing
+                        ? list.contexts.map(c => c.podUrl === foreignPodUrl ? { ...c, label: name! } : c)
+                        : [...list.contexts, name
+                            ? { podUrl: foreignPodUrl, addedAt: new Date().toISOString(), label: name }
+                            : { podUrl: foreignPodUrl, addedAt: new Date().toISOString() }],
                     lastModified: new Date().toISOString(),
                 }
                 await db.saveSharedWithMe(updated)

--- a/src/components/ForeignPodLayout.tsx
+++ b/src/components/ForeignPodLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Outlet, useParams, Navigate } from 'react-router-dom'
+import { Outlet, useParams, Navigate, useSearchParams } from 'react-router-dom'
 import { ForeignPodContext } from './ForeignPodContext'
 import { useSolidPod } from './SolidPodContext'
 import { useDatabase } from './DatabaseContext'
@@ -17,10 +17,13 @@ import type { SharedWithMeList } from '../services/rdfSerialization'
 export function ForeignPodLayout() {
     const { encodedPodUrl } = useParams<{ encodedPodUrl: string }>()
     const foreignPodUrl = decodeURIComponent(encodedPodUrl ?? '')
+    const [searchParams] = useSearchParams()
+    const ownerWebIdFromUrl = searchParams.get('owner') ?? undefined
     const { isLoggedIn, session } = useSolidPod()
     const { db } = useDatabase()
     const [accessState, setAccessState] = useState<'pending' | 'ok' | 'denied'>('pending')
     const [ownerName, setOwnerName] = useState<string | null>(null)
+    const [resolvedWebId, setResolvedWebId] = useState<string | undefined>(ownerWebIdFromUrl)
     const storedRef = useRef(false)
 
     useEffect(() => {
@@ -34,9 +37,6 @@ export function ForeignPodLayout() {
             }
             setAccessState('ok')
 
-            const name = await getPodOwnerName(session!, foreignPodUrl)
-            setOwnerName(name)
-
             if (storedRef.current) return
             storedRef.current = true
 
@@ -49,14 +49,26 @@ export function ForeignPodLayout() {
                 }
 
                 const existing = list.contexts.find(c => c.podUrl === foreignPodUrl)
-                if (existing && (existing.label || !name)) return
+                const webId = ownerWebIdFromUrl ?? existing?.webId
+                setResolvedWebId(webId)
+
+                const name = await getPodOwnerName(session!, foreignPodUrl, webId)
+                setOwnerName(name)
+
+                const needsUpdate = !existing || (webId && !existing.webId) || (name && !existing.label)
+                if (!needsUpdate) return
 
                 const updated: SharedWithMeList = {
                     contexts: existing
-                        ? list.contexts.map(c => c.podUrl === foreignPodUrl ? { ...c, label: name! } : c)
-                        : [...list.contexts, name
-                            ? { podUrl: foreignPodUrl, addedAt: new Date().toISOString(), label: name }
-                            : { podUrl: foreignPodUrl, addedAt: new Date().toISOString() }],
+                        ? list.contexts.map(c => c.podUrl === foreignPodUrl
+                            ? { ...c, ...(webId ? { webId } : {}), ...(name ? { label: name } : {}) }
+                            : c)
+                        : [...list.contexts, {
+                            podUrl: foreignPodUrl,
+                            addedAt: new Date().toISOString(),
+                            ...(webId ? { webId } : {}),
+                            ...(name ? { label: name } : {}),
+                        }],
                     lastModified: new Date().toISOString(),
                 }
                 await db.saveSharedWithMe(updated)
@@ -110,7 +122,7 @@ export function ForeignPodLayout() {
     return (
         <ForeignPodContext.Provider value={{ foreignPodUrl }}>
             <div className="bg-blue-50 border-b border-blue-200 px-4 py-2 text-sm text-blue-800 -mx-4 -mt-8 mb-6">
-                Viewing <span className="font-semibold" title={foreignPodUrl}>{ownerName ?? friendlyPodName(foreignPodUrl)}</span>'s data
+                Viewing <span className="font-semibold" title={foreignPodUrl}>{ownerName ?? (resolvedWebId ? friendlyPodName(resolvedWebId) : null) ?? friendlyPodName(foreignPodUrl)}</span>'s data
             </div>
             <Outlet />
         </ForeignPodContext.Provider>

--- a/src/components/ForeignPodLayout.tsx
+++ b/src/components/ForeignPodLayout.tsx
@@ -9,6 +9,7 @@ import {
     POD_CONTAINERS,
     getPrimaryPodUrl,
     getPodOwnerName,
+    friendlyPodName,
 } from '../services/solidPod'
 import { sharedWithMeToDataset } from '../services/rdfSerialization'
 import type { SharedWithMeList } from '../services/rdfSerialization'
@@ -109,7 +110,7 @@ export function ForeignPodLayout() {
     return (
         <ForeignPodContext.Provider value={{ foreignPodUrl }}>
             <div className="bg-blue-50 border-b border-blue-200 px-4 py-2 text-sm text-blue-800 -mx-4 -mt-8 mb-6">
-                Viewing <span className="font-semibold" title={foreignPodUrl}>{ownerName ?? foreignPodUrl}</span>'s data
+                Viewing <span className="font-semibold" title={foreignPodUrl}>{ownerName ?? friendlyPodName(foreignPodUrl)}</span>'s data
             </div>
             <Outlet />
         </ForeignPodContext.Provider>

--- a/src/components/ForeignPodLayout.tsx
+++ b/src/components/ForeignPodLayout.tsx
@@ -8,6 +8,7 @@ import {
     saveRdfToPod,
     POD_CONTAINERS,
     getPrimaryPodUrl,
+    getPodOwnerName,
 } from '../services/solidPod'
 import { sharedWithMeToDataset } from '../services/rdfSerialization'
 import type { SharedWithMeList } from '../services/rdfSerialization'
@@ -18,6 +19,7 @@ export function ForeignPodLayout() {
     const { isLoggedIn, session } = useSolidPod()
     const { db } = useDatabase()
     const [accessState, setAccessState] = useState<'pending' | 'ok' | 'denied'>('pending')
+    const [ownerName, setOwnerName] = useState<string | null>(null)
     const storedRef = useRef(false)
 
     useEffect(() => {
@@ -30,6 +32,9 @@ export function ForeignPodLayout() {
                 return
             }
             setAccessState('ok')
+
+            const name = await getPodOwnerName(session!, foreignPodUrl)
+            setOwnerName(name)
 
             if (storedRef.current) return
             storedRef.current = true
@@ -45,8 +50,11 @@ export function ForeignPodLayout() {
                 const alreadyStored = list.contexts.some(c => c.podUrl === foreignPodUrl)
                 if (alreadyStored) return
 
+                const newContext = name
+                    ? { podUrl: foreignPodUrl, addedAt: new Date().toISOString(), label: name }
+                    : { podUrl: foreignPodUrl, addedAt: new Date().toISOString() }
                 const updated: SharedWithMeList = {
-                    contexts: [...list.contexts, { podUrl: foreignPodUrl, addedAt: new Date().toISOString() }],
+                    contexts: [...list.contexts, newContext],
                     lastModified: new Date().toISOString(),
                 }
                 await db.saveSharedWithMe(updated)
@@ -100,7 +108,7 @@ export function ForeignPodLayout() {
     return (
         <ForeignPodContext.Provider value={{ foreignPodUrl }}>
             <div className="bg-blue-50 border-b border-blue-200 px-4 py-2 text-sm text-blue-800 -mx-4 -mt-8 mb-6">
-                Viewing <span className="font-semibold">{foreignPodUrl}</span>'s data
+                Viewing <span className="font-semibold" title={foreignPodUrl}>{ownerName ?? foreignPodUrl}</span>'s data
             </div>
             <Outlet />
         </ForeignPodContext.Provider>

--- a/src/pages/sharing-settings.test.tsx
+++ b/src/pages/sharing-settings.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { SharingSettingsPage } from './sharing-settings'
+import type { PackingAppDatabase } from '../services/database'
+
+vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
+vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn() }))
+vi.mock('../components/ToastContext', () => ({ useToast: vi.fn(() => ({ showToast: vi.fn() })) }))
+vi.mock('../services/solidPod', () => ({
+    grantFullCollaboratorAccess: vi.fn(),
+    revokeFullCollaboratorAccess: vi.fn(),
+    getFullCollaborators: vi.fn(() => Promise.resolve([])),
+    getPrimaryPodUrl: vi.fn(() => Promise.resolve('https://pod.example.com/')),
+    getPodOwnerName: vi.fn(() => Promise.resolve(null)),
+    friendlyPodName: vi.fn((url: string) => url),
+    saveRdfToPod: vi.fn(() => Promise.resolve()),
+    POD_CONTAINERS: { SHARED_WITH_ME: 'pack-me-up/shared-with-me.ttl' },
+}))
+
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+import { saveRdfToPod } from '../services/solidPod'
+
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockSaveRdfToPod = vi.mocked(saveRdfToPod)
+
+const mockSession = { info: { isLoggedIn: true, webId: 'https://me.example.com/profile#me' }, fetch: vi.fn() }
+
+function renderPage(dbOverrides: Partial<PackingAppDatabase> = {}) {
+    const db: Partial<PackingAppDatabase> = {
+        getSharedWithMe: vi.fn(() => Promise.resolve({ contexts: [], lastModified: '' })),
+        saveSharedWithMe: vi.fn(() => Promise.resolve({ rev: '1' })),
+        ...dbOverrides,
+    }
+    mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+    mockUseSolidPod.mockReturnValue({ session: mockSession, isLoggedIn: true } as ReturnType<typeof useSolidPod>)
+    return render(<MemoryRouter><SharingSettingsPage /></MemoryRouter>)
+}
+
+describe('SharingSettingsPage — remove shared context', () => {
+    beforeEach(() => { vi.clearAllMocks() })
+
+    it('shows a Remove button for each shared context', async () => {
+        renderPage({
+            getSharedWithMe: vi.fn(() => Promise.resolve({
+                contexts: [{ podUrl: 'https://pod.example.com/', addedAt: '', webId: 'https://id.example.com/alice' }],
+                lastModified: '',
+            })),
+        })
+
+        expect(await screen.findByRole('button', { name: /remove/i })).toBeTruthy()
+    })
+
+    it('removes the entry from local DB and pod on click', async () => {
+        const saveSharedWithMe = vi.fn(() => Promise.resolve({ rev: '1' }))
+        renderPage({
+            getSharedWithMe: vi.fn(() => Promise.resolve({
+                contexts: [{ podUrl: 'https://pod.example.com/', addedAt: '', webId: 'https://id.example.com/alice' }],
+                lastModified: '',
+            })),
+            saveSharedWithMe,
+        })
+
+        fireEvent.click(await screen.findByRole('button', { name: /remove/i }))
+
+        await waitFor(() => {
+            expect(saveSharedWithMe).toHaveBeenCalledWith(
+                expect.objectContaining({ contexts: [] })
+            )
+        })
+        expect(mockSaveRdfToPod).toHaveBeenCalled()
+    })
+
+    it('removes the entry from the UI after clicking Remove', async () => {
+        renderPage({
+            getSharedWithMe: vi.fn(() => Promise.resolve({
+                contexts: [{ podUrl: 'https://pod.example.com/', addedAt: '' }],
+                lastModified: '',
+            })),
+            saveSharedWithMe: vi.fn(() => Promise.resolve({ rev: '1' })),
+        })
+
+        fireEvent.click(await screen.findByRole('button', { name: /remove/i }))
+
+        await waitFor(() => {
+            expect(screen.queryByRole('button', { name: /remove/i })).toBeNull()
+        })
+    })
+})

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -8,6 +8,8 @@ import {
     revokeFullCollaboratorAccess,
     getFullCollaborators,
     getPrimaryPodUrl,
+    getPodOwnerName,
+    friendlyPodName,
 } from '../services/solidPod'
 import type { SharedContext } from '../services/rdfSerialization'
 
@@ -25,6 +27,7 @@ export function SharingSettingsPage() {
     const [isLoadingCollaborators, setIsLoadingCollaborators] = useState(false)
     const [revokingWebId, setRevokingWebId] = useState<string | null>(null)
     const [sharedContexts, setSharedContexts] = useState<SharedContext[]>([])
+    const [podNames, setPodNames] = useState<Record<string, string>>({})
 
     useEffect(() => {
         if (!isLoggedIn || !session) return
@@ -53,6 +56,20 @@ export function SharingSettingsPage() {
             .then(swm => setSharedContexts(swm.contexts))
             .catch(() => setSharedContexts([]))
     }, [db])
+
+    useEffect(() => {
+        if (!session || sharedContexts.length === 0) return
+        const unlabeled = sharedContexts.filter(c => !c.label)
+        if (unlabeled.length === 0) return
+        Promise.all(unlabeled.map(c => getPodOwnerName(session, c.podUrl).then(n => [c.podUrl, n] as const)))
+            .then(results => {
+                const names: Record<string, string> = {}
+                for (const [podUrl, name] of results) {
+                    if (name) names[podUrl] = name
+                }
+                setPodNames(names)
+            })
+    }, [sharedContexts, session])
 
     const handleGrantAccess = async () => {
         if (!session || !ownPodUrl || !collaboratorWebId.trim()) return
@@ -178,7 +195,7 @@ export function SharingSettingsPage() {
                         {sharedContexts.map(ctx => (
                             <li key={ctx.podUrl} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
                                 <span className="text-sm text-gray-800 truncate flex-1" title={ctx.podUrl}>
-                                    {ctx.label ?? ctx.podUrl}
+                                    {ctx.label ?? podNames[ctx.podUrl] ?? friendlyPodName(ctx.podUrl)}
                                 </span>
                                 <button
                                     onClick={() => navigate(`/pod/${encodeURIComponent(ctx.podUrl)}/view-lists`)}

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -10,7 +10,10 @@ import {
     getPrimaryPodUrl,
     getPodOwnerName,
     friendlyPodName,
+    saveRdfToPod,
+    POD_CONTAINERS,
 } from '../services/solidPod'
+import { sharedWithMeToDataset } from '../services/rdfSerialization'
 import type { SharedContext } from '../services/rdfSerialization'
 
 export function SharingSettingsPage() {
@@ -28,6 +31,7 @@ export function SharingSettingsPage() {
     const [revokingWebId, setRevokingWebId] = useState<string | null>(null)
     const [sharedContexts, setSharedContexts] = useState<SharedContext[]>([])
     const [podNames, setPodNames] = useState<Record<string, string>>({})
+    const [removingPodUrl, setRemovingPodUrl] = useState<string | null>(null)
 
     useEffect(() => {
         if (!isLoggedIn || !session) return
@@ -90,6 +94,34 @@ export function SharingSettingsPage() {
             showToast(`Failed to grant access: ${msg}`, 'error')
         } finally {
             setIsGranting(false)
+        }
+    }
+
+    const handleRemoveSharedContext = async (podUrl: string) => {
+        setRemovingPodUrl(podUrl)
+        try {
+            const list = await db.getSharedWithMe()
+            const updated = {
+                contexts: list.contexts.filter(c => c.podUrl !== podUrl),
+                lastModified: new Date().toISOString(),
+            }
+            await db.saveSharedWithMe(updated)
+            setSharedContexts(updated.contexts)
+            const ownPodUrl = await getPrimaryPodUrl(session!)
+            if (ownPodUrl) {
+                await saveRdfToPod({
+                    session: session!,
+                    fileUrl: `${ownPodUrl}${POD_CONTAINERS.SHARED_WITH_ME}`,
+                    data: updated,
+                    serializer: sharedWithMeToDataset,
+                })
+            }
+            showToast('Removed', 'success')
+        } catch (err) {
+            console.error('SharingSettingsPage: failed to remove shared context', err)
+            showToast('Failed to remove. Please try again.', 'error')
+        } finally {
+            setRemovingPodUrl(null)
         }
     }
 
@@ -204,6 +236,14 @@ export function SharingSettingsPage() {
                                     className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 text-primary-700 hover:bg-primary-200 transition-colors"
                                 >
                                     Open
+                                </button>
+                                <button
+                                    onClick={() => handleRemoveSharedContext(ctx.podUrl)}
+                                    disabled={removingPodUrl === ctx.podUrl}
+                                    aria-label={`Remove shared pod`}
+                                    className="ml-2 px-3 py-1 text-xs font-semibold rounded-md bg-red-100 text-red-700 hover:bg-red-200 disabled:opacity-50 transition-colors"
+                                >
+                                    {removingPodUrl === ctx.podUrl ? 'Removing…' : 'Remove'}
                                 </button>
                             </li>
                         ))}

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -61,7 +61,7 @@ export function SharingSettingsPage() {
         if (!session || sharedContexts.length === 0) return
         const unlabeled = sharedContexts.filter(c => !c.label)
         if (unlabeled.length === 0) return
-        Promise.all(unlabeled.map(c => getPodOwnerName(session, c.podUrl).then(n => [c.podUrl, n] as const)))
+        Promise.all(unlabeled.map(c => getPodOwnerName(session, c.podUrl, c.webId).then(n => [c.podUrl, n] as const)))
             .then(results => {
                 const names: Record<string, string> = {}
                 for (const [podUrl, name] of results) {
@@ -77,7 +77,9 @@ export function SharingSettingsPage() {
         setInviteLink(null)
         try {
             await grantFullCollaboratorAccess(session, ownPodUrl, collaboratorWebId.trim())
-            const link = `${window.location.origin}/#/pod/${encodeURIComponent(ownPodUrl)}/view-lists`
+            const ownerWebId = session?.info.webId
+            const ownerParam = ownerWebId ? `?owner=${encodeURIComponent(ownerWebId)}` : ''
+            const link = `${window.location.origin}/#/pod/${encodeURIComponent(ownPodUrl)}/view-lists${ownerParam}`
             setInviteLink(link)
             setCollaboratorWebId('')
             await loadCollaborators()
@@ -195,7 +197,7 @@ export function SharingSettingsPage() {
                         {sharedContexts.map(ctx => (
                             <li key={ctx.podUrl} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
                                 <span className="text-sm text-gray-800 truncate flex-1" title={ctx.podUrl}>
-                                    {ctx.label ?? podNames[ctx.podUrl] ?? friendlyPodName(ctx.podUrl)}
+                                    {ctx.label ?? podNames[ctx.podUrl] ?? (ctx.webId ? friendlyPodName(ctx.webId) : undefined) ?? friendlyPodName(ctx.podUrl)}
                                 </span>
                                 <button
                                     onClick={() => navigate(`/pod/${encodeURIComponent(ctx.podUrl)}/view-lists`)}

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -14,6 +14,7 @@ import {
     grantPublicAccess,
     revokeCollaboratorAccess,
     getCollaborators,
+    getPodOwnerName,
 } from './solidPod'
 import { AuthenticationError } from './solidPod'
 import type { PackingAppDatabase } from './database'
@@ -903,5 +904,46 @@ describe('getCollaborators', () => {
         mockGetAgentAccessAll.mockRejectedValue(err)
 
         await expect(getCollaborators(mockSession, FILE_URL)).rejects.toThrow('Network failure')
+    })
+})
+
+// ─── getPodOwnerName ─────────────────────────────────────────────────────────
+
+describe('getPodOwnerName', () => {
+    const POD = 'https://pod.example.com/'
+    const WEB_ID = 'https://pod.example.com/profile/card#me'
+    const PROFILE_CARD_URL = 'https://pod.example.com/profile/card'
+
+    it('returns the foaf:name from the profile card', async () => {
+        const { buildThing, setThing, createSolidDataset } = await import('@inrupt/solid-client')
+        const thing = buildThing({ url: WEB_ID })
+            .addStringNoLocale('http://xmlns.com/foaf/0.1/name', 'Alice Smith')
+            .build()
+        const dataset = setThing(createSolidDataset(), thing)
+        mockGetSolidDataset.mockResolvedValueOnce(dataset as unknown as SolidDataset & WithServerResourceInfo)
+
+        const result = await getPodOwnerName(mockSession, POD)
+
+        expect(result).toBe('Alice Smith')
+        expect(mockGetSolidDataset).toHaveBeenCalledWith(PROFILE_CARD_URL, expect.objectContaining({ fetch: mockSession.fetch }))
+    })
+
+    it('returns null when profile card fetch fails', async () => {
+        mockGetSolidDataset.mockRejectedValueOnce(new Error('Not found'))
+
+        const result = await getPodOwnerName(mockSession, POD)
+
+        expect(result).toBeNull()
+    })
+
+    it('returns null when profile card has no foaf:name', async () => {
+        const { buildThing, setThing, createSolidDataset } = await import('@inrupt/solid-client')
+        const thing = buildThing({ url: WEB_ID }).build()
+        const dataset = setThing(createSolidDataset(), thing)
+        mockGetSolidDataset.mockResolvedValueOnce(dataset as unknown as SolidDataset & WithServerResourceInfo)
+
+        const result = await getPodOwnerName(mockSession, POD)
+
+        expect(result).toBeNull()
     })
 })

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -15,6 +15,7 @@ import {
     revokeCollaboratorAccess,
     getCollaborators,
     getPodOwnerName,
+    friendlyPodName,
 } from './solidPod'
 import { AuthenticationError } from './solidPod'
 import type { PackingAppDatabase } from './database'
@@ -945,5 +946,25 @@ describe('getPodOwnerName', () => {
         const result = await getPodOwnerName(mockSession, POD)
 
         expect(result).toBeNull()
+    })
+})
+
+// ─── friendlyPodName ─────────────────────────────────────────────────────────
+
+describe('friendlyPodName', () => {
+    it('returns hostname when path is a UUID', () => {
+        expect(friendlyPodName('https://storage.inrupt.com/d8c8c02b-b47c-48e9-b737-619f2958689f/')).toBe('storage.inrupt.com')
+    })
+
+    it('returns "segment on hostname" for a meaningful path segment', () => {
+        expect(friendlyPodName('https://solidcommunity.net/alice/')).toBe('alice on solidcommunity.net')
+    })
+
+    it('returns hostname when there is no path segment', () => {
+        expect(friendlyPodName('https://alice.solidcommunity.net/')).toBe('alice.solidcommunity.net')
+    })
+
+    it('returns the input unchanged when the URL is invalid', () => {
+        expect(friendlyPodName('not-a-url')).toBe('not-a-url')
     })
 })

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -947,6 +947,21 @@ describe('getPodOwnerName', () => {
 
         expect(result).toBeNull()
     })
+
+    it('uses an explicit WebID instead of deriving from the pod URL', async () => {
+        const EXPLICIT_WEB_ID = 'https://id.example.com/alice'
+        const { buildThing, setThing, createSolidDataset } = await import('@inrupt/solid-client')
+        const thing = buildThing({ url: EXPLICIT_WEB_ID })
+            .addStringNoLocale('http://xmlns.com/foaf/0.1/name', 'Alice')
+            .build()
+        const dataset = setThing(createSolidDataset(), thing)
+        mockGetSolidDataset.mockResolvedValueOnce(dataset as unknown as SolidDataset & WithServerResourceInfo)
+
+        const result = await getPodOwnerName(mockSession, POD, EXPLICIT_WEB_ID)
+
+        expect(result).toBe('Alice')
+        expect(mockGetSolidDataset).toHaveBeenCalledWith(EXPLICIT_WEB_ID, expect.objectContaining({ fetch: mockSession.fetch }))
+    })
 })
 
 // ─── friendlyPodName ─────────────────────────────────────────────────────────

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -125,8 +125,8 @@ export function deriveWebIdFromPodUrl(podUrl: string): string {
     return `${base}/profile/card#me`
 }
 
-export async function getPodOwnerName(session: Session, podUrl: string): Promise<string | null> {
-    const webId = deriveWebIdFromPodUrl(podUrl)
+export async function getPodOwnerName(session: Session, podUrl: string, explicitWebId?: string): Promise<string | null> {
+    const webId = explicitWebId ?? deriveWebIdFromPodUrl(podUrl)
     const profileCardUrl = webId.replace(/#.*$/, '')
     try {
         const dataset = await getSolidDataset(profileCardUrl, { fetch: session.fetch })

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -1,5 +1,5 @@
 import { AppSession as Session } from '../types/AppSession'
-import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile, solidDatasetAsTurtle, universalAccess, getResourceInfoWithAcl, hasResourceAcl, hasFallbackAcl, hasAccessibleAcl, getResourceAcl, createAclFromFallbackAcl, saveAclFor, setAgentResourceAccess, setAgentDefaultAccess, createContainerAt, acp_ess_2 } from '@inrupt/solid-client'
+import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile, solidDatasetAsTurtle, universalAccess, getResourceInfoWithAcl, hasResourceAcl, hasFallbackAcl, hasAccessibleAcl, getResourceAcl, createAclFromFallbackAcl, saveAclFor, setAgentResourceAccess, setAgentDefaultAccess, createContainerAt, acp_ess_2, getThing, getStringNoLocale } from '@inrupt/solid-client'
 import type { SolidDataset, Access } from '@inrupt/solid-client'
 const { getAgentAccessAll, setPublicAccess } = universalAccess
 import { PackingAppDatabase } from './database'
@@ -108,6 +108,19 @@ export function handlePodError(error: unknown): never {
 export function deriveWebIdFromPodUrl(podUrl: string): string {
     const base = podUrl.replace(/\/+$/, '')
     return `${base}/profile/card#me`
+}
+
+export async function getPodOwnerName(session: Session, podUrl: string): Promise<string | null> {
+    const webId = deriveWebIdFromPodUrl(podUrl)
+    const profileCardUrl = webId.replace(/#.*$/, '')
+    try {
+        const dataset = await getSolidDataset(profileCardUrl, { fetch: session.fetch })
+        const profile = getThing(dataset, webId)
+        if (!profile) return null
+        return getStringNoLocale(profile, 'http://xmlns.com/foaf/0.1/name') ?? null
+    } catch {
+        return null
+    }
 }
 
 export function derivePodUrlFromWebId(webId: string): string | null {

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -105,6 +105,21 @@ export function handlePodError(error: unknown): never {
     throw error
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function friendlyPodName(podUrl: string): string {
+    try {
+        const url = new URL(podUrl)
+        const firstSegment = url.pathname.split('/').find(s => s.length > 0)
+        if (firstSegment && !UUID_RE.test(firstSegment)) {
+            return `${firstSegment} on ${url.hostname}`
+        }
+        return url.hostname
+    } catch {
+        return podUrl
+    }
+}
+
 export function deriveWebIdFromPodUrl(podUrl: string): string {
     const base = podUrl.replace(/\/+$/, '')
     return `${base}/profile/card#me`


### PR DESCRIPTION
Fetches foaf:name from the pod owner's profile card and displays it
in the "Viewing X's data" banner and stores it as the label on the
SharedContext so the sharing settings page also shows it nicely.
Falls back to the raw URL when the profile card is unavailable or
has no name.