### PR TITLE
Fix sync for anonymous editors of publicly shared packing lists

### DIFF
--- a/e2e/tests/l-sharing.spec.ts
+++ b/e2e/tests/l-sharing.spec.ts
@@ -140,8 +140,14 @@ test.describe('L – Sharing a packing list', () => {
     })
 
     test('L4: anonymous user checks item on public link; owner sees the change within one poll cycle', async ({ browser }) => {
-        // User A shares the list publicly (L3 already has 1 packed item hidden on pageA)
-        await expect(pageA.getByRole('button', { name: 'Share' })).toBeEnabled({ timeout: 10_000 })
+        // Close any dialog left open from L1: the Modal component has no Escape handler,
+        // so clicking the X close button is the only reliable way to dismiss it.
+        const residualDialog = pageA.locator('[role="dialog"]')
+        if (await residualDialog.isVisible()) {
+            await residualDialog.getByRole('button', { name: 'Close' }).click()
+            await expect(residualDialog).toHaveCount(0)
+        }
+        // Now the toolbar Share button is the only one visible
         await pageA.getByRole('button', { name: 'Share' }).click()
         await expect(pageA.getByText('Manage sharing')).toBeVisible({ timeout: 5_000 })
         await pageA.getByRole('button', { name: 'Anyone with the link' }).click()

--- a/e2e/tests/l-sharing.spec.ts
+++ b/e2e/tests/l-sharing.spec.ts
@@ -138,4 +138,47 @@ test.describe('L – Sharing a packing list', () => {
             await ctxB.close()
         }
     })
+
+    test('L4: anonymous user checks item on public link; owner sees the change within one poll cycle', async ({ browser }) => {
+        // User A shares the list publicly (L3 already has 1 packed item hidden on pageA)
+        await expect(pageA.getByRole('button', { name: 'Share' })).toBeEnabled({ timeout: 10_000 })
+        await pageA.getByRole('button', { name: 'Share' }).click()
+        await expect(pageA.getByText('Manage sharing')).toBeVisible({ timeout: 5_000 })
+        await pageA.getByRole('button', { name: 'Anyone with the link' }).click()
+        await pageA.getByRole('dialog').getByRole('button', { name: /^Share publicly/i }).click()
+        await expect(pageA.getByRole('textbox', { name: /shareable link/i })).toBeVisible({ timeout: 15_000 })
+        const publicLink = await pageA.getByRole('textbox', { name: /shareable link/i }).inputValue()
+        await pageA.keyboard.press('Escape')
+
+        // Open a fresh anonymous context — no login
+        const ctxAnon = await browser.newContext()
+        const pageAnon = await ctxAnon.newPage()
+        try {
+            await pageAnon.goto(publicLink)
+
+            // Wait for list items to load via pod poll.
+            // Item 1 is already packed (from L3) so it's hidden with showPacked=false;
+            // the first visible checkbox is item 2.
+            const firstCheckbox = pageAnon.locator('input[type="checkbox"]').first()
+            await firstCheckbox.waitFor({ timeout: 20_000 })
+
+            // Check the first visible item
+            await firstCheckbox.click()
+
+            // Wait for the anonymous write to reach the pod
+            await pageAnon.waitForResponse(
+                r => r.url().includes('/pack-me-up/packing-lists/') && r.request().method() === 'PUT',
+                { timeout: 10_000 }
+            )
+
+            // Confirm no pod-write error was surfaced
+            await expect(pageAnon.getByText(/Failed to save to Pod/i)).not.toBeVisible()
+
+            // User A polls every 5 s — give 3 cycles (15 s) for propagation.
+            // After L3 there was 1 packed item hidden; after L4 there should be 2.
+            await expect(pageA.getByText(/2 packed.*hidden/i)).toBeVisible({ timeout: 20_000 })
+        } finally {
+            await ctxAnon.close()
+        }
+    })
 })

--- a/src/hooks/usePodSync.test.ts
+++ b/src/hooks/usePodSync.test.ts
@@ -363,7 +363,7 @@ describe('usePodSync', () => {
       expect(onSaveError).toHaveBeenCalledWith('network error')
     })
 
-    it('does not save when not logged in', async () => {
+    it('does not save when not logged in and no foreign pod configured', async () => {
       setupLoggedOut()
 
       const { result } = renderHook(() =>
@@ -381,6 +381,36 @@ describe('usePodSync', () => {
 
       expect(success).toBe(false)
       expect(mockSaveRdfToPod).not.toHaveBeenCalled()
+    })
+
+    it('saves to a foreign pod when not logged in (anonymous write)', async () => {
+      setupLoggedOut()
+      mockSaveRdfToPod.mockResolvedValue(undefined)
+
+      const { result } = renderHook(() =>
+        usePodSync({
+          pathConfig: {
+            container: 'pack-me-up/packing-lists/',
+            filename: 'test-list.ttl',
+            podUrl: 'https://alice.solidcommunity.net/',
+          },
+          enabled: true,
+          rdf: rdfOptions,
+        })
+      )
+
+      let success: boolean | undefined
+      await act(async () => {
+        success = await result.current.saveToPod(QUESTION_SET_DATA)
+      })
+
+      expect(success).toBe(true)
+      expect(mockSaveRdfToPod).toHaveBeenCalledWith(
+        expect.objectContaining({
+          session: null,
+          fileUrl: 'https://alice.solidcommunity.net/pack-me-up/packing-lists/test-list.ttl',
+        })
+      )
     })
   })
 

--- a/src/hooks/usePodSync.ts
+++ b/src/hooks/usePodSync.ts
@@ -241,14 +241,15 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
    * Save data to the Pod
    */
   const saveToPod = useCallback(async (data: T): Promise<boolean> => {
-    if (!enabled || !isLoggedIn) {
+    const isForeignPod = !!pathConfig.podUrl
+    if (!enabled || (!isLoggedIn && !isForeignPod)) {
       return false;
     }
 
     setError(null);
 
     try {
-      const podUrl = pathConfig.podUrl ?? await getPrimaryPodUrl(session);
+      const podUrl = pathConfig.podUrl ?? await getPrimaryPodUrl(session!);
 
       if (!podUrl) {
         throw new Error('No pod URL found');
@@ -261,7 +262,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
       }
 
       await saveRdfToPod({
-        session: session!,
+        session: isLoggedIn ? session! : null,
         fileUrl,
         data,
         serializer: rdf.serialize,

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -282,8 +282,10 @@ export function ViewPackingList() {
                 }))
             }
 
-            // Save with sync prevention (handles local DB + Pod save)
-            if (isLoggedIn) {
+            // Save with sync prevention (handles local DB + Pod save).
+            // Also applies when not logged in but viewing a foreign pod — saveToPod
+            // will use globalThis.fetch for anonymous writes to publicly-shared resources.
+            if (isLoggedIn || foreignPodUrl) {
                 console.log('handleItemChange: Saving to local DB and Pod...')
                 const savedPackingList = await saveWithSyncPrevention(updatedPackingList, saveToPod);
                 if (savedPackingList) {
@@ -291,7 +293,7 @@ export function ViewPackingList() {
                     console.log('handleItemChange: Saved to local DB and Pod')
                 }
             } else {
-                // Not logged in, just save locally
+                // Not logged in and no pod target — local only
                 const dataWithTimestamp = {
                     ...updatedPackingList,
                     lastModified: new Date().toISOString()
@@ -302,7 +304,7 @@ export function ViewPackingList() {
                     _rev: dbResult.rev
                 };
                 setPackingList(savedPackingList);
-                console.log('handleItemChange: Saved to local DB')
+                console.log('handleItemChange: Saved to local DB only')
             }
 
             setAutoSaveStatus('saved')
@@ -331,12 +333,13 @@ export function ViewPackingList() {
     }, [watchedItems, handleItemChange])
 
     const persistPackingList = async (updatedPackingList: PackingList) => {
-        if (isLoggedIn) {
+        if (isLoggedIn || foreignPodUrl) {
             const savedPackingList = await saveWithSyncPrevention(updatedPackingList, saveToPod)
             if (savedPackingList) {
                 setPackingList(savedPackingList)
             }
-        } else if (!foreignPodCtx) {
+        } else {
+            // No pod target — save locally only
             const dataWithTimestamp = { ...updatedPackingList, lastModified: new Date().toISOString() }
             const dbResult = await db.savePackingList(dataWithTimestamp)
             setPackingList({ ...dataWithTimestamp, _rev: dbResult.rev })

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -498,6 +498,27 @@ describe('saveRdfToPod', () => {
             saveRdfToPod({ session: mockSession, fileUrl: 'https://x.example.com/f.ttl', data: {}, serializer: () => createSolidDataset() })
         ).rejects.toThrow(AuthenticationError)
     })
+
+    it('uses globalThis.fetch when session is null', async () => {
+        const url = `${POD_URL}pack-me-up/packing-lists/my-list.ttl`
+        const mockFetch = vi.fn() as typeof fetch
+        vi.stubGlobal('fetch', mockFetch)
+        mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
+
+        await saveRdfToPod({
+            session: null,
+            fileUrl: url,
+            data: makePackingList('my-list'),
+            serializer: packingListToDataset,
+        })
+
+        expect(mockOverwriteFile).toHaveBeenCalledWith(
+            url,
+            expect.any(Blob),
+            expect.objectContaining({ fetch: mockFetch, contentType: 'text/turtle' })
+        )
+        vi.unstubAllGlobals()
+    })
 })
 
 // ─── loadMultipleRdfFromPod ──────────────────────────────────────────────────

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -592,7 +592,7 @@ export async function loadFileFromPod<T>(options: LoadFromPodOptions): Promise<T
 // ── RDF Pod operations ────────────────────────────────────────────────────────
 
 export interface SaveRdfToPodOptions<T> {
-    session: Session
+    session: Session | null
     fileUrl: string
     data: T
     serializer: (data: T, datasetUrl: string) => SolidDataset
@@ -624,13 +624,14 @@ export async function loadRdfFromPod<T>(
  */
 export async function saveRdfToPod<T>(options: SaveRdfToPodOptions<T>): Promise<void> {
     const { session, fileUrl, data, serializer } = options
+    const fetchFn = session?.fetch ?? globalThis.fetch
     try {
         const newDataset = serializer(data, fileUrl)
         const turtleContent = await solidDatasetAsTurtle(newDataset)
         const blob = new Blob([turtleContent], { type: 'text/turtle' })
-        await overwriteFile(fileUrl, blob, { fetch: session.fetch, contentType: 'text/turtle' })
+        await overwriteFile(fileUrl, blob, { fetch: fetchFn, contentType: 'text/turtle' })
     } catch (error: unknown) {
-        if (isAuthenticationError(error)) handlePodError(error)
+        if (session && isAuthenticationError(error)) handlePodError(error)
         throw error
     }
 }


### PR DESCRIPTION
When User B (unauthenticated) edits a publicly shared list, changes were
only saved to their local browser storage and never reached the owner's pod.
The write path lacked the same anonymous-fetch fallback that the read path
already had.

Root cause: `saveRdfToPod` required a non-null Session and `usePodSync.saveToPod`
returned false immediately when `!isLoggedIn`, even for foreign pods that
grant public write access via ACL.

Fix:
- `saveRdfToPod` now accepts `session: Session | null` and falls back to
  `globalThis.fetch` for anonymous writes, matching `loadRdfFromPod`.
- `usePodSync.saveToPod` relaxes the `isLoggedIn` guard for foreign pods:
  allows writes when `pathConfig.podUrl` is set, passes `null` session.
- `view-packing-list` `handleItemChange` and `persistPackingList` now enter
  the pod-save path when `foreignPodUrl` is set, not only when logged in.

Tests: 2 new unit tests (red→green); 1 new E2E test L4 verifying an
anonymous checkbox change propagates to the list owner within one poll cycle.

https://claude.ai/code/session_015LeZnh1Q3hAX16RbB5Cx6L