### PR TITLE
Increase CI worker count from 1 to 2

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,7 +43,7 @@ const executablePath = existsSync(localChromium) ? localChromium : undefined
 export default defineConfig({
   testDir: './e2e/tests',
   fullyParallel: true,
-  workers: process.env.CI ? 1 : 4,
+  workers: process.env.CI ? 2 : 4,
   retries: process.env.CI ? 1 : 0,
   reporter: [['list'], ['html', { open: 'never' }]],
   globalSetup: './e2e/global-setup.ts',


### PR DESCRIPTION
## Summary
Increase the number of parallel workers used in CI environments from 1 to 2 to improve test execution time while maintaining stability.

## Changes
- Updated `playwright.config.ts` to use 2 workers in CI instead of 1
- Local development continues to use 4 workers

## Details
This change allows CI pipelines to run Playwright tests with 2 parallel workers instead of 1, reducing overall test execution time. The local development environment remains unchanged at 4 workers. This adjustment balances test throughput with CI resource constraints and stability.

https://claude.ai/code/session_01Es1KnUc6KyG1qQw3UduMk7