### PR TITLE
Implement CRDT conflict resolution for question sets

### DIFF
--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -29,7 +29,9 @@ export const PersonSchema = z.object({
   id: z.string(),
   name: z.string(),
   ageRange: AgeRangeSchema.optional(),
-  gender: GenderSchema.optional()
+  gender: GenderSchema.optional(),
+  lastModified: z.string().optional(),
+  deletedAt: z.string().optional(),
 })
 
 export const PersonSelectionSchema = z.object({
@@ -38,8 +40,11 @@ export const PersonSelectionSchema = z.object({
 })
 
 export const ItemSchema = z.object({
+  id: z.string().optional(),
   text: z.string(),
-  personSelections: z.array(PersonSelectionSchema)
+  personSelections: z.array(PersonSelectionSchema),
+  lastModified: z.string().optional(),
+  deletedAt: z.string().optional(),
 })
 
 export const QuestionTypeSchema = z.enum(['single-choice', 'multiple-choice'])
@@ -56,7 +61,9 @@ const CommonQuestionSchema = z.object({
   text: z.string(),
   options: z.array(OptionSchema),
   order: z.number(),
-  questionType: QuestionTypeSchema.optional() // Optional for backward compatibility
+  questionType: QuestionTypeSchema.optional(),
+  lastModified: z.string().optional(),
+  deletedAt: z.string().optional(),
 })
 
 export const DraftQuestionSchema = CommonQuestionSchema.extend({

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -6,6 +6,7 @@ import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, n
 import { Link } from 'react-router-dom'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 import { usePodSync } from '../hooks/usePodSync'
+import { mergeQuestionSets } from '../utils/mergeQuestionSets'
 import { POD_CONTAINERS } from '../services/solidPod'
 import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSerialization'
 import { useSolidPod } from '../components/SolidPodContext'
@@ -889,6 +890,8 @@ export function QuestionsPage() {
     const [peopleModal, setPeopleModal] = useState(false)
     const [alwaysModal, setAlwaysModal] = useState(false)
 
+    const saveToPodRef = useRef<((data: PackingListQuestionSet) => Promise<boolean>) | undefined>(undefined)
+
     const { saveWithSyncPrevention, handleSyncSuccess, handleSyncError } = useSyncCoordinator<PackingListQuestionSet>({
         currentData: data,
         saveToLocalDb: async (d) => db.saveQuestionSet({ _id: '1', ...d, _rev: rev }),
@@ -897,6 +900,8 @@ export function QuestionsPage() {
             setData({ ...d, _rev: newRev })
         },
         conflictStrategy: 'fallback-to-pod',
+        mergeFunction: mergeQuestionSets,
+        saveToPod: saveToPodRef.current,
     })
 
     const { saveToPod } = usePodSync<PackingListQuestionSet>({
@@ -907,6 +912,9 @@ export function QuestionsPage() {
         onSyncSuccess: handleSyncSuccess,
         onSyncError: handleSyncError,
     })
+
+    // Keep saveToPodRef in sync so useSyncCoordinator can push merge results back to pod
+    useEffect(() => { saveToPodRef.current = saveToPod }, [saveToPod])
 
     useEffect(() => {
         if (loginSyncInProgress) return
@@ -939,14 +947,15 @@ export function QuestionsPage() {
     const handleQuestionModalSave = useCallback(async (text: string, type: QuestionType) => {
         if (!data || questionModal === null) return
         const questions = data.questions ?? []
+        const now = new Date().toISOString()
         let newQuestions: Question[]
         if (questionModal.question) {
             newQuestions = questions.map(q =>
-                q.id === questionModal.question!.id ? { ...q, text, questionType: type } : q
+                q.id === questionModal.question!.id ? { ...q, text, questionType: type, lastModified: now } : q
             )
         } else {
             const maxOrder = questions.reduce((max, q) => Math.max(max, q.order), -1)
-            newQuestions = [...questions, { ...newDraftQuestion(maxOrder + 1), text, questionType: type }]
+            newQuestions = [...questions, { ...newDraftQuestion(maxOrder + 1), text, questionType: type, lastModified: now }]
         }
         setQuestionModal(null)
         await saveData({ ...data, questions: newQuestions })
@@ -954,18 +963,25 @@ export function QuestionsPage() {
 
     const handleDeleteQuestion = useCallback(async (id: string) => {
         if (!data) return
-        await saveData({ ...data, questions: data.questions.filter(q => q.id !== id) })
+        const now = new Date().toISOString()
+        await saveData({
+            ...data,
+            questions: data.questions.map(q => q.id === id ? { ...q, deletedAt: now } : q),
+        })
     }, [data, saveData])
 
     const handleMoveQuestion = useCallback(async (id: string, direction: 'up' | 'down') => {
         if (!data) return
-        const idx = data.questions.findIndex(q => q.id === id)
+        const active = data.questions.filter(q => !q.deletedAt)
+        const idx = active.findIndex(q => q.id === id)
         if (idx < 0) return
         const swapIdx = direction === 'up' ? idx - 1 : idx + 1
-        if (swapIdx < 0 || swapIdx >= data.questions.length) return
-        const newQuestions = [...data.questions]
-        ;[newQuestions[idx], newQuestions[swapIdx]] = [newQuestions[swapIdx], newQuestions[idx]]
-        await saveData({ ...data, questions: newQuestions })
+        if (swapIdx < 0 || swapIdx >= active.length) return
+        const newActive = [...active]
+        ;[newActive[idx], newActive[swapIdx]] = [newActive[swapIdx], newActive[idx]]
+        // Rebuild full questions array preserving deleted ones
+        const deletedQuestions = data.questions.filter(q => q.deletedAt)
+        await saveData({ ...data, questions: [...newActive, ...deletedQuestions] })
     }, [data, saveData])
 
     const handleOptionModalSave = useCallback(async (updatedOption: Option) => {
@@ -996,10 +1012,29 @@ export function QuestionsPage() {
     const handlePeopleSave = useCallback(async (newPeople: Person[]) => {
         if (!data) return
         const oldPeople = data.people ?? []
-        const reconcile = (items: Item[]) => reconcileItems(items, oldPeople, newPeople)
+        const oldPeopleMap = new Map(oldPeople.map(p => [p.id, p]))
+        const newPeopleIds = new Set(newPeople.map(p => p.id))
+        const now = new Date().toISOString()
+
+        // Stamp lastModified on new or changed people
+        const stamped: Person[] = newPeople.map(p => {
+            const existing = oldPeopleMap.get(p.id)
+            const changed = !existing || existing.name !== p.name ||
+                existing.ageRange !== p.ageRange || existing.gender !== p.gender
+            return changed ? { ...p, lastModified: now } : p
+        })
+
+        // Mark removed people as deleted; preserve previously-deleted people
+        const previouslyDeleted = oldPeople.filter(p => p.deletedAt)
+        const nowDeleted = oldPeople
+            .filter(p => !p.deletedAt && !newPeopleIds.has(p.id))
+            .map(p => ({ ...p, deletedAt: now }))
+        const allPeople = [...stamped, ...nowDeleted, ...previouslyDeleted]
+
+        const reconcile = (items: Item[]) => reconcileItems(items, oldPeople.filter(p => !p.deletedAt), stamped)
         const newData: PackingListQuestionSet = {
             ...data,
-            people: newPeople,
+            people: allPeople,
             alwaysNeededItems: reconcile(data.alwaysNeededItems ?? []),
             questions: data.questions.map(q => ({
                 ...q,
@@ -1021,8 +1056,8 @@ export function QuestionsPage() {
     const allItemNames = useMemo(() => {
         if (!data) return []
         const names = [
-            ...(data.alwaysNeededItems ?? []).map(i => i.text),
-            ...data.questions.flatMap(q => q.options.flatMap(o => o.items.map(i => i.text))),
+            ...(data.alwaysNeededItems ?? []).filter(i => !i.deletedAt).map(i => i.text),
+            ...data.questions.filter(q => !q.deletedAt).flatMap(q => q.options.flatMap(o => o.items.filter(i => !i.deletedAt).map(i => i.text))),
         ].filter(Boolean)
         return [...new Set(names)]
     }, [data])
@@ -1030,7 +1065,9 @@ export function QuestionsPage() {
     if (error) return <div className="p-8 text-red-600">Error: {error}</div>
     if (!data) return <div className="p-8 text-gray-500">Loading…</div>
 
-    const people = data.people ?? []
+    const people = (data.people ?? []).filter(p => !p.deletedAt)
+    const activeQuestions = data.questions.filter(q => !q.deletedAt)
+    const activeAlwaysNeededItems = (data.alwaysNeededItems ?? []).filter(i => !i.deletedAt)
 
     return (
         <div className="w-full flex flex-col items-center py-8 px-4">
@@ -1041,8 +1078,8 @@ export function QuestionsPage() {
                     {!isForeign && <p className="mt-1 text-xs text-gray-400">Want to start from scratch? <Link to="/wizard" className="text-primary-600 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</p>}
                 </div>
                 <PersonLegend people={people} onEdit={() => setPeopleModal(true)} />
-                <AlwaysSection items={data.alwaysNeededItems ?? []} people={people} onEdit={() => setAlwaysModal(true)} />
-                {data.questions.map((q, qi) => (
+                <AlwaysSection items={activeAlwaysNeededItems} people={people} onEdit={() => setAlwaysModal(true)} />
+                {activeQuestions.map((q, qi) => (
                     <QuestionSection
                         key={q.id}
                         question={q}
@@ -1053,7 +1090,7 @@ export function QuestionsPage() {
                         onEditOption={(option) => setOptionModal({ questionId: q.id, option })}
                         onDeleteOption={(optionId) => handleDeleteOption(q.id, optionId)}
                         onMoveUp={qi > 0 ? () => handleMoveQuestion(q.id, 'up') : undefined}
-                        onMoveDown={qi < data.questions.length - 1 ? () => handleMoveQuestion(q.id, 'down') : undefined}
+                        onMoveDown={qi < activeQuestions.length - 1 ? () => handleMoveQuestion(q.id, 'down') : undefined}
                     />
                 ))}
                 <button
@@ -1082,7 +1119,7 @@ export function QuestionsPage() {
             )}
             {alwaysModal && (
                 <AlwaysNeededModal
-                    initialItems={data.alwaysNeededItems ?? []}
+                    initialItems={activeAlwaysNeededItems}
                     people={people}
                     allItemNames={allItemNames}
                     onSave={handleAlwaysSave}

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -223,21 +223,27 @@ function personToThing(person: Person, personUrl: string): Thing {
 
     if (person.ageRange) t = t.addStringNoLocale(PMU.ageRange, person.ageRange)
     if (person.gender) t = t.addStringNoLocale(PMU.gender, person.gender)
+    if (person.lastModified) t = t.addDatetime(PMU.personLastModified, new Date(person.lastModified))
+    if (person.deletedAt) t = t.addDatetime(PMU.personDeletedAt, new Date(person.deletedAt))
 
     return t.build()
 }
 
 function thingToPerson(thing: Thing | null, url: string): Person | null {
     if (!thing) return null
-    const id = url.split('#person-')[1] ?? url
+    const id = (url.split('#')[1] ?? '').replace(/^person-/, '') || url
     const name = getStringNoLocale(thing, PMU.name) ?? ''
     const ageRange = getStringNoLocale(thing, PMU.ageRange) ?? undefined
     const gender = getStringNoLocale(thing, PMU.gender) ?? undefined
+    const lastModified = getDatetime(thing, PMU.personLastModified)?.toISOString()
+    const deletedAt = getDatetime(thing, PMU.personDeletedAt)?.toISOString()
     return {
         id,
         name,
         ...(ageRange !== undefined ? { ageRange: ageRange as Person['ageRange'] } : {}),
         ...(gender !== undefined ? { gender: gender as Person['gender'] } : {}),
+        ...(lastModified !== undefined ? { lastModified } : {}),
+        ...(deletedAt !== undefined ? { deletedAt } : {}),
     }
 }
 
@@ -257,6 +263,12 @@ function questionToThings(
     if (question.questionType) {
         qBuilder = qBuilder.addStringNoLocale(PMU.questionType, question.questionType)
     }
+    if (question.lastModified) {
+        qBuilder = qBuilder.addDatetime(PMU.questionLastModified, new Date(question.lastModified))
+    }
+    if (question.deletedAt) {
+        qBuilder = qBuilder.addDatetime(PMU.questionDeletedAt, new Date(question.deletedAt))
+    }
 
     for (const option of question.options) {
         const optionUrl = `${datasetUrl}#option-${option.id}`
@@ -272,11 +284,13 @@ function thingToQuestion(dataset: SolidDataset, url: string): Question | null {
     const thing = getThing(dataset, url)
     if (!thing) return null
 
-    const id = url.split('#question-')[1] ?? url
+    const id = (url.split('#')[1] ?? '').replace(/^question-/, '') || url
     const text = getStringNoLocale(thing, PMU.text) ?? ''
     const type = (getStringNoLocale(thing, PMU.questionStatus) ?? 'saved') as Question['type']
     const order = getInteger(thing, PMU.order) ?? 0
     const questionType = getStringNoLocale(thing, PMU.questionType) ?? undefined
+    const lastModified = getDatetime(thing, PMU.questionLastModified)?.toISOString()
+    const deletedAt = getDatetime(thing, PMU.questionDeletedAt)?.toISOString()
 
     const optionUrls = getUrlAll(thing, PMU.hasOption)
     const options = optionUrls
@@ -291,6 +305,8 @@ function thingToQuestion(dataset: SolidDataset, url: string): Question | null {
         order,
         options,
         ...(questionType !== undefined ? { questionType: questionType as Question['questionType'] } : {}),
+        ...(lastModified !== undefined ? { lastModified } : {}),
+        ...(deletedAt !== undefined ? { deletedAt } : {}),
     }
 }
 
@@ -347,6 +363,10 @@ function questionItemToThings(
     let itemBuilder = buildThing({ url: itemUrl })
         .addUrl(RDF.type, PMU.QuestionItem)
         .addStringNoLocale(PMU.text, item.text)
+
+    if (item.id) itemBuilder = itemBuilder.addStringNoLocale(PMU.questionItemId, item.id)
+    if (item.lastModified) itemBuilder = itemBuilder.addDatetime(PMU.questionItemLastModified, new Date(item.lastModified))
+    if (item.deletedAt) itemBuilder = itemBuilder.addDatetime(PMU.questionItemDeletedAt, new Date(item.deletedAt))
 
     for (let i = 0; i < item.personSelections.length; i++) {
         const ps = item.personSelections[i]
@@ -506,6 +526,9 @@ function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
     if (!thing) return null
 
     const text = getStringNoLocale(thing, PMU.text) ?? ''
+    const id = getStringNoLocale(thing, PMU.questionItemId) ?? undefined
+    const lastModified = getDatetime(thing, PMU.questionItemLastModified)?.toISOString()
+    const deletedAt = getDatetime(thing, PMU.questionItemDeletedAt)?.toISOString()
 
     const psUrls = getUrlAll(thing, PMU.hasPersonSelection)
     const personSelectionsWithOrder: Array<PersonSelection & { order: number }> = psUrls
@@ -522,5 +545,11 @@ function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
     personSelectionsWithOrder.sort((a, b) => a.order - b.order)
     const personSelections: PersonSelection[] = personSelectionsWithOrder.map(({ personId, selected }) => ({ personId, selected }))
 
-    return { text, personSelections }
+    return {
+        text,
+        personSelections,
+        ...(id !== undefined ? { id } : {}),
+        ...(lastModified !== undefined ? { lastModified } : {}),
+        ...(deletedAt !== undefined ? { deletedAt } : {}),
+    }
 }

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -37,6 +37,8 @@ export const PMU = {
     // Person predicates
     ageRange: `${PMU_NS}ageRange`,
     gender: `${PMU_NS}gender`,
+    personLastModified: `${PMU_NS}personLastModified`,
+    personDeletedAt: `${PMU_NS}personDeletedAt`,
 
     // Question predicates
     hasOption: `${PMU_NS}hasOption`,
@@ -44,12 +46,17 @@ export const PMU = {
     questionStatus: `${PMU_NS}questionStatus`,
     order: `${PMU_NS}order`,
     text: `${PMU_NS}text`,
+    questionLastModified: `${PMU_NS}questionLastModified`,
+    questionDeletedAt: `${PMU_NS}questionDeletedAt`,
 
     // Option predicates
     hasQuestionItem: `${PMU_NS}hasQuestionItem`,
 
     // Item predicates (on option items and always-needed items)
     hasPersonSelection: `${PMU_NS}hasPersonSelection`,
+    questionItemId: `${PMU_NS}questionItemId`,
+    questionItemLastModified: `${PMU_NS}questionItemLastModified`,
+    questionItemDeletedAt: `${PMU_NS}questionItemDeletedAt`,
 
     // PersonSelection predicates
     selectionPersonId: `${PMU_NS}selectionPersonId`,

--- a/src/utils/mergeQuestionSets.test.ts
+++ b/src/utils/mergeQuestionSets.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from 'vitest'
+import { mergeQuestionSets } from './mergeQuestionSets'
+import type { PackingListQuestionSet, Question, Person, Item } from '../edit-questions/types'
+
+function makePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: 'p1',
+    name: 'Alice',
+    ...overrides,
+  }
+}
+
+function makeQuestion(overrides: Partial<Question> = {}): Question {
+  return {
+    id: 'q1',
+    text: 'Do you need a car seat?',
+    type: 'saved',
+    order: 0,
+    options: [],
+    ...overrides,
+  }
+}
+
+function makeItem(overrides: Partial<Item> = {}): Item {
+  return {
+    id: crypto.randomUUID(),
+    text: 'Sunscreen',
+    personSelections: [],
+    ...overrides,
+  }
+}
+
+function makeQS(overrides: Partial<PackingListQuestionSet> = {}): PackingListQuestionSet {
+  return {
+    _id: '1',
+    people: [],
+    questions: [],
+    alwaysNeededItems: [],
+    lastModified: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+// ── Concurrent adds ───────────────────────────────────────────────────────────
+
+describe('concurrent question adds', () => {
+  it('preserves both questions when each side added a unique one', () => {
+    const q1 = makeQuestion({ id: 'q1', text: 'Question 1', lastModified: '2024-01-01T10:00:00.000Z' })
+    const q2 = makeQuestion({ id: 'q2', text: 'Question 2', lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const local = makeQS({ questions: [q1], lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ questions: [q2], lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    const ids = result.questions.filter(q => !q.deletedAt).map(q => q.id)
+    expect(ids).toContain('q1')
+    expect(ids).toContain('q2')
+  })
+})
+
+describe('concurrent person adds', () => {
+  it('preserves both people when each side added a unique one', () => {
+    const p1 = makePerson({ id: 'p1', name: 'Alice', lastModified: '2024-01-01T10:00:00.000Z' })
+    const p2 = makePerson({ id: 'p2', name: 'Bob',   lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const local = makeQS({ people: [p1], lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ people: [p2], lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    const ids = result.people.filter(p => !p.deletedAt).map(p => p.id)
+    expect(ids).toContain('p1')
+    expect(ids).toContain('p2')
+  })
+})
+
+// ── Delete-wins ───────────────────────────────────────────────────────────────
+
+describe('delete-wins for questions', () => {
+  it('pod deletedAt beats local active question', () => {
+    const q = makeQuestion({ id: 'q1', lastModified: '2024-01-01T10:00:00.000Z' })
+    const qDeleted = { ...q, deletedAt: '2024-01-01T11:00:00.000Z' }
+
+    const local = makeQS({ questions: [q],        lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ questions: [qDeleted], lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    const active = result.questions.filter(q => !q.deletedAt)
+    expect(active.map(q => q.id)).not.toContain('q1')
+  })
+
+  it('local deletedAt beats pod active question', () => {
+    const q = makeQuestion({ id: 'q1', lastModified: '2024-01-01T10:00:00.000Z' })
+    const qDeleted = { ...q, deletedAt: '2024-01-01T09:00:00.000Z' }
+
+    const local = makeQS({ questions: [qDeleted], lastModified: '2024-01-01T09:00:00.000Z' })
+    const pod   = makeQS({ questions: [q],        lastModified: '2024-01-01T10:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    const active = result.questions.filter(q => !q.deletedAt)
+    expect(active.map(q => q.id)).not.toContain('q1')
+  })
+
+  it('deleted question is retained in the array so it propagates on next sync', () => {
+    const q = makeQuestion({ id: 'q1' })
+    const qDeleted = { ...q, deletedAt: '2024-01-01T11:00:00.000Z' }
+
+    const local = makeQS({ questions: [q],        lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ questions: [qDeleted], lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    expect(result.questions.some(q => q.id === 'q1' && q.deletedAt)).toBe(true)
+  })
+})
+
+describe('delete-wins for people', () => {
+  it('pod deletedAt beats local active person', () => {
+    const p = makePerson({ id: 'p1', lastModified: '2024-01-01T10:00:00.000Z' })
+    const pDeleted = { ...p, deletedAt: '2024-01-01T11:00:00.000Z' }
+
+    const local = makeQS({ people: [p],        lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ people: [pDeleted], lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    const active = result.people.filter(p => !p.deletedAt)
+    expect(active.map(p => p.id)).not.toContain('p1')
+  })
+})
+
+// ── Per-entity LWW ────────────────────────────────────────────────────────────
+
+describe('per-question LWW', () => {
+  it('pod question wins when its lastModified is newer, even if doc-level is older', () => {
+    const base = makeQuestion({ id: 'q1' })
+    const localQ = { ...base, text: 'Local text', lastModified: '2024-01-01T09:00:00.000Z' }
+    const podQ   = { ...base, text: 'Pod text',   lastModified: '2024-01-01T11:00:00.000Z' }
+
+    // Local doc is newer at doc level, but pod question has newer per-question timestamp
+    const local = makeQS({ questions: [localQ], lastModified: '2024-01-01T12:00:00.000Z' })
+    const pod   = makeQS({ questions: [podQ],   lastModified: '2024-01-01T10:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    const q = result.questions.find(q => q.id === 'q1')
+    expect(q?.text).toBe('Pod text')
+  })
+
+  it('local question wins when its lastModified is newer', () => {
+    const base = makeQuestion({ id: 'q1' })
+    const localQ = { ...base, text: 'Local text', lastModified: '2024-01-01T12:00:00.000Z' }
+    const podQ   = { ...base, text: 'Pod text',   lastModified: '2024-01-01T10:00:00.000Z' }
+
+    const local = makeQS({ questions: [localQ], lastModified: '2024-01-01T09:00:00.000Z' })
+    const pod   = makeQS({ questions: [podQ],   lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    const q = result.questions.find(q => q.id === 'q1')
+    expect(q?.text).toBe('Local text')
+  })
+
+  it('pod wins on timestamp tie', () => {
+    const ts = '2024-01-01T10:00:00.000Z'
+    const base = makeQuestion({ id: 'q1', lastModified: ts })
+    const localQ = { ...base, text: 'Local text' }
+    const podQ   = { ...base, text: 'Pod text' }
+
+    const local = makeQS({ questions: [localQ], lastModified: ts })
+    const pod   = makeQS({ questions: [podQ],   lastModified: ts })
+
+    const result = mergeQuestionSets(local, pod)
+    const q = result.questions.find(q => q.id === 'q1')
+    expect(q?.text).toBe('Pod text')
+  })
+})
+
+describe('per-person LWW', () => {
+  it('pod person wins when its lastModified is newer', () => {
+    const base = makePerson({ id: 'p1' })
+    const localP = { ...base, name: 'Alice', lastModified: '2024-01-01T09:00:00.000Z' }
+    const podP   = { ...base, name: 'Alicia', lastModified: '2024-01-01T11:00:00.000Z' }
+
+    const local = makeQS({ people: [localP], lastModified: '2024-01-01T12:00:00.000Z' })
+    const pod   = makeQS({ people: [podP],   lastModified: '2024-01-01T10:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    const p = result.people.find(p => p.id === 'p1')
+    expect(p?.name).toBe('Alicia')
+  })
+})
+
+// ── Fallback to doc-level LWW ─────────────────────────────────────────────────
+
+describe('fallback to doc-level LWW', () => {
+  it('local question wins when local doc is newer and neither question has lastModified', () => {
+    const localQ = makeQuestion({ id: 'q1', text: 'Local text' })
+    const podQ   = makeQuestion({ id: 'q1', text: 'Pod text' })
+    // No per-question lastModified on either
+
+    const local = makeQS({ questions: [localQ], lastModified: '2024-01-01T12:00:00.000Z' })
+    const pod   = makeQS({ questions: [podQ],   lastModified: '2024-01-01T10:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    expect(result.questions.find(q => q.id === 'q1')?.text).toBe('Local text')
+  })
+
+  it('pod question wins when pod doc is newer and neither question has lastModified', () => {
+    const localQ = makeQuestion({ id: 'q1', text: 'Local text' })
+    const podQ   = makeQuestion({ id: 'q1', text: 'Pod text' })
+
+    const local = makeQS({ questions: [localQ], lastModified: '2024-01-01T09:00:00.000Z' })
+    const pod   = makeQS({ questions: [podQ],   lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    expect(result.questions.find(q => q.id === 'q1')?.text).toBe('Pod text')
+  })
+})
+
+// ── alwaysNeededItems ─────────────────────────────────────────────────────────
+
+describe('alwaysNeededItems', () => {
+  it('items with IDs are merged with add-wins', () => {
+    const item1 = makeItem({ id: 'i1', text: 'Passport' })
+    const item2 = makeItem({ id: 'i2', text: 'Sunscreen' })
+
+    const local = makeQS({ alwaysNeededItems: [item1], lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ alwaysNeededItems: [item2], lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    const active = result.alwaysNeededItems.filter(i => !i.deletedAt)
+    const texts = active.map(i => i.text)
+    expect(texts).toContain('Passport')
+    expect(texts).toContain('Sunscreen')
+  })
+
+  it('item delete-wins: pod deletedAt removes item from active', () => {
+    const item = makeItem({ id: 'i1', text: 'Passport' })
+    const deletedItem = { ...item, deletedAt: '2024-01-01T11:00:00.000Z' }
+
+    const local = makeQS({ alwaysNeededItems: [item],        lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ alwaysNeededItems: [deletedItem], lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    const active = result.alwaysNeededItems.filter(i => !i.deletedAt)
+    expect(active.map(i => i.id)).not.toContain('i1')
+  })
+
+  it('falls back to doc-level LWW when items have no IDs', () => {
+    const localItem: Item = { text: 'Passport', personSelections: [] }
+    const podItem: Item   = { text: 'Sunscreen', personSelections: [] }
+
+    const local = makeQS({ alwaysNeededItems: [localItem], lastModified: '2024-01-01T12:00:00.000Z' })
+    const pod   = makeQS({ alwaysNeededItems: [podItem],   lastModified: '2024-01-01T10:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    // Local is newer → local's items win
+    expect(result.alwaysNeededItems.map(i => i.text)).toContain('Passport')
+    expect(result.alwaysNeededItems.map(i => i.text)).not.toContain('Sunscreen')
+  })
+})
+
+// ── deletedAt entities propagate ──────────────────────────────────────────────
+
+describe('deleted entities survive in output for propagation', () => {
+  it('question deletedAt from both sides are unioned', () => {
+    const q1 = makeQuestion({ id: 'q1', deletedAt: '2024-01-01T10:00:00.000Z' })
+    const q2 = makeQuestion({ id: 'q2', deletedAt: '2024-01-01T11:00:00.000Z' })
+
+    const local = makeQS({ questions: [q1], lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ questions: [q2], lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    const deletedIds = result.questions.filter(q => q.deletedAt).map(q => q.id)
+    expect(deletedIds).toContain('q1')
+    expect(deletedIds).toContain('q2')
+  })
+})
+
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+describe('edge cases', () => {
+  it('handles empty questions and people on both sides', () => {
+    const local = makeQS({})
+    const pod   = makeQS({ lastModified: '2024-01-01T11:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    expect(result.questions).toEqual([])
+    expect(result.people).toEqual([])
+  })
+
+  it('returns stable result when both sides are identical', () => {
+    const q = makeQuestion({ id: 'q1', lastModified: '2024-01-01T10:00:00.000Z' })
+    const p = makePerson({ id: 'p1', lastModified: '2024-01-01T10:00:00.000Z' })
+    const qs = makeQS({ questions: [q], people: [p] })
+
+    const result = mergeQuestionSets(qs, qs)
+    expect(result.questions.filter(q => !q.deletedAt)).toHaveLength(1)
+    expect(result.people.filter(p => !p.deletedAt)).toHaveLength(1)
+  })
+
+  it('handles missing root lastModified on both sides', () => {
+    const q1 = makeQuestion({ id: 'q1' })
+    const q2 = makeQuestion({ id: 'q2' })
+    const local: PackingListQuestionSet = { _id: '1', people: [], questions: [q1], alwaysNeededItems: [] }
+    const pod:   PackingListQuestionSet = { _id: '1', people: [], questions: [q2], alwaysNeededItems: [] }
+
+    const result = mergeQuestionSets(local, pod)
+    const ids = result.questions.filter(q => !q.deletedAt).map(q => q.id)
+    expect(ids).toContain('q1')
+    expect(ids).toContain('q2')
+  })
+})

--- a/src/utils/mergeQuestionSets.ts
+++ b/src/utils/mergeQuestionSets.ts
@@ -1,0 +1,160 @@
+import type { PackingListQuestionSet, Question, Person, Item } from '../edit-questions/types'
+
+function ms(ts: string | undefined): number {
+  return ts ? new Date(ts).getTime() : 0
+}
+
+function resolveQuestion(
+  local: Question,
+  pod: Question,
+  docLevelNewerIsLocal: boolean,
+): Question {
+  const localMs = local.lastModified ? ms(local.lastModified) : null
+  const podMs   = pod.lastModified   ? ms(pod.lastModified)   : null
+
+  if (localMs !== null && podMs !== null) {
+    return podMs >= localMs ? pod : local
+  }
+  return docLevelNewerIsLocal ? local : pod
+}
+
+function resolvePerson(
+  local: Person,
+  pod: Person,
+  docLevelNewerIsLocal: boolean,
+): Person {
+  const localMs = local.lastModified ? ms(local.lastModified) : null
+  const podMs   = pod.lastModified   ? ms(pod.lastModified)   : null
+
+  if (localMs !== null && podMs !== null) {
+    return podMs >= localMs ? pod : local
+  }
+  return docLevelNewerIsLocal ? local : pod
+}
+
+function resolveItem(
+  local: Item,
+  pod: Item,
+  docLevelNewerIsLocal: boolean,
+): Item {
+  const localMs = local.lastModified ? ms(local.lastModified) : null
+  const podMs   = pod.lastModified   ? ms(pod.lastModified)   : null
+
+  if (localMs !== null && podMs !== null) {
+    return podMs >= localMs ? pod : local
+  }
+  return docLevelNewerIsLocal ? local : pod
+}
+
+function mergeItemsById(
+  localItems: Item[],
+  podItems: Item[],
+  docLevelNewerIsLocal: boolean,
+): Item[] {
+  const localMap = new Map(localItems.map(i => [i.id!, i]))
+  const podMap   = new Map(podItems.map(i => [i.id!, i]))
+  const allIds   = new Set([...localMap.keys(), ...podMap.keys()])
+
+  const result: Item[] = []
+  for (const id of allIds) {
+    const localItem = localMap.get(id)
+    const podItem   = podMap.get(id)
+    if (localItem && podItem) {
+      const localDeleted = localItem.deletedAt
+      const podDeleted   = podItem.deletedAt
+      if (localDeleted || podDeleted) {
+        // delete-wins: keep whichever has deletedAt (prefer later deletedAt on tie)
+        if (localDeleted && podDeleted) {
+          result.push(ms(podDeleted) >= ms(localDeleted) ? podItem : localItem)
+        } else {
+          result.push(localDeleted ? localItem : podItem)
+        }
+      } else {
+        result.push(resolveItem(localItem, podItem, docLevelNewerIsLocal))
+      }
+    } else {
+      result.push((localItem ?? podItem)!)
+    }
+  }
+  return result
+}
+
+export function mergeQuestionSets(
+  local: PackingListQuestionSet,
+  pod: PackingListQuestionSet,
+): PackingListQuestionSet {
+  const localMs = ms(local.lastModified)
+  const podMs   = ms(pod.lastModified)
+  const newer = podMs >= localMs ? pod : local
+  const docLevelNewerIsLocal = localMs > podMs
+
+  // ── Questions ──────────────────────────────────────────────────────────────
+  const localQMap = new Map(local.questions.map(q => [q.id, q]))
+  const podQMap   = new Map(pod.questions.map(q => [q.id, q]))
+  const allQIds   = new Set([...localQMap.keys(), ...podQMap.keys()])
+
+  const questions: Question[] = []
+  for (const id of allQIds) {
+    const localQ = localQMap.get(id)
+    const podQ   = podQMap.get(id)
+    if (localQ && podQ) {
+      const localDeleted = localQ.deletedAt
+      const podDeleted   = podQ.deletedAt
+      if (localDeleted || podDeleted) {
+        if (localDeleted && podDeleted) {
+          questions.push(ms(podDeleted) >= ms(localDeleted) ? podQ : localQ)
+        } else {
+          questions.push(localDeleted ? localQ : podQ)
+        }
+      } else {
+        questions.push(resolveQuestion(localQ, podQ, docLevelNewerIsLocal))
+      }
+    } else {
+      questions.push((localQ ?? podQ)!)
+    }
+  }
+
+  // ── People ─────────────────────────────────────────────────────────────────
+  const localPMap = new Map(local.people.map(p => [p.id, p]))
+  const podPMap   = new Map(pod.people.map(p => [p.id, p]))
+  const allPIds   = new Set([...localPMap.keys(), ...podPMap.keys()])
+
+  const people: Person[] = []
+  for (const id of allPIds) {
+    const localP = localPMap.get(id)
+    const podP   = podPMap.get(id)
+    if (localP && podP) {
+      const localDeleted = localP.deletedAt
+      const podDeleted   = podP.deletedAt
+      if (localDeleted || podDeleted) {
+        if (localDeleted && podDeleted) {
+          people.push(ms(podDeleted) >= ms(localDeleted) ? podP : localP)
+        } else {
+          people.push(localDeleted ? localP : podP)
+        }
+      } else {
+        people.push(resolvePerson(localP, podP, docLevelNewerIsLocal))
+      }
+    } else {
+      people.push((localP ?? podP)!)
+    }
+  }
+
+  // ── alwaysNeededItems ──────────────────────────────────────────────────────
+  // If all items on both sides have IDs, merge per-item; otherwise doc-level LWW.
+  const localItems = local.alwaysNeededItems ?? []
+  const podItems   = pod.alwaysNeededItems ?? []
+  const allHaveIds =
+    localItems.every(i => i.id) && podItems.every(i => i.id)
+
+  const alwaysNeededItems = allHaveIds && (localItems.length > 0 || podItems.length > 0)
+    ? mergeItemsById(localItems, podItems, docLevelNewerIsLocal)
+    : newer.alwaysNeededItems ?? []
+
+  return {
+    ...newer,
+    questions,
+    people,
+    alwaysNeededItems,
+  }
+}


### PR DESCRIPTION
Mirrors the packing list merge approach: per-entity lastModified timestamps
for LWW, deletedAt tombstones for delete-wins semantics, and add-wins union
by ID for concurrent additions from multiple devices.

- Add lastModified, deletedAt to Person and Question schemas; add id,
  lastModified, deletedAt to Item schema (enables per-item merge for
  alwaysNeededItems and option items)
- New mergeQuestionSets function with 19 unit tests (TDD)
- RDF vocab and serialization updated to round-trip all new fields
- questions-page wires merge function into useSyncCoordinator and
  uses deletedAt tombstones instead of array filtering on delete

https://claude.ai/code/session_01AmhVrQzoPi4U3hdE4r77p6