### PR TITLE
Filter out items with no assigned people from packing lists

### DIFF
--- a/src/edit-questions/example-data.test.ts
+++ b/src/edit-questions/example-data.test.ts
@@ -73,6 +73,58 @@ describe('createExampleData', () => {
     })
 })
 
+describe('createExampleData - unassigned items excluded', () => {
+    const adult: Person = { id: 'a1', name: 'Alice', ageRange: 'Adult' }
+    const baby: Person = { id: 'b1', name: 'Baby', ageRange: 'Baby' }
+    const toddler: Person = { id: 't1', name: 'Toddler', ageRange: 'Toddler' }
+
+    it('excludes baby items from alwaysNeededItems when no babies in group', () => {
+        const result = createExampleData([adult])
+        const babyItemTexts = ['Nappies (pack/supply)', 'Baby wipes', 'Nappy bags', 'Change mat', 'Bibs', 'Muslins/Burp cloths']
+        for (const text of babyItemTexts) {
+            expect(result.alwaysNeededItems.find(i => i.text === text), `"${text}" should not appear`).toBeUndefined()
+        }
+    })
+
+    it('excludes toddler items from alwaysNeededItems when no toddlers in group', () => {
+        const result = createExampleData([adult])
+        const toddlerItemTexts = ['Pull-ups/Toddler nappies', 'Potty (travel potty)', 'Sippy cup/Toddler cup', 'Toddler snacks', 'Comfort item (teddy/blanket)']
+        for (const text of toddlerItemTexts) {
+            expect(result.alwaysNeededItems.find(i => i.text === text), `"${text}" should not appear`).toBeUndefined()
+        }
+    })
+
+    it('includes baby items in alwaysNeededItems when babies are in the group', () => {
+        const result = createExampleData([adult, baby])
+        expect(result.alwaysNeededItems.find(i => i.text === 'Nappies (pack/supply)')).toBeTruthy()
+    })
+
+    it('excludes baby swimming items when no babies in group', () => {
+        const result = createExampleData([adult])
+        const activities = result.questions.find(q => q.text === 'What activities will you be doing?')!
+        const swimmingItems = activities.options.find(o => o.id === ACTIVITY_OPTION_IDS.swimming)!.items
+        expect(swimmingItems.find(i => i.text === 'Baby swim nappy')).toBeUndefined()
+        expect(swimmingItems.find(i => i.text === 'Baby float/Swim seat')).toBeUndefined()
+    })
+
+    it('includes toddler items in alwaysNeededItems when toddlers are in the group', () => {
+        const result = createExampleData([adult, toddler])
+        expect(result.alwaysNeededItems.find(i => i.text === 'Sippy cup/Toddler cup')).toBeTruthy()
+    })
+
+    it('no item in the question set has all personSelections unselected', () => {
+        const result = createExampleData([adult])
+        const allItems = [
+            ...result.alwaysNeededItems,
+            ...result.questions.flatMap(q => q.options.flatMap(o => o.items)),
+        ]
+        for (const item of allItems) {
+            const anySelected = item.personSelections.some(ps => ps.selected)
+            expect(anySelected, `Item "${item.text}" has no one assigned`).toBe(true)
+        }
+    })
+})
+
 describe('createExampleData - gender-specific items', () => {
     function getOvernightYesItems(result: ReturnType<typeof createExampleData>) {
         const overnight = result.questions.find(q => q.text === 'Will you be staying overnight?')!
@@ -93,12 +145,10 @@ describe('createExampleData - gender-specific items', () => {
         expect(item!.personSelections.find(ps => ps.personId === maleAdult.id)?.selected).toBe(false)
     })
 
-    it('does not select Menstrual products for male adult', () => {
+    it('does not include Menstrual products for male-only group', () => {
         const result = createExampleData([maleAdult])
         const items = getOvernightYesItems(result)
-        const item = items.find(i => i.text === 'Menstrual products')
-        expect(item).toBeTruthy()
-        expect(item!.personSelections.find(ps => ps.personId === maleAdult.id)?.selected).toBe(false)
+        expect(items.find(i => i.text === 'Menstrual products')).toBeUndefined()
     })
 
     it('includes Sports bra selected for female adult runner', () => {
@@ -136,6 +186,12 @@ describe('createExampleData - gender-specific items', () => {
         expect(item).toBeTruthy()
         expect(item!.personSelections.find(ps => ps.personId === femaleAdult.id)?.selected).toBe(true)
         expect(item!.personSelections.find(ps => ps.personId === maleAdult.id)?.selected).toBe(false)
+    })
+
+    it('does not include Shaving kit for female-only group', () => {
+        const result = createExampleData([femaleAdult])
+        const items = getOvernightYesItems(result)
+        expect(items.find(i => i.text === 'Shaving kit')).toBeUndefined()
     })
 
     it('includes Shaving kit selected for male adult', () => {

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -29,9 +29,8 @@ import {
  * @param people - All people in the group
  * @param ageFilter - Optional function to filter people by age range (defaults to everyone)
  */
-function item(text: string, people: Person[], ageFilter?: (p: Person[]) => Person[]): Item | null {
+function item(text: string, people: Person[], ageFilter?: (p: Person[]) => Person[]): Item {
     const selectedPeople = ageFilter ? ageFilter(people) : people;
-    if (selectedPeople.length === 0) return null;
     return {
         text,
         personSelections: people.map(p => ({
@@ -41,8 +40,8 @@ function item(text: string, people: Person[], ageFilter?: (p: Person[]) => Perso
     };
 }
 
-function items(...args: (Item | null)[]): Item[] {
-    return args.filter((i): i is Item => i !== null);
+function items(...args: Item[]): Item[] {
+    return args.filter(i => i.personSelections.some(ps => ps.selected));
 }
 
 export function createExampleData(people: Person[], selectedActivityIds: string[] = []): PackingListQuestionSet {

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -29,8 +29,9 @@ import {
  * @param people - All people in the group
  * @param ageFilter - Optional function to filter people by age range (defaults to everyone)
  */
-function item(text: string, people: Person[], ageFilter?: (p: Person[]) => Person[]): Item {
+function item(text: string, people: Person[], ageFilter?: (p: Person[]) => Person[]): Item | null {
     const selectedPeople = ageFilter ? ageFilter(people) : people;
+    if (selectedPeople.length === 0) return null;
     return {
         text,
         personSelections: people.map(p => ({
@@ -38,6 +39,10 @@ function item(text: string, people: Person[], ageFilter?: (p: Person[]) => Perso
             selected: selectedPeople.some(sp => sp.id === p.id)
         }))
     };
+}
+
+function items(...args: (Item | null)[]): Item[] {
+    return args.filter((i): i is Item => i !== null);
 }
 
 export function createExampleData(people: Person[], selectedActivityIds: string[] = []): PackingListQuestionSet {
@@ -50,101 +55,96 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             id: ACTIVITY_OPTION_IDS.swimming,
             text: "Swimming",
             order: 0,
-            items: [
+            items: items(
                 item("Swimsuit", people, getToddlersAndOlder),
                 item("Swim towel", people),
                 item("Goggles", people, getChildrenAndOlder),
                 item("Swim cap", people, getChildrenAndOlder),
-                // Baby items
                 item("Baby swim nappy", people, getBabies),
                 item("Baby float/Swim seat", people, getBabies),
                 item("Baby sun hat with neck protection", people, getBabies),
                 item("Baby rash guard/Sun suit", people, getBabies),
-                // Toddler items
                 item("Swim nappy (if not potty trained)", people, getToddlers),
                 item("Armbands/Floaties", people, getToddlers),
                 item("Toddler sun hat", people, getToddlers),
-                // Child items
-                item("Swim aids (noodles, kickboard)", people, getChildren)
-            ]
+                item("Swim aids (noodles, kickboard)", people, getChildren),
+            )
         },
         {
             id: ACTIVITY_OPTION_IDS.watersports,
             text: "Watersports",
             order: 1,
-            items: [
+            items: items(
                 item("Wetsuit", people, getTeenagersAndAdults),
                 item("Water shoes", people, getTeenagersAndAdults),
                 item("Waterproof bag", people, getTeenagersAndAdults),
-                item("Rash guard", people, getTeenagersAndAdults)
-            ]
+                item("Rash guard", people, getTeenagersAndAdults),
+            )
         },
         {
             id: ACTIVITY_OPTION_IDS.cycling,
             text: "Cycling",
             order: 2,
-            items: [
+            items: items(
                 item("Cycling shorts", people, getTeenagersAndAdults),
                 item("Sports bra", people, getFemaleTeenagersAndAdults),
                 item("Helmet", people, getTeenagersAndAdults),
                 item("Water bottle", people, getTeenagersAndAdults),
                 item("Bike repair kit", people, getTeenagersAndAdults),
-                item("Cycling gloves", people, getTeenagersAndAdults)
-            ]
+                item("Cycling gloves", people, getTeenagersAndAdults),
+            )
         },
         {
             id: ACTIVITY_OPTION_IDS.running,
             text: "Running",
             order: 3,
-            items: [
+            items: items(
                 item("Running shoes", people, getTeenagersAndAdults),
                 item("Running clothes", people, getTeenagersAndAdults),
                 item("Sports bra", people, getFemaleTeenagersAndAdults),
                 item("Sports watch", people, getTeenagersAndAdults),
-                item("Running socks", people, getTeenagersAndAdults)
-            ]
+                item("Running socks", people, getTeenagersAndAdults),
+            )
         },
         {
             id: ACTIVITY_OPTION_IDS.climbing,
             text: "Climbing",
             order: 4,
-            items: [
+            items: items(
                 item("Climbing shoes", people, getTeenagersAndAdults),
                 item("Sports bra", people, getFemaleTeenagersAndAdults),
                 item("Chalk bag", people, getTeenagersAndAdults),
                 item("Harness", people, getTeenagersAndAdults),
                 item("Climbing gloves", people, getTeenagersAndAdults),
-                item("Belay device", people, getTeenagersAndAdults)
-            ]
+                item("Belay device", people, getTeenagersAndAdults),
+            )
         },
         {
             id: ACTIVITY_OPTION_IDS.hiking,
             text: "Hiking",
             order: 5,
-            items: [
+            items: items(
                 item("Hiking boots", people, getChildrenAndOlder),
                 item("Sports bra", people, getFemaleTeenagersAndAdults),
                 item("Daypack/Backpack", people, getTeenagersAndAdults),
                 item("Walking poles", people, getAdults),
                 item("Trail map", people, getAdults),
                 item("First aid kit", people, getAdults),
-                // Baby items
                 item("Baby carrier/Sling", people, getBabies),
-                // Toddler items
                 item("Toddler reins/Backpack harness", people, getToddlers),
-                item("Lightweight buggy/Stroller", people, getToddlers)
-            ]
+                item("Lightweight buggy/Stroller", people, getToddlers),
+            )
         },
         {
             id: ACTIVITY_OPTION_IDS.formalOccasions,
             text: "Formal occasions",
             order: 6,
-            items: [
+            items: items(
                 item("Formal outfit", people),
                 item("Dress shoes", people, getToddlersAndOlder),
                 item("Accessories (watch, jewelry, etc.)", people, getTeenagersAndAdults),
-                item("Evening bag/Clutch", people, getTeenagersAndAdults)
-            ]
+                item("Evening bag/Clutch", people, getTeenagersAndAdults),
+            )
         }
     ]
 
@@ -155,11 +155,10 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
     return {
         _id: "1",
         people,
-        alwaysNeededItems: [
+        alwaysNeededItems: items(
             item("Day bag / Backpack", people, getChildrenAndOlder),
             item("Snacks", people),
             item("Water bottle", people, getToddlersAndOlder),
-            // Baby items
             item("Nappies (pack/supply)", people, getBabies),
             item("Baby wipes", people, getBabies),
             item("Nappy bags", people, getBabies),
@@ -170,7 +169,6 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             item("Formula/Baby food", people, getBabies),
             item("Dummy/Pacifier (if used)", people, getBabies),
             item("Spare clothes (×3-4 sets)", people, getBabies),
-            // Toddler items
             item("Pull-ups/Toddler nappies", people, getToddlers),
             item("Potty (travel potty)", people, getToddlers),
             item("Wipes", people, getToddlers),
@@ -178,17 +176,14 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             item("Sippy cup/Toddler cup", people, getToddlers),
             item("Toddler snacks", people, getToddlers),
             item("Comfort item (teddy/blanket)", people, getToddlers),
-            // Child items
             item("Entertainment (books/small toys)", people, getChildren),
             item("Playing cards/Travel games", people, getChildren),
-            // Teenager items
             item("Headphones", people, getTeenagers),
             item("Phone charger", people, getTeenagers),
-            // First aid / medication
             item("First aid kit", people),
             item("Plasters / Band-aids", people),
             item("Pain relief (paracetamol / ibuprofen)", people, getAdults),
-        ],
+        ),
         questions: [
             {
                 id: generateUUID(),
@@ -201,7 +196,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         id: generateUUID(),
                         text: "Yes",
                         order: 0,
-                        items: [
+                        items: items(
                             item("Toothbrush", people, getToddlersAndOlder),
                             item("Toothpaste", people, getAdults),
                             item("Deodorant", people, getTeenagersAndAdults),
@@ -217,21 +212,17 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                             item("T-shirt/Top", people),
                             item("Trousers/Shorts", people),
                             item("Jumper", people),
-                            // Baby items
                             item("Baby monitor", people, getBabies),
                             item("Nightlight", people, getBabies),
                             item("Baby sleeping bag/Swaddle", people, getBabies),
                             item("Extra bedding/sheets", people, getBabies),
                             item("Bedtime bottle", people, getBabies),
-                            // Toddler items
                             item("Bedtime books", people, getToddlers),
                             item("Night nappy/Pull-up", people, getToddlers),
-                            // Child items
                             item("Favorite toy/Stuffed animal", people, getChildren),
                             item("Flashlight", people, getChildren),
-                            // Teenager items
-                            item("Personal care items (face wash, etc.)", people, getTeenagers)
-                        ]
+                            item("Personal care items (face wash, etc.)", people, getTeenagers),
+                        )
                     },
                     {
                         id: generateUUID(),
@@ -252,12 +243,12 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         id: generateUUID(),
                         text: "Yes",
                         order: 0,
-                        items: [
+                        items: items(
                             item("Dish soap and sponge", people, getAdults),
                             item("Dishwasher tablets", people, getAdults),
                             item("Tea towels", people, getAdults),
-                            item("Shopping bags", people, getAdults)
-                        ]
+                            item("Shopping bags", people, getAdults),
+                        )
                     },
                     {
                         id: generateUUID(),
@@ -286,66 +277,61 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         id: generateUUID(),
                         text: "Hot",
                         order: 0,
-                        items: [
+                        items: items(
                             item("Sunscreen", people),
                             item("Sun hat", people),
                             item("Sunglasses", people, getChildrenAndOlder),
                             item("Light, breathable clothing", people),
                             item("Sandals", people, getToddlersAndOlder),
-                            // Baby items
                             item("Baby sunscreen (SPF 50+)", people, getBabies),
                             item("Sun protective baby clothing", people, getBabies),
                             item("Shade cover/Parasol for pram", people, getBabies),
-                            // Toddler items
                             item("Toddler sunscreen", people, getToddlers),
                             item("Sun protective clothing", people, getToddlers),
-                            // Child items
-                            item("Kids sunscreen", people, getChildren)
-                        ]
+                            item("Kids sunscreen", people, getChildren),
+                        )
                     },
                     {
                         id: generateUUID(),
                         text: "Rain",
                         order: 1,
-                        items: [
+                        items: items(
                             item("Raincoat", people),
                             item("Umbrella", people),
                             item("Waterproof shoes/boots", people),
-                            item("Waterproof bag cover", people)
-                        ]
+                            item("Waterproof bag cover", people),
+                        )
                     },
                     {
                         id: generateUUID(),
                         text: "Warm",
                         order: 2,
-                        items: [
+                        items: items(
                             item("Light jacket", people),
                             item("Comfortable layers", people),
                             item("Long-sleeved shirts", people),
-                            item("Comfortable walking shoes", people)
-                        ]
+                            item("Comfortable walking shoes", people),
+                        )
                     },
                     {
                         id: generateUUID(),
                         text: "Cold",
                         order: 3,
-                        items: [
+                        items: items(
                             item("Winter coat", people),
                             item("Gloves", people),
                             item("Scarf", people),
                             item("Warm hat/Beanie", people),
                             item("Thermal underwear", people),
                             item("Warm boots", people),
-                            // Baby items
                             item("Baby snowsuit/Pramsuit", people, getBabies),
                             item("Baby mittens", people, getBabies),
                             item("Baby warm hat with ear coverage", people, getBabies),
                             item("Blanket for carrier/pram", people, getBabies),
-                            // Toddler items
                             item("Toddler snowsuit/Winter coat", people, getToddlers),
                             item("Toddler mittens (not gloves - easier)", people, getToddlers),
-                            item("Toddler warm hat", people, getToddlers)
-                        ]
+                            item("Toddler warm hat", people, getToddlers),
+                        )
                     }
                 ]
             }


### PR DESCRIPTION
## Summary
Refactored the example data generation to automatically exclude packing list items when no one in the group matches the item's age/gender requirements. This prevents cluttering the UI with irrelevant items.

## Key Changes
- Modified `item()` function to return `Item | null` and return `null` when no people match the age filter
- Added new `items()` helper function that filters out `null` values, converting `(Item | null)[]` to `Item[]`
- Updated all item array definitions throughout the data structure to use the `items()` wrapper
- Removed inline comments (e.g., "// Baby items", "// Toddler items") as they're no longer needed with the filtering approach

## Implementation Details
- The filtering happens at data generation time, not at runtime, so the packing list only contains relevant items for the specific group composition
- For example, if there are no babies in the group, all baby-specific items (nappies, baby wipes, etc.) are automatically excluded
- Gender-specific items like "Menstrual products" and "Shaving kit" are also excluded if no one in the group matches the filter
- Added comprehensive test coverage to verify items are properly excluded based on group composition and that no item ends up with all people unselected

https://claude.ai/code/session_0122Xg8Hc5jjaVnLWWRE9RLH