### PR TITLE
Resolve concurrent packing list edits with CRDT set merge

### DIFF
--- a/src/hooks/useSyncCoordinator.test.ts
+++ b/src/hooks/useSyncCoordinator.test.ts
@@ -193,4 +193,131 @@ describe('useSyncCoordinator', () => {
       expect(updateFormAndState).toHaveBeenCalledOnce()
     })
   })
+
+  // ─────────────────────────────────────────────────────────────────
+  // CRDT merge function
+  // ─────────────────────────────────────────────────────────────────
+
+  describe('mergeFunction', () => {
+    interface MergeTestData extends TimestampedData {
+      id: string
+      items: string[]
+    }
+
+    const makeMergeData = (overrides: Partial<MergeTestData> = {}): MergeTestData => ({
+      id: 'list-1',
+      items: [],
+      ...overrides,
+    })
+
+    const mergeFn = (local: MergeTestData, pod: MergeTestData): MergeTestData => ({
+      ...(pod.lastModified! >= (local.lastModified ?? '') ? pod : local),
+      items: [...new Set([...local.items, ...pod.items])],
+    })
+
+    it('applies mergeFunction result instead of raw pod data when pod is newer', async () => {
+      const LOCAL_TIME = 1700000000000
+      const POD_TIME = LOCAL_TIME + 1000
+
+      const saveToLocalDb = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+      const updateFormAndState = vi.fn()
+      const currentData = makeMergeData({
+        items: ['local-item'],
+        lastModified: new Date(LOCAL_TIME).toISOString(),
+      })
+      const options = makeOptions({
+        currentData,
+        saveToLocalDb,
+        updateFormAndState,
+        conflictStrategy: 'fallback-to-pod',
+        mergeFunction: mergeFn,
+      })
+
+      const { result } = renderHook(() => useSyncCoordinator<MergeTestData>(options))
+
+      const podData = makeMergeData({
+        items: ['pod-item'],
+        lastModified: new Date(POD_TIME).toISOString(),
+      })
+
+      await act(async () => {
+        await result.current.handleSyncSuccess(podData)
+      })
+
+      // updateFormAndState should be called with merged items (both items present)
+      expect(updateFormAndState).toHaveBeenCalledOnce()
+      const [savedArg] = updateFormAndState.mock.calls[0]
+      expect(savedArg.items).toEqual(expect.arrayContaining(['local-item', 'pod-item']))
+    })
+
+    it('calls saveToPod with merged result to push convergence back to pod', async () => {
+      const LOCAL_TIME = 1700000000000
+      const POD_TIME = LOCAL_TIME + 1000
+
+      const saveToLocalDb = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+      const updateFormAndState = vi.fn()
+      const saveToPod = vi.fn().mockResolvedValue(true)
+      const currentData = makeMergeData({
+        items: ['local-item'],
+        lastModified: new Date(LOCAL_TIME).toISOString(),
+      })
+      const options = makeOptions({
+        currentData,
+        saveToLocalDb,
+        updateFormAndState,
+        conflictStrategy: 'fallback-to-pod',
+        mergeFunction: mergeFn,
+        saveToPod,
+      })
+
+      const { result } = renderHook(() => useSyncCoordinator<MergeTestData>(options))
+
+      const podData = makeMergeData({
+        items: ['pod-item'],
+        lastModified: new Date(POD_TIME).toISOString(),
+      })
+
+      await act(async () => {
+        await result.current.handleSyncSuccess(podData)
+      })
+
+      expect(saveToPod).toHaveBeenCalledOnce()
+      const pushedData = saveToPod.mock.calls[0][0]
+      expect(pushedData.items).toEqual(expect.arrayContaining(['local-item', 'pod-item']))
+    })
+
+    it('does not call saveToPod during merge-back push when no saveToPod is configured', async () => {
+      const LOCAL_TIME = 1700000000000
+      const POD_TIME = LOCAL_TIME + 1000
+
+      const saveToLocalDb = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+      const updateFormAndState = vi.fn()
+      const currentData = makeMergeData({
+        items: ['local-item'],
+        lastModified: new Date(LOCAL_TIME).toISOString(),
+      })
+      // No saveToPod provided
+      const options = makeOptions({
+        currentData,
+        saveToLocalDb,
+        updateFormAndState,
+        conflictStrategy: 'fallback-to-pod',
+        mergeFunction: mergeFn,
+      })
+
+      const { result } = renderHook(() => useSyncCoordinator<MergeTestData>(options))
+
+      const podData = makeMergeData({
+        items: ['pod-item'],
+        lastModified: new Date(POD_TIME).toISOString(),
+      })
+
+      // Should not throw even without saveToPod
+      await expect(act(async () => {
+        await result.current.handleSyncSuccess(podData)
+      })).resolves.not.toThrow()
+
+      expect(updateFormAndState).toHaveBeenCalledOnce()
+    })
+  })
 })

--- a/src/hooks/useSyncCoordinator.ts
+++ b/src/hooks/useSyncCoordinator.ts
@@ -43,6 +43,20 @@ export interface SyncCoordinatorOptions<T extends TimestampedData> {
   conflictStrategy?: ConflictStrategy;
 
   /**
+   * Optional merge function for CRDT-style conflict resolution.
+   * When provided, called instead of simple replacement when pod data is applicable.
+   * The result is saved locally and, if saveToPod is also provided, pushed back to
+   * the pod so both peers converge to the same merged state.
+   */
+  mergeFunction?: (local: T, remote: T) => T;
+
+  /**
+   * Optional pod save function used to push merged results back after a merge.
+   * Only called when mergeFunction is also provided.
+   */
+  saveToPod?: (data: T) => Promise<boolean>;
+
+  /**
    * Duration to show sync indicator (milliseconds)
    */
   syncIndicatorDuration?: number;
@@ -105,6 +119,8 @@ export function useSyncCoordinator<T extends TimestampedData>(
     saveToLocalDb,
     updateFormAndState,
     conflictStrategy = 'fallback-to-pod',
+    mergeFunction,
+    saveToPod: saveToPodOption,
     syncIndicatorDuration = 2000,
   } = options;
 
@@ -228,19 +244,35 @@ export function useSyncCoordinator<T extends TimestampedData>(
       setSyncingFromPod(true);
 
       try {
+        // Apply merge function if provided, otherwise use pod data as-is
+        const resolved: T = mergeFunction && currentData
+          ? mergeFunction(currentData, data)
+          : { ...data };
+
         // Remove _rev to avoid conflicts with local database version
-        const dataWithoutRev = { ...data };
-        delete dataWithoutRev._rev;
+        delete (resolved as Record<string, unknown>)._rev;
 
         // Save to local database to get the proper _rev
-        const dbResult = await saveToLocalDb(dataWithoutRev as T);
+        const dbResult = await saveToLocalDb(resolved);
 
-        // Update form and state with synced data
+        const resolvedWithRev = { ...resolved, _rev: dbResult.rev } as T;
+
+        // Update form and state with resolved data
         preserveFocusAndSelection(() => {
-          updateFormAndState(dataWithoutRev as T, dbResult.rev);
+          updateFormAndState(resolved, dbResult.rev);
         });
 
-        lastSyncedDataRef.current = incomingDataString;
+        lastSyncedDataRef.current = JSON.stringify(resolvedWithRev);
+
+        // Push merged result back to pod so both peers converge
+        if (mergeFunction && saveToPodOption && currentData) {
+          const mergedTimestamp = resolved.lastModified;
+          lastSavedTimestampRef.current = mergedTimestamp ?? null;
+          isLocalChangeRef.current = true;
+          saveToPodOption(resolvedWithRev).finally(() => {
+            setTimeout(() => { isLocalChangeRef.current = false; }, SYNC_PREVENTION_WINDOW_MS);
+          });
+        }
 
         // Show sync indicator briefly
         setTimeout(() => setSyncingFromPod(false), syncIndicatorDuration);
@@ -256,6 +288,8 @@ export function useSyncCoordinator<T extends TimestampedData>(
       shouldApplyPodData,
       preserveFocusAndSelection,
       syncIndicatorDuration,
+      mergeFunction,
+      saveToPodOption,
     ]
   );
 

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -16,6 +16,7 @@ import { packingListToDataset, datasetToPackingList } from '../services/rdfSeria
 import { SharePackingListModal } from '../components/SharePackingListModal'
 import { useForeignPod } from '../components/ForeignPodContext'
 import { useSharedListsSync } from '../hooks/useSharedListsSync'
+import { mergePackingLists } from '../utils/mergePackingLists'
 
 type FormData = {
     items: Record<string, boolean>
@@ -145,6 +146,10 @@ export function ViewPackingList() {
     // Use useWatch instead of watch() for proper re-renders on form changes
     const watchedItems = useWatch({ control, name: 'items', defaultValue: {} })
 
+    // Ref to the pod save function so useSyncCoordinator can push merged results back.
+    // Populated after usePodSync is called below.
+    const saveToPodRef = useRef<((data: PackingList) => Promise<boolean>) | undefined>(undefined)
+
     // Set up sync coordination (handles conflict resolution, focus preservation, etc.)
     const { syncingFromPod, handleSyncSuccess, handleSyncError, saveWithSyncPrevention } =
         useSyncCoordinator<PackingList>({
@@ -166,7 +171,9 @@ export function ViewPackingList() {
                 });
                 reset({ items: formValues });
             },
-            conflictStrategy: 'fallback-to-pod', // Use same strategy as edit questions for consistency
+            conflictStrategy: 'fallback-to-pod',
+            mergeFunction: mergePackingLists,
+            saveToPod: saveToPodRef.current,
         });
 
     // When viewing a shared (foreign) pod list and the initial pod fetch fails,
@@ -207,6 +214,11 @@ export function ViewPackingList() {
         onSaveSuccess: handleSaveSuccess,
         onSaveError: handleSaveError,
     });
+
+    // Keep saveToPodRef in sync so useSyncCoordinator can push merge results back to pod
+    useEffect(() => {
+        saveToPodRef.current = saveToPod
+    }, [saveToPod])
 
     useEffect(() => {
         const fetchPackingList = async () => {

--- a/src/utils/mergePackingLists.test.ts
+++ b/src/utils/mergePackingLists.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest'
+import { mergePackingLists } from './mergePackingLists'
+import { PackingList, PackingListItem } from '../create-packing-list/types'
+
+const makeItem = (overrides: Partial<PackingListItem> = {}): PackingListItem => ({
+  id: 'item-1',
+  itemText: 'Toothbrush',
+  personId: 'person-1',
+  personName: 'Alice',
+  questionId: 'q-1',
+  optionId: 'opt-1',
+  packed: false,
+  ...overrides,
+})
+
+const makeList = (overrides: Partial<PackingList> = {}): PackingList => ({
+  id: 'list-1',
+  name: 'Trip',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  lastModified: '2024-01-01T10:00:00.000Z',
+  items: [],
+  ...overrides,
+})
+
+describe('mergePackingLists', () => {
+  describe('concurrent adds', () => {
+    it('preserves items added by both users', () => {
+      const itemP = makeItem({ id: 'item-P', itemText: 'Passport' })
+      const itemQ = makeItem({ id: 'item-Q', itemText: 'Sunscreen' })
+
+      const local = makeList({
+        items: [itemP],
+        lastModified: '2024-01-01T10:00:00.000Z',
+      })
+      const pod = makeList({
+        items: [itemQ],
+        lastModified: '2024-01-01T10:00:01.000Z',
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items).toHaveLength(2)
+      expect(result.items.map(i => i.id)).toEqual(expect.arrayContaining(['item-P', 'item-Q']))
+    })
+
+    it('preserves all pre-existing shared items alongside newly added ones', () => {
+      const shared = makeItem({ id: 'item-X', itemText: 'Shoes' })
+      const itemP = makeItem({ id: 'item-P', itemText: 'Passport' })
+      const itemQ = makeItem({ id: 'item-Q', itemText: 'Sunscreen' })
+
+      const local = makeList({
+        items: [shared, itemP],
+        lastModified: '2024-01-01T10:00:00.000Z',
+      })
+      const pod = makeList({
+        items: [shared, itemQ],
+        lastModified: '2024-01-01T10:00:01.000Z',
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items).toHaveLength(3)
+      expect(result.items.map(i => i.id)).toEqual(expect.arrayContaining(['item-X', 'item-P', 'item-Q']))
+    })
+  })
+
+  describe('metadata', () => {
+    it('uses newer list metadata for list-level fields', () => {
+      const local = makeList({
+        name: 'Old name',
+        lastModified: '2024-01-01T10:00:00.000Z',
+      })
+      const pod = makeList({
+        name: 'New name',
+        lastModified: '2024-01-01T10:00:01.000Z',
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.name).toBe('New name')
+      expect(result.lastModified).toBe('2024-01-01T10:00:01.000Z')
+    })
+
+    it('uses local metadata when local is newer', () => {
+      const local = makeList({
+        name: 'Local name',
+        lastModified: '2024-01-01T10:00:02.000Z',
+      })
+      const pod = makeList({
+        name: 'Pod name',
+        lastModified: '2024-01-01T10:00:00.000Z',
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.name).toBe('Local name')
+    })
+  })
+
+  describe('same item field conflicts', () => {
+    it('uses newer list version of an item when both sides have same item ID', () => {
+      const itemInPod = makeItem({ id: 'item-1', packed: true })
+      const itemInLocal = makeItem({ id: 'item-1', packed: false })
+
+      const local = makeList({
+        items: [itemInLocal],
+        lastModified: '2024-01-01T10:00:00.000Z',
+      })
+      const pod = makeList({
+        items: [itemInPod],
+        lastModified: '2024-01-01T10:00:01.000Z',
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items).toHaveLength(1)
+      expect(result.items[0].packed).toBe(true)
+    })
+  })
+
+  describe('deletions', () => {
+    it('excludes items that appear in either deletedItems list (delete-wins)', () => {
+      const itemA = makeItem({ id: 'item-A', itemText: 'A' })
+      const itemB = makeItem({ id: 'item-B', itemText: 'B' })
+
+      const local = makeList({
+        items: [itemA, itemB],
+        lastModified: '2024-01-01T10:00:00.000Z',
+      })
+      const pod = makeList({
+        items: [itemA],
+        deletedItems: [itemB],
+        lastModified: '2024-01-01T10:00:01.000Z',
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items.map(i => i.id)).not.toContain('item-B')
+      expect(result.deletedItems?.map(i => i.id)).toContain('item-B')
+    })
+
+    it('unions deletedItems from both sides', () => {
+      const itemA = makeItem({ id: 'item-A', itemText: 'A' })
+      const itemB = makeItem({ id: 'item-B', itemText: 'B' })
+      const itemC = makeItem({ id: 'item-C', itemText: 'C' })
+
+      const local = makeList({
+        items: [itemC],
+        deletedItems: [itemA],
+        lastModified: '2024-01-01T10:00:00.000Z',
+      })
+      const pod = makeList({
+        items: [itemC],
+        deletedItems: [itemB],
+        lastModified: '2024-01-01T10:00:01.000Z',
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.deletedItems?.map(i => i.id)).toEqual(expect.arrayContaining(['item-A', 'item-B']))
+    })
+
+    it('add-vs-delete conflict: delete wins', () => {
+      const itemA = makeItem({ id: 'item-A', itemText: 'A' })
+
+      // Local still has the item; pod has deleted it
+      const local = makeList({
+        items: [itemA],
+        lastModified: '2024-01-01T10:00:00.000Z',
+      })
+      const pod = makeList({
+        items: [],
+        deletedItems: [itemA],
+        lastModified: '2024-01-01T10:00:01.000Z',
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items).toHaveLength(0)
+      expect(result.deletedItems?.map(i => i.id)).toContain('item-A')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles local with no items', () => {
+      const itemQ = makeItem({ id: 'item-Q', itemText: 'Sunscreen' })
+
+      const local = makeList({ items: [], lastModified: '2024-01-01T10:00:00.000Z' })
+      const pod = makeList({ items: [itemQ], lastModified: '2024-01-01T10:00:01.000Z' })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items).toHaveLength(1)
+      expect(result.items[0].id).toBe('item-Q')
+    })
+
+    it('handles pod with no items', () => {
+      const itemP = makeItem({ id: 'item-P', itemText: 'Passport' })
+
+      const local = makeList({ items: [itemP], lastModified: '2024-01-01T10:00:01.000Z' })
+      const pod = makeList({ items: [], lastModified: '2024-01-01T10:00:00.000Z' })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items).toHaveLength(1)
+      expect(result.items[0].id).toBe('item-P')
+    })
+
+    it('returns stable result when both sides are identical', () => {
+      const item = makeItem({ id: 'item-1' })
+      const local = makeList({ items: [item], lastModified: '2024-01-01T10:00:00.000Z' })
+      const pod = makeList({ items: [item], lastModified: '2024-01-01T10:00:00.000Z' })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items).toHaveLength(1)
+    })
+
+    it('handles missing lastModified on one side', () => {
+      const itemP = makeItem({ id: 'item-P' })
+      const itemQ = makeItem({ id: 'item-Q' })
+
+      const local: PackingList = { ...makeList({ items: [itemP] }), lastModified: undefined }
+      const pod = makeList({ items: [itemQ], lastModified: '2024-01-01T10:00:01.000Z' })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items.map(i => i.id)).toEqual(expect.arrayContaining(['item-P', 'item-Q']))
+    })
+  })
+})

--- a/src/utils/mergePackingLists.ts
+++ b/src/utils/mergePackingLists.ts
@@ -1,0 +1,29 @@
+import { PackingList, PackingListItem } from '../create-packing-list/types'
+
+export function mergePackingLists(local: PackingList, pod: PackingList): PackingList {
+  const localMs = local.lastModified ? new Date(local.lastModified).getTime() : 0
+  const podMs = pod.lastModified ? new Date(pod.lastModified).getTime() : 0
+  const [newer, older] = podMs >= localMs ? [pod, local] : [local, pod]
+
+  // Build item map: older items first, then overlay newer (LWW per item by list timestamp)
+  const itemMap = new Map<string, PackingListItem>()
+  for (const item of [...older.items, ...newer.items]) itemMap.set(item.id, item)
+
+  // Union of deleted IDs from both versions (delete-wins)
+  const deletedIds = new Set([
+    ...(local.deletedItems ?? []).map(i => i.id),
+    ...(pod.deletedItems ?? []).map(i => i.id),
+  ])
+
+  // Union of deleted item objects, deduplicated by ID
+  const deletedMap = new Map<string, PackingListItem>()
+  for (const item of [...(local.deletedItems ?? []), ...(pod.deletedItems ?? [])]) {
+    deletedMap.set(item.id, item)
+  }
+
+  return {
+    ...newer,
+    items: [...itemMap.values()].filter(i => !deletedIds.has(i.id)),
+    deletedItems: [...deletedMap.values()],
+  }
+}


### PR DESCRIPTION
When two users add items simultaneously, the second PUT overwrites the
first under the old last-write-wins strategy, silently dropping items.

Introduce a merge function (add-wins set with delete-wins semantics) that
unions items by ID from both local and pod versions whenever the sync
coordinator receives newer pod data. After merging, the coordinator pushes
the converged result back to the pod so both peers reach the same state
within one extra poll cycle.

- src/utils/mergePackingLists.ts: pure CRDT merge (union items, delete-wins)
- src/hooks/useSyncCoordinator.ts: optional mergeFunction + saveToPod opts
- src/pages/view-packing-list.tsx: wire mergePackingLists into the coordinator
- 15 new unit tests (12 for merge logic, 3 for coordinator merge path)

https://claude.ai/code/session_01YP3zqCVdzioUnqsiAD74ub