### PR TITLE
Extract & test item generation logic; confirm unselected options contribute no items (#205)

### DIFF
--- a/src/create-packing-list/generatePackingListItems.test.ts
+++ b/src/create-packing-list/generatePackingListItems.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import { generateQuestionBasedItems } from './generatePackingListItems'
+import { Question } from '../edit-questions/types'
+
+const p1 = { id: 'p1', name: 'Alice' }
+const p2 = { id: 'p2', name: 'Bob' }
+
+const swimmingOpt = {
+    id: 'opt-swimming',
+    text: 'Swimming',
+    order: 0,
+    items: [
+        { text: 'Swimsuit', personSelections: [{ personId: 'p1', selected: true }] },
+        { text: 'Goggles', personSelections: [{ personId: 'p1', selected: true }] },
+    ],
+}
+const runningOpt = {
+    id: 'opt-running',
+    text: 'Running',
+    order: 1,
+    items: [
+        { text: 'Running shoes', personSelections: [{ personId: 'p1', selected: true }] },
+        { text: 'Running socks', personSelections: [{ personId: 'p1', selected: true }] },
+    ],
+}
+const hikingOpt = {
+    id: 'opt-hiking',
+    text: 'Hiking',
+    order: 2,
+    items: [
+        { text: 'Hiking boots', personSelections: [{ personId: 'p1', selected: true }] },
+    ],
+}
+
+const activitiesQuestion: Question = {
+    id: 'q-activities',
+    type: 'saved',
+    text: 'What activities will you be doing?',
+    order: 0,
+    questionType: 'multiple-choice',
+    options: [swimmingOpt, runningOpt, hikingOpt],
+}
+
+const overnightQuestion: Question = {
+    id: 'q-overnight',
+    type: 'saved',
+    text: 'Staying overnight?',
+    order: 1,
+    questionType: 'single-choice',
+    options: [
+        {
+            id: 'opt-yes',
+            text: 'Yes',
+            order: 0,
+            items: [{ text: 'Toothbrush', personSelections: [{ personId: 'p1', selected: true }] }],
+        },
+        {
+            id: 'opt-no',
+            text: 'No',
+            order: 1,
+            items: [],
+        },
+    ],
+}
+
+// ─── Core regression test from issue #205 ────────────────────────────────────
+
+describe('generateQuestionBasedItems – unselected options contribute no items', () => {
+    it('excludes items from options that were not selected (the issue #205 regression)', () => {
+        const answers = [
+            { questionId: 'q-activities', selectedOptionIds: ['opt-swimming', 'opt-hiking'] },
+        ]
+        const result = generateQuestionBasedItems(
+            [activitiesQuestion],
+            answers,
+            [p1],
+            ['p1']
+        )
+
+        const itemTexts = result.map(i => i.itemText)
+        // Swimming and Hiking items should be present
+        expect(itemTexts).toContain('Swimsuit')
+        expect(itemTexts).toContain('Goggles')
+        expect(itemTexts).toContain('Hiking boots')
+        // Running items must NOT appear even though Running is in the question set
+        expect(itemTexts).not.toContain('Running shoes')
+        expect(itemTexts).not.toContain('Running socks')
+    })
+
+    it('produces no items when no options are selected for a multiple-choice question', () => {
+        const answers = [{ questionId: 'q-activities', selectedOptionIds: [] }]
+        const result = generateQuestionBasedItems([activitiesQuestion], answers, [p1], ['p1'])
+        expect(result).toHaveLength(0)
+    })
+
+    it('produces no items when selectedOptionIds is missing (user skipped the question)', () => {
+        const answers = [{ questionId: 'q-activities' }]
+        const result = generateQuestionBasedItems([activitiesQuestion], answers, [p1], ['p1'])
+        expect(result).toHaveLength(0)
+    })
+})
+
+// ─── Selected options do contribute items ─────────────────────────────────────
+
+describe('generateQuestionBasedItems – selected options contribute items', () => {
+    it('includes all items from all selected options', () => {
+        const answers = [
+            { questionId: 'q-activities', selectedOptionIds: ['opt-swimming', 'opt-running'] },
+        ]
+        const result = generateQuestionBasedItems([activitiesQuestion], answers, [p1], ['p1'])
+        const itemTexts = result.map(i => i.itemText)
+        expect(itemTexts).toContain('Swimsuit')
+        expect(itemTexts).toContain('Goggles')
+        expect(itemTexts).toContain('Running shoes')
+        expect(itemTexts).toContain('Running socks')
+        expect(itemTexts).not.toContain('Hiking boots')
+    })
+
+    it('includes only items for selected people', () => {
+        const optWithTwoPeople = {
+            id: 'opt-swimming',
+            text: 'Swimming',
+            order: 0,
+            items: [
+                {
+                    text: 'Swimsuit',
+                    personSelections: [
+                        { personId: 'p1', selected: true },
+                        { personId: 'p2', selected: true },
+                    ],
+                },
+            ],
+        }
+        const q: Question = { ...activitiesQuestion, options: [optWithTwoPeople] }
+        const answers = [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }]
+
+        // Only p1 is travelling
+        const result = generateQuestionBasedItems([q], answers, [p1, p2], ['p1'])
+        expect(result).toHaveLength(1)
+        expect(result[0].personId).toBe('p1')
+    })
+
+    it('sets category to option text for multiple-choice questions', () => {
+        const answers = [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }]
+        const result = generateQuestionBasedItems([activitiesQuestion], answers, [p1], ['p1'])
+        result.forEach(item => expect(item.category).toBe('Swimming'))
+    })
+
+    it('sets category to question text for single-choice questions', () => {
+        const answers = [{ questionId: 'q-overnight', selectedOptionIds: ['opt-yes'] }]
+        const result = generateQuestionBasedItems([overnightQuestion], answers, [p1], ['p1'])
+        result.forEach(item => expect(item.category).toBe('Staying overnight?'))
+    })
+
+    it('processes multiple questions and merges their items', () => {
+        const answers = [
+            { questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] },
+            { questionId: 'q-overnight', selectedOptionIds: ['opt-yes'] },
+        ]
+        const result = generateQuestionBasedItems(
+            [activitiesQuestion, overnightQuestion],
+            answers,
+            [p1],
+            ['p1']
+        )
+        const itemTexts = result.map(i => i.itemText)
+        expect(itemTexts).toContain('Swimsuit')
+        expect(itemTexts).toContain('Toothbrush')
+    })
+
+    it('returns empty array when questionAnswers is empty', () => {
+        const result = generateQuestionBasedItems([activitiesQuestion], [], [p1], ['p1'])
+        expect(result).toHaveLength(0)
+    })
+
+    it('skips a question when the questionId does not match any question', () => {
+        const answers = [{ questionId: 'unknown-id', selectedOptionIds: ['opt-swimming'] }]
+        const result = generateQuestionBasedItems([activitiesQuestion], answers, [p1], ['p1'])
+        expect(result).toHaveLength(0)
+    })
+})

--- a/src/create-packing-list/generatePackingListItems.ts
+++ b/src/create-packing-list/generatePackingListItems.ts
@@ -1,0 +1,42 @@
+import { Question, Person } from '../edit-questions/types'
+import { PackingListItem } from './types'
+
+export function generateQuestionBasedItems(
+    questions: Question[],
+    questionAnswers: Array<{ questionId: string; selectedOptionIds?: string[] }>,
+    people: Person[],
+    selectedPeopleIds: string[]
+): PackingListItem[] {
+    return questionAnswers.flatMap(qa => {
+        const selectedOptionIds = qa.selectedOptionIds ?? []
+        const question = questions.find(q => q.id === qa.questionId)
+        if (!question) return []
+
+        return selectedOptionIds.flatMap(selectedOptionId => {
+            if (!selectedOptionId) return []
+            const selectedOption = question.options.find(o => o.id === selectedOptionId)
+            if (!selectedOption) return []
+
+            return selectedOption.items.flatMap(item => {
+                const selectedPeople = item.personSelections.filter(
+                    ps => ps.selected && selectedPeopleIds.includes(ps.personId)
+                )
+                return selectedPeople.flatMap(ps => {
+                    const person = people.find(p => p.id === ps.personId)!
+                    return {
+                        id: crypto.randomUUID(),
+                        itemText: item.text,
+                        personId: ps.personId,
+                        personName: person.name,
+                        questionId: question.id,
+                        optionId: selectedOption.id,
+                        packed: false,
+                        category: question.questionType === 'multiple-choice'
+                            ? selectedOption.text
+                            : question.text,
+                    } satisfies PackingListItem
+                })
+            })
+        })
+    })
+}

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -926,7 +926,7 @@ describe('CreatePackingList – deletion suggestion card', () => {
 
         const keepButtons = screen.getAllByRole('button', { name: /keep/i })
         fireEvent.click(keepButtons[0])
-        await waitFor(() => screen.getAllByRole('button', { name: /keep/i }).length < 2)
+        await waitFor(() => expect(screen.getAllByRole('button', { name: /keep/i })).toHaveLength(1))
         fireEvent.click(screen.getByRole('button', { name: /keep/i }))
 
         await waitFor(() => expect(screen.queryByText(/previously removed/i)).toBeNull())

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -13,6 +13,7 @@ import { getPrimaryPodUrl, saveRdfToPod, POD_CONTAINERS, loadMultipleRdfFromPod 
 import { usePodSync } from '../hooks/usePodSync'
 import { questionSetToDataset, datasetToQuestionSet, packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { useForeignPod } from '../components/ForeignPodContext'
+import { generateQuestionBasedItems } from '../create-packing-list/generatePackingListItems'
 
 export function deduplicateItems(items: PackingListItem[]): PackingListItem[] {
     const seen = new Set<string>()
@@ -543,38 +544,12 @@ export function CreatePackingList() {
         if (!questionSet) return
 
         // Get items from question answers
-        const questionBasedItems = data.questionAnswers.flatMap((qa: { questionId: string; selectedOptionIds: string[] }) => {
-            const questionId = qa.questionId
-            const selectedOptionIds = qa.selectedOptionIds || []
-            const question = questionSet.questions.find((q) => q.id === questionId)
-            if (!question) return []
-
-            // For each selected option, get all items
-            return selectedOptionIds.flatMap((selectedOptionId) => {
-                if (!selectedOptionId) return []
-                const selectedOption = question.options.find((option) => (option.id === selectedOptionId))
-                if (!selectedOption) return []
-                const packingListItems: PackingListItem[] = selectedOption.items.flatMap((item) => {
-                    const selectedPeople = item.personSelections.filter((person) => (
-                        person.selected && selectedPeopleIds.includes(person.personId)
-                    ))
-                    return selectedPeople.flatMap((person) => {
-                        const personName = questionSet.people.find((p) => p.id === person.personId)!.name
-                        return {
-                            id: crypto.randomUUID(),
-                            itemText: item.text,
-                            personId: person.personId,
-                            personName,
-                            questionId: question.id,
-                            optionId: selectedOption.id,
-                            packed: false,
-                            category: question.questionType === 'multiple-choice' ? selectedOption.text : question.text,
-                        }
-                    })
-                })
-                return packingListItems
-            })
-        })
+        const questionBasedItems = generateQuestionBasedItems(
+            questionSet.questions,
+            data.questionAnswers,
+            questionSet.people,
+            selectedPeopleIds
+        )
 
         // Get always needed items
         const alwaysNeededItems = questionSet.alwaysNeededItems.flatMap((item) => {


### PR DESCRIPTION
Pulls the question-answer → PackingListItem mapping out of the onSubmit
inline block into a pure `generateQuestionBasedItems` utility, and adds
10 unit tests that prove unselected options are never included in the
generated list (the regression scenario from the issue).

The filtering logic was already correct; this commit provides the
documented test coverage the issue required and simplifies create-packing-list.tsx.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K5LY9v2JgxxavS8JEUM9o6