### PR TITLE
Add guest person support to individual packing lists

### DIFF
--- a/src/create-packing-list/types.ts
+++ b/src/create-packing-list/types.ts
@@ -6,6 +6,7 @@ export interface PackingList {
     lastModified?: string // ISO timestamp for conflict resolution
     items: PackingListItem[]
     deletedItems?: PackingListItem[]
+    guests?: Array<{ id: string; name: string }>
 }
 
 export interface PackingListItem {

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -235,6 +235,18 @@ describe('getUnreviewedCustomItems', () => {
         expect(result[1].listId).toBe('list-2')
         expect(result[1].listName).toBe('London Trip')
     })
+
+    it('excludes custom items belonging to a guest (personId not in question set)', () => {
+        const guestItem = makeCustomItem({ itemText: 'Guest snacks', personId: 'guest-uuid-123', personName: 'Dave' })
+        const list = makePackingList({ items: [guestItem] })
+        expect(getUnreviewedCustomItems([list], makeQuestionSet())).toHaveLength(0)
+    })
+
+    it('still includes custom items with empty personId (regular manually-added items)', () => {
+        const item = makeCustomItem({ itemText: 'Sunscreen SPF50', personId: '' })
+        const list = makePackingList({ items: [item] })
+        expect(getUnreviewedCustomItems([list], makeQuestionSet())).toHaveLength(1)
+    })
 })
 
 // ─── CreatePackingList – suggestion card ──────────────────────────────────────
@@ -739,6 +751,20 @@ describe('getUnreviewedDeletedItems', () => {
         expect(result).toHaveLength(2)
         expect(result[0].listId).toBe('list-1')
         expect(result[1].listId).toBe('list-2')
+    })
+
+    it('excludes deleted items belonging to a guest (personId not in question set)', () => {
+        const guestItem = makeDeletedItem({ itemText: 'Passport', personId: 'guest-uuid-123' })
+        const list = makePackingList({ items: [], deletedItems: [guestItem] })
+        const qs = makeQsWithAlwaysNeeded('Passport')
+        expect(getUnreviewedDeletedItems([list], qs)).toHaveLength(0)
+    })
+
+    it('still includes deleted items with a personId that is in the question set', () => {
+        const item = makeDeletedItem({ itemText: 'Passport', personId: 'p1' })
+        const list = makePackingList({ items: [], deletedItems: [item] })
+        const qs = makeQsWithAlwaysNeeded('Passport')
+        expect(getUnreviewedDeletedItems([list], qs)).toHaveLength(1)
     })
 })
 

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -40,9 +40,12 @@ export function getUnreviewedDeletedItems(
         }
     }
 
+    const questionSetPersonIds = new Set(questionSet.people.map(p => p.id))
+
     const results: Array<{ listId: string; listName: string; item: PackingListItem }> = []
     for (const list of packingLists) {
         for (const item of (list.deletedItems ?? [])) {
+            if (item.personId !== '' && !questionSetPersonIds.has(item.personId)) continue
             if (item.reviewed === true) continue
             if (!existingTexts.has(item.itemText.trim().toLowerCase())) continue
             results.push({ listId: list.id, listName: list.name, item })
@@ -68,9 +71,12 @@ export function getUnreviewedCustomItems(
         }
     }
 
+    const questionSetPersonIds = new Set(questionSet.people.map(p => p.id))
+
     const results: Array<{ listId: string; listName: string; item: PackingListItem }> = []
     for (const list of packingLists) {
         for (const item of list.items) {
+            if (item.personId !== '' && !questionSetPersonIds.has(item.personId)) continue
             if (item.questionId !== '') continue
             if (item.reviewed === true) continue
             if (existingTexts.has(item.itemText.trim().toLowerCase())) continue

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -503,87 +503,70 @@ export function ViewPackingList() {
     return (
         <>
         <div className="w-full flex flex-col items-center py-8 px-4">
-            {/* Sticky top toolbar */}
-            <div className="sticky top-0 z-50 w-full mb-6 flex justify-center">
-                <div className="w-full max-w-screen-2xl">
-                    <div className="backdrop-blur-md bg-white/90 border border-gray-200 shadow-lg rounded-xl px-4 py-3 relative">
-                        {/* Sync indicator - absolutely positioned to avoid layout shift */}
-                        {isLoggedIn && syncingFromPod && (
-                            <div className="absolute top-2 right-2 z-10 bg-blue-50 border border-blue-200 rounded-md px-2 py-1 flex items-center gap-1.5 shadow-sm">
-                                <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
-                                <span className="text-xs text-blue-700 whitespace-nowrap">Syncing...</span>
-                            </div>
+            {/* Non-sticky header: name, actions */}
+            <div className="w-full max-w-screen-2xl mb-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="flex items-center gap-3 min-w-0">
+                        <h1 className="text-xl font-bold text-gray-900 truncate">{packingList.name}</h1>
+                        {foreignPodUrl && (
+                            <span className="text-xs font-medium text-blue-700 bg-blue-100 border border-blue-200 rounded-full px-2 py-0.5 shrink-0">
+                                Shared list
+                            </span>
                         )}
-
-                        <div className="flex flex-wrap items-center justify-between gap-3">
-                            <div className="flex items-center gap-3">
-                                <h1 className="text-xl font-bold text-gray-900">{packingList.name}</h1>
-                                {foreignPodUrl && (
-                                    <span className="text-xs font-medium text-blue-700 bg-blue-100 border border-blue-200 rounded-full px-2 py-0.5">
-                                        Shared list
-                                    </span>
-                                )}
-                                <span className={`text-sm font-medium ${allPacked ? 'text-emerald-600' : 'text-gray-600'}`}>
-                                    {allPacked ? '🎉 All packed!' : `${packedCount} / ${totalCount} packed (${percentComplete}%)`}
-                                </span>
-                                {/* Always reserve space for auto-save status to prevent layout jump */}
-                                <div className={`flex items-center space-x-2 min-w-[120px] transition-opacity duration-200 ${autoSaveStatus === 'idle' ? 'opacity-0' : 'opacity-100'}`}>
-                                    {autoSaveStatus === 'saving' && (
-                                        <>
-                                            <div className="animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full"></div>
-                                            <span className="text-sm text-blue-600">Auto-saving...</span>
-                                        </>
-                                    )}
-                                    {autoSaveStatus === 'saved' && (
-                                        <>
-                                            <div className="h-4 w-4 text-green-500">✓</div>
-                                            <span className="text-sm text-green-600">Saved</span>
-                                        </>
-                                    )}
-                                    {autoSaveStatus === 'error' && (
-                                        <>
-                                            <div className="h-4 w-4 text-red-500">✗</div>
-                                            <span className="text-sm text-red-600">Error</span>
-                                        </>
-                                    )}
-                                </div>
-                            </div>
-                            <div className="flex flex-wrap items-center gap-2">
-                                {!foreignPodUrl && (
-                                    <Button
-                                        type="button"
-                                        variant="secondary"
-                                        onClick={() => { setShowAddGuest(v => !v); setNewGuestName('') }}
-                                    >
-                                        + Add Guest
-                                    </Button>
-                                )}
-                                <Button
-                                    type="button"
-                                    variant={hiddenPackedCount > 0 ? 'primary' : 'secondary'}
-                                    onClick={() => setShowPacked(!showPacked)}
-                                >
-                                    {showPacked ? 'Hide Packed' : 'Show Packed'}
-                                </Button>
-                                {isLoggedIn && !foreignPodUrl && (
-                                    <Button
-                                        type="button"
-                                        variant="secondary"
-                                        onClick={() => setShareModalOpen(true)}
-                                        disabled={!ownPodUrl}
-                                    >
-                                        Share
-                                    </Button>
-                                )}
-                                <Button
-                                    type="button"
-                                    variant="secondary"
-                                    onClick={() => navigate(backPath)}
-                                >
-                                    Back to Lists
-                                </Button>
-                            </div>
+                        {isLoggedIn && syncingFromPod && (
+                            <span className="text-xs text-blue-600 shrink-0">Syncing…</span>
+                        )}
+                        <div className={`flex items-center gap-1 transition-opacity duration-200 shrink-0 ${autoSaveStatus === 'idle' ? 'opacity-0' : 'opacity-100'}`}>
+                            {autoSaveStatus === 'saving' && <span className="text-xs text-blue-500">Saving…</span>}
+                            {autoSaveStatus === 'saved' && <span className="text-xs text-green-600">Saved</span>}
+                            {autoSaveStatus === 'error' && <span className="text-xs text-red-600">Error saving</span>}
                         </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                        {!foreignPodUrl && (
+                            <Button
+                                type="button"
+                                variant="secondary"
+                                onClick={() => { setShowAddGuest(v => !v); setNewGuestName('') }}
+                            >
+                                + Add Guest
+                            </Button>
+                        )}
+                        {isLoggedIn && !foreignPodUrl && (
+                            <Button
+                                type="button"
+                                variant="secondary"
+                                onClick={() => setShareModalOpen(true)}
+                                disabled={!ownPodUrl}
+                            >
+                                Share
+                            </Button>
+                        )}
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            onClick={() => navigate(backPath)}
+                        >
+                            Back to Lists
+                        </Button>
+                    </div>
+                </div>
+            </div>
+
+            {/* Slim sticky progress strip */}
+            <div className="sticky top-0 z-50 w-full mb-4 flex justify-center">
+                <div className="w-full max-w-screen-2xl">
+                    <div className="backdrop-blur-md bg-white/90 border border-gray-200 shadow-sm rounded-lg px-4 py-2 flex items-center justify-between gap-3">
+                        <span className={`text-sm font-medium ${allPacked ? 'text-emerald-600' : 'text-gray-600'}`}>
+                            {allPacked ? '🎉 All packed!' : `${packedCount} / ${totalCount} packed (${percentComplete}%)`}
+                        </span>
+                        <Button
+                            type="button"
+                            variant={hiddenPackedCount > 0 ? 'primary' : 'secondary'}
+                            onClick={() => setShowPacked(!showPacked)}
+                        >
+                            {showPacked ? 'Hide Packed' : 'Show Packed'}
+                        </Button>
                     </div>
                 </div>
             </div>

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -67,6 +67,8 @@ export function ViewPackingList() {
     const [editingItemText, setEditingItemText] = useState<string>('')
     const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
     const [collapsedPersons, setCollapsedPersons] = useState<Set<string>>(new Set())
+    const [showAddGuest, setShowAddGuest] = useState(false)
+    const [newGuestName, setNewGuestName] = useState('')
 
     const toggleCategory = (key: string) =>
         setCollapsedCategories(prev => {
@@ -373,7 +375,7 @@ export function ViewPackingList() {
         }
     }
 
-    const handleAddItem = async (personName: string) => {
+    const handleAddItem = async (personName: string, personId: string = '') => {
         if (!packingList) return
 
         const newItemText = newItemInputs[personName]?.trim()
@@ -386,7 +388,7 @@ export function ViewPackingList() {
                 id: `item-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
                 itemText: newItemText,
                 personName: personName,
-                personId: '',
+                personId: personId,
                 questionId: '',
                 optionId: '',
                 packed: false
@@ -404,6 +406,17 @@ export function ViewPackingList() {
             console.error('Error adding item:', err)
             setAutoSaveStatus('error')
         }
+    }
+
+    const handleAddGuest = async () => {
+        if (!packingList || !newGuestName.trim()) return
+        const guest = { id: crypto.randomUUID(), name: newGuestName.trim() }
+        await persistPackingList({
+            ...packingList,
+            guests: [...(packingList.guests ?? []), guest],
+        })
+        setNewGuestName('')
+        setShowAddGuest(false)
     }
 
     if (isLoading) {
@@ -436,6 +449,20 @@ export function ViewPackingList() {
         if (watchedItems[item.id]) acc[item.personName].packed++
         return acc
     }, {} as Record<string, { packed: number; total: number }>)
+
+    const guestPersonIdByName = new Map(
+        (packingList.guests ?? []).map(g => [g.name, g.id])
+    )
+
+    const personSectionsBase: Record<string, PackingListItem[]> = {}
+    for (const guest of (packingList.guests ?? [])) personSectionsBase[guest.name] = []
+    const personSections = Object.entries(
+        filteredItems.reduce((acc, item) => {
+            if (!acc[item.personName]) acc[item.personName] = []
+            acc[item.personName].push(item)
+            return acc
+        }, personSectionsBase)
+    ).sort(([a], [b]) => a.localeCompare(b))
 
     return (
         <>
@@ -548,15 +575,7 @@ export function ViewPackingList() {
             <div className="w-full">
                 <div>
                     <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))' }}>
-                        {Object.entries(
-                            filteredItems.reduce((acc, item) => {
-                                if (!acc[item.personName]) {
-                                    acc[item.personName] = [];
-                                }
-                                acc[item.personName].push(item);
-                                return acc;
-                            }, {} as Record<string, typeof filteredItems>)
-                        ).sort(([nameA], [nameB]) => nameA.localeCompare(nameB)).map(([personName, items]) => {
+                        {personSections.map(([personName, items]) => {
                             const stats = personStats[personName] ?? { packed: 0, total: 0 }
                             return (
                             <div key={personName} className="border border-gray-200 rounded-lg p-4 bg-white shadow-sm">
@@ -678,7 +697,7 @@ export function ViewPackingList() {
                                                 onKeyPress={(e) => {
                                                     if (e.key === 'Enter') {
                                                         e.preventDefault()
-                                                        handleAddItem(personName)
+                                                        handleAddItem(personName, guestPersonIdByName.get(personName) ?? '')
                                                     }
                                                 }}
                                                 placeholder="Add new item..."
@@ -686,7 +705,7 @@ export function ViewPackingList() {
                                             />
                                             <button
                                                 type="button"
-                                                onClick={() => handleAddItem(personName)}
+                                                onClick={() => handleAddItem(personName, guestPersonIdByName.get(personName) ?? '')}
                                                 className="shrink-0 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
                                             >
                                                 Add
@@ -697,6 +716,48 @@ export function ViewPackingList() {
                             </div>
                         )})}
                     </div>
+                </div>
+
+                {/* Add Guest */}
+                <div className="mt-6">
+                    {showAddGuest ? (
+                        <div className="flex gap-2 max-w-sm">
+                            <input
+                                type="text"
+                                value={newGuestName}
+                                onChange={(e) => setNewGuestName(e.target.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter') { e.preventDefault(); handleAddGuest() }
+                                    if (e.key === 'Escape') { setShowAddGuest(false); setNewGuestName('') }
+                                }}
+                                placeholder="Guest name..."
+                                autoFocus
+                                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                            />
+                            <button
+                                type="button"
+                                onClick={handleAddGuest}
+                                className="shrink-0 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
+                            >
+                                Add
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => { setShowAddGuest(false); setNewGuestName('') }}
+                                className="shrink-0 px-3 py-2 text-gray-600 hover:text-gray-900 border border-gray-300 rounded-md text-sm"
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    ) : (
+                        <button
+                            type="button"
+                            onClick={() => setShowAddGuest(true)}
+                            className="text-sm text-blue-600 hover:text-blue-800 flex items-center gap-1"
+                        >
+                            <span className="text-lg leading-none">+</span> Add guest
+                        </button>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -69,6 +69,9 @@ export function ViewPackingList() {
     const [collapsedPersons, setCollapsedPersons] = useState<Set<string>>(new Set())
     const [showAddGuest, setShowAddGuest] = useState(false)
     const [newGuestName, setNewGuestName] = useState('')
+    const [renamingGuestId, setRenamingGuestId] = useState<string | null>(null)
+    const [renamingGuestName, setRenamingGuestName] = useState('')
+    const [guestToRemove, setGuestToRemove] = useState<string | null>(null)
 
     const toggleCategory = (key: string) =>
         setCollapsedCategories(prev => {
@@ -419,6 +422,32 @@ export function ViewPackingList() {
         setShowAddGuest(false)
     }
 
+    const handleRenameGuest = async (guestId: string, newName: string) => {
+        if (!packingList) return
+        const trimmed = newName.trim()
+        setRenamingGuestId(null)
+        setRenamingGuestName('')
+        if (!trimmed) return
+        const oldGuest = (packingList.guests ?? []).find(g => g.id === guestId)
+        if (!oldGuest || trimmed === oldGuest.name) return
+        await persistPackingList({
+            ...packingList,
+            guests: (packingList.guests ?? []).map(g => g.id === guestId ? { ...g, name: trimmed } : g),
+            items: packingList.items.map(item => item.personId === guestId ? { ...item, personName: trimmed } : item),
+            deletedItems: (packingList.deletedItems ?? []).map(item => item.personId === guestId ? { ...item, personName: trimmed } : item),
+        })
+    }
+
+    const handleRemoveGuest = async (guestId: string) => {
+        if (!packingList) return
+        await persistPackingList({
+            ...packingList,
+            guests: (packingList.guests ?? []).filter(g => g.id !== guestId),
+            items: packingList.items.filter(item => item.personId !== guestId),
+            deletedItems: (packingList.deletedItems ?? []).filter(item => item.personId !== guestId),
+        })
+    }
+
     if (isLoading) {
         return <div className="max-w-4xl mx-auto py-8 px-4">Loading packing list...</div>
     }
@@ -453,16 +482,23 @@ export function ViewPackingList() {
     const guestPersonIdByName = new Map(
         (packingList.guests ?? []).map(g => [g.name, g.id])
     )
+    const guestNames = new Set((packingList.guests ?? []).map(g => g.name))
 
-    const personSectionsBase: Record<string, PackingListItem[]> = {}
-    for (const guest of (packingList.guests ?? [])) personSectionsBase[guest.name] = []
-    const personSections = Object.entries(
-        filteredItems.reduce((acc, item) => {
-            if (!acc[item.personName]) acc[item.personName] = []
-            acc[item.personName].push(item)
-            return acc
-        }, personSectionsBase)
-    ).sort(([a], [b]) => a.localeCompare(b))
+    // Build grouped item map, seeding guest names so their sections exist even when empty
+    const groupedItems: Record<string, PackingListItem[]> = {}
+    for (const guest of (packingList.guests ?? [])) groupedItems[guest.name] = []
+    for (const item of filteredItems) {
+        if (!groupedItems[item.personName]) groupedItems[item.personName] = []
+        groupedItems[item.personName].push(item)
+    }
+
+    // Regular people (from question set) alphabetically first, then guests in add-order
+    const regularSections = Object.entries(groupedItems)
+        .filter(([name]) => !guestNames.has(name))
+        .sort(([a], [b]) => a.localeCompare(b))
+    const guestSections = (packingList.guests ?? [])
+        .map(g => [g.name, groupedItems[g.name] ?? []] as [string, PackingListItem[]])
+    const personSections = [...regularSections, ...guestSections]
 
     return (
         <>
@@ -513,6 +549,15 @@ export function ViewPackingList() {
                                 </div>
                             </div>
                             <div className="flex flex-wrap items-center gap-2">
+                                {!foreignPodUrl && (
+                                    <Button
+                                        type="button"
+                                        variant="secondary"
+                                        onClick={() => { setShowAddGuest(v => !v); setNewGuestName('') }}
+                                    >
+                                        + Add Guest
+                                    </Button>
+                                )}
                                 <Button
                                     type="button"
                                     variant={hiddenPackedCount > 0 ? 'primary' : 'secondary'}
@@ -573,24 +618,102 @@ export function ViewPackingList() {
 
             {/* Main content */}
             <div className="w-full">
+                {/* Add Guest inline form — appears just above the grid */}
+                {showAddGuest && (
+                    <div className="mb-4 flex gap-2 max-w-sm">
+                        <input
+                            type="text"
+                            value={newGuestName}
+                            onChange={(e) => setNewGuestName(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') { e.preventDefault(); handleAddGuest() }
+                                if (e.key === 'Escape') { setShowAddGuest(false); setNewGuestName('') }
+                            }}
+                            placeholder="Guest name..."
+                            autoFocus
+                            className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                        />
+                        <button
+                            type="button"
+                            onClick={handleAddGuest}
+                            className="shrink-0 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
+                        >
+                            Add
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => { setShowAddGuest(false); setNewGuestName('') }}
+                            className="shrink-0 px-3 py-2 text-gray-600 hover:text-gray-900 border border-gray-300 rounded-md text-sm"
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                )}
                 <div>
                     <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))' }}>
                         {personSections.map(([personName, items]) => {
                             const stats = personStats[personName] ?? { packed: 0, total: 0 }
+                            const guestId = guestPersonIdByName.get(personName)
+                            const isGuest = guestId !== undefined
                             return (
-                            <div key={personName} className="border border-gray-200 rounded-lg p-4 bg-white shadow-sm">
-                                <h2 className="text-xl font-semibold text-gray-800 mb-4 pb-2 border-b border-gray-200">
-                                    <button
-                                        type="button"
-                                        aria-label={`${collapsedPersons.has(personName) ? 'Expand' : 'Collapse'} ${personName}'s list`}
-                                        onClick={() => togglePerson(personName)}
-                                        className="flex items-center gap-2 w-full text-left"
-                                    >
-                                        <span className="text-sm text-gray-400">{collapsedPersons.has(personName) ? '▶' : '▼'}</span>
-                                        <span>{personName}'s Items</span>
-                                        <span className="ml-2 text-sm font-normal text-gray-500">{stats.packed} / {stats.total}</span>
-                                    </button>
-                                </h2>
+                            <div key={personName} className={`border rounded-lg p-4 bg-white shadow-sm ${isGuest ? 'border-amber-200' : 'border-gray-200'}`}>
+                                <div className="mb-4 pb-2 border-b border-gray-200">
+                                    <div className="flex items-center gap-1 min-h-[2rem]">
+                                        {isGuest && renamingGuestId === guestId ? (
+                                            <>
+                                                <span className="text-sm text-gray-400 px-1" aria-hidden>▼</span>
+                                                <input
+                                                    type="text"
+                                                    value={renamingGuestName}
+                                                    onChange={(e) => setRenamingGuestName(e.target.value)}
+                                                    onKeyDown={(e) => {
+                                                        if (e.key === 'Enter') { e.preventDefault(); handleRenameGuest(guestId, renamingGuestName) }
+                                                        if (e.key === 'Escape') { setRenamingGuestId(null); setRenamingGuestName('') }
+                                                    }}
+                                                    onBlur={() => handleRenameGuest(guestId, renamingGuestName)}
+                                                    autoFocus
+                                                    className="flex-1 px-2 py-1 border border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-lg font-semibold text-gray-800"
+                                                />
+                                            </>
+                                        ) : (
+                                            <button
+                                                type="button"
+                                                aria-label={`${collapsedPersons.has(personName) ? 'Expand' : 'Collapse'} ${personName}'s list`}
+                                                onClick={() => togglePerson(personName)}
+                                                className="flex items-center gap-2 flex-1 text-left"
+                                            >
+                                                <span className="text-sm text-gray-400">{collapsedPersons.has(personName) ? '▶' : '▼'}</span>
+                                                <span className="text-xl font-semibold text-gray-800">{personName}'s Items</span>
+                                                <span className="ml-1 text-sm font-normal text-gray-500">{stats.packed} / {stats.total}</span>
+                                            </button>
+                                        )}
+                                        {isGuest && renamingGuestId !== guestId && (
+                                            <>
+                                                <span className="text-xs font-medium text-amber-700 bg-amber-100 rounded-full px-2 py-0.5 shrink-0">Guest</span>
+                                                <button
+                                                    type="button"
+                                                    aria-label={`Rename ${personName}`}
+                                                    onClick={() => { setRenamingGuestId(guestId); setRenamingGuestName(personName) }}
+                                                    className="p-2 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-md transition-colors"
+                                                >
+                                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                        <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                                                    </svg>
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    aria-label={`Remove ${personName}`}
+                                                    onClick={() => setGuestToRemove(guestId)}
+                                                    className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                                                >
+                                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                        <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+                                                    </svg>
+                                                </button>
+                                            </>
+                                        )}
+                                    </div>
+                                </div>
                                 {!collapsedPersons.has(personName) && <div>
                                     {groupByCategory(items).map(({ category, items: catItems }) => {
                                         const sectionKey = `${personName}::${category}`
@@ -717,48 +840,6 @@ export function ViewPackingList() {
                         )})}
                     </div>
                 </div>
-
-                {/* Add Guest */}
-                <div className="mt-6">
-                    {showAddGuest ? (
-                        <div className="flex gap-2 max-w-sm">
-                            <input
-                                type="text"
-                                value={newGuestName}
-                                onChange={(e) => setNewGuestName(e.target.value)}
-                                onKeyDown={(e) => {
-                                    if (e.key === 'Enter') { e.preventDefault(); handleAddGuest() }
-                                    if (e.key === 'Escape') { setShowAddGuest(false); setNewGuestName('') }
-                                }}
-                                placeholder="Guest name..."
-                                autoFocus
-                                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
-                            />
-                            <button
-                                type="button"
-                                onClick={handleAddGuest}
-                                className="shrink-0 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
-                            >
-                                Add
-                            </button>
-                            <button
-                                type="button"
-                                onClick={() => { setShowAddGuest(false); setNewGuestName('') }}
-                                className="shrink-0 px-3 py-2 text-gray-600 hover:text-gray-900 border border-gray-300 rounded-md text-sm"
-                            >
-                                Cancel
-                            </button>
-                        </div>
-                    ) : (
-                        <button
-                            type="button"
-                            onClick={() => setShowAddGuest(true)}
-                            className="text-sm text-blue-600 hover:text-blue-800 flex items-center gap-1"
-                        >
-                            <span className="text-lg leading-none">+</span> Add guest
-                        </button>
-                    )}
-                </div>
             </div>
         </div>
         <ConfirmationDialog
@@ -767,6 +848,15 @@ export function ViewPackingList() {
             onConfirm={() => { handleDeleteItem(itemToDelete!); setItemToDelete(null) }}
             title="Remove item"
             message="Are you sure you want to remove this item?"
+            confirmText="Remove"
+            confirmVariant="danger"
+        />
+        <ConfirmationDialog
+            isOpen={guestToRemove !== null}
+            onClose={() => setGuestToRemove(null)}
+            onConfirm={() => { handleRemoveGuest(guestToRemove!); setGuestToRemove(null) }}
+            title="Remove guest"
+            message="Remove this guest and all their items from this list?"
             confirmText="Remove"
             confirmVariant="danger"
         />

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -199,6 +199,7 @@ export class PackingAppDatabase {
                         lastModified: packingList.lastModified,
                         items: packingList.items,
                         deletedItems: packingList.deletedItems,
+                        guests: packingList.guests,
                     }
                 }
 
@@ -236,6 +237,7 @@ export class PackingAppDatabase {
                         lastModified: row.doc.data.lastModified,
                         items: row.doc.data.items,
                         deletedItems: row.doc.data.deletedItems,
+                        guests: row.doc.data.guests,
                     }
                     packingLists.push(packingList)
                 }

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -47,6 +47,14 @@ export function packingListToDataset(list: PackingList, datasetUrl: string): Sol
         ds = setThing(ds, packingListItemToThing(item, itemUrl))
     }
 
+    for (const guest of (list.guests ?? [])) {
+        const guestUrl = `${datasetUrl}#guest-${guest.id}`
+        rootBuilder = rootBuilder.addUrl(PMU.hasGuest, guestUrl)
+        ds = setThing(ds, buildThing({ url: guestUrl })
+            .addStringNoLocale(PMU.name, guest.name)
+            .build())
+    }
+
     return setThing(ds, rootBuilder.build())
 }
 
@@ -69,6 +77,16 @@ export function datasetToPackingList(dataset: SolidDataset, datasetUrl: string):
         .map(url => thingToPackingListItem(getThing(dataset, url), url))
         .filter((item): item is PackingListItem => item !== null)
 
+    const guests = getUrlAll(rootThing, PMU.hasGuest)
+        .map(url => {
+            const thing = getThing(dataset, url)
+            if (!thing) return null
+            const id = (url.split('#')[1] ?? '').replace('guest-', '')
+            const name = getStringNoLocale(thing, PMU.name) ?? ''
+            return { id, name }
+        })
+        .filter((g): g is { id: string; name: string } => g !== null)
+
     return {
         id,
         name,
@@ -76,6 +94,7 @@ export function datasetToPackingList(dataset: SolidDataset, datasetUrl: string):
         ...(lastModified !== undefined ? { lastModified } : {}),
         items,
         deletedItems,
+        ...(guests.length > 0 ? { guests } : {}),
     }
 }
 

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -18,6 +18,7 @@ export const PMU = {
     // PackingList predicates
     hasItem: `${PMU_NS}hasItem`,
     hasDeletedItem: `${PMU_NS}hasDeletedItem`,
+    hasGuest: `${PMU_NS}hasGuest`,
     itemText: `${PMU_NS}itemText`,
     personId: `${PMU_NS}personId`,
     personName: `${PMU_NS}personName`,


### PR DESCRIPTION
A guest (e.g. a one-off holiday visitor) can now be added directly to an
existing packing list without touching the question set. Their section
appears on the view page immediately, items added for them carry their UUID
as personId, and the "suggest for next time" system ignores any items
belonging to people not in the question set.

https://claude.ai/code/session_01KqgizujwvAMhmzaGHqkKQ3