### PR TITLE
Add hybrid static/DCR Solid OIDC client registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Set to the hosted Client ID Document URL for static OIDC registration (production only).
+# Leave unset for local dev and preview deploys — they fall back to dynamic client registration.
+# VITE_CLIENT_ID_URL=https://packmeup.tim-gent.com/client-id.json

--- a/public/client-id.json
+++ b/public/client-id.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
+  "client_id": "https://packmeup.tim-gent.com/client-id.json",
+  "redirect_uris": ["https://packmeup.tim-gent.com/"],
+  "client_name": "Pack Me Up",
+  "client_uri": "https://packmeup.tim-gent.com/",
+  "scope": "openid offline_access webid",
+  "grant_types": ["refresh_token", "authorization_code"]
+}

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -28,14 +28,20 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
   const uvdslSessionRef = useRef<SessionCore>(null!);
   if (!uvdslSessionRef.current) {
     const origin = window.location.origin || "http://localhost";
+    // On production, VITE_CLIENT_ID_URL is set so the provider fetches the hosted Client ID
+    // Document (static registration). On preview deploys and localhost it is unset, so we fall
+    // back to dynamic client registration using the current origin's redirect URI.
+    const clientIdUrl = import.meta.env.VITE_CLIENT_ID_URL as string | undefined;
     uvdslSessionRef.current = new SessionCore(
-      {
-        // Use SPA root so the redirect_uri in the token exchange matches what's registered.
-        // If we go through pod-auth-callback.html, the library strips params from that URL
-        // and sends the wrong redirect_uri to the token endpoint.
-        redirect_uris: [origin + "/"],
-        client_name: "Pack Me Up",
-      },
+      clientIdUrl
+        ? { client_id: clientIdUrl }
+        : {
+            // Use SPA root so the redirect_uri in the token exchange matches what's registered.
+            // If we go through pod-auth-callback.html, the library strips params from that URL
+            // and sends the wrong redirect_uri to the token endpoint.
+            redirect_uris: [origin + "/"],
+            client_name: "Pack Me Up",
+          },
       {
         database: new SessionIDB(),
         onSessionStateChange: (e) => {


### PR DESCRIPTION
On production (VITE_CLIENT_ID_URL set), SessionCore uses the hosted
Client ID Document at packmeup.tim-gent.com/client-id.json for static
registration per the Solid-OIDC spec. On preview deploys and localhost
(env var unset) it falls back to dynamic client registration as before.

https://claude.ai/code/session_01QAJmZ6fsLdWGPGVWZ8U5aQ