### PR TITLE
Add Capacitor iOS & Android mobile app with UX polish

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ function App() {
           <div className="min-h-screen bg-gradient-to-br from-primary-50 via-white to-accent-50">
             <Navigation />
             <SessionExpiredBanner />
-            <div className="container mx-auto px-4 py-8">
+            <div className="container mx-auto px-4 py-8" style={{ paddingBottom: 'calc(2rem + env(safe-area-inset-bottom))' }}>
               <Routes>
                 <Route path="/" element={<LandingPage />} />
                 <Route path="/wizard" element={<Wizard />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -152,7 +152,7 @@ export const Navigation = () => {
                         <div className="md:hidden">
                             <button
                                 onClick={() => setIsOpen(!isOpen)}
-                                className="inline-flex items-center justify-center p-2 rounded-lg text-white hover:bg-white/20 focus:outline-none transition-all duration-200"
+                                className="inline-flex items-center justify-center p-2.5 rounded-lg text-white hover:bg-white/20 focus:outline-none transition-all duration-200"
                                 aria-expanded="false"
                             >
                                 <span className="sr-only">Open main menu</span>
@@ -186,21 +186,21 @@ export const Navigation = () => {
                     <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
                         <Link
                             to={manageQuestionsPath}
-                            className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
+                            className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                             onClick={() => setIsOpen(false)}
                         >
                             {inForeignContext ? 'Questions & Items' : 'My Questions & Items'}
                         </Link>
                         <Link
                             to={createListPath}
-                            className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
+                            className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                             onClick={() => setIsOpen(false)}
                         >
                             Create List
                         </Link>
                         <Link
                             to={viewListsPath}
-                            className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
+                            className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                             onClick={() => setIsOpen(false)}
                         >
                             View Lists
@@ -208,7 +208,7 @@ export const Navigation = () => {
                         {isLoggedIn && (
                             <Link
                                 to="/backups"
-                                className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
+                                className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                                 onClick={() => setIsOpen(false)}
                             >
                                 Backups
@@ -217,7 +217,7 @@ export const Navigation = () => {
                         {isLoggedIn && (
                             <Link
                                 to="/sharing"
-                                className="block px-3 py-2 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
+                                className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                                 onClick={() => setIsOpen(false)}
                             >
                                 Sharing
@@ -225,7 +225,7 @@ export const Navigation = () => {
                         )}
                         <a
                             href="mailto:tim.packmeup@gmail.com"
-                            className="block px-3 py-2 rounded-xl text-base font-medium text-white/70 hover:text-white transition-colors duration-200"
+                            className="block px-3 py-3 rounded-xl text-base font-medium text-white/70 hover:text-white transition-colors duration-200"
                             onClick={() => setIsOpen(false)}
                         >
                             Feedback
@@ -242,7 +242,7 @@ export const Navigation = () => {
                                             handleLogout()
                                             setIsOpen(false)
                                         }}
-                                        className="w-full text-left px-3 py-2 rounded-xl text-base font-semibold bg-white/20 hover:bg-white/30 transition-all duration-200"
+                                        className="w-full text-left px-3 py-3 rounded-xl text-base font-semibold bg-white/20 hover:bg-white/30 transition-all duration-200"
                                     >
                                         Logout
                                     </button>
@@ -254,7 +254,7 @@ export const Navigation = () => {
                                             handleSolidLogin()
                                             setIsOpen(false)
                                         }}
-                                        className="w-full text-left px-3 py-2 rounded-xl text-base font-semibold bg-white/90 text-primary-700 hover:bg-white transition-all duration-200"
+                                        className="w-full text-left px-3 py-3 rounded-xl text-base font-semibold bg-white/90 text-primary-700 hover:bg-white transition-all duration-200"
                                         title="Store your packing lists in your own personal Pod - you own your data"
                                     >
                                         Login with Solid Pod

--- a/src/index.css
+++ b/src/index.css
@@ -91,6 +91,10 @@
   --box-shadow-glow-accent: 0 0 20px rgba(168, 85, 247, 0.4);
 }
 
+body {
+  overscroll-behavior: none;
+}
+
 /* Celebration animations */
 @keyframes celebration-float {
   0%, 100% { transform: translateY(0px) rotate(-5deg); }


### PR DESCRIPTION
## What this PR does

Wraps the existing Vite/React web app in Capacitor to produce native iOS and Android apps.

- **Android** (`android/`): native project via `npx cap add android`, with release signing config and OIDC callback interception in `MainActivity` so the auth redirect lands back in the app
- **iOS** (`ios/`): native Xcode project via `npx cap add ios` using Swift Package Manager; `@capacitor/app` plugin wired in
- **Capacitor config**: `androidScheme` and `iosScheme` both set to `https` so the OIDC `redirect_uri` origin is `https://localhost` on both platforms; `allowNavigation: ['*']` to permit navigation to any Solid provider during login
- **iOS status bar**: `viewport-fit=cover` added to the viewport meta tag; nav bar gets `padding-top: env(safe-area-inset-top)` so content sits below the status bar
- **Mobile UX polish**: `overscroll-behavior: none` on body to stop pull-to-refresh interference; `env(safe-area-inset-bottom)` padding on the main content container for the iOS home indicator; hamburger button and mobile nav links bumped to 44px touch targets

**npm scripts added:** `cap:ios`, `cap:android`, `cap:sync`, `build:mobile`

## Manual testing steps

**iOS (requires macOS + Xcode):**
1. `npm run cap:ios` — builds web assets, syncs to iOS, opens Xcode
2. Select a simulator (e.g. iPhone 17 Pro) and hit ⌘R
3. Confirm the home screen loads and the nav bar sits below the status bar
4. Log in with a Solid account — confirm the OIDC redirect returns to the app
5. Scroll to the bottom of a page — content should clear the home indicator bar
6. Pull down on a scrollable page — should not trigger browser pull-to-refresh

**Android:**
1. `npm run cap:android` — builds web assets, syncs to Android, opens Android Studio
2. Run in an emulator and confirm the home screen loads
3. Log in with a Solid account — confirm the OIDC redirect returns to the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)