### PR TITLE
Implement per-item LWW conflict resolution for packing list items

### DIFF
--- a/src/create-packing-list/types.ts
+++ b/src/create-packing-list/types.ts
@@ -21,6 +21,7 @@ export interface PackingListItem {
     packed: boolean
     category?: string
     reviewed?: boolean
+    lastModified?: string // ISO timestamp; absent on legacy items
 }
 
 export interface PackingListFormData {

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -286,12 +286,14 @@ export function ViewPackingList() {
 
             console.log('handleItemChange: Changes detected, saving...')
             setAutoSaveStatus('saving')
+            const now = new Date().toISOString()
             const updatedPackingList: PackingList = {
                 ...packingList,
-                items: packingList.items.map(item => ({
-                    ...item,
-                    packed: currentFormValues[item.id] ?? false
-                }))
+                items: packingList.items.map(item => {
+                    const newPacked = currentFormValues[item.id] ?? false
+                    if (item.packed === newPacked) return item
+                    return { ...item, packed: newPacked, lastModified: now }
+                })
             }
 
             // Save with sync prevention (handles local DB + Pod save).
@@ -368,8 +370,9 @@ export function ViewPackingList() {
             const updatedItems = packingList.items.filter(i => i.id !== itemId)
 
             // Track deletions for question-set items so the user can be prompted later
+            const deletedAt = new Date().toISOString()
             const newDeletedItems = item && item.questionId !== ''
-                ? [...(packingList.deletedItems ?? []), { ...item, reviewed: false }]
+                ? [...(packingList.deletedItems ?? []), { ...item, reviewed: false, lastModified: deletedAt }]
                 : (packingList.deletedItems ?? [])
 
             const updatedPackingList: PackingList = {
@@ -414,8 +417,9 @@ export function ViewPackingList() {
         try {
             setAutoSaveStatus('saving')
 
+            const now = new Date().toISOString()
             const updatedItems = packingList.items.map(item =>
-                item.id === itemId ? { ...item, itemText: trimmed } : item
+                item.id === itemId ? { ...item, itemText: trimmed, lastModified: now } : item
             )
             await persistPackingList({ ...packingList, items: updatedItems })
 
@@ -446,7 +450,8 @@ export function ViewPackingList() {
                 personId: personId,
                 questionId: '',
                 optionId: '',
-                packed: false
+                packed: false,
+                lastModified: new Date().toISOString(),
             }
 
             // Add to form values and clear the input before saving

--- a/src/services/rdfSerialization.test.ts
+++ b/src/services/rdfSerialization.test.ts
@@ -153,6 +153,23 @@ describe('packingListToDataset / datasetToPackingList', () => {
         const result = roundTripList(makePackingList())
         expect(result.deletedItems).toEqual([])
     })
+
+    it('round-trips item lastModified', () => {
+        const item = makeItem({ lastModified: '2024-06-01T12:00:00.000Z' })
+        const result = roundTripList(makePackingList({ items: [item] }))
+        expect(result.items[0].lastModified).toBe('2024-06-01T12:00:00.000Z')
+    })
+
+    it('omits item lastModified when not set', () => {
+        const result = roundTripList(makePackingList({ items: [makeItem()] }))
+        expect(result.items[0].lastModified).toBeUndefined()
+    })
+
+    it('round-trips deletedItem lastModified', () => {
+        const deleted = makeItem({ id: 'item-del', lastModified: '2024-05-01T00:00:00.000Z' })
+        const result = roundTripList(makePackingList({ deletedItems: [deleted] }))
+        expect(result.deletedItems![0].lastModified).toBe('2024-05-01T00:00:00.000Z')
+    })
 })
 
 // ── QuestionSet round-trip ────────────────────────────────────────────────────

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -110,6 +110,7 @@ function packingListItemToThing(item: PackingListItem, itemUrl: string): Thing {
 
     if (item.category !== undefined) t = t.addStringNoLocale(PMU.category, item.category)
     if (item.reviewed !== undefined) t = t.addBoolean(PMU.reviewed, item.reviewed)
+    if (item.lastModified !== undefined) t = t.addDatetime(PMU.itemLastModified, new Date(item.lastModified))
 
     return t.build()
 }
@@ -127,6 +128,7 @@ function thingToPackingListItem(thing: Thing | null, url: string): PackingListIt
     const packed = getBoolean(thing, PMU.packed) ?? false
     const category = getStringNoLocale(thing, PMU.category) ?? undefined
     const reviewed = getBoolean(thing, PMU.reviewed)
+    const itemLastModified = getDatetime(thing, PMU.itemLastModified)?.toISOString()
 
     return {
         id,
@@ -138,6 +140,7 @@ function thingToPackingListItem(thing: Thing | null, url: string): PackingListIt
         packed,
         ...(category !== undefined ? { category } : {}),
         ...(reviewed !== null ? { reviewed } : {}),
+        ...(itemLastModified !== undefined ? { lastModified: itemLastModified } : {}),
     }
 }
 

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -27,6 +27,7 @@ export const PMU = {
     packed: `${PMU_NS}packed`,
     category: `${PMU_NS}category`,
     reviewed: `${PMU_NS}reviewed`,
+    itemLastModified: `${PMU_NS}itemLastModified`,
 
     // QuestionSet predicates
     hasPerson: `${PMU_NS}hasPerson`,

--- a/src/utils/mergePackingLists.test.ts
+++ b/src/utils/mergePackingLists.test.ts
@@ -181,6 +181,100 @@ describe('mergePackingLists', () => {
     })
   })
 
+  describe('per-item LWW (item-level lastModified)', () => {
+    it('local item wins when its lastModified is newer, regardless of list timestamps', () => {
+      const local = makeList({
+        lastModified: '2024-01-01T10:00:05.000Z',
+        items: [makeItem({ id: 'item-1', packed: true, lastModified: '2024-01-01T10:00:10.000Z' })],
+      })
+      const pod = makeList({
+        lastModified: '2024-01-01T10:00:05.000Z',
+        items: [makeItem({ id: 'item-1', packed: false, lastModified: '2024-01-01T10:00:03.000Z' })],
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items[0].packed).toBe(true)
+    })
+
+    it('pod item wins when its lastModified is newer, even when local list is newer', () => {
+      const local = makeList({
+        lastModified: '2024-01-01T10:00:10.000Z',
+        items: [makeItem({ id: 'item-1', packed: false, lastModified: '2024-01-01T10:00:03.000Z' })],
+      })
+      const pod = makeList({
+        lastModified: '2024-01-01T10:00:05.000Z',
+        items: [makeItem({ id: 'item-1', packed: true, lastModified: '2024-01-01T10:00:08.000Z' })],
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items[0].packed).toBe(true)
+    })
+
+    it('falls back to list-level LWW when local item has no timestamp', () => {
+      const local = makeList({
+        lastModified: '2024-01-01T10:00:03.000Z',
+        items: [makeItem({ id: 'item-1', packed: false })],
+      })
+      const pod = makeList({
+        lastModified: '2024-01-01T10:00:10.000Z',
+        items: [makeItem({ id: 'item-1', packed: true, lastModified: '2024-01-01T10:00:08.000Z' })],
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items[0].packed).toBe(true) // pod list is newer → list-level LWW → pod wins
+    })
+
+    it('falls back to list-level LWW when neither item has a timestamp', () => {
+      const local = makeList({
+        lastModified: '2024-01-01T10:00:10.000Z',
+        items: [makeItem({ id: 'item-1', packed: true })],
+      })
+      const pod = makeList({
+        lastModified: '2024-01-01T10:00:05.000Z',
+        items: [makeItem({ id: 'item-1', packed: false })],
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items[0].packed).toBe(true) // local list is newer → existing behavior
+    })
+
+    it('pod item wins when both have equal item-level timestamps', () => {
+      const ts = '2024-01-01T10:00:05.000Z'
+      const local = makeList({
+        lastModified: '2024-01-01T10:00:03.000Z',
+        items: [makeItem({ id: 'item-1', packed: false, lastModified: ts })],
+      })
+      const pod = makeList({
+        lastModified: '2024-01-01T10:00:03.000Z',
+        items: [makeItem({ id: 'item-1', packed: true, lastModified: ts })],
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items[0].packed).toBe(true) // pod wins on tie
+    })
+
+    it('items unique to each side are preserved regardless of item timestamps', () => {
+      const local = makeList({
+        lastModified: '2024-01-01T10:00:05.000Z',
+        items: [makeItem({ id: 'item-local', packed: false, lastModified: '2024-01-01T10:00:04.000Z' })],
+      })
+      const pod = makeList({
+        lastModified: '2024-01-01T10:00:05.000Z',
+        items: [makeItem({ id: 'item-pod', packed: true, lastModified: '2024-01-01T10:00:04.000Z' })],
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.items).toHaveLength(2)
+      expect(result.items.map(i => i.id)).toEqual(expect.arrayContaining(['item-local', 'item-pod']))
+    })
+  })
+
   describe('edge cases', () => {
     it('handles local with no items', () => {
       const itemQ = makeItem({ id: 'item-Q', itemText: 'Sunscreen' })

--- a/src/utils/mergePackingLists.ts
+++ b/src/utils/mergePackingLists.ts
@@ -1,13 +1,39 @@
 import { PackingList, PackingListItem } from '../create-packing-list/types'
 
+function resolveItem(
+  localItem: PackingListItem,
+  podItem: PackingListItem,
+  listLevelNewerIsLocal: boolean,
+): PackingListItem {
+  const localItemMs = localItem.lastModified ? new Date(localItem.lastModified).getTime() : null
+  const podItemMs = podItem.lastModified ? new Date(podItem.lastModified).getTime() : null
+
+  if (localItemMs !== null && podItemMs !== null) {
+    return podItemMs >= localItemMs ? podItem : localItem
+  }
+  return listLevelNewerIsLocal ? localItem : podItem
+}
+
 export function mergePackingLists(local: PackingList, pod: PackingList): PackingList {
   const localMs = local.lastModified ? new Date(local.lastModified).getTime() : 0
   const podMs = pod.lastModified ? new Date(pod.lastModified).getTime() : 0
-  const [newer, older] = podMs >= localMs ? [pod, local] : [local, pod]
+  const [newer] = podMs >= localMs ? [pod, local] : [local, pod]
+  const listLevelNewerIsLocal = localMs > podMs
 
-  // Build item map: older items first, then overlay newer (LWW per item by list timestamp)
+  const localItemMap = new Map(local.items.map(i => [i.id, i]))
+  const podItemMap = new Map(pod.items.map(i => [i.id, i]))
+  const allIds = new Set([...localItemMap.keys(), ...podItemMap.keys()])
+
   const itemMap = new Map<string, PackingListItem>()
-  for (const item of [...older.items, ...newer.items]) itemMap.set(item.id, item)
+  for (const id of allIds) {
+    const localItem = localItemMap.get(id)
+    const podItem = podItemMap.get(id)
+    if (localItem && podItem) {
+      itemMap.set(id, resolveItem(localItem, podItem, listLevelNewerIsLocal))
+    } else {
+      itemMap.set(id, (localItem ?? podItem)!)
+    }
+  }
 
   // Union of deleted IDs from both versions (delete-wins)
   const deletedIds = new Set([


### PR DESCRIPTION
When two versions of the same item conflict during sync, the item with
the newer per-item lastModified timestamp now wins, regardless of which
list version is newer overall. This prevents offline packed-status changes
from being silently overwritten by an unrelated list update from another
device. Items without per-item timestamps (all existing data) fall back to
the previous list-level LWW behaviour, preserving full backward compatibility.

https://claude.ai/code/session_01P3i9XCGdL3Tq3FmaUUCXYC