### PR TITLE
Rewrite edit-questions page as Svelte 5 to fix cascade re-render performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "@inrupt/solid-client": "^2.1.2",
         "@inrupt/vocab-common-rdf": "^1.0.5",
         "@inrupt/vocab-solid": "^1.0.4",
+        "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@tailwindcss/vite": "^4.1.4",
+        "@testing-library/dom": "^10.4.1",
         "@types/pouchdb": "^6.4.2",
         "@types/react-select": "^5.0.1",
         "@uvdsl/solid-oidc-client-browser": "^0.2.2",
@@ -25,6 +27,7 @@
         "react-hook-form": "^7.55.0",
         "react-router-dom": "^7.6.0",
         "react-select": "^5.10.1",
+        "svelte": "^5.56.0",
         "tailwindcss": "^4.1.4",
         "use-debounce": "^10.0.5",
         "zod": "^4.1.12"
@@ -3524,6 +3527,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3540,6 +3544,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3556,6 +3561,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3572,6 +3578,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3588,6 +3595,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3604,6 +3612,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3620,6 +3629,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3636,6 +3646,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3652,6 +3663,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3668,6 +3680,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3684,6 +3697,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3700,6 +3714,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3716,6 +3731,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3732,6 +3748,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3748,6 +3765,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3764,6 +3782,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3780,6 +3799,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3796,6 +3816,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3812,6 +3833,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3828,6 +3850,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3844,6 +3867,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3860,6 +3884,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3876,6 +3901,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3892,6 +3918,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3908,6 +3935,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3924,6 +3952,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4504,6 +4533,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4517,6 +4547,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4530,6 +4561,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4543,6 +4575,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4556,6 +4589,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4569,6 +4603,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4582,6 +4617,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4595,6 +4631,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4608,6 +4645,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4621,6 +4659,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4634,6 +4673,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4647,6 +4687,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4660,6 +4701,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4673,6 +4715,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4686,6 +4729,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4699,6 +4743,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4712,6 +4757,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4725,6 +4771,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4738,6 +4785,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4751,6 +4799,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4764,6 +4813,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4777,6 +4827,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5107,6 +5158,34 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.1.2.tgz",
+      "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.3.1",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.0",
+        "vitefu": "^1.1.2"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24"
+      },
+      "peerDependencies": {
+        "svelte": "^5.46.4",
+        "vite": "^8.0.0-beta.7 || ^8.0.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -5381,9 +5460,7 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5467,9 +5544,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/async-lock": {
       "version": "1.4.2",
@@ -6099,6 +6174,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -6199,6 +6275,12 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
     "node_modules/@types/uritemplate": {
@@ -6796,12 +6878,10 @@
       }
     },
     "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6840,7 +6920,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6873,7 +6952,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -6928,6 +7006,15 @@
       "license": "MIT",
       "dependencies": {
         "asynciterator": "^3.9.0"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -7261,6 +7348,15 @@
       "dependencies": {
         "@rdfjs/data-model": "^1.1.0",
         "@rdfjs/namespace": "^1.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -7717,6 +7813,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -7772,7 +7877,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7798,13 +7902,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "license": "MIT"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8075,6 +8183,7 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -8254,6 +8363,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -8272,19 +8387,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/espree/node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -8296,6 +8398,23 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/esrap": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/esrecurse": {
@@ -8447,6 +8566,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -9498,6 +9618,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -10491,6 +10620,12 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -10598,9 +10733,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10860,6 +10993,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11002,6 +11136,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/oidc-provider": {
       "version": "8.8.1",
@@ -11255,6 +11399,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -11314,6 +11459,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11580,9 +11726,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11596,9 +11740,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11610,9 +11752,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -12450,6 +12590,7 @@
       "version": "4.53.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.1.tgz",
       "integrity": "sha512-n2I0V0lN3E9cxxMqBCT3opWOiQBzRN7UG60z/WDKqdX2zHUS/39lezBcsckZFsV6fUTSnfqI7kHf60jDAPGKug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -13072,6 +13213,42 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svelte": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.0.tgz",
+      "integrity": "sha512-kTXr26t1bchFp28ROrb957LtbujpBmBDibmqMGziVpUs7awBi96TGgX6SovrA8BNoEUDVRK2Fb9FkeYlGspoVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.9",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte/node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
@@ -13154,6 +13331,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -13524,6 +13702,7 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -13590,6 +13769,25 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
           "optional": true
         }
       }
@@ -13987,6 +14185,12 @@
         "toposort": "^2.0.2",
         "type-fest": "^2.19.0"
       }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.1.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@inrupt/solid-client": "^2.1.2",
         "@inrupt/vocab-common-rdf": "^1.0.5",
         "@inrupt/vocab-solid": "^1.0.4",
-        "@sveltejs/vite-plugin-svelte": "^7.1.2",
+        "@sveltejs/vite-plugin-svelte": "^6.2.4",
         "@tailwindcss/vite": "^4.1.4",
         "@testing-library/dom": "^10.4.1",
         "@types/pouchdb": "^6.4.2",
@@ -3527,7 +3527,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3544,7 +3543,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3561,7 +3559,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3578,7 +3575,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3595,7 +3591,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3612,7 +3607,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3629,7 +3623,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3646,7 +3639,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3663,7 +3655,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3680,7 +3671,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3697,7 +3687,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3714,7 +3703,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3731,7 +3719,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3748,7 +3735,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3765,7 +3751,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3782,7 +3767,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3799,7 +3783,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3816,7 +3799,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3833,7 +3815,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3850,7 +3831,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3867,7 +3847,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3884,7 +3863,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3901,7 +3879,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3918,7 +3895,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3935,7 +3911,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3952,7 +3927,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4533,7 +4507,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4547,7 +4520,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4561,7 +4533,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4575,7 +4546,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4589,7 +4559,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4603,7 +4572,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4617,7 +4585,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4631,7 +4598,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4645,7 +4611,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4659,7 +4624,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4673,7 +4637,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4687,7 +4650,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4701,7 +4663,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4715,7 +4676,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4729,7 +4689,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4743,7 +4702,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4757,7 +4715,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4771,7 +4728,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4785,7 +4741,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4799,7 +4754,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4813,7 +4767,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4827,7 +4780,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5168,22 +5120,40 @@
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.1.2.tgz",
-      "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.4.tgz",
+      "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "license": "MIT",
       "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
         "obug": "^2.1.0",
-        "vitefu": "^1.1.2"
+        "vitefu": "^1.1.1"
       },
       "engines": {
         "node": "^20.19 || ^22.12 || >=24"
       },
       "peerDependencies": {
-        "svelte": "^5.46.4",
-        "vite": "^8.0.0-beta.7 || ^8.0.0"
+        "svelte": "^5.0.0",
+        "vite": "^6.3.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-5.0.2.tgz",
+      "integrity": "sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "obug": "^2.1.0"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.3.0 || ^7.0.0"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -6174,7 +6144,6 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -6489,7 +6458,7 @@
       "version": "8.46.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.3.tgz",
       "integrity": "sha512-G7Ok9WN/ggW7e/tOf8TQYMaxgID3Iujn231hfi0Pc7ZheztIJVpO44ekY00b7akqc6nZcvregk0Jpah3kep6hA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8183,7 +8152,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -8566,7 +8534,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -10993,7 +10960,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11399,7 +11365,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -11459,7 +11424,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12590,7 +12554,6 @@
       "version": "4.53.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.1.tgz",
       "integrity": "sha512-n2I0V0lN3E9cxxMqBCT3opWOiQBzRN7UG60z/WDKqdX2zHUS/39lezBcsckZFsV6fUTSnfqI7kHf60jDAPGKug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -13331,7 +13294,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -13702,7 +13664,6 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@inrupt/solid-client": "^2.1.2",
     "@inrupt/vocab-common-rdf": "^1.0.5",
     "@inrupt/vocab-solid": "^1.0.4",
-    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@tailwindcss/vite": "^4.1.4",
     "@testing-library/dom": "^10.4.1",
     "@types/pouchdb": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "@inrupt/solid-client": "^2.1.2",
     "@inrupt/vocab-common-rdf": "^1.0.5",
     "@inrupt/vocab-solid": "^1.0.4",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tailwindcss/vite": "^4.1.4",
+    "@testing-library/dom": "^10.4.1",
     "@types/pouchdb": "^6.4.2",
     "@types/react-select": "^5.0.1",
     "@uvdsl/solid-oidc-client-browser": "^0.2.2",
@@ -35,6 +37,7 @@
     "react-hook-form": "^7.55.0",
     "react-router-dom": "^7.6.0",
     "react-select": "^5.10.1",
+    "svelte": "^5.56.0",
     "tailwindcss": "^4.1.4",
     "use-debounce": "^10.0.5",
     "zod": "^4.1.12"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { Navigation } from './components/Navigation'
 import { SessionExpiredBanner } from './components/SessionExpiredBanner'
 import { ToastProvider } from './components/ToastContext'
 import { LandingPage } from './pages/landing-page'
-import { EditQuestionsForm } from './pages/edit-questions-form'
+import { EditQuestionsBridge } from './edit-questions-svelte/EditQuestionsBridge'
 import { CreatePackingList } from './pages/create-packing-list'
 import { PackingLists } from './pages/packing-lists'
 import { ViewPackingList } from './pages/view-packing-list'
@@ -35,7 +35,7 @@ function App() {
               <Routes>
                 <Route path="/" element={<LandingPage />} />
                 <Route path="/wizard" element={<Wizard />} />
-                <Route path="/manage-questions" element={<EditQuestionsForm />} />
+                <Route path="/manage-questions" element={<EditQuestionsBridge />} />
                 <Route path="/create-packing-list" element={<CreatePackingList />} />
                 <Route path="/view-lists" element={<PackingLists />} />
                 <Route path="/view-lists/:id" element={<ViewPackingList />} />
@@ -46,7 +46,7 @@ function App() {
                   <Route index element={<Navigate to="view-lists" replace />} />
                   <Route path="view-lists" element={<ForeignPackingListsPage />} />
                   <Route path="view-lists/:id" element={<ViewPackingList />} />
-                  <Route path="manage-questions" element={<EditQuestionsForm />} />
+                  <Route path="manage-questions" element={<EditQuestionsBridge />} />
                   <Route path="create-packing-list" element={<CreatePackingList />} />
                 </Route>
               </Routes>

--- a/src/edit-questions-svelte/AddItemModal.svelte
+++ b/src/edit-questions-svelte/AddItemModal.svelte
@@ -1,0 +1,207 @@
+<script lang="ts">
+  import type { Question, Person, PersonSelection, Item } from '../edit-questions/types'
+  import CreatableInput from './CreatableInput.svelte'
+
+  export type AddItemDestination =
+    | { type: 'always' }
+    | { type: 'option'; questionId: string; optionId: string }
+
+  interface Props {
+    isOpen: boolean
+    questions: Question[]
+    people: Person[]
+    existingItemNames: string[]
+    onClose: () => void
+    onConfirm: (destination: AddItemDestination, item: Item) => void
+  }
+
+  let { isOpen, questions, people, existingItemNames, onClose, onConfirm }: Props = $props()
+
+  let step = $state<'destination' | 'details'>('destination')
+  let selectedDest = $state<AddItemDestination | null>(null)
+  let destLabel = $state('')
+  let text = $state('')
+  let personSelections = $state<PersonSelection[]>([])
+  let textError = $state(false)
+  let peopleError = $state(false)
+
+  $effect(() => {
+    if (isOpen) {
+      step = 'destination'
+      selectedDest = null
+      destLabel = ''
+      text = ''
+      personSelections = people.map(p => ({ personId: p.id, selected: false }))
+      textError = false
+      peopleError = false
+    }
+  })
+
+  let allSelected = $derived(personSelections.length > 0 && personSelections.every(s => s.selected))
+
+  function pickDestination(dest: AddItemDestination, label: string) {
+    selectedDest = dest
+    destLabel = label
+    step = 'details'
+  }
+
+  function handleToggleAll() {
+    const next = !allSelected
+    personSelections = personSelections.map(s => ({ ...s, selected: next }))
+    if (next) peopleError = false
+  }
+
+  function handleTogglePerson(idx: number) {
+    personSelections = personSelections.map((s, i) => i === idx ? { ...s, selected: !s.selected } : s)
+    if (personSelections.some(s => s.selected)) peopleError = false
+  }
+
+  function handleTextChange(val: string) {
+    text = val
+    if (val.trim()) textError = false
+  }
+
+  function handleConfirm() {
+    if (!selectedDest) return
+    const trimmed = text.trim()
+    const missingText = !trimmed
+    const missingPeople = people.length > 0 && !personSelections.some(s => s.selected)
+    if (missingText) textError = true
+    if (missingPeople) peopleError = true
+    if (missingText || missingPeople) return
+    onConfirm(selectedDest, { text: trimmed, personSelections })
+    onClose()
+  }
+</script>
+
+{#if isOpen}
+  <div class="fixed inset-0 z-50 flex items-stretch sm:items-center sm:justify-center sm:p-8">
+    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" role="button" tabindex="-1" onclick={onClose} onkeydown={(e) => e.key === 'Escape' && onClose()}></div>
+    <div
+      role="dialog"
+      aria-modal="true"
+      class="relative flex flex-col w-full bg-white shadow-xl sm:rounded-lg sm:max-w-lg sm:h-[calc(100vh-8rem)]"
+    >
+      <div class="flex items-center justify-between px-4 py-4 border-b border-gray-200 sm:px-6">
+        {#if step === 'details'}
+          <button
+            type="button"
+            onclick={() => (step = 'destination')}
+            class="mr-2 text-gray-400 hover:text-gray-600 focus:outline-none"
+            aria-label="Back"
+          >
+            <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+            </svg>
+          </button>
+        {/if}
+        <h3 class="text-lg font-semibold text-gray-900 flex-1 truncate">
+          {step === 'destination' ? 'Add Item — where?' : destLabel}
+        </h3>
+        <button
+          type="button"
+          class="rounded-md text-gray-400 hover:text-gray-500 focus:outline-none"
+          onclick={onClose}
+        >
+          <span class="sr-only">Close</span>
+          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      {#if step === 'destination'}
+        <div class="flex-1 overflow-y-auto px-2 py-2 space-y-1">
+          <button
+            type="button"
+            onclick={() => pickDestination({ type: 'always' }, 'Always Needed Items')}
+            class="w-full text-left px-3 py-2 rounded-md text-sm text-gray-800 hover:bg-gray-100 active:bg-gray-200 transition-colors"
+          >
+            Always Needed Items
+          </button>
+          {#each questions as q}
+            {#each q.options as o (`${q.id}::${o.id}`)}
+              <button
+                type="button"
+                onclick={() => pickDestination({ type: 'option', questionId: q.id, optionId: o.id }, `${q.text}: ${o.text}`)}
+                class="w-full text-left px-3 py-2 rounded-md text-sm text-gray-800 hover:bg-gray-100 active:bg-gray-200 transition-colors"
+              >
+                <span class="text-gray-500">{q.text}:</span> {o.text}
+              </button>
+            {/each}
+          {/each}
+        </div>
+      {/if}
+
+      {#if step === 'details'}
+        <div class="flex-1 overflow-y-auto px-4 py-4 sm:px-6 space-y-4">
+          <div>
+            <CreatableInput
+              value={text}
+              options={existingItemNames}
+              placeholder="Enter item name"
+              onchange={handleTextChange}
+            />
+            {#if textError}
+              <p class="text-sm text-red-600 mt-1">Please enter an item name.</p>
+            {/if}
+          </div>
+
+          {#if people.length > 0}
+            <div>
+              <div class="text-sm font-medium text-gray-700 mb-2">Who needs it?</div>
+              {#if peopleError}
+                <p class="text-sm text-red-600 mb-2">Please select at least one person.</p>
+              {/if}
+              <div class="flex items-center gap-2 flex-wrap">
+                <button
+                  type="button"
+                  onclick={handleToggleAll}
+                  class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border-2 border-primary-200 text-primary-700 bg-white hover:bg-primary-50 hover:border-primary-300 transition-all duration-200 focus:outline-none"
+                >
+                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    {#if allSelected}
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    {:else}
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                    {/if}
+                  </svg>
+                  {allSelected ? 'Unselect All' : 'Select All'}
+                </button>
+                {#each people as person, i (person.id)}
+                  {@const isSelected = personSelections[i]?.selected ?? false}
+                  <button
+                    type="button"
+                    onclick={() => handleTogglePerson(i)}
+                    class="inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg border-2 cursor-pointer transition-all duration-200 {isSelected
+                      ? 'bg-primary-50 border-primary-400 text-primary-900 shadow-sm'
+                      : 'bg-white border-gray-200 text-gray-700 hover:border-gray-300 hover:bg-gray-50'}"
+                  >
+                    {person.name}
+                  </button>
+                {/each}
+              </div>
+            </div>
+          {/if}
+
+          <div class="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onclick={onClose}
+              class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 rounded-md transition-colors duration-200"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onclick={handleConfirm}
+              class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-md transition-colors duration-200"
+            >
+              Add Item
+            </button>
+          </div>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/src/edit-questions-svelte/AlwaysNeededItemsSection.svelte
+++ b/src/edit-questions-svelte/AlwaysNeededItemsSection.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import type { Item, Person } from '../edit-questions/types'
+  import ItemPeopleSection from './ItemPeopleSection.svelte'
+  import CreatableInput from './CreatableInput.svelte'
+
+  interface Props {
+    items: Item[]
+    allPeople: Person[]
+    allItemNames: string[]
+    onAddItem: () => void
+    onRemoveItem: (idx: number) => void
+    onChangeItem: (idx: number, updated: Item) => void
+    scrollToLastVersion?: number
+  }
+
+  let { items, allPeople, allItemNames, onAddItem, onRemoveItem, onChangeItem, scrollToLastVersion }: Props = $props()
+
+  let isExpanded = $state(false)
+  let newItemIndex = $state<number | null>(null)
+  let itemEls: HTMLDivElement[] = []
+
+  $effect(() => {
+    if (!scrollToLastVersion) return
+    isExpanded = true
+    const idx = items.length - 1
+    if (idx >= 0) {
+      requestAnimationFrame(() => {
+        itemEls[idx]?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        newItemIndex = idx
+      })
+    }
+  })
+
+  function handleAddItem() {
+    onAddItem()
+    requestAnimationFrame(() => {
+      const idx = items.length // will be length after add
+      newItemIndex = idx
+    })
+  }
+
+  let itemCount = $derived(items.length)
+  let itemLabel = $derived(`${itemCount} ${itemCount === 1 ? 'item' : 'items'}`)
+</script>
+
+<div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6">
+  <button
+    type="button"
+    onclick={() => (isExpanded = !isExpanded)}
+    class="flex items-center gap-2 mb-4 w-full text-left hover:bg-gray-50 -mx-4 -mt-4 px-4 pt-4 rounded-t-lg transition-colors duration-200"
+  >
+    <svg
+      class="w-5 h-5 text-gray-400 transform transition-transform duration-200 {isExpanded ? 'rotate-180' : ''}"
+      fill="none" viewBox="0 0 24 24" stroke="currentColor"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+    </svg>
+    <div>
+      <h2 class="text-lg font-medium text-gray-900">Always Needed Items <span class="text-sm font-normal text-gray-500">({itemLabel})</span></h2>
+      <p class="text-sm text-gray-600">Items that should always be included in the packing list.</p>
+    </div>
+  </button>
+
+  {#if isExpanded}
+    <div class="space-y-3">
+      {#each items as item, i}
+        <div
+          bind:this={itemEls[i]}
+          class="flex items-start gap-2 sm:gap-3 rounded-md {i === newItemIndex ? 'ring-2 ring-primary-300' : ''}"
+        >
+          <div class="flex-1">
+            <ItemPeopleSection
+              personSelections={item.personSelections}
+              {allPeople}
+              onchange={(sels) => onChangeItem(i, { ...item, personSelections: sels })}
+            />
+            <CreatableInput
+              value={item.text}
+              options={allItemNames}
+              placeholder="Enter item"
+              onchange={(val) => onChangeItem(i, { ...item, text: val })}
+            />
+          </div>
+          <button
+            type="button"
+            onclick={() => onRemoveItem(i)}
+            aria-label={`Remove item ${i + 1}`}
+            class="mt-1 rounded-full p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors duration-200"
+          >
+            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      {/each}
+      <button
+        type="button"
+        onclick={handleAddItem}
+        class="mt-2 inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-md transition-colors duration-200"
+      >
+        Add Item
+      </button>
+    </div>
+  {/if}
+</div>

--- a/src/edit-questions-svelte/CreatableInput.svelte
+++ b/src/edit-questions-svelte/CreatableInput.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  interface Props {
+    value: string
+    options: string[]
+    placeholder?: string
+    onchange: (value: string) => void
+    autofocus?: boolean
+  }
+
+  let { value, options, placeholder = 'Enter item', onchange, autofocus = false }: Props = $props()
+
+  let inputEl: HTMLInputElement
+  const listId = `creatable-${Math.random().toString(36).slice(2)}`
+
+  onMount(() => {
+    if (autofocus) inputEl?.focus()
+  })
+
+  function handleBlur() {
+    const trimmed = inputEl.value.trim()
+    if (trimmed && trimmed !== value) onchange(trimmed)
+  }
+
+  function handleInput(e: Event) {
+    // live-update so the datalist matches as the user types
+    const v = (e.target as HTMLInputElement).value
+    if (!v) onchange('')
+  }
+
+  function handleChange(e: Event) {
+    const v = (e.target as HTMLInputElement).value
+    onchange(v)
+  }
+</script>
+
+<div class="relative">
+  <input
+    bind:this={inputEl}
+    type="text"
+    list={listId}
+    {value}
+    {placeholder}
+    oninput={handleInput}
+    onchange={handleChange}
+    onblur={handleBlur}
+    class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+  />
+  <datalist id={listId}>
+    {#each options as opt (opt)}
+      <option value={opt}></option>
+    {/each}
+  </datalist>
+</div>

--- a/src/edit-questions-svelte/EditQuestionsApp.svelte
+++ b/src/edit-questions-svelte/EditQuestionsApp.svelte
@@ -1,0 +1,401 @@
+<script lang="ts">
+  import { bridgeStore } from './bridge-store'
+  import type { PackingListQuestionSet, Question, Item, Person } from '../edit-questions/types'
+  import { newDraftQuestion } from '../edit-questions/types'
+  import PeopleSection from './PeopleSection.svelte'
+  import AlwaysNeededItemsSection from './AlwaysNeededItemsSection.svelte'
+  import QuestionSection from './QuestionSection.svelte'
+  import AddItemModal, { type AddItemDestination } from './AddItemModal.svelte'
+  import JsonEditor from './JsonEditor.svelte'
+
+  interface Props {
+    initialData: PackingListQuestionSet
+  }
+  let { initialData }: Props = $props()
+
+  let questionSet = $state<PackingListQuestionSet>(structuredClone(initialData))
+  let autoSaveStatus = $state<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  let editorMode = $state<'visual' | 'json'>('visual')
+  let jsonValue = $state('')
+  let originalJsonValue = $state('')
+  let jsonError = $state<string | null>(null)
+  let allQuestionsCollapsed = $state<boolean | null>(true)
+  let isAddItemModalOpen = $state(false)
+  let addItemModalQuestions = $state<Question[]>([])
+  let scrollVersion = $state(0)
+
+  type ScrollTarget =
+    | { type: 'always'; version: number }
+    | { type: 'option'; qi: number; oi: number; version: number }
+    | null
+  let scrollTarget = $state<ScrollTarget>(null)
+
+  // KEY FIX: allItemNames computed once, not on every render of every child
+  let allItemNames = $derived(
+    questionSet.questions.flatMap(q => q.options.flatMap(o => o.items.map(i => i.text)))
+  )
+
+  // Auto-save: skip pod sync updates using a flag
+  let mounted = false
+  let skipNextSave = false
+
+  // Apply pod sync updates without triggering auto-save
+  $effect(() => {
+    const podData = $bridgeStore.podSyncData
+    if (!podData) return
+    skipNextSave = true
+    questionSet = structuredClone(podData)
+  })
+
+  $effect(() => {
+    JSON.stringify(questionSet) // track
+    if (!mounted) { mounted = true; return }
+    if (skipNextSave) { skipNextSave = false; return }
+    debouncedSave()
+  })
+
+  let saveTimer: ReturnType<typeof setTimeout>
+  function debouncedSave() {
+    clearTimeout(saveTimer)
+    autoSaveStatus = 'saving'
+    saveTimer = setTimeout(async () => {
+      const ok = await $bridgeStore.onSave($state.snapshot(questionSet) as PackingListQuestionSet)
+      autoSaveStatus = ok ? 'saved' : 'error'
+      if (ok) setTimeout(() => { autoSaveStatus = 'idle' }, 2000)
+    }, 800)
+  }
+
+  function formatLastSync(date: Date | null) {
+    if (!date) return 'Never'
+    const diffSecs = Math.floor((Date.now() - date.getTime()) / 1000)
+    if (diffSecs < 60) return 'Just now'
+    if (diffSecs < 120) return '1 minute ago'
+    if (diffSecs < 3600) return `${Math.floor(diffSecs / 60)} minutes ago`
+    return date.toLocaleTimeString()
+  }
+
+  // ── People mutations ──────────────────────────────────────────────
+  function addPerson() {
+    const newPerson: Person = { id: crypto.randomUUID(), name: '' }
+    const newSel = { personId: newPerson.id, selected: false }
+    for (const q of questionSet.questions) {
+      for (const o of q.options) {
+        for (const item of o.items) item.personSelections.push({ ...newSel })
+      }
+    }
+    for (const item of questionSet.alwaysNeededItems) item.personSelections.push({ ...newSel })
+    questionSet.people.push(newPerson)
+  }
+
+  function removePerson(idx: number) {
+    for (const q of questionSet.questions) {
+      for (const o of q.options) {
+        for (const item of o.items) item.personSelections.splice(idx, 1)
+      }
+    }
+    for (const item of questionSet.alwaysNeededItems) item.personSelections.splice(idx, 1)
+    questionSet.people.splice(idx, 1)
+  }
+
+  function changePersonName(idx: number, name: string) {
+    questionSet.people[idx].name = name
+  }
+
+  // ── Always-needed item mutations ──────────────────────────────────
+  function addAlwaysNeededItem() {
+    const personSelections = questionSet.people.map(p => ({ personId: p.id, selected: false }))
+    questionSet.alwaysNeededItems.push({ text: '', personSelections })
+    scrollTarget = { type: 'always', version: ++scrollVersion }
+  }
+
+  function removeAlwaysNeededItem(idx: number) {
+    questionSet.alwaysNeededItems.splice(idx, 1)
+  }
+
+  function changeAlwaysNeededItem(idx: number, updated: Item) {
+    questionSet.alwaysNeededItems[idx] = updated
+  }
+
+  // ── Question mutations ────────────────────────────────────────────
+  function addQuestion() {
+    allQuestionsCollapsed = null
+    questionSet.questions.push(newDraftQuestion(questionSet.questions.length))
+  }
+
+  function removeQuestion(qi: number) {
+    questionSet.questions.splice(qi, 1)
+  }
+
+  function changeQuestion(qi: number, updated: Question) {
+    questionSet.questions[qi] = updated
+  }
+
+  function moveQuestion(qi: number, direction: 'up' | 'down') {
+    const target = direction === 'up' ? qi - 1 : qi + 1
+    if (target < 0 || target >= questionSet.questions.length) return
+    const tmp = questionSet.questions[qi]
+    questionSet.questions[qi] = questionSet.questions[target]
+    questionSet.questions[target] = tmp
+  }
+
+  // ── Add Item modal ────────────────────────────────────────────────
+  function handleOpenAddItemModal() {
+    addItemModalQuestions = $state.snapshot(questionSet.questions) as Question[]
+    isAddItemModalOpen = true
+  }
+
+  function handleAddItemConfirm(destination: AddItemDestination, item: Item) {
+    scrollVersion++
+    if (destination.type === 'always') {
+      questionSet.alwaysNeededItems.push(item)
+      scrollTarget = { type: 'always', version: scrollVersion }
+    } else {
+      const qi = questionSet.questions.findIndex(q => q.id === destination.questionId)
+      const oi = qi >= 0 ? questionSet.questions[qi].options.findIndex(o => o.id === destination.optionId) : -1
+      if (qi >= 0 && oi >= 0) {
+        questionSet.questions[qi].options[oi].items.push(item)
+        scrollTarget = { type: 'option', qi, oi, version: scrollVersion }
+      }
+    }
+    $bridgeStore.onShowToast(`Added "${item.text}"`, 'success')
+  }
+
+  // ── Reset ─────────────────────────────────────────────────────────
+  function handleReset() {
+    $bridgeStore.onReset()
+  }
+
+  // ── JSON editor ───────────────────────────────────────────────────
+  async function handleSaveJson() {
+    const result = await $bridgeStore.onSaveJson(jsonValue)
+    if (result.error) {
+      jsonError = result.error
+      $bridgeStore.onShowToast('Cannot save: JSON validation failed', 'error')
+    } else {
+      jsonError = null
+      originalJsonValue = jsonValue
+      $bridgeStore.onShowToast('JSON saved successfully!', 'success')
+    }
+  }
+
+  $effect(() => {
+    // When switching to JSON mode, populate editor with current data
+    if (editorMode === 'json') {
+      const { _id, _rev, lastModified, ...clean } = $state.snapshot(questionSet) as PackingListQuestionSet
+      const json = JSON.stringify(clean, null, 2)
+      jsonValue = json
+      originalJsonValue = json
+    }
+  })
+</script>
+
+<div class="w-full flex flex-col items-center py-8 px-4">
+  <div class="mb-8 w-full max-w-5xl">
+    <h1 class="text-2xl font-bold text-gray-900">
+      {$bridgeStore.foreignPodUrl ? 'Questions & Items' : 'My Questions & Items'}
+    </h1>
+    <p class="mt-2 text-gray-600">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>
+    <p class="mt-1 text-sm text-gray-400">Want to start from scratch? <a href="#/wizard" class="text-primary-600 hover:underline">Redo the setup wizard</a> to regenerate your questions.</p>
+
+
+    <!-- Mobile status line -->
+    <div class="lg:hidden mt-2 flex items-center gap-3 text-xs text-gray-400">
+      {#if autoSaveStatus === 'saving'}
+        <span class="flex items-center gap-1 text-blue-600">
+          <svg class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/></svg>
+          Saving…
+        </span>
+      {:else}
+        <span>Saved</span>
+      {/if}
+      {#if $bridgeStore.isLoggedIn && !$bridgeStore.isSyncing && !$bridgeStore.syncError}
+        <span>· Pod synced {formatLastSync($bridgeStore.lastSync)}</span>
+      {/if}
+    </div>
+  </div>
+
+  {#if editorMode === 'visual'}
+    <div class="w-full max-w-5xl flex flex-col lg:flex-row lg:items-start lg:gap-8">
+      <!-- Main form content -->
+      <div class="space-y-6 flex-1 pb-32 lg:pb-8">
+        <PeopleSection
+          people={questionSet.people}
+          onAddPerson={addPerson}
+          onRemovePerson={removePerson}
+          onChangeName={changePersonName}
+        />
+        <AlwaysNeededItemsSection
+          items={questionSet.alwaysNeededItems}
+          allPeople={questionSet.people}
+          {allItemNames}
+          onAddItem={addAlwaysNeededItem}
+          onRemoveItem={removeAlwaysNeededItem}
+          onChangeItem={changeAlwaysNeededItem}
+          scrollToLastVersion={scrollTarget?.type === 'always' ? scrollTarget.version : undefined}
+        />
+
+        {#if questionSet.questions.length > 0}
+          <div class="flex justify-end">
+            <button
+              type="button"
+              onclick={() => (allQuestionsCollapsed = !allQuestionsCollapsed)}
+              class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors duration-200"
+            >
+              {allQuestionsCollapsed ? 'Expand All' : 'Collapse All'}
+            </button>
+          </div>
+        {/if}
+
+        {#each questionSet.questions as question, qi (question.id)}
+          <QuestionSection
+            {question}
+            questionIndex={qi}
+            allPeople={questionSet.people}
+            {allItemNames}
+            forceCollapsed={allQuestionsCollapsed}
+            onRemove={() => removeQuestion(qi)}
+            onChange={(updated) => changeQuestion(qi, updated)}
+            onMoveUp={qi > 0 ? () => moveQuestion(qi, 'up') : undefined}
+            onMoveDown={qi < questionSet.questions.length - 1 ? () => moveQuestion(qi, 'down') : undefined}
+            scrollToOptionIndex={scrollTarget?.type === 'option' && scrollTarget.qi === qi ? scrollTarget.oi : undefined}
+            scrollToLastVersion={scrollTarget?.type === 'option' && scrollTarget.qi === qi ? scrollTarget.version : undefined}
+          />
+        {/each}
+
+        <!-- Add Question button (large screens) -->
+        <div class="hidden lg:block">
+          <button
+            type="button"
+            onclick={addQuestion}
+            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors duration-200"
+          >
+            Add Question
+          </button>
+        </div>
+      </div>
+
+      <!-- Sticky sidebar (large screens) -->
+      <div class="hidden lg:block lg:w-64 lg:sticky lg:top-24 flex-shrink-0">
+        <div class="backdrop-blur-md bg-white/80 border border-gray-200 shadow-xl rounded-xl flex flex-col items-stretch gap-4 py-6 px-4 relative">
+          {#if $bridgeStore.isLoggedIn && $bridgeStore.syncingFromPod}
+            <div class="absolute -top-3 left-1/2 transform -translate-x-1/2 z-10 bg-blue-50 border border-blue-200 rounded-md px-3 py-1.5 flex items-center gap-1.5 shadow-md">
+              <div class="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
+              <span class="text-xs text-blue-700 font-medium whitespace-nowrap">Syncing from Pod...</span>
+            </div>
+          {/if}
+
+          <!-- Auto-save status -->
+          <div class="bg-gray-50 border border-gray-200 rounded-md p-3">
+            <p class="text-xs font-semibold text-gray-700 mb-2">Auto-Save Status</p>
+            <div class="flex items-center gap-2 transition-opacity duration-200 {autoSaveStatus === 'idle' ? 'opacity-60' : 'opacity-100'}">
+              {#if autoSaveStatus === 'saving'}
+                <div class="animate-spin h-3 w-3 border-2 border-blue-500 border-t-transparent rounded-full"></div>
+                <span class="text-xs text-blue-600">Saving...</span>
+              {:else if autoSaveStatus === 'saved'}
+                <div class="h-3 w-3 flex items-center justify-center text-green-500">✓</div>
+                <span class="text-xs text-green-600">Saved</span>
+              {:else if autoSaveStatus === 'error'}
+                <div class="h-3 w-3 flex items-center justify-center text-red-500">✗</div>
+                <span class="text-xs text-red-600">Error</span>
+              {:else}
+                <div class="h-3 w-3 flex items-center justify-center text-gray-500">✓</div>
+                <span class="text-xs text-gray-600">All changes saved</span>
+              {/if}
+            </div>
+          </div>
+
+          {#if $bridgeStore.isLoggedIn}
+            <div class="bg-gray-50 border border-gray-200 rounded-md p-3">
+              <p class="text-xs font-semibold text-gray-700 mb-1">Pod Sync Status</p>
+              <div class="flex items-center gap-2 mb-1">
+                {#if $bridgeStore.isSyncing}
+                  <div class="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
+                  <p class="text-xs text-gray-600">Polling...</p>
+                {:else if $bridgeStore.syncError}
+                  <div class="w-2 h-2 bg-red-500 rounded-full"></div>
+                  <p class="text-xs text-red-600">Error</p>
+                {:else}
+                  <div class="w-2 h-2 bg-green-500 rounded-full"></div>
+                  <p class="text-xs text-gray-600">Active</p>
+                {/if}
+              </div>
+              <p class="text-xs text-gray-500">Last sync: {formatLastSync($bridgeStore.lastSync)}</p>
+              {#if $bridgeStore.syncError}
+                <p class="text-xs text-red-500 mt-1">{$bridgeStore.syncError}</p>
+              {/if}
+            </div>
+          {/if}
+
+          <button
+            type="button"
+            onclick={addQuestion}
+            class="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors duration-200"
+          >Add Question</button>
+          <button
+            type="button"
+            onclick={handleOpenAddItemModal}
+            class="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors duration-200"
+          >Add Item...</button>
+          <button
+            type="button"
+            onclick={() => (editorMode = 'json')}
+            class="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors duration-200"
+          >Edit JSON</button>
+          <button
+            type="button"
+            onclick={handleReset}
+            class="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors duration-200"
+          >Reset form</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Sticky bottom bar (mobile) -->
+    <div class="fixed bottom-0 left-0 w-full z-50 flex justify-center pointer-events-none lg:hidden">
+      <div class="max-w-4xl w-full px-4 pb-4">
+        <div class="backdrop-blur-md bg-white/80 border border-gray-200 shadow-xl rounded-xl flex items-center justify-center gap-3 py-3 px-4 pointer-events-auto relative">
+          {#if $bridgeStore.isLoggedIn && $bridgeStore.syncingFromPod}
+            <div class="absolute -top-3 left-1/2 transform -translate-x-1/2 z-10 bg-blue-50 border border-blue-200 rounded-md px-3 py-1.5 flex items-center gap-1.5 shadow-md">
+              <div class="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
+              <span class="text-xs text-blue-700 font-medium whitespace-nowrap">Syncing from Pod...</span>
+            </div>
+          {/if}
+          <button type="button" onclick={addQuestion} class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors duration-200">Add Question</button>
+          <button type="button" onclick={handleOpenAddItemModal} class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors duration-200">Add Item...</button>
+          <button type="button" onclick={handleReset} class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-md transition-colors duration-200">Reset</button>
+        </div>
+      </div>
+    </div>
+
+    <AddItemModal
+      isOpen={isAddItemModalOpen}
+      questions={addItemModalQuestions}
+      people={questionSet.people}
+      existingItemNames={allItemNames}
+      onClose={() => (isAddItemModalOpen = false)}
+      onConfirm={handleAddItemConfirm}
+    />
+  {:else}
+    <!-- JSON editor mode -->
+    <div class="w-full max-w-5xl">
+      <div class="mb-4 flex items-center gap-3">
+        <button
+          type="button"
+          onclick={() => (editorMode = 'visual')}
+          class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors duration-200"
+        >
+          ← Back to Visual Editor
+        </button>
+      </div>
+      <JsonEditor
+        value={jsonValue}
+        originalValue={originalJsonValue}
+        error={jsonError}
+        hasUnsavedChanges={jsonValue !== originalJsonValue}
+        onchange={(v) => (jsonValue = v)}
+        onsave={handleSaveJson}
+        onValidationChange={(errs) => { if (errs === null && jsonError) jsonError = null }}
+      />
+    </div>
+  {/if}
+</div>

--- a/src/edit-questions-svelte/EditQuestionsBridge.tsx
+++ b/src/edit-questions-svelte/EditQuestionsBridge.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useRef, useCallback, useState } from 'react'
+import { mount, unmount } from 'svelte'
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+import { useForeignPod } from '../components/ForeignPodContext'
+import { useToast } from '../components/ToastContext'
+import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
+import { usePodSync } from '../hooks/usePodSync'
+import { DatabaseMigration } from '../services/migration'
+import { POD_CONTAINERS } from '../services/solidPod'
+import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSerialization'
+import { PackingListQuestionSet } from '../edit-questions/types'
+import { validateQuestionSet } from '../edit-questions/validation'
+import { bridgeStore } from './bridge-store'
+// @ts-ignore — Svelte component import
+import EditQuestionsApp from './EditQuestionsApp.svelte'
+
+export function EditQuestionsBridge() {
+  const mountRef = useRef<HTMLDivElement>(null)
+  const svelteInstanceRef = useRef<ReturnType<typeof mount> | null>(null)
+  const [initialData, setInitialData] = useState<PackingListQuestionSet | null>(null)
+  const [rev, setRev] = useState<string | undefined>(undefined)
+
+  const { db, loginSyncInProgress } = useDatabase()
+  const { isLoggedIn } = useSolidPod()
+  const foreignPodCtx = useForeignPod()
+  const foreignPodUrl = foreignPodCtx?.foreignPodUrl
+  const { showToast } = useToast()
+
+  const currentDataRef = useRef<PackingListQuestionSet | null>(null)
+  const revRef = useRef<string | undefined>(undefined)
+  revRef.current = rev
+
+  const { syncingFromPod, handleSyncSuccess, handleSyncError, saveWithSyncPrevention } =
+    useSyncCoordinator<PackingListQuestionSet>({
+      currentData: currentDataRef.current,
+      saveToLocalDb: async (data) => {
+        if (foreignPodCtx) return { rev: '' }
+        return await db.saveQuestionSet({ _id: '1', ...data, _rev: revRef.current })
+      },
+      updateFormAndState: (data, newRev) => {
+        const updated = { ...data, _rev: newRev }
+        currentDataRef.current = updated
+        setRev(newRev)
+        bridgeStore.update(s => ({ ...s, podSyncData: updated }))
+      },
+      conflictStrategy: 'fallback-to-pod',
+    })
+
+  const { lastSync, isSyncing, error: syncError, saveToPod } = usePodSync<PackingListQuestionSet>({
+    pathConfig: {
+      container: POD_CONTAINERS.ROOT,
+      filename: 'packing-list-questions.ttl',
+      podUrl: foreignPodUrl,
+    },
+    rdf: { serialize: questionSetToDataset, deserialize: datasetToQuestionSet },
+    pollInterval: 5000,
+    enabled: isLoggedIn || !!foreignPodUrl,
+    onSyncSuccess: handleSyncSuccess,
+    onSyncError: handleSyncError,
+    onSaveSuccess: () => {},
+    onSaveError: (error) => showToast(`Failed to save to Pod: ${error}`, 'error'),
+  })
+
+  const onSave = useCallback(async (data: PackingListQuestionSet): Promise<boolean> => {
+    try {
+      const dataToSave = { _id: '1', ...data, _rev: revRef.current }
+      if (isLoggedIn) {
+        const saved = await saveWithSyncPrevention(dataToSave, saveToPod)
+        if (saved) {
+          revRef.current = saved._rev
+          setRev(saved._rev)
+          currentDataRef.current = saved
+          return true
+        }
+        return false
+      } else {
+        const withTs = { ...dataToSave, lastModified: new Date().toISOString() }
+        const result = await db.saveQuestionSet(withTs)
+        const saved = { ...withTs, _rev: result.rev }
+        revRef.current = result.rev
+        setRev(result.rev)
+        currentDataRef.current = saved
+        return true
+      }
+    } catch {
+      return false
+    }
+  }, [isLoggedIn, db, saveWithSyncPrevention, saveToPod])
+
+  const onSaveJson = useCallback(async (json: string): Promise<{ error?: string }> => {
+    try {
+      const parsed = JSON.parse(json)
+      const validation = validateQuestionSet(parsed, json)
+      if (!validation.valid) return { error: validation.error || 'Invalid question set structure' }
+      const ok = await onSave(parsed)
+      return ok ? {} : { error: 'Save failed' }
+    } catch (e) {
+      return { error: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}` }
+    }
+  }, [onSave])
+
+  const onReset = useCallback(() => {
+    const defaultData: PackingListQuestionSet = {
+      questions: [],
+      people: [{ id: crypto.randomUUID(), name: 'Me' }],
+      alwaysNeededItems: [],
+    }
+    // Re-mount Svelte with fresh data
+    if (svelteInstanceRef.current) unmount(svelteInstanceRef.current)
+    if (mountRef.current) {
+      svelteInstanceRef.current = mount(EditQuestionsApp, {
+        target: mountRef.current,
+        props: { initialData: defaultData },
+      })
+    }
+    currentDataRef.current = defaultData
+    showToast('Form has been reset to default state', 'success')
+  }, [showToast])
+
+  // Keep bridge store in sync with React context values
+  useEffect(() => {
+    bridgeStore.update(s => ({
+      ...s,
+      isLoggedIn,
+      foreignPodUrl,
+      syncingFromPod,
+      isSyncing,
+      lastSync,
+      syncError,
+      onSave,
+      onSaveJson,
+      onShowToast: showToast,
+      onReset,
+    }))
+  }, [isLoggedIn, foreignPodUrl, syncingFromPod, isSyncing, lastSync, syncError, onSave, onSaveJson, showToast, onReset])
+
+  // Load initial data from PouchDB
+  useEffect(() => {
+    if (loginSyncInProgress) return
+    const load = async () => {
+      try {
+        const migrationCheck = await DatabaseMigration.checkMigrationNeeded(db)
+        if (migrationCheck.needed) {
+          const result = await DatabaseMigration.performMigration(db)
+          if (!result.success) { showToast('Database migration failed', 'error'); return }
+          showToast('Database migrated successfully', 'success')
+        }
+        const doc = await db.getQuestionSet()
+        setRev(doc._rev)
+        currentDataRef.current = doc
+        setInitialData(doc)
+      } catch (err: unknown) {
+        const name = typeof err === 'object' && err !== null && 'name' in err ? (err as { name: string }).name : ''
+        if (name === 'not_found') {
+          try {
+            const newDoc = { _id: '1', questions: [], people: [{ id: crypto.randomUUID(), name: 'Me' }], alwaysNeededItems: [] }
+            const result = await db.saveQuestionSet(newDoc)
+            const saved = { ...newDoc, _rev: result.rev }
+            setRev(result.rev)
+            currentDataRef.current = saved
+            setInitialData(saved)
+          } catch { showToast('Failed to initialize database', 'error') }
+        } else {
+          showToast('Failed to load data', 'error')
+        }
+      }
+    }
+    load()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loginSyncInProgress])
+
+  // Mount Svelte once initial data is ready
+  useEffect(() => {
+    if (!initialData || !mountRef.current) return
+    svelteInstanceRef.current = mount(EditQuestionsApp, {
+      target: mountRef.current,
+      props: { initialData },
+    })
+    return () => {
+      if (svelteInstanceRef.current) unmount(svelteInstanceRef.current)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [!!initialData])
+
+  if (!initialData) {
+    return (
+      <div className="w-full flex flex-col items-center py-8 px-4">
+        <div className="text-gray-500">Loading...</div>
+      </div>
+    )
+  }
+
+  return <div ref={mountRef} />
+}

--- a/src/edit-questions-svelte/ItemPeopleSection.svelte
+++ b/src/edit-questions-svelte/ItemPeopleSection.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import type { PersonSelection, Person } from '../edit-questions/types'
+
+  interface Props {
+    personSelections: PersonSelection[]
+    allPeople: Person[]
+    onchange: (selections: PersonSelection[]) => void
+  }
+
+  let { personSelections, allPeople, onchange }: Props = $props()
+
+  let allSelected = $derived(personSelections.length > 0 && personSelections.every(s => s.selected))
+
+  function toggleAll() {
+    const next = !allSelected
+    onchange(allPeople.map((p, i) => ({
+      personId: personSelections[i]?.personId ?? p.id,
+      selected: next,
+    })))
+  }
+
+  function togglePerson(idx: number) {
+    onchange(personSelections.map((s, i) => i === idx ? { ...s, selected: !s.selected } : s))
+  }
+</script>
+
+<div class="flex items-center gap-2 flex-wrap mb-2">
+  <button
+    type="button"
+    onclick={toggleAll}
+    class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border-2 border-primary-200 text-primary-700 bg-white hover:bg-primary-50 hover:border-primary-300 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1"
+    aria-label={allSelected ? 'Unselect all people' : 'Select all people'}
+  >
+    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+      {#if allSelected}
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      {:else}
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+      {/if}
+    </svg>
+    {allSelected ? 'Unselect All' : 'Select All'}
+  </button>
+
+  {#each allPeople as person, i (person.id)}
+    {@const isSelected = personSelections[i]?.selected ?? false}
+    <label
+      class="inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg border-2 cursor-pointer transition-all duration-200 {isSelected
+        ? 'bg-primary-50 border-primary-400 text-primary-900 shadow-sm'
+        : 'bg-white border-gray-200 text-gray-700 hover:border-gray-300 hover:bg-gray-50'}"
+    >
+      <input
+        type="checkbox"
+        checked={isSelected}
+        onchange={() => togglePerson(i)}
+        class="w-4 h-4 rounded border-gray-300 text-primary-600 focus:ring-2 focus:ring-primary-500 focus:ring-offset-0 cursor-pointer"
+        aria-label={`Select ${person.name}`}
+      />
+      <span class="font-medium select-none">{person.name}</span>
+    </label>
+  {/each}
+</div>

--- a/src/edit-questions-svelte/JsonEditor.svelte
+++ b/src/edit-questions-svelte/JsonEditor.svelte
@@ -1,0 +1,416 @@
+<script lang="ts">
+  import { validateQuestionSet, type ValidationError } from '../edit-questions/validation'
+
+  interface Props {
+    value: string
+    originalValue: string
+    error: string | null
+    hasUnsavedChanges: boolean
+    onchange: (v: string) => void
+    onsave: () => void
+    onValidationChange?: (errors: ValidationError[] | null) => void
+  }
+
+  let { value, originalValue, error, hasUnsavedChanges, onchange, onsave, onValidationChange }: Props = $props()
+
+  let textarea: HTMLTextAreaElement
+  let lineNumbers: HTMLDivElement
+  let userPrompt = $state('')
+  let copySuccess = $state(false)
+  let showScrollTop = $state(false)
+  let showDiff = $state(false)
+  let diffTab = $state<'summary' | 'questions' | 'items'>('summary')
+  let validationErrors = $state<ValidationError[] | null>(null)
+  let isValidating = $state(false)
+
+  let lineCount = $derived(value.split('\n').length)
+
+  // Debounced validation
+  let validationTimer: ReturnType<typeof setTimeout>
+  $effect(() => {
+    const v = value // track
+    clearTimeout(validationTimer)
+    validationTimer = setTimeout(() => {
+      isValidating = true
+      try {
+        const parsed = JSON.parse(v)
+        const result = validateQuestionSet(parsed, v)
+        validationErrors = result.valid ? null : (result.errors ?? null)
+        onValidationChange?.(validationErrors)
+      } catch {
+        validationErrors = null
+        onValidationChange?.(null)
+      }
+      isValidating = false
+    }, 800)
+  })
+
+  function jumpToLine(lineNumber: number) {
+    if (!textarea) return
+    const lines = value.split('\n')
+    let charPosition = 0
+    for (let i = 0; i < Math.min(lineNumber - 1, lines.length); i++) {
+      charPosition += lines[i].length + 1
+    }
+    textarea.focus()
+    textarea.setSelectionRange(charPosition, charPosition + (lines[lineNumber - 1]?.length || 0))
+    textarea.scrollTop = Math.max(0, (lineNumber - 1) * 24 - 100)
+  }
+
+  function handleScroll() {
+    if (textarea && lineNumbers) {
+      lineNumbers.scrollTop = textarea.scrollTop
+      showScrollTop = textarea.scrollTop > 200
+    }
+  }
+
+  function generatePrompt() {
+    return `You are helping to modify a packing list question set JSON. Please read the specifications below, review the current JSON, and make the requested changes.
+
+# JSON Structure Specification
+
+The JSON represents a packing list question set with the following structure:
+
+## Top-Level Fields:
+- **people**: Array of people who will be packing
+  - Each person has: { id: string, name: string }
+
+- **alwaysNeededItems**: Array of items always needed regardless of answers
+  - Each item has: { text: string, personSelections: Array<{ personId: string, selected: boolean }> }
+
+- **questions**: Array of questions that determine what to pack
+  - Each question has:
+    - id: string (UUID)
+    - type: "draft" | "saved"
+    - text: string (the question text)
+    - order: number (display order)
+    - questionType: "single-choice" | "multiple-choice" (optional, defaults to single-choice)
+    - options: Array of answer options
+      - Each option has:
+        - id: string (UUID)
+        - text: string (the answer text)
+        - order: number (display order)
+        - items: Array of items needed if this option is selected
+          - Each item: { text: string, personSelections: Array<{ personId: string, selected: boolean }> }
+
+## Important Rules:
+1. All IDs should be valid UUIDs
+2. questionType can be "single-choice" or "multiple-choice"
+3. personSelections tracks which people need each item
+4. The order field determines display order (lower numbers appear first)
+
+# Current JSON:
+
+\`\`\`json
+${value}
+\`\`\`
+
+# Instructions:
+
+Please make the following changes to the JSON and return ONLY the complete updated JSON (no explanations, just the JSON):
+
+${userPrompt}`
+  }
+
+  async function handleCopyPrompt() {
+    try {
+      await navigator.clipboard.writeText(generatePrompt())
+      copySuccess = true
+      setTimeout(() => (copySuccess = false), 2000)
+    } catch {
+      alert('Failed to copy to clipboard')
+    }
+  }
+
+  // Diff computations — only run when diff is shown
+  function computeSummary() {
+    try {
+      const orig = JSON.parse(originalValue || '{}')
+      const cur = JSON.parse(value || '{}')
+      const oq = orig.questions || []; const cq = cur.questions || []
+      const op = orig.people || []; const cp = cur.people || []
+      const oi = new Set<string>(); const ci = new Set<string>()
+      oq.forEach((q: {options?: {items?: {text: string}[]}[]}) => q.options?.forEach(o => o.items?.forEach(i => oi.add(i.text))))
+      orig.alwaysNeededItems?.forEach((i: {text: string}) => oi.add(i.text))
+      cq.forEach((q: {options?: {items?: {text: string}[]}[]}) => q.options?.forEach(o => o.items?.forEach(i => ci.add(i.text))))
+      cur.alwaysNeededItems?.forEach((i: {text: string}) => ci.add(i.text))
+      return {
+        questionsAdded: cq.filter((q: {text: string}) => !oq.find((o: {text: string}) => o.text === q.text)).length,
+        questionsRemoved: oq.filter((q: {text: string}) => !cq.find((c: {text: string}) => c.text === q.text)).length,
+        questionsModified: cq.filter((q: {questionType?: string; text: string}) => { const o = oq.find((oq: {text: string}) => oq.text === q.text); return o && (o as {questionType?: string}).questionType !== q.questionType }).length,
+        itemsAdded: Array.from(ci).filter(t => !oi.has(t)).length,
+        itemsRemoved: Array.from(oi).filter(t => !ci.has(t)).length,
+        peopleAdded: cp.filter((p: {name: string}) => !op.find((o: {name: string}) => o.name === p.name)).length,
+        peopleRemoved: op.filter((p: {name: string}) => !cp.find((c: {name: string}) => c.name === p.name)).length,
+      }
+    } catch { return { questionsAdded: 0, questionsRemoved: 0, questionsModified: 0, itemsAdded: 0, itemsRemoved: 0, peopleAdded: 0, peopleRemoved: 0 } }
+  }
+
+  function computeQuestionsDiff() {
+    try {
+      const orig = JSON.parse(originalValue || '{}'); const cur = JSON.parse(value || '{}')
+      const oq = orig.questions || []; const cq = cur.questions || []
+      type Q = { text: string; questionType?: string }
+      const added = cq.filter((q: Q) => !oq.find((o: Q) => o.text === q.text))
+      const removed = oq.filter((q: Q) => !cq.find((c: Q) => c.text === q.text))
+      const modified = cq.filter((q: Q) => { const o = oq.find((o: Q) => o.text === q.text); return o && o.questionType !== q.questionType })
+        .map((q: Q) => { const o = oq.find((o: Q) => o.text === q.text); return { text: q.text, oldType: o?.questionType || 'single-choice', newType: q.questionType || 'single-choice' } })
+      return { added, removed, modified }
+    } catch { return { added: [], removed: [], modified: [] } }
+  }
+
+  function computeItemsDiff() {
+    try {
+      const orig = JSON.parse(originalValue || '{}'); const cur = JSON.parse(value || '{}')
+      type Item = { text: string }; type Opt = { items?: Item[]; text: string }; type Q = { text: string; options?: Opt[] }
+      const oLocs = new Map<string, string[]>(); const cLocs = new Map<string, string[]>()
+      const collect = (qs: Q[], always: Item[], map: Map<string, string[]>) => {
+        qs.forEach(q => q.options?.forEach(o => o.items?.forEach(i => { const l = map.get(i.text) || []; l.push(`${q.text} > ${o.text}`); map.set(i.text, l) })))
+        always?.forEach(i => { const l = map.get(i.text) || []; l.push('Always Needed'); map.set(i.text, l) })
+      }
+      collect(orig.questions || [], orig.alwaysNeededItems || [], oLocs)
+      collect(cur.questions || [], cur.alwaysNeededItems || [], cLocs)
+      const added: {text: string; locations: string[]}[] = [], removed: {text: string; locations: string[]}[] = [], modified: {text: string; oldLocations: string[]; newLocations: string[]}[] = []
+      cLocs.forEach((locs, text) => { const old = oLocs.get(text); if (!old) added.push({ text, locations: locs }); else if (JSON.stringify(locs.sort()) !== JSON.stringify(old.sort())) modified.push({ text, oldLocations: old, newLocations: locs }) })
+      oLocs.forEach((locs, text) => { if (!cLocs.has(text)) removed.push({ text, locations: locs }) })
+      return { added, removed, modified }
+    } catch { return { added: [], removed: [], modified: [] } }
+  }
+</script>
+
+<div class="json-editor-container">
+  <div class="json-editor-header">
+    <h3>Raw JSON Editor</h3>
+    <p class="json-editor-help">Edit the question set JSON directly.</p>
+  </div>
+
+  {#if error}
+    <div class="json-editor-error json-editor-error-sticky">
+      <div class="json-editor-error-header">
+        <strong>{error.includes('Invalid JSON') ? 'JSON Syntax Error' : 'Validation Errors'}</strong>
+        {#if !error.includes('Invalid JSON') && validationErrors && validationErrors.length > 0}
+          <span class="json-editor-error-count">{validationErrors.length} issue{validationErrors.length > 1 ? 's' : ''}</span>
+        {/if}
+      </div>
+      {#if validationErrors && validationErrors.length > 0}
+        <ul class="json-editor-error-list">
+          {#each validationErrors as err, idx}
+            <li class="json-editor-error-item">
+              <div class="json-editor-error-item-header">
+                {#if err.lineNumber}<span class="json-editor-error-line">Line {err.lineNumber}</span>{/if}
+                <code class="json-editor-error-path">{err.path}</code>
+              </div>
+              <div class="json-editor-error-message">{err.message}</div>
+              {#if err.context}<div class="json-editor-error-context">{err.context}</div>{/if}
+              {#if err.lineNumber}
+                <button type="button" onclick={() => jumpToLine(err.lineNumber!)} class="json-editor-jump-button">
+                  <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                  </svg>
+                  Jump to error
+                </button>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {:else}
+        <p class="json-editor-error-simple">{error}</p>
+      {/if}
+    </div>
+  {/if}
+
+  {#if !error && validationErrors === null && hasUnsavedChanges}
+    <div class="json-editor-success json-editor-success-sticky">
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <span>JSON is valid and ready to save</span>
+    </div>
+  {/if}
+
+  <div class="llm-prompt-section">
+    <div class="llm-prompt-header">
+      <h4>🤖 AI Assistant Prompt Generator</h4>
+      <p class="llm-prompt-help">Describe changes you want, then click to generate a prompt for your favourite LLM.</p>
+    </div>
+    <div class="llm-prompt-input-group">
+      <textarea
+        class="llm-prompt-textarea"
+        value={userPrompt}
+        oninput={(e) => (userPrompt = (e.target as HTMLTextAreaElement).value)}
+        placeholder="Example: Add a new question about the weather with options for sunny, rainy, and snowy."
+        rows={3}
+      ></textarea>
+      <button
+        type="button"
+        onclick={handleCopyPrompt}
+        class="llm-prompt-button"
+        disabled={!userPrompt.trim()}
+      >
+        {#if copySuccess}
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          </svg>
+          Copied!
+        {:else}
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+          Generate and Copy Prompt
+        {/if}
+      </button>
+    </div>
+  </div>
+
+  <div class="json-editor-save-section">
+    <button
+      type="button"
+      onclick={onsave}
+      class="json-editor-save-button {hasUnsavedChanges ? 'has-changes' : ''}"
+      disabled={!!error}
+    >
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4" />
+      </svg>
+      {hasUnsavedChanges ? 'Save JSON Changes' : 'No Changes to Save'}
+    </button>
+    {#if hasUnsavedChanges}
+      <p class="json-editor-save-hint">You have unsaved changes in the JSON editor</p>
+    {/if}
+  </div>
+
+  {#if hasUnsavedChanges}
+    <div class="diff-toggle-section">
+      <button type="button" onclick={() => (showDiff = !showDiff)} class="diff-toggle-button">
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+        </svg>
+        {showDiff ? 'Hide' : 'Show'} Changes (Diff View)
+      </button>
+    </div>
+  {/if}
+
+  {#if showDiff && hasUnsavedChanges}
+    {@const qDiff = computeQuestionsDiff()}
+    {@const iDiff = computeItemsDiff()}
+    <div class="diff-view-container">
+      <div class="diff-tabs">
+        <button class="diff-tab {diffTab === 'summary' ? 'active' : ''}" onclick={() => (diffTab = 'summary')}>Summary</button>
+        <button class="diff-tab {diffTab === 'questions' ? 'active' : ''}" onclick={() => (diffTab = 'questions')}>
+          Questions ({qDiff.added.length + qDiff.removed.length + qDiff.modified.length})
+        </button>
+        <button class="diff-tab {diffTab === 'items' ? 'active' : ''}" onclick={() => (diffTab = 'items')}>
+          Items ({iDiff.added.length + iDiff.removed.length + iDiff.modified.length})
+        </button>
+      </div>
+      <div class="diff-tab-content">
+        {#if diffTab === 'summary'}
+          {@const s = computeSummary()}
+          <div class="diff-summary">
+            <div class="diff-summary-section">
+              <h4>Questions</h4>
+              {#if s.questionsAdded > 0}<div class="diff-summary-item added">+ {s.questionsAdded} added</div>{/if}
+              {#if s.questionsRemoved > 0}<div class="diff-summary-item removed">- {s.questionsRemoved} removed</div>{/if}
+              {#if s.questionsModified > 0}<div class="diff-summary-item modified">~ {s.questionsModified} modified</div>{/if}
+              {#if !s.questionsAdded && !s.questionsRemoved && !s.questionsModified}<div class="diff-summary-item">No changes</div>{/if}
+            </div>
+            <div class="diff-summary-section">
+              <h4>Items</h4>
+              {#if s.itemsAdded > 0}<div class="diff-summary-item added">+ {s.itemsAdded} added</div>{/if}
+              {#if s.itemsRemoved > 0}<div class="diff-summary-item removed">- {s.itemsRemoved} removed</div>{/if}
+              {#if !s.itemsAdded && !s.itemsRemoved}<div class="diff-summary-item">No changes</div>{/if}
+            </div>
+            <div class="diff-summary-section">
+              <h4>People</h4>
+              {#if s.peopleAdded > 0}<div class="diff-summary-item added">+ {s.peopleAdded} added</div>{/if}
+              {#if s.peopleRemoved > 0}<div class="diff-summary-item removed">- {s.peopleRemoved} removed</div>{/if}
+              {#if !s.peopleAdded && !s.peopleRemoved}<div class="diff-summary-item">No changes</div>{/if}
+            </div>
+          </div>
+        {/if}
+        {#if diffTab === 'questions'}
+          <div class="diff-questions">
+            {#if qDiff.added.length + qDiff.removed.length + qDiff.modified.length === 0}
+              <p class="diff-no-changes">No question changes</p>
+            {:else}
+              {#if qDiff.added.length > 0}
+                <div class="diff-section">
+                  <h4 class="diff-section-title added">Added Questions</h4>
+                  {#each qDiff.added as q, i}<div class="diff-item added"><strong>{q.text}</strong> <span class="diff-item-meta">({q.questionType || 'single-choice'})</span></div>{/each}
+                </div>
+              {/if}
+              {#if qDiff.removed.length > 0}
+                <div class="diff-section">
+                  <h4 class="diff-section-title removed">Removed Questions</h4>
+                  {#each qDiff.removed as q}<div class="diff-item removed"><strong>{q.text}</strong></div>{/each}
+                </div>
+              {/if}
+              {#if qDiff.modified.length > 0}
+                <div class="diff-section">
+                  <h4 class="diff-section-title modified">Modified Questions</h4>
+                  {#each qDiff.modified as q}<div class="diff-item modified"><strong>{q.text}</strong><div class="diff-item-change">Type: {q.oldType} → {q.newType}</div></div>{/each}
+                </div>
+              {/if}
+            {/if}
+          </div>
+        {/if}
+        {#if diffTab === 'items'}
+          <div class="diff-items">
+            {#if iDiff.added.length + iDiff.removed.length + iDiff.modified.length === 0}
+              <p class="diff-no-changes">No item changes</p>
+            {:else}
+              {#if iDiff.added.length > 0}
+                <div class="diff-section">
+                  <h4 class="diff-section-title added">Added Items</h4>
+                  {#each iDiff.added as item}<div class="diff-item added"><strong>+ {item.text}</strong><div class="diff-item-locations">in: {item.locations.join(', ')}</div></div>{/each}
+                </div>
+              {/if}
+              {#if iDiff.removed.length > 0}
+                <div class="diff-section">
+                  <h4 class="diff-section-title removed">Removed Items</h4>
+                  {#each iDiff.removed as item}<div class="diff-item removed"><strong>- {item.text}</strong><div class="diff-item-locations">was in: {item.locations.join(', ')}</div></div>{/each}
+                </div>
+              {/if}
+              {#if iDiff.modified.length > 0}
+                <div class="diff-section">
+                  <h4 class="diff-section-title modified">Modified Items</h4>
+                  {#each iDiff.modified as item}<div class="diff-item modified"><strong>~ {item.text}</strong><div class="diff-item-locations">was: {item.oldLocations.join(', ')}</div><div class="diff-item-locations">now: {item.newLocations.join(', ')}</div></div>{/each}
+                </div>
+              {/if}
+            {/if}
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/if}
+
+  <div class="json-editor-wrapper">
+    <div class="json-editor-line-numbers" bind:this={lineNumbers}>
+      {#each { length: lineCount } as _, i}
+        <div class="json-editor-line-number">{i + 1}</div>
+      {/each}
+    </div>
+    <textarea
+      bind:this={textarea}
+      class="json-editor-textarea"
+      {value}
+      oninput={(e) => onchange((e.target as HTMLTextAreaElement).value)}
+      onscroll={handleScroll}
+      spellcheck={false}
+      placeholder="Enter question set JSON..."
+    ></textarea>
+  </div>
+
+  {#if showScrollTop}
+    <button
+      type="button"
+      onclick={() => { if (textarea) textarea.scrollTop = 0 }}
+      class="json-editor-scroll-top"
+      title="Scroll to top"
+    >
+      <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+      </svg>
+    </button>
+  {/if}
+</div>

--- a/src/edit-questions-svelte/OptionSection.svelte
+++ b/src/edit-questions-svelte/OptionSection.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+  import type { Option, Person, Item } from '../edit-questions/types'
+  import ItemPeopleSection from './ItemPeopleSection.svelte'
+  import CreatableInput from './CreatableInput.svelte'
+
+  interface Props {
+    option: Option
+    optionIndex: number
+    allPeople: Person[]
+    allItemNames: string[]
+    onRemove: () => void
+    onChange: (updated: Option) => void
+    scrollToLastVersion?: number
+  }
+
+  let { option, optionIndex, allPeople, allItemNames, onRemove, onChange, scrollToLastVersion }: Props = $props()
+
+  let isExpanded = $state(false)
+  let newItemIndex = $state<number | null>(null)
+  let itemEls: HTMLDivElement[] = []
+
+  $effect(() => {
+    if (!scrollToLastVersion) return
+    isExpanded = true
+    requestAnimationFrame(() => {
+      const idx = option.items.length - 1
+      if (idx >= 0) {
+        itemEls[idx]?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        newItemIndex = idx
+      }
+    })
+  })
+
+  function updateText(text: string) {
+    onChange({ ...option, text })
+  }
+
+  function addItem() {
+    const newItem: Item = { text: '', personSelections: allPeople.map(p => ({ personId: p.id, selected: false })) }
+    const updated = { ...option, items: [...option.items, newItem] }
+    onChange(updated)
+    requestAnimationFrame(() => { newItemIndex = updated.items.length - 1 })
+  }
+
+  function removeItem(idx: number) {
+    onChange({ ...option, items: option.items.filter((_, i) => i !== idx) })
+  }
+
+  function changeItem(idx: number, updated: Item) {
+    const items = option.items.map((it, i) => i === idx ? updated : it)
+    onChange({ ...option, items })
+  }
+</script>
+
+<div class="bg-gray-50 rounded-lg p-4">
+  <div class="flex items-start gap-2 sm:gap-4 {isExpanded ? 'mb-4' : ''}">
+    <button
+      type="button"
+      onclick={() => (isExpanded = !isExpanded)}
+      class="text-gray-400 hover:text-gray-600 transition-colors duration-200 mt-7"
+      title={isExpanded ? 'Collapse' : 'Expand'}
+    >
+      <svg
+        class="w-5 h-5 transform transition-transform duration-200 {isExpanded ? 'rotate-180' : ''}"
+        fill="none" viewBox="0 0 24 24" stroke="currentColor"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+      </svg>
+    </button>
+    <div class="flex-1">
+      <label class="block text-sm font-medium text-gray-700 mb-1" for="option-{optionIndex}">Option {optionIndex + 1}</label>
+      <input
+        id="option-{optionIndex}"
+        type="text"
+        value={option.text}
+        placeholder="Enter option text"
+        oninput={(e) => updateText((e.target as HTMLInputElement).value)}
+        class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+      />
+    </div>
+    <button
+      type="button"
+      onclick={onRemove}
+      aria-label={`Remove option ${optionIndex + 1}`}
+      class="mt-6 rounded-full p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors duration-200"
+    >
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
+
+  {#if isExpanded}
+    <div class="ml-0 sm:ml-4 space-y-3">
+      <div class="text-sm font-medium text-gray-700 mb-2">Items:</div>
+      {#each option.items as item, i}
+        <div
+          bind:this={itemEls[i]}
+          class="flex items-start gap-2 sm:gap-3 rounded-md {i === newItemIndex ? 'ring-2 ring-primary-300' : ''}"
+        >
+          <div class="flex-1">
+            <ItemPeopleSection
+              personSelections={item.personSelections}
+              {allPeople}
+              onchange={(sels) => changeItem(i, { ...item, personSelections: sels })}
+            />
+            <CreatableInput
+              value={item.text}
+              options={allItemNames}
+              placeholder="Enter item"
+              onchange={(val) => changeItem(i, { ...item, text: val })}
+            />
+          </div>
+          <button
+            type="button"
+            onclick={() => removeItem(i)}
+            aria-label={`Remove item ${i + 1}`}
+            class="mt-1 rounded-full p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors duration-200"
+          >
+            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      {/each}
+      <button
+        type="button"
+        onclick={addItem}
+        class="mt-2 inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-md transition-colors duration-200"
+      >
+        Add Item
+      </button>
+    </div>
+  {/if}
+</div>

--- a/src/edit-questions-svelte/OptionSection.svelte
+++ b/src/edit-questions-svelte/OptionSection.svelte
@@ -16,12 +16,18 @@
   let { option, optionIndex, allPeople, allItemNames, onRemove, onChange, scrollToLastVersion }: Props = $props()
 
   let isExpanded = $state(false)
+  let everExpanded = $state(false)
   let newItemIndex = $state<number | null>(null)
   let itemEls: HTMLDivElement[] = []
 
+  function expand() {
+    if (!everExpanded) everExpanded = true
+    isExpanded = true
+  }
+
   $effect(() => {
     if (!scrollToLastVersion) return
-    isExpanded = true
+    expand()
     requestAnimationFrame(() => {
       const idx = option.items.length - 1
       if (idx >= 0) {
@@ -56,7 +62,7 @@
   <div class="flex items-start gap-2 sm:gap-4 {isExpanded ? 'mb-4' : ''}">
     <button
       type="button"
-      onclick={() => (isExpanded = !isExpanded)}
+      onclick={() => isExpanded ? (isExpanded = false) : expand()}
       class="text-gray-400 hover:text-gray-600 transition-colors duration-200 mt-7"
       title={isExpanded ? 'Collapse' : 'Expand'}
     >
@@ -90,8 +96,8 @@
     </button>
   </div>
 
-  {#if isExpanded}
-    <div class="ml-0 sm:ml-4 space-y-3">
+  {#if everExpanded}
+    <div class="ml-0 sm:ml-4 space-y-3" class:hidden={!isExpanded}>
       <div class="text-sm font-medium text-gray-700 mb-2">Items:</div>
       {#each option.items as item, i}
         <div

--- a/src/edit-questions-svelte/PeopleSection.svelte
+++ b/src/edit-questions-svelte/PeopleSection.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import type { Person } from '../edit-questions/types'
+
+  interface Props {
+    people: Person[]
+    onAddPerson: () => void
+    onRemovePerson: (idx: number) => void
+    onChangeName: (idx: number, name: string) => void
+  }
+
+  let { people, onAddPerson, onRemovePerson, onChangeName }: Props = $props()
+
+  let isExpanded = $state(false)
+
+  let personLabel = $derived(people.length === 1 ? '1 person' : `${people.length} people`)
+</script>
+
+<div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6">
+  <button
+    type="button"
+    onclick={() => (isExpanded = !isExpanded)}
+    class="flex items-center gap-2 mb-4 w-full text-left hover:bg-gray-50 -mx-4 -mt-4 px-4 pt-4 rounded-t-lg transition-colors duration-200"
+  >
+    <svg
+      class="w-5 h-5 text-gray-400 transform transition-transform duration-200 {isExpanded ? 'rotate-180' : ''}"
+      fill="none" viewBox="0 0 24 24" stroke="currentColor"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+    </svg>
+    <div>
+      <h2 class="text-lg font-medium text-gray-900">People <span class="text-sm font-normal text-gray-500">({personLabel})</span></h2>
+      <p class="text-sm text-gray-600">Who you are packing for.</p>
+    </div>
+  </button>
+
+  {#if isExpanded}
+    <div class="space-y-4">
+      {#each people as person, i (person.id)}
+        <div class="flex items-center gap-2">
+          <div class="flex-1">
+            <label class="block text-sm font-medium text-gray-700 mb-1" for="person-{i}">Person {i + 1}</label>
+            <input
+              id="person-{i}"
+              type="text"
+              value={person.name}
+              placeholder="Enter person name"
+              oninput={(e) => onChangeName(i, (e.target as HTMLInputElement).value)}
+              class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+            />
+          </div>
+          {#if people.length > 1}
+            <button
+              type="button"
+              onclick={() => onRemovePerson(i)}
+              aria-label={`Remove person ${i + 1}`}
+              class="mt-6 rounded-full p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors duration-200"
+            >
+              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          {/if}
+        </div>
+      {/each}
+    </div>
+    <div class="mt-4">
+      <button
+        type="button"
+        onclick={onAddPerson}
+        class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors duration-200"
+      >
+        Add Person
+      </button>
+    </div>
+  {/if}
+</div>

--- a/src/edit-questions-svelte/QuestionSection.svelte
+++ b/src/edit-questions-svelte/QuestionSection.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+  import type { Question, Person, Option } from '../edit-questions/types'
+  import { newOption } from '../edit-questions/types'
+  import OptionSection from './OptionSection.svelte'
+
+  interface Props {
+    question: Question
+    questionIndex: number
+    allPeople: Person[]
+    allItemNames: string[]
+    forceCollapsed: boolean | null
+    onRemove: () => void
+    onChange: (updated: Question) => void
+    onMoveUp?: () => void
+    onMoveDown?: () => void
+    scrollToOptionIndex?: number
+    scrollToLastVersion?: number
+  }
+
+  let { question, questionIndex, allPeople, allItemNames, forceCollapsed, onRemove, onChange, onMoveUp, onMoveDown, scrollToOptionIndex, scrollToLastVersion }: Props = $props()
+
+  let isExpanded = $state(true)
+
+  $effect(() => {
+    if (forceCollapsed !== null && forceCollapsed !== undefined) {
+      isExpanded = !forceCollapsed
+    }
+  })
+
+  $effect(() => {
+    if (scrollToLastVersion != null) isExpanded = true
+  })
+
+  function updateText(text: string) {
+    onChange({ ...question, text })
+  }
+
+  function updateQuestionType(questionType: 'single-choice' | 'multiple-choice') {
+    onChange({ ...question, questionType })
+  }
+
+  function addOption() {
+    const updated = { ...question, options: [...question.options, newOption(question.options.length)] }
+    onChange(updated)
+  }
+
+  function removeOption(idx: number) {
+    onChange({ ...question, options: question.options.filter((_, i) => i !== idx) })
+  }
+
+  function changeOption(idx: number, updated: Option) {
+    const options = question.options.map((o, i) => i === idx ? updated : o)
+    onChange({ ...question, options })
+  }
+</script>
+
+<div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+  <div class="p-4 sm:p-6">
+    <div class="flex items-center gap-2 sm:gap-4 mb-6">
+      <button
+        type="button"
+        onclick={() => (isExpanded = !isExpanded)}
+        class="text-gray-400 hover:text-gray-600 transition-colors duration-200"
+        title={isExpanded ? 'Collapse' : 'Expand'}
+      >
+        <svg
+          class="w-5 h-5 transform transition-transform duration-200 {isExpanded ? 'rotate-180' : ''}"
+          fill="none" viewBox="0 0 24 24" stroke="currentColor"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      <div class="flex flex-col gap-1">
+        <button
+          type="button"
+          onclick={onMoveUp}
+          disabled={!onMoveUp}
+          class="text-gray-400 transition-colors duration-200 {onMoveUp ? 'hover:text-gray-600 cursor-pointer' : 'opacity-30 cursor-not-allowed'}"
+          title="Move up"
+        >
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          onclick={onMoveDown}
+          disabled={!onMoveDown}
+          class="text-gray-400 transition-colors duration-200 {onMoveDown ? 'hover:text-gray-600 cursor-pointer' : 'opacity-30 cursor-not-allowed'}"
+          title="Move down"
+        >
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      </div>
+
+      <div class="flex-1">
+        <label class="block text-sm font-medium text-gray-700 mb-1" for="question-{questionIndex}">Question {questionIndex + 1}</label>
+        <input
+          id="question-{questionIndex}"
+          type="text"
+          value={question.text}
+          placeholder="Enter your question"
+          oninput={(e) => updateText((e.target as HTMLInputElement).value)}
+          class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+        />
+      </div>
+
+      <button
+        type="button"
+        onclick={onRemove}
+        aria-label={`Remove question ${questionIndex + 1}`}
+        class="mt-6 rounded-full p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors duration-200"
+      >
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    {#if isExpanded}
+      <div class="mb-4 pb-4 border-b border-gray-200">
+        <p class="block text-sm font-medium text-gray-700 mb-2">Question Type</p>
+        <div class="flex gap-4">
+          <label class="flex items-center">
+            <input
+              type="radio"
+              value="single-choice"
+              checked={question.questionType === 'single-choice' || !question.questionType}
+              onchange={() => updateQuestionType('single-choice')}
+              class="mr-2"
+            />
+            <span class="text-sm text-gray-700">Single Choice</span>
+          </label>
+          <label class="flex items-center">
+            <input
+              type="radio"
+              value="multiple-choice"
+              checked={question.questionType === 'multiple-choice'}
+              onchange={() => updateQuestionType('multiple-choice')}
+              class="mr-2"
+            />
+            <span class="text-sm text-gray-700">Multiple Choice</span>
+          </label>
+        </div>
+      </div>
+
+      <div class="space-y-4">
+        {#each question.options as option, oi (option.id)}
+          <OptionSection
+            {option}
+            optionIndex={oi}
+            {allPeople}
+            {allItemNames}
+            onRemove={() => removeOption(oi)}
+            onChange={(updated) => changeOption(oi, updated)}
+            scrollToLastVersion={oi === scrollToOptionIndex ? scrollToLastVersion : undefined}
+          />
+        {/each}
+        <div class="mt-4">
+          <button
+            type="button"
+            onclick={addOption}
+            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors duration-200"
+          >
+            Add Option
+          </button>
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/edit-questions-svelte/QuestionSection.svelte
+++ b/src/edit-questions-svelte/QuestionSection.svelte
@@ -20,15 +20,23 @@
   let { question, questionIndex, allPeople, allItemNames, forceCollapsed, onRemove, onChange, onMoveUp, onMoveDown, scrollToOptionIndex, scrollToLastVersion }: Props = $props()
 
   let isExpanded = $state(true)
+  // Questions start expanded so everExpanded starts true
+  let everExpanded = $state(true)
+
+  function expand() {
+    if (!everExpanded) everExpanded = true
+    isExpanded = true
+  }
 
   $effect(() => {
     if (forceCollapsed !== null && forceCollapsed !== undefined) {
-      isExpanded = !forceCollapsed
+      if (forceCollapsed) isExpanded = false
+      else expand()
     }
   })
 
   $effect(() => {
-    if (scrollToLastVersion != null) isExpanded = true
+    if (scrollToLastVersion != null) expand()
   })
 
   function updateText(text: string) {
@@ -59,7 +67,7 @@
     <div class="flex items-center gap-2 sm:gap-4 mb-6">
       <button
         type="button"
-        onclick={() => (isExpanded = !isExpanded)}
+        onclick={() => isExpanded ? (isExpanded = false) : expand()}
         class="text-gray-400 hover:text-gray-600 transition-colors duration-200"
         title={isExpanded ? 'Collapse' : 'Expand'}
       >
@@ -120,53 +128,55 @@
       </button>
     </div>
 
-    {#if isExpanded}
-      <div class="mb-4 pb-4 border-b border-gray-200">
-        <p class="block text-sm font-medium text-gray-700 mb-2">Question Type</p>
-        <div class="flex gap-4">
-          <label class="flex items-center">
-            <input
-              type="radio"
-              value="single-choice"
-              checked={question.questionType === 'single-choice' || !question.questionType}
-              onchange={() => updateQuestionType('single-choice')}
-              class="mr-2"
-            />
-            <span class="text-sm text-gray-700">Single Choice</span>
-          </label>
-          <label class="flex items-center">
-            <input
-              type="radio"
-              value="multiple-choice"
-              checked={question.questionType === 'multiple-choice'}
-              onchange={() => updateQuestionType('multiple-choice')}
-              class="mr-2"
-            />
-            <span class="text-sm text-gray-700">Multiple Choice</span>
-          </label>
+    {#if everExpanded}
+      <div class:hidden={!isExpanded}>
+        <div class="mb-4 pb-4 border-b border-gray-200">
+          <p class="block text-sm font-medium text-gray-700 mb-2">Question Type</p>
+          <div class="flex gap-4">
+            <label class="flex items-center">
+              <input
+                type="radio"
+                value="single-choice"
+                checked={question.questionType === 'single-choice' || !question.questionType}
+                onchange={() => updateQuestionType('single-choice')}
+                class="mr-2"
+              />
+              <span class="text-sm text-gray-700">Single Choice</span>
+            </label>
+            <label class="flex items-center">
+              <input
+                type="radio"
+                value="multiple-choice"
+                checked={question.questionType === 'multiple-choice'}
+                onchange={() => updateQuestionType('multiple-choice')}
+                class="mr-2"
+              />
+              <span class="text-sm text-gray-700">Multiple Choice</span>
+            </label>
+          </div>
         </div>
-      </div>
 
-      <div class="space-y-4">
-        {#each question.options as option, oi (option.id)}
-          <OptionSection
-            {option}
-            optionIndex={oi}
-            {allPeople}
-            {allItemNames}
-            onRemove={() => removeOption(oi)}
-            onChange={(updated) => changeOption(oi, updated)}
-            scrollToLastVersion={oi === scrollToOptionIndex ? scrollToLastVersion : undefined}
-          />
-        {/each}
-        <div class="mt-4">
-          <button
-            type="button"
-            onclick={addOption}
-            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors duration-200"
-          >
-            Add Option
-          </button>
+        <div class="space-y-4">
+          {#each question.options as option, oi (option.id)}
+            <OptionSection
+              {option}
+              optionIndex={oi}
+              {allPeople}
+              {allItemNames}
+              onRemove={() => removeOption(oi)}
+              onChange={(updated) => changeOption(oi, updated)}
+              scrollToLastVersion={oi === scrollToOptionIndex ? scrollToLastVersion : undefined}
+            />
+          {/each}
+          <div class="mt-4">
+            <button
+              type="button"
+              onclick={addOption}
+              class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors duration-200"
+            >
+              Add Option
+            </button>
+          </div>
         </div>
       </div>
     {/if}

--- a/src/edit-questions-svelte/bridge-store.ts
+++ b/src/edit-questions-svelte/bridge-store.ts
@@ -1,0 +1,32 @@
+import { writable } from 'svelte/store'
+import type { PackingListQuestionSet } from '../edit-questions/types'
+
+export interface BridgeState {
+  isLoggedIn: boolean
+  foreignPodUrl: string | null | undefined
+  syncingFromPod: boolean
+  isSyncing: boolean
+  lastSync: Date | null
+  syncError: string | null
+  podSyncData: PackingListQuestionSet | null
+  onSave: (data: PackingListQuestionSet) => Promise<boolean>
+  onSaveJson: (json: string) => Promise<{ error?: string }>
+  onShowToast: (msg: string, type: 'success' | 'error') => void
+  onReset: () => void
+}
+
+const noop = () => {}
+
+export const bridgeStore = writable<BridgeState>({
+  isLoggedIn: false,
+  foreignPodUrl: null,
+  syncingFromPod: false,
+  isSyncing: false,
+  lastSync: null,
+  syncError: null,
+  podSyncData: null,
+  onSave: async () => false,
+  onSaveJson: async () => ({}),
+  onShowToast: noop,
+  onReset: noop,
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,16 @@ import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [svelte(), react(), tailwindcss()],
+  plugins: [
+    svelte({
+      onwarn(warning, defaultHandler) {
+        // Intentional: initialData is captured once as the initial $state value
+        if (warning.code === 'state_referenced_locally') return
+        defaultHandler?.(warning)
+      },
+    }),
+    react(),
+    tailwindcss(),
+  ],
   define: { global: "window" }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [svelte(), react(), tailwindcss()],
   define: { global: "window" }
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vitest/config'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  plugins: [svelte({ hot: false }), react()],
   test: {
     environment: 'happy-dom',
     globals: true,


### PR DESCRIPTION
The edit-questions page suffered from cascading React re-renders: react-hook-form
helpers prop-drilled 4 levels deep, getAllItemNames() scanning the full question
tree on every render of every option/item, and inline IIFEs re-running expensive
JSON diffs unconditionally.

The Svelte 5 rewrite eliminates these problems structurally:
- $derived(collectAllItemNames(questionSet)) replaces the useCallback that scanned
  the tree on every render — now recomputes only when questionSet actually changes
- No prop drilling of control/register/watch/setValue — child components receive
  only the slice they need and mutate $state proxies directly
- $effect auto-save with a skipNextSave flag prevents saving pod-sync updates back
  to the pod, replacing the complex watch subscription in React

Architecture: thin React bridge (EditQuestionsBridge.tsx) reads all React contexts
(useDatabase, useSolidPod, useForeignPod, useToast, useSyncCoordinator, usePodSync)
and mounts the Svelte app via mount()/unmount(). A Svelte writable store (bridge-store.ts)
carries reactive values and callbacks from React into Svelte.

All framework-agnostic code (types.ts, validation.ts, database services, sync hooks)
is reused unchanged.

https://claude.ai/code/session_01HDe8663aMNBzjcLccFTQSq