### PR TITLE
Add Share action to packing list cards (issue #203)

### DIFF
--- a/e2e/tests/i-migration.spec.ts
+++ b/e2e/tests/i-migration.spec.ts
@@ -42,7 +42,7 @@ test.describe('I – Data Migration', () => {
     await loginToCss(localPage, CSS_ISSUER, migrationEmail, migrationPassword, { waitForLoggedIn: false })
     // DatabaseContext detects: pod empty + local has data → migration prompt
     await expect(
-      localPage.getByRole('heading', { name: /You have local data/i })
+      localPage.getByRole('heading', { name: /Add your browser lists/i })
     ).toBeVisible({ timeout: 15_000 })
     await localCtx.close()
   })
@@ -52,9 +52,9 @@ test.describe('I – Data Migration', () => {
     const localPage = await localCtx.newPage()
     await generateLocalData(localPage)
     await loginToCss(localPage, CSS_ISSUER, migrationEmail, migrationPassword, { waitForLoggedIn: false })
-    // Accept migration: confirm button text is "Use my local data"
+    // Accept migration: confirm button text is "Add to my Pod"
     const dialog = localPage.getByRole('dialog')
-    const confirmBtn = dialog.getByRole('button').filter({ hasText: /use my local data|use.*local|local/i }).first()
+    const confirmBtn = dialog.getByRole('button').filter({ hasText: /add to my pod|add/i }).first()
     await confirmBtn.click({ timeout: 10_000 })
     // Wait for copyAllDataFrom to finish and dialog to close
     await expect(localPage.getByRole('dialog')).not.toBeVisible({ timeout: 10_000 })
@@ -70,9 +70,9 @@ test.describe('I – Data Migration', () => {
     const localPage = await localCtx.newPage()
     await generateLocalData(localPage)
     await loginToCss(localPage, CSS_ISSUER, migrationEmail, migrationPassword, { waitForLoggedIn: false })
-    // Cancel migration: cancel button text is "Start fresh"
+    // Cancel migration: cancel button text is "Not now"
     const dialog = localPage.getByRole('dialog')
-    const cancelBtn = dialog.getByRole('button').filter({ hasText: /no|cancel|skip|start fresh/i }).first()
+    const cancelBtn = dialog.getByRole('button').filter({ hasText: /not now|no|cancel|skip/i }).first()
     await cancelBtn.click({ timeout: 10_000 })
     // Landing page should show "Get Started" (empty pod namespace)
     await localPage.goto('/')

--- a/src/components/DatabaseContext.test.tsx
+++ b/src/components/DatabaseContext.test.tsx
@@ -57,9 +57,9 @@ function makeDb(namespace: string, overrides: {
   }
 }
 
-/** Default instance factory: local db is non-empty by default (avoids migration prompt) */
+/** Default instance factory: local db is empty by default (avoids migration prompt) */
 function defaultInstanceFactory(namespace: string) {
-  return makeDb(namespace)
+  return makeDb(namespace, { isEmpty: true })
 }
 
 function NamespaceDisplay() {
@@ -232,11 +232,13 @@ describe('DatabaseContext', () => {
         </DatabaseProvider>
       )
 
-      await waitFor(() => screen.getByText(/you have local data/i))
+      await waitFor(() => screen.getByText(/add your browser lists/i))
       expect(screen.queryByTestId('child')).toBeNull()
     })
 
-    it('does not show migration dialog when pod already has remote data', async () => {
+    it('shows migration dialog when pod already has remote data and local has data', async () => {
+      // Anonymous session data must not be silently stranded when signing into
+      // a pod that already contains lists — the prompt should still appear.
       mockDetectPodDataFormat.mockResolvedValue('rdf')
       mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
 
@@ -246,8 +248,8 @@ describe('DatabaseContext', () => {
         </DatabaseProvider>
       )
 
-      await waitFor(() => screen.getByTestId('child'))
-      expect(screen.queryByText(/you have local data/i)).toBeNull()
+      await waitFor(() => screen.getByText(/add your browser lists/i))
+      expect(screen.queryByTestId('child')).toBeNull()
     })
 
     it('does not show migration dialog when local db is empty', async () => {
@@ -262,7 +264,7 @@ describe('DatabaseContext', () => {
       )
 
       await waitFor(() => screen.getByTestId('child'))
-      expect(screen.queryByText(/you have local data/i)).toBeNull()
+      expect(screen.queryByText(/add your browser lists/i)).toBeNull()
     })
 
     it('does not show migration dialog when localStorage dismissed key is set', async () => {
@@ -277,10 +279,10 @@ describe('DatabaseContext', () => {
       )
 
       await waitFor(() => screen.getByTestId('child'))
-      expect(screen.queryByText(/you have local data/i)).toBeNull()
+      expect(screen.queryByText(/add your browser lists/i)).toBeNull()
     })
 
-    it('copies data to pod and renders children when user clicks "Use my local data"', async () => {
+    it('copies data to pod and renders children when user clicks "Add to my Pod"', async () => {
       mockDetectPodDataFormat.mockResolvedValue('empty')
       const copyAllDataFrom = vi.fn().mockResolvedValue(undefined)
       mockGetInstance.mockImplementation((ns: string) =>
@@ -293,13 +295,32 @@ describe('DatabaseContext', () => {
         </DatabaseProvider>
       )
 
-      await waitFor(() => screen.getByText('Use my local data'))
-      fireEvent.click(screen.getByText('Use my local data'))
+      await waitFor(() => screen.getByText('Add to my Pod'))
+      fireEvent.click(screen.getByText('Add to my Pod'))
       await waitFor(() => screen.getByTestId('child'))
       expect(copyAllDataFrom).toHaveBeenCalledOnce()
     })
 
-    it('skips migration and renders children when user clicks "Start fresh"', async () => {
+    it('runs syncAllDataFromPod after the user accepts the merge', async () => {
+      mockDetectPodDataFormat.mockResolvedValue('rdf')
+      const copyAllDataFrom = vi.fn().mockResolvedValue(undefined)
+      mockGetInstance.mockImplementation((ns: string) =>
+        makeDb(ns, { isEmpty: false, copyAllDataFrom })
+      )
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByText('Add to my Pod'))
+      fireEvent.click(screen.getByText('Add to my Pod'))
+      await waitFor(() => expect(copyAllDataFrom).toHaveBeenCalledOnce())
+      await waitFor(() => expect(mockSyncAllDataFromPod).toHaveBeenCalled())
+    })
+
+    it('skips migration and renders children when user clicks "Not now"', async () => {
       mockDetectPodDataFormat.mockResolvedValue('empty')
       const copyAllDataFrom = vi.fn()
       mockGetInstance.mockImplementation((ns: string) =>
@@ -312,13 +333,28 @@ describe('DatabaseContext', () => {
         </DatabaseProvider>
       )
 
-      await waitFor(() => screen.getByText('Start fresh'))
-      fireEvent.click(screen.getByText('Start fresh'))
+      await waitFor(() => screen.getByText('Not now'))
+      fireEvent.click(screen.getByText('Not now'))
       await waitFor(() => screen.getByTestId('child'))
       expect(copyAllDataFrom).not.toHaveBeenCalled()
     })
 
-    it('sets localStorage dismissed key when user clicks "Start fresh"', async () => {
+    it('still runs syncAllDataFromPod after the user declines the merge', async () => {
+      mockDetectPodDataFormat.mockResolvedValue('rdf')
+      mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByText('Not now'))
+      fireEvent.click(screen.getByText('Not now'))
+      await waitFor(() => expect(mockSyncAllDataFromPod).toHaveBeenCalled())
+    })
+
+    it('sets localStorage dismissed key when user clicks "Not now"', async () => {
       mockDetectPodDataFormat.mockResolvedValue('empty')
       mockGetInstance.mockImplementation((ns: string) => makeDb(ns, { isEmpty: false }))
 
@@ -328,8 +364,8 @@ describe('DatabaseContext', () => {
         </DatabaseProvider>
       )
 
-      await waitFor(() => screen.getByText('Start fresh'))
-      fireEvent.click(screen.getByText('Start fresh'))
+      await waitFor(() => screen.getByText('Not now'))
+      fireEvent.click(screen.getByText('Not now'))
       expect(localStorage.getItem('pod-migration-dismissed-example.com')).toBe('true')
     })
   })
@@ -394,7 +430,7 @@ describe('DatabaseContext', () => {
         </DatabaseProvider>
       )
 
-      await waitFor(() => screen.getByText(/you have local data/i))
+      await waitFor(() => screen.getByText(/add your browser lists/i))
       expect(mockSyncAllDataFromPod).not.toHaveBeenCalled()
     })
 

--- a/src/components/DatabaseContext.tsx
+++ b/src/components/DatabaseContext.tsx
@@ -44,6 +44,11 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
     // do not trigger a second full syncAllDataFromPod call.
     const syncedNamespaceRef = useRef<string | null>(null)
 
+    // Holds the background-sync closure for the current pod identity while the
+    // migration prompt is open, so the dialog handlers can start the sync once
+    // the user has chosen whether to bring their local data across.
+    const deferredSyncRef = useRef<(() => void) | null>(null)
+
     useEffect(() => {
         // While session is still initialising, wait
         if (isLoading) {
@@ -92,33 +97,10 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
             // a DPoP nonce race on CSS and results in TypeError: Failed to fetch.
             let cachedFormat: 'rdf' | 'json' | 'empty' | null = null
 
-            if (!dismissed && podUrl && session) {
-                const [format, localEmpty] = await Promise.all([
-                    detectPodDataFormat(session, podUrl),
-                    local.isEmpty()
-                ])
-                cachedFormat = format
-                const podHasRemoteData = format !== 'empty'
-                if (!podHasRemoteData && !localEmpty) {
-                    if (cancelled) return
-                    setLocalDb(local)
-                    setNamespace(resolvedNamespace)
-                    setDb(podDb)
-                    setShowMigrationPrompt(true)
-                    setIsResolvingPod(false)
-                    return
-                }
-            }
-
-            if (cancelled) return
-            setNamespace(resolvedNamespace)
-            setDb(podDb)
-            setIsResolvingPod(false)
-
-            // Background: migrate if needed, then sync.
-            // Only run once per namespace (login event), not on every session refresh.
-            // Fire-and-forget – failures must not block the app.
-            if (podUrl && session) {
+            // Background: migrate if needed, then sync. Only runs once per
+            // namespace (login event). Fire-and-forget – failures must not block.
+            const startBackgroundSync = () => {
+                if (!podUrl || !session) return
                 syncedNamespaceRef.current = resolvedNamespace
                 setLoginSyncInProgress(true)
                 ;(async () => {
@@ -140,6 +122,36 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
                     }
                 })()
             }
+
+            // If there is local (anonymous-session) data, offer to bring it across
+            // before syncing — regardless of whether the pod already has data. The
+            // copy/sync paths merge by list ID, so existing pod data is never lost.
+            if (!dismissed && podUrl && session) {
+                const [format, localEmpty] = await Promise.all([
+                    detectPodDataFormat(session, podUrl),
+                    local.isEmpty()
+                ])
+                cachedFormat = format
+                if (!localEmpty) {
+                    if (cancelled) return
+                    setLocalDb(local)
+                    setNamespace(resolvedNamespace)
+                    setDb(podDb)
+                    deferredSyncRef.current = startBackgroundSync
+                    setShowMigrationPrompt(true)
+                    setIsResolvingPod(false)
+                    return
+                }
+            }
+
+            if (cancelled) return
+            setNamespace(resolvedNamespace)
+            setDb(podDb)
+            setIsResolvingPod(false)
+
+            if (podUrl && session) {
+                startBackgroundSync()
+            }
         })
 
         return () => {
@@ -155,21 +167,23 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
         return (
             <ConfirmationDialog
                 isOpen
-                title="You have local data"
-                message={"You have data saved locally in this browser.\nWould you like to copy it to your Pod so it's available across all your devices?"}
-                confirmText="Use my local data"
-                cancelText="Start fresh"
+                title="Add your browser lists to your Pod?"
+                message={"You have packing lists saved in this browser. Would you like to add them to your Pod so they're available on all your devices?\n\nYour existing Pod data is kept — nothing is overwritten."}
+                confirmText="Add to my Pod"
+                cancelText="Not now"
                 onConfirm={async () => {
+                    // Merge local data into the pod database, then sync with the
+                    // remote pod. Merging (by list ID) means existing pod data is
+                    // preserved alongside the browser's lists.
                     await db.copyAllDataFrom(localDb)
-                    // Mark as dismissed so a full-page reload doesn't re-prompt
-                    // (local data was copied; pod will be out of sync until next
-                    // explicit save, but hasPodData checks the remote pod)
                     localStorage.setItem(`pod-migration-dismissed-${namespace}`, 'true')
                     setShowMigrationPrompt(false)
+                    deferredSyncRef.current?.()
                 }}
                 onClose={() => {
                     localStorage.setItem(`pod-migration-dismissed-${namespace}`, 'true')
                     setShowMigrationPrompt(false)
+                    deferredSyncRef.current?.()
                 }}
             />
         )

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -51,6 +51,12 @@ vi.mock('../services/solidPod', () => ({
     },
 }))
 
+vi.mock('../components/SolidProviderSelector', () => ({
+    SolidProviderSelector: vi.fn(({ isOpen }: { isOpen: boolean }) =>
+        isOpen ? <div data-testid="sign-in-modal">Sign in to share</div> : null
+    ),
+}))
+
 vi.mock('../components/SharePackingListModal', () => ({
     SharePackingListModal: vi.fn(({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
         isOpen ? <div data-testid="share-modal"><button onClick={onClose}>Close</button></div> : null
@@ -683,7 +689,7 @@ describe('PackingLists share', () => {
         fireEvent.click(screen.getByRole('button', { name: /share/i }))
 
         await waitFor(() => {
-            expect(screen.getByRole('button', { name: /^sign in$/i })).toBeTruthy()
+            expect(screen.getByTestId('sign-in-modal')).toBeTruthy()
         })
     })
 

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -51,12 +51,6 @@ vi.mock('../services/solidPod', () => ({
     },
 }))
 
-vi.mock('../components/SolidProviderSelector', () => ({
-    SolidProviderSelector: vi.fn(({ isOpen }: { isOpen: boolean }) =>
-        isOpen ? <div data-testid="sign-in-modal">Sign in to share</div> : null
-    ),
-}))
-
 vi.mock('../components/SharePackingListModal', () => ({
     SharePackingListModal: vi.fn(({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
         isOpen ? <div data-testid="share-modal"><button onClick={onClose}>Close</button></div> : null
@@ -672,7 +666,7 @@ describe('PackingLists share', () => {
         })
     })
 
-    it('shows a sign-in prompt when Share is clicked while logged out', async () => {
+    it('shows a contextual sign-in modal with the list name when Share is clicked while logged out', async () => {
         mockUseSolidPod.mockReturnValue({
             isLoggedIn: false,
             session: null,
@@ -689,7 +683,59 @@ describe('PackingLists share', () => {
         fireEvent.click(screen.getByRole('button', { name: /share/i }))
 
         await waitFor(() => {
-            expect(screen.getByTestId('sign-in-modal')).toBeTruthy()
+            expect(screen.getByTestId('share-sign-in-modal')).toBeTruthy()
+            // Shows the list name in the modal
+            expect(screen.getByTestId('share-sign-in-modal').textContent).toContain('Summer Holiday')
+        })
+    })
+
+    it('calls login with the selected provider and saves pendingShareAction when provider clicked', async () => {
+        const mockLogin = vi.fn()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: mockLogin,
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeShareDb() as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+        fireEvent.click(screen.getByRole('button', { name: /share/i }))
+        await screen.findByTestId('share-sign-in-modal')
+
+        // Click the first provider button
+        const providerBtn = screen.getAllByTestId('share-sign-in-provider').at(0)!
+        fireEvent.click(providerBtn)
+
+        await waitFor(() => {
+            expect(mockLogin).toHaveBeenCalled()
+            expect(sessionStorage.getItem('pendingShareAction')).toContain('list-1')
+        })
+    })
+
+    it('auto-opens SharePackingListModal for pending list when already logged in on mount', async () => {
+        sessionStorage.setItem('pendingShareAction', JSON.stringify({ listId: 'list-1' }))
+        const loggedInSession = { fetch: vi.fn(), info: { webId: 'https://user.solidcommunity.net/profile/card#me' } } as unknown as Session
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: loggedInSession,
+            webId: 'https://user.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockGetPrimaryPodUrl.mockResolvedValue('https://user.solidcommunity.net')
+        mockUseDatabase.mockReturnValue({ db: makeShareDb() as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('share-modal')).toBeTruthy()
+            expect(sessionStorage.getItem('pendingShareAction')).toBeNull()
         })
     })
 

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -38,6 +38,9 @@ vi.mock('../services/solidPod', () => ({
     getCollaborators: vi.fn().mockResolvedValue([]),
     isPubliclyAccessible: vi.fn().mockResolvedValue(false),
     friendlyPodName: vi.fn((url: string) => url),
+    buildSharedListPath: vi.fn((id: string) => `/view-lists/${id}`),
+    resolveOwnerDisplayName: vi.fn(() => 'Owner'),
+    getPodOwnerName: vi.fn().mockResolvedValue(null),
     POD_CONTAINERS: { PACKING_LISTS: '/packing-lists/' },
     POD_ERROR_MESSAGES: {
         NOT_LOGGED_IN: 'Not logged in',
@@ -48,16 +51,24 @@ vi.mock('../services/solidPod', () => ({
     },
 }))
 
+vi.mock('../components/SharePackingListModal', () => ({
+    SharePackingListModal: vi.fn(({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+        isOpen ? <div data-testid="share-modal"><button onClick={onClose}>Close</button></div> : null
+    ),
+}))
+
 import type { AppSession as Session } from '../types/AppSession'
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { getPrimaryPodUrl, saveRdfToPod, deleteFileFromPod } from '../services/solidPod'
+import { SharePackingListModal } from '../components/SharePackingListModal'
 
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
 const mockSaveRdfToPod = vi.mocked(saveRdfToPod)
 const mockDeleteFileFromPod = vi.mocked(deleteFileFromPod)
+const mockSharePackingListModal = vi.mocked(SharePackingListModal)
 
 const testPackingList = {
     id: 'list-1',
@@ -563,6 +574,141 @@ describe('PackingLists pod sync on mutation', () => {
             expect(makeDb().savePackingList).toBeDefined()
         })
         expect(mockSaveRdfToPod).not.toHaveBeenCalled()
+    })
+})
+
+describe('PackingLists share', () => {
+    const loggedInSession = { fetch: vi.fn(), info: { webId: 'https://user.solidcommunity.net/profile/card#me' } } as unknown as Session
+
+    function makeShareDb() {
+        return {
+            getAllPackingLists: vi.fn().mockResolvedValue([testList]),
+            deletePackingList: vi.fn().mockResolvedValue(undefined),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+            getSharedListsWithMe: vi.fn().mockResolvedValue({ lists: [], lastModified: '' }),
+        }
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockSharePackingListModal.mockImplementation(
+            ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+                isOpen ? <div data-testid="share-modal"><button onClick={onClose}>Close</button></div> : null
+        )
+        mockGetPrimaryPodUrl.mockResolvedValue('https://user.solidcommunity.net')
+    })
+
+    it('shows a Share button on each own list card', async () => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeShareDb() as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+
+        expect(screen.getByRole('button', { name: /share/i })).toBeTruthy()
+    })
+
+    it('does not show Share button on foreign (shared-with-me) lists', async () => {
+        const foreignList = {
+            ...testList,
+            id: 'foreign-1',
+            name: 'Friend Holiday',
+            sharedFromPodUrl: 'https://friend.solidcommunity.net',
+        }
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: loggedInSession,
+            webId: 'https://user.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn().mockResolvedValue([foreignList]),
+                deletePackingList: vi.fn(),
+                savePackingList: vi.fn(),
+                getSharedListsWithMe: vi.fn().mockResolvedValue({ lists: [], lastModified: '' }),
+            } as unknown as PackingAppDatabase,
+        })
+
+        renderComponent()
+        await screen.findByText(/Friend Holiday/)
+
+        expect(screen.queryByRole('button', { name: /🔗 share/i })).toBeNull()
+    })
+
+    it('opens the SharePackingListModal when Share is clicked while logged in', async () => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: loggedInSession,
+            webId: 'https://user.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeShareDb() as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByRole('button', { name: /share/i }))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('share-modal')).toBeTruthy()
+        })
+    })
+
+    it('shows a sign-in prompt when Share is clicked while logged out', async () => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeShareDb() as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByRole('button', { name: /share/i }))
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /^sign in$/i })).toBeTruthy()
+        })
+    })
+
+    it('closes the SharePackingListModal when onClose is called', async () => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: loggedInSession,
+            webId: 'https://user.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeShareDb() as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByRole('button', { name: /share/i }))
+        await screen.findByTestId('share-modal')
+
+        fireEvent.click(screen.getByRole('button', { name: /close/i }))
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('share-modal')).toBeNull()
+        })
     })
 })
 

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -7,12 +7,14 @@ import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { Modal } from '../components/Modal'
 import { SharePackingListModal } from '../components/SharePackingListModal'
-import { SolidProviderSelector } from '../components/SolidProviderSelector'
+import { COMMON_PROVIDERS } from '../components/SolidProviderSelector'
 import { getPrimaryPodUrl, saveRdfToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES, getCollaborators, isPubliclyAccessible, resolveOwnerDisplayName, buildSharedListPath } from '../services/solidPod'
 import { useOwnerDisplayNames } from '../hooks/useOwnerDisplayName'
 import { packingListToDataset } from '../services/rdfSerialization'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { generateUUID } from '../utils/uuid'
+
+const PENDING_SHARE_KEY = 'pendingShareAction'
 
 type SharingStatus = 'public' | 'shared' | 'private'
 
@@ -24,7 +26,7 @@ export function PackingLists() {
     const [renameValue, setRenameValue] = useState('')
     const [sharingStatus, setSharingStatus] = useState<Record<string, SharingStatus>>({})
     const [listToShare, setListToShare] = useState<{ id: string; fileUrl: string; podUrl: string } | null>(null)
-    const [showSignInPrompt, setShowSignInPrompt] = useState(false)
+    const [shareSignInList, setShareSignInList] = useState<PackingList | null>(null)
     const navigate = useNavigate()
     const { isLoggedIn, session, login } = useSolidPod()
     const ownerNames = useOwnerDisplayNames(
@@ -84,13 +86,20 @@ export function PackingLists() {
     const handleSharePackingList = async (list: PackingList, event: React.MouseEvent) => {
         event.stopPropagation()
         if (!isLoggedIn) {
-            setShowSignInPrompt(true)
+            setShareSignInList(list)
             return
         }
         const podUrl = await getPrimaryPodUrl(session)
         if (!podUrl) return
         const fileUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${list.id}.ttl`
         setListToShare({ id: list.id, fileUrl, podUrl })
+    }
+
+    const handleShareSignIn = (issuer: string) => {
+        if (!shareSignInList) return
+        sessionStorage.setItem(PENDING_SHARE_KEY, JSON.stringify({ listId: shareSignInList.id }))
+        setShareSignInList(null)
+        login(issuer, '/view-lists')
     }
 
     const confirmDeletePackingList = async () => {
@@ -168,6 +177,22 @@ export function PackingLists() {
             }
         }).catch(() => {})
     }, [packingLists, isLoggedIn, session])
+
+    // Auto-resume a pending share action after login redirect
+    useEffect(() => {
+        if (!isLoggedIn || !session || packingLists.length === 0) return
+        const raw = sessionStorage.getItem(PENDING_SHARE_KEY)
+        if (!raw) return
+        sessionStorage.removeItem(PENDING_SHARE_KEY)
+        let pending: { listId: string }
+        try { pending = JSON.parse(raw) } catch { return }
+        const list = packingLists.find(l => l.id === pending.listId)
+        if (!list) return
+        getPrimaryPodUrl(session).then(podUrl => {
+            if (!podUrl) return
+            setListToShare({ id: list.id, fileUrl: `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${list.id}.ttl`, podUrl })
+        }).catch(() => {})
+    }, [isLoggedIn, session, packingLists])
 
     if (isLoading || loginSyncInProgress) {
         return <div className="max-w-4xl mx-auto py-8 px-4 text-center text-gray-700 font-semibold">Loading packing lists...</div>
@@ -312,11 +337,39 @@ export function PackingLists() {
                 </div>
             </Modal>
 
-            <SolidProviderSelector
-                isOpen={showSignInPrompt}
-                onClose={() => setShowSignInPrompt(false)}
-                onSelect={(issuer) => login(issuer)}
-            />
+            <Modal
+                isOpen={shareSignInList !== null}
+                onClose={() => setShareSignInList(null)}
+                title={`Share "${shareSignInList?.name}"`}
+            >
+                <div className="space-y-4" data-testid="share-sign-in-modal">
+                    <p className="text-sm text-gray-700">
+                        To share <strong>{shareSignInList?.name}</strong> with friends for your trip, you need a free Solid Pod — your personal storage that keeps your data yours. Takes about 30 seconds to set up.
+                    </p>
+                    <p className="text-xs text-indigo-600 font-medium">
+                        After signing in we'll bring you right back here to complete the share. ✨
+                    </p>
+                    <div className="space-y-2 pt-1">
+                        {COMMON_PROVIDERS.map(provider => (
+                            <button
+                                key={provider.issuer}
+                                data-testid="share-sign-in-provider"
+                                onClick={() => handleShareSignIn(provider.issuer)}
+                                className="w-full text-left px-4 py-3 border-2 border-gray-200 hover:border-indigo-400 hover:bg-indigo-50 rounded-xl transition-all duration-150 group"
+                            >
+                                <div className="font-semibold text-gray-900 group-hover:text-indigo-900">{provider.name}</div>
+                                {provider.description && (
+                                    <div className="text-xs text-green-700 font-medium">{provider.description}</div>
+                                )}
+                                <div className="text-xs text-gray-400">{provider.issuer}</div>
+                            </button>
+                        ))}
+                    </div>
+                    <p className="text-xs text-gray-400 text-center pt-1">
+                        Already have a pod? Sign in above — your data is already waiting.
+                    </p>
+                </div>
+            </Modal>
 
             {listToShare && session && (
                 <SharePackingListModal

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -13,8 +13,7 @@ import { useOwnerDisplayNames } from '../hooks/useOwnerDisplayName'
 import { packingListToDataset } from '../services/rdfSerialization'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { generateUUID } from '../utils/uuid'
-
-const PENDING_SHARE_KEY = 'pendingShareAction'
+import { PENDING_SHARE_KEY } from './solid-pod-handle-redirect-page'
 
 type SharingStatus = 'public' | 'shared' | 'private'
 

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -6,6 +6,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { Modal } from '../components/Modal'
+import { SharePackingListModal } from '../components/SharePackingListModal'
 import { getPrimaryPodUrl, saveRdfToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES, getCollaborators, isPubliclyAccessible, resolveOwnerDisplayName, buildSharedListPath } from '../services/solidPod'
 import { useOwnerDisplayNames } from '../hooks/useOwnerDisplayName'
 import { packingListToDataset } from '../services/rdfSerialization'
@@ -21,6 +22,8 @@ export function PackingLists() {
     const [listToRename, setListToRename] = useState<{ id: string; name: string } | null>(null)
     const [renameValue, setRenameValue] = useState('')
     const [sharingStatus, setSharingStatus] = useState<Record<string, SharingStatus>>({})
+    const [listToShare, setListToShare] = useState<{ id: string; fileUrl: string; podUrl: string } | null>(null)
+    const [showSignInPrompt, setShowSignInPrompt] = useState(false)
     const navigate = useNavigate()
     const { isLoggedIn, session } = useSolidPod()
     const ownerNames = useOwnerDisplayNames(
@@ -75,6 +78,18 @@ export function PackingLists() {
         } catch (err) {
             console.error('Error duplicating packing list:', err)
         }
+    }
+
+    const handleSharePackingList = async (list: PackingList, event: React.MouseEvent) => {
+        event.stopPropagation()
+        if (!isLoggedIn) {
+            setShowSignInPrompt(true)
+            return
+        }
+        const podUrl = await getPrimaryPodUrl(session)
+        if (!podUrl) return
+        const fileUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${list.id}.ttl`
+        setListToShare({ id: list.id, fileUrl, podUrl })
     }
 
     const confirmDeletePackingList = async () => {
@@ -242,6 +257,14 @@ export function PackingLists() {
                                         >
                                             🗑️ Delete
                                         </button>
+                                        {!list.sharedFromPodUrl && (
+                                            <button
+                                                onClick={(e) => handleSharePackingList(list, e)}
+                                                className="text-blue-600 hover:text-blue-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
+                                            >
+                                                🔗 Share
+                                            </button>
+                                        )}
                                     </div>
                                 </div>
                                 <div className="flex items-center gap-4">
@@ -287,6 +310,27 @@ export function PackingLists() {
                     </div>
                 </div>
             </Modal>
+
+            <Modal isOpen={showSignInPrompt} onClose={() => setShowSignInPrompt(false)} title="Sign in to share">
+                <div className="space-y-4">
+                    <p className="text-gray-700">You need to sign in to share a list with friends for your holiday.</p>
+                    <div className="flex gap-3 justify-end">
+                        <Button variant="ghost" onClick={() => setShowSignInPrompt(false)}>Cancel</Button>
+                        <Button variant="primary" onClick={() => { setShowSignInPrompt(false); navigate('/') }}>Sign in</Button>
+                    </div>
+                </div>
+            </Modal>
+
+            {listToShare && session && (
+                <SharePackingListModal
+                    isOpen={listToShare !== null}
+                    onClose={() => setListToShare(null)}
+                    session={session}
+                    fileUrl={listToShare.fileUrl}
+                    listId={listToShare.id}
+                    sharerPodUrl={listToShare.podUrl}
+                />
+            )}
         </div>
     )
 }

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -7,6 +7,7 @@ import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { Modal } from '../components/Modal'
 import { SharePackingListModal } from '../components/SharePackingListModal'
+import { SolidProviderSelector } from '../components/SolidProviderSelector'
 import { getPrimaryPodUrl, saveRdfToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES, getCollaborators, isPubliclyAccessible, resolveOwnerDisplayName, buildSharedListPath } from '../services/solidPod'
 import { useOwnerDisplayNames } from '../hooks/useOwnerDisplayName'
 import { packingListToDataset } from '../services/rdfSerialization'
@@ -25,7 +26,7 @@ export function PackingLists() {
     const [listToShare, setListToShare] = useState<{ id: string; fileUrl: string; podUrl: string } | null>(null)
     const [showSignInPrompt, setShowSignInPrompt] = useState(false)
     const navigate = useNavigate()
-    const { isLoggedIn, session } = useSolidPod()
+    const { isLoggedIn, session, login } = useSolidPod()
     const ownerNames = useOwnerDisplayNames(
         packingLists
             .filter(l => !!l.sharedFromPodUrl)
@@ -311,15 +312,11 @@ export function PackingLists() {
                 </div>
             </Modal>
 
-            <Modal isOpen={showSignInPrompt} onClose={() => setShowSignInPrompt(false)} title="Sign in to share">
-                <div className="space-y-4">
-                    <p className="text-gray-700">You need to sign in to share a list with friends for your holiday.</p>
-                    <div className="flex gap-3 justify-end">
-                        <Button variant="ghost" onClick={() => setShowSignInPrompt(false)}>Cancel</Button>
-                        <Button variant="primary" onClick={() => { setShowSignInPrompt(false); navigate('/') }}>Sign in</Button>
-                    </div>
-                </div>
-            </Modal>
+            <SolidProviderSelector
+                isOpen={showSignInPrompt}
+                onClose={() => setShowSignInPrompt(false)}
+                onSelect={(issuer) => login(issuer)}
+            />
 
             {listToShare && session && (
                 <SharePackingListModal

--- a/src/pages/solid-pod-handle-redirect-page.tsx
+++ b/src/pages/solid-pod-handle-redirect-page.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 export const AUTH_RETURN_TO_KEY = "authReturnTo";
+export const PENDING_SHARE_KEY = "pendingShareAction";
 
 export const SolidPodHandleRedirectPage = () => {
     const navigate = useNavigate();

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { ViewPackingList } from './view-packing-list'
@@ -508,6 +508,87 @@ describe('ViewPackingList checked item styling', () => {
 
         const span = screen.getByText('Passport')
         expect(span.className).not.toContain('line-through')
+    })
+})
+
+describe('ViewPackingList share while logged out', () => {
+    const mockLogin = vi.fn()
+
+    beforeEach(() => {
+        sessionStorage.clear()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: mockLogin,
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn(), syncFromPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({ saveWithSyncPrevention: vi.fn() })
+    })
+
+    afterEach(() => {
+        sessionStorage.clear()
+        vi.clearAllMocks()
+    })
+
+    it('shows the Share button even when logged out', async () => {
+        renderComponent()
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+        expect(screen.getByRole('button', { name: /share/i })).toBeTruthy()
+    })
+
+    it('shows a contextual sign-in modal with the list name when Share is clicked while logged out', async () => {
+        renderComponent()
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /share/i }))
+
+        await waitFor(() => {
+            const modal = screen.getByTestId('share-sign-in-modal')
+            expect(within(modal).getByText(/Test Trip/)).toBeTruthy()
+        })
+    })
+
+    it('saves pendingShareAction and calls login when a provider is selected', async () => {
+        renderComponent()
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /share/i }))
+        await screen.findByTestId('share-sign-in-modal')
+
+        const providerBtn = screen.getAllByTestId('share-sign-in-provider').at(0)!
+        fireEvent.click(providerBtn)
+
+        await waitFor(() => {
+            expect(mockLogin).toHaveBeenCalled()
+            expect(sessionStorage.getItem('pendingShareAction')).toContain('test-list-1')
+        })
+    })
+
+    it('auto-opens SharePackingListModal when pendingShareAction matches list id on mount', async () => {
+        sessionStorage.setItem('pendingShareAction', JSON.stringify({ listId: 'test-list-1' }))
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: { fetch: vi.fn(), info: { webId: 'https://user.pod/profile/card#me' } },
+            webId: 'https://user.pod/profile/card#me',
+            isLoading: false,
+            login: mockLogin,
+            logout: vi.fn(),
+        })
+        const { SharePackingListModal } = await import('../components/SharePackingListModal')
+        const mockModal = vi.mocked(SharePackingListModal)
+        mockModal.mockImplementation(({ isOpen }) => isOpen ? <div data-testid="share-modal" /> : null)
+
+        renderComponent()
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+
+        await waitFor(() => {
+            expect(screen.getByTestId('share-modal')).toBeTruthy()
+            expect(sessionStorage.getItem('pendingShareAction')).toBeNull()
+        })
     })
 })
 

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -14,9 +14,12 @@ import { POD_CONTAINERS, getPrimaryPodUrl, saveRdfToPod, resolveOwnerDisplayName
 import { useOwnerDisplayName } from '../hooks/useOwnerDisplayName'
 import { packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { SharePackingListModal } from '../components/SharePackingListModal'
+import { Modal } from '../components/Modal'
+import { COMMON_PROVIDERS } from '../components/SolidProviderSelector'
 import { useForeignPod } from '../components/ForeignPodContext'
 import { useSharedListsSync } from '../hooks/useSharedListsSync'
 import { mergePackingLists } from '../utils/mergePackingLists'
+import { PENDING_SHARE_KEY } from './solid-pod-handle-redirect-page'
 
 type FormData = {
     items: Record<string, boolean>
@@ -58,6 +61,7 @@ export function ViewPackingList() {
     const [packingList, setPackingList] = useState<PackingList | null>(null)
     const [isLoading, setIsLoading] = useState(true)
     const [shareModalOpen, setShareModalOpen] = useState(false)
+    const [showShareSignIn, setShowShareSignIn] = useState(false)
     const [ownPodUrl, setOwnPodUrl] = useState<string | null>(null)
     // Tracks whether initial data has been loaded (local DB or pod).
     // Used to surface a real error to the user instead of hanging on "Loading…"
@@ -94,7 +98,7 @@ export function ViewPackingList() {
 
     const handleCheckAll = (items: PackingListItem[]) =>
         items.forEach(item => setValue(`items.${item.id}`, true))
-    const { isLoggedIn, session } = useSolidPod()
+    const { isLoggedIn, session, login } = useSolidPod()
     const { showToast } = useToast()
     const { db } = useDatabase()
     const { sharedListsWithMe, saveSharedListsWithMe } = useSharedListsSync()
@@ -106,6 +110,18 @@ export function ViewPackingList() {
             getPrimaryPodUrl(session).then(url => setOwnPodUrl(url ?? null))
         }
     }, [isLoggedIn, session])
+
+    // Auto-resume a pending share action after login redirect
+    useEffect(() => {
+        if (!isLoggedIn || !id) return
+        const raw = sessionStorage.getItem(PENDING_SHARE_KEY)
+        if (!raw) return
+        let pending: { listId: string }
+        try { pending = JSON.parse(raw) } catch { return }
+        if (pending.listId !== id) return
+        sessionStorage.removeItem(PENDING_SHARE_KEY)
+        setShareModalOpen(true)
+    }, [isLoggedIn, id])
 
     useEffect(() => {
         if (!packingList || !foreignPodUrl || !id || !sharedListsWithMe) return
@@ -557,6 +573,13 @@ export function ViewPackingList() {
         .map(g => [g.name, groupedItems[g.name] ?? []] as [string, PackingListItem[]])
     const personSections = [...regularSections, ...guestSections]
 
+    const handleShareSignIn = (issuer: string) => {
+        if (!id) return
+        sessionStorage.setItem(PENDING_SHARE_KEY, JSON.stringify({ listId: id }))
+        setShowShareSignIn(false)
+        login(issuer, `/view-list/${id}`)
+    }
+
     return (
         <>
         <div className="w-full flex flex-col items-center py-8 px-4">
@@ -589,12 +612,12 @@ export function ViewPackingList() {
                                 + Add Guest
                             </Button>
                         )}
-                        {isLoggedIn && !foreignPodUrl && (
+                        {!foreignPodUrl && (
                             <Button
                                 type="button"
                                 variant="secondary"
-                                onClick={() => setShareModalOpen(true)}
-                                disabled={!ownPodUrl}
+                                onClick={() => isLoggedIn ? setShareModalOpen(true) : setShowShareSignIn(true)}
+                                disabled={isLoggedIn && !ownPodUrl}
                             >
                                 Share
                             </Button>
@@ -909,6 +932,37 @@ export function ViewPackingList() {
             confirmText="Remove"
             confirmVariant="danger"
         />
+        <Modal
+            isOpen={showShareSignIn}
+            onClose={() => setShowShareSignIn(false)}
+            title={`Share "${packingList?.name}"`}
+        >
+            <div className="space-y-4" data-testid="share-sign-in-modal">
+                <p className="text-sm text-gray-700">
+                    To share <strong>{packingList?.name}</strong> with friends for your trip, you need a free Solid Pod — your personal storage that keeps your data yours.
+                </p>
+                <p className="text-xs text-indigo-600 font-medium">
+                    After signing in we'll bring you right back here to complete the share. ✨
+                </p>
+                <div className="space-y-2 pt-1">
+                    {COMMON_PROVIDERS.map(provider => (
+                        <button
+                            key={provider.issuer}
+                            data-testid="share-sign-in-provider"
+                            onClick={() => handleShareSignIn(provider.issuer)}
+                            className="w-full text-left px-4 py-3 border-2 border-gray-200 hover:border-indigo-400 hover:bg-indigo-50 rounded-xl transition-all duration-150 group"
+                        >
+                            <div className="font-semibold text-gray-900 group-hover:text-indigo-900">{provider.name}</div>
+                            {provider.description && (
+                                <div className="text-xs text-green-700 font-medium">{provider.description}</div>
+                            )}
+                            <div className="text-xs text-gray-400">{provider.issuer}</div>
+                        </button>
+                    ))}
+                </div>
+            </div>
+        </Modal>
+
         {session && ownPodUrl && id && (
             <SharePackingListModal
                 isOpen={shareModalOpen}

--- a/src/services/database.test.ts
+++ b/src/services/database.test.ts
@@ -511,6 +511,34 @@ describe('PackingAppDatabase', () => {
       const qs = await target.getQuestionSet()
       expect(qs._rev).toBeTruthy()
     })
+
+    it('merges items rather than overwriting when a list with the same ID exists in the target', async () => {
+      const source = PackingAppDatabase.getInstance('copy-merge-source')
+      const target = PackingAppDatabase.getInstance('copy-merge-target')
+      // Target already has the list with one item
+      await target.savePackingList({
+        id: 'shared-list',
+        name: 'Trip',
+        createdAt: '2025-06-01T00:00:00.000Z',
+        lastModified: '2025-06-01T00:00:00.000Z',
+        items: [{ id: 'a', itemText: 'Passport', personId: 'p1', personName: 'Alice', questionId: 'q', optionId: 'o', packed: false }],
+      })
+      // Source (local) has the same list with a different item, modified later
+      await source.savePackingList({
+        id: 'shared-list',
+        name: 'Trip',
+        createdAt: '2025-06-01T00:00:00.000Z',
+        lastModified: '2025-06-02T00:00:00.000Z',
+        items: [{ id: 'b', itemText: 'Towel', personId: 'p1', personName: 'Alice', questionId: 'q', optionId: 'o', packed: false }],
+      })
+
+      await target.copyAllDataFrom(source)
+
+      const lists = await target.getAllPackingLists()
+      expect(lists).toHaveLength(1)
+      const itemIds = lists[0].items.map(i => i.id).sort()
+      expect(itemIds).toEqual(['a', 'b'])
+    })
   })
 
   describe('Stale Revision Handling', () => {

--- a/src/services/database.test.ts
+++ b/src/services/database.test.ts
@@ -512,6 +512,29 @@ describe('PackingAppDatabase', () => {
       expect(qs._rev).toBeTruthy()
     })
 
+    it('merges question sets rather than overwriting when target already has one', async () => {
+      const source = PackingAppDatabase.getInstance('copy-qs-merge-source')
+      const target = PackingAppDatabase.getInstance('copy-qs-merge-target')
+      await target.saveQuestionSet({
+        _id: '1',
+        people: [{ id: 'pod-person', name: 'Bob' }],
+        alwaysNeededItems: [],
+        questions: [],
+      })
+      await source.saveQuestionSet({
+        _id: '1',
+        people: [{ id: 'local-person', name: 'Alice' }],
+        alwaysNeededItems: [],
+        questions: [],
+      })
+
+      await target.copyAllDataFrom(source)
+
+      const qs = await target.getQuestionSet()
+      const personIds = qs.people.map(p => p.id).sort()
+      expect(personIds).toEqual(['local-person', 'pod-person'])
+    })
+
     it('merges items rather than overwriting when a list with the same ID exists in the target', async () => {
       const source = PackingAppDatabase.getInstance('copy-merge-source')
       const target = PackingAppDatabase.getInstance('copy-merge-target')

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1,6 +1,7 @@
 import PouchDB from 'pouchdb'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList } from '../create-packing-list/types'
+import { mergePackingLists } from '../utils/mergePackingLists'
 import type { SharedWithMeList, SharedListsWithMe } from './rdfSerialization'
 
 export type DocumentType = 'question-set' | 'packing-list' | 'shared-with-me' | 'shared-lists-with-me'
@@ -439,9 +440,15 @@ export class PackingAppDatabase {
             if (!hasName(err) || err.name !== 'not_found') throw err
         }
 
-        const lists = await source.getAllPackingLists()
-        for (const list of lists) {
-            await this.savePackingList({ ...list, _rev: undefined })
+        const sourceLists = await source.getAllPackingLists()
+        const existingLists = await this.getAllPackingLists()
+        const existingById = new Map(existingLists.map(l => [l.id, l]))
+        for (const list of sourceLists) {
+            // Merge rather than overwrite if a list with this ID already exists
+            // in the target, so neither side's items are lost.
+            const existing = existingById.get(list.id)
+            const toSave = existing ? mergePackingLists(list, existing) : list
+            await this.savePackingList({ ...toSave, _rev: undefined })
         }
     }
 }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2,6 +2,7 @@ import PouchDB from 'pouchdb'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList } from '../create-packing-list/types'
 import { mergePackingLists } from '../utils/mergePackingLists'
+import { mergeQuestionSets } from '../utils/mergeQuestionSets'
 import type { SharedWithMeList, SharedListsWithMe } from './rdfSerialization'
 
 export type DocumentType = 'question-set' | 'packing-list' | 'shared-with-me' | 'shared-lists-with-me'
@@ -434,8 +435,11 @@ export class PackingAppDatabase {
 
     public async copyAllDataFrom(source: PackingAppDatabase): Promise<void> {
         try {
-            const questionSet = await source.getQuestionSet()
-            await this.saveQuestionSet({ ...questionSet, _rev: undefined })
+            const sourceQs = await source.getQuestionSet()
+            let existingQs: Awaited<ReturnType<typeof this.getQuestionSet>> | null = null
+            try { existingQs = await this.getQuestionSet() } catch { /* not_found = ok */ }
+            const toSave = existingQs ? mergeQuestionSets(existingQs, sourceQs) : sourceQs
+            await this.saveQuestionSet({ ...toSave, _rev: undefined })
         } catch (err: unknown) {
             if (!hasName(err) || err.name !== 'not_found') throw err
         }

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -309,9 +309,11 @@ describe('syncAllDataFromPod', () => {
             expect(result.questionSetSynced).toBe(true)
         })
 
-        it('does not overwrite local question set when local is newer', async () => {
-            const podQs = makeQuestionSet({ lastModified: '2024-01-01T10:00:00.000Z' })
-            const localQs = makeQuestionSet({ lastModified: '2024-06-01T12:00:00.000Z' })
+        it('merges local and pod question sets, preserving people from both sides', async () => {
+            const localPerson = { id: 'local-person', name: 'Alice' }
+            const podPerson = { id: 'pod-person', name: 'Bob' }
+            const podQs = makeQuestionSet({ lastModified: '2024-01-01T10:00:00.000Z', people: [podPerson] })
+            const localQs = makeQuestionSet({ lastModified: '2024-06-01T12:00:00.000Z', people: [localPerson] })
             const db = makeDb({ questionSet: localQs, packingLists: [] })
 
             mockGetSolidDataset
@@ -320,8 +322,11 @@ describe('syncAllDataFromPod', () => {
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
 
-            expect(db.saveQuestionSet).not.toHaveBeenCalled()
-            expect(result.questionSetSynced).toBe(false)
+            expect(db.saveQuestionSet).toHaveBeenCalledOnce()
+            const saved = (db.saveQuestionSet as ReturnType<typeof vi.fn>).mock.calls[0][0]
+            const savedPersonIds = saved.people.map((p: { id: string }) => p.id).sort()
+            expect(savedPersonIds).toEqual(['local-person', 'pod-person'])
+            expect(result.questionSetSynced).toBe(true)
         })
 
         it('saves pod question set when no local copy exists', async () => {
@@ -426,6 +431,32 @@ describe('syncAllDataFromPod', () => {
             const saved = (db.savePackingList as ReturnType<typeof vi.fn>).mock.calls[0][0] as PackingList
             const savedItemIds = saved.items.map(i => i.id).sort()
             expect(savedItemIds).toEqual(['local-item', 'pod-item'])
+        })
+
+        it('writes the merged list back to the pod so the remote copy is updated', async () => {
+            const localItem = { id: 'local-item', itemText: 'Towel', personId: 'p1', personName: 'Alice', questionId: 'q', optionId: 'o', packed: false }
+            const localList = makePackingList('shared-list', { items: [localItem], lastModified: '2024-06-01T12:00:00.000Z' })
+            const podItem   = { id: 'pod-item', itemText: 'Passport', personId: 'p1', personName: 'Alice', questionId: 'q', optionId: 'o', packed: false }
+            const podList   = makePackingList('shared-list', { items: [podItem], lastModified: '2024-01-01T10:00:00.000Z' })
+            const db = makeDb({ questionSet: null, packingLists: [localList] })
+
+            const listUrl = `${LISTS_CONTAINER_URL}shared-list.ttl`
+            mockGetSolidDataset
+                .mockRejectedValueOnce({ statusCode: 404 })
+                .mockResolvedValueOnce(makeContainerDataset([listUrl]))
+                .mockResolvedValueOnce(makeRdfListDataset(podList))
+
+            mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            // The merged list should be written back to the pod
+            expect(mockOverwriteFile).toHaveBeenCalledWith(
+                expect.stringContaining('shared-list.ttl'),
+                expect.any(Blob),
+                expect.objectContaining({ fetch: mockSession.fetch })
+            )
+            expect(result.packingListsUploaded).toBe(1)
         })
 
         it('returns correct counts when both pod and local lists exist', async () => {

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -398,6 +398,36 @@ describe('syncAllDataFromPod', () => {
             expect(result.packingListsUploaded).toBe(1)
         })
 
+        it('merges a pod list with the existing local list of the same ID instead of overwriting', async () => {
+            // Local (e.g. anonymous-session) copy has an item the pod copy lacks.
+            const localItem = { id: 'local-item', itemText: 'Towel', personId: 'p1', personName: 'Alice', questionId: 'q', optionId: 'o', packed: false }
+            const localList = makePackingList('shared-list', {
+                items: [localItem],
+                lastModified: '2024-06-01T12:00:00.000Z',
+            })
+            const podItem = { id: 'pod-item', itemText: 'Passport', personId: 'p1', personName: 'Alice', questionId: 'q', optionId: 'o', packed: false }
+            const podList = makePackingList('shared-list', {
+                items: [podItem],
+                lastModified: '2024-01-01T10:00:00.000Z',
+            })
+            const db = makeDb({ questionSet: null, packingLists: [localList] })
+
+            const listUrl = `${LISTS_CONTAINER_URL}shared-list.ttl`
+            mockGetSolidDataset
+                .mockRejectedValueOnce({ statusCode: 404 }) // no question set
+                .mockResolvedValueOnce(makeContainerDataset([listUrl]))
+                .mockResolvedValueOnce(makeRdfListDataset(podList))
+
+            await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            // The saved list must contain BOTH the local and pod items (a merge),
+            // not just the pod copy.
+            expect(db.savePackingList).toHaveBeenCalledTimes(1)
+            const saved = (db.savePackingList as ReturnType<typeof vi.fn>).mock.calls[0][0] as PackingList
+            const savedItemIds = saved.items.map(i => i.id).sort()
+            expect(savedItemIds).toEqual(['local-item', 'pod-item'])
+        })
+
         it('returns correct counts when both pod and local lists exist', async () => {
             const podList = makePackingList('pod-list')
             const localOnlyList = makePackingList('local-only')

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -5,6 +5,7 @@ const { getAgentAccessAll, setPublicAccess, getPublicAccess } = universalAccess
 import { PackingAppDatabase } from './database'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList } from '../create-packing-list/types'
+import { mergePackingLists } from '../utils/mergePackingLists'
 import { packingListToDataset, datasetToPackingList, datasetToQuestionSet, datasetToSharedWithMe, datasetToSharedListsWithMe } from './rdfSerialization'
 import type { SharedWithMeList, SharedListsWithMe } from './rdfSerialization'
 
@@ -1014,9 +1015,18 @@ export async function syncAllDataFromPod(
     const { data: podLists } = podListsResult.value
     const podListIds = new Set(podLists.map((l) => l.id))
 
-    // Save all pod lists to local DB in parallel (pod wins for conflicting IDs)
+    // Merge each pod list with any existing local list of the same ID so that
+    // unsynced local edits (e.g. lists created in an anonymous session before
+    // login) are preserved rather than clobbered by the pod copy.
+    const existingLocalLists = await db.getAllPackingLists()
+    const localListsById = new Map(existingLocalLists.map(l => [l.id, l]))
+
     const saveResults = await Promise.allSettled(
-        podLists.map(podList => db.savePackingList({ ...podList, _rev: undefined }))
+        podLists.map(podList => {
+            const localList = localListsById.get(podList.id)
+            const toSave = localList ? mergePackingLists(localList, podList) : podList
+            return db.savePackingList({ ...toSave, _rev: undefined })
+        })
     )
     for (let i = 0; i < saveResults.length; i++) {
         if (saveResults[i].status === 'fulfilled') {

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -6,6 +6,7 @@ import { PackingAppDatabase } from './database'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList } from '../create-packing-list/types'
 import { mergePackingLists } from '../utils/mergePackingLists'
+import { mergeQuestionSets } from '../utils/mergeQuestionSets'
 import { packingListToDataset, datasetToPackingList, datasetToQuestionSet, datasetToSharedWithMe, datasetToSharedListsWithMe } from './rdfSerialization'
 import type { SharedWithMeList, SharedListsWithMe } from './rdfSerialization'
 
@@ -982,14 +983,11 @@ export async function syncAllDataFromPod(
                 // not_found is expected for a fresh login
             }
 
-            const podTime = podQs.lastModified ? new Date(podQs.lastModified).getTime() : 0
-            const localTime = localQs?.lastModified ? new Date(localQs.lastModified).getTime() : 0
-
-            // Fallback-to-pod: save when there is no local copy OR pod is newer
-            if (!localQs || podTime > localTime) {
-                await db.saveQuestionSet({ ...podQs, _rev: undefined })
-                questionSetSynced = true
-            }
+            // Merge so neither side's people/questions are lost; if no local copy
+            // exists the pod version is taken as-is.
+            const toSave = localQs ? mergeQuestionSets(localQs, podQs) : podQs
+            await db.saveQuestionSet({ ...toSave, _rev: undefined })
+            questionSetSynced = true
         } catch (err: unknown) {
             if (err instanceof AuthenticationError) throw err
             console.error('syncAllDataFromPod: error syncing question set', err)
@@ -1021,11 +1019,18 @@ export async function syncAllDataFromPod(
     const existingLocalLists = await db.getAllPackingLists()
     const localListsById = new Map(existingLocalLists.map(l => [l.id, l]))
 
+    // Track which pod lists were merged so we can write the richer result back.
+    const mergedLists: PackingList[] = []
+
     const saveResults = await Promise.allSettled(
         podLists.map(podList => {
             const localList = localListsById.get(podList.id)
-            const toSave = localList ? mergePackingLists(localList, podList) : podList
-            return db.savePackingList({ ...toSave, _rev: undefined })
+            if (localList) {
+                const merged = mergePackingLists(localList, podList)
+                mergedLists.push(merged)
+                return db.savePackingList({ ...merged, _rev: undefined })
+            }
+            return db.savePackingList({ ...podList, _rev: undefined })
         })
     )
     for (let i = 0; i < saveResults.length; i++) {
@@ -1036,7 +1041,24 @@ export async function syncAllDataFromPod(
         }
     }
 
-    // Upload any local-only lists to the pod so they are not lost
+    // Push merged lists back to the pod so the richer (merged) content is
+    // reflected remotely, not just locally.
+    for (const merged of mergedLists) {
+        try {
+            await saveRdfToPod({
+                session,
+                fileUrl: `${containerUrl}${merged.id}.ttl`,
+                data: merged,
+                serializer: packingListToDataset,
+            })
+            packingListsUploaded++
+        } catch (err) {
+            if (err instanceof AuthenticationError) throw err
+            console.error(`syncAllDataFromPod: error writing back merged list ${merged.id}`, err)
+        }
+    }
+
+    // Upload any local-only lists to the pod so they are not lost.
     const localLists = await db.getAllPackingLists()
     for (const localList of localLists) {
         if (podListIds.has(localList.id)) continue


### PR DESCRIPTION
Surfaces the existing SharePackingListModal directly from the lists
index so logged-in users can share a single list in one click.
Logged-out users see a sign-in prompt explaining the sharing context.
Foreign (shared-with-me) lists do not show the Share button.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ErNUhxkxySE57T5xuNGeqs