### PR TITLE
Pre-select all travellers and add select-all/none toggle on create-list form

### DIFF
--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -1198,3 +1198,94 @@ describe('CreatePackingList – question set pod sync on mount', () => {
         expect(db.saveQuestionSet).not.toHaveBeenCalled()
     })
 })
+
+// ─── CreatePackingList – travellers select-all/none and validation ─────────────
+
+const twoPersonQuestionSet: PackingListQuestionSet = {
+    people: [
+        { id: 'p1', name: 'Alice' },
+        { id: 'p2', name: 'Bob' },
+    ],
+    alwaysNeededItems: [],
+    questions: [
+        {
+            id: 'q1',
+            text: 'Where are you going?',
+            order: 0,
+            type: 'saved',
+            options: [{ id: 'o1', text: 'Beach', order: 0, items: [] }],
+        },
+    ],
+}
+
+function makeTwoPersonDb(overrides: Record<string, unknown> = {}) {
+    return {
+        getQuestionSet: vi.fn().mockResolvedValue(twoPersonQuestionSet),
+        getAllPackingLists: vi.fn().mockResolvedValue([]),
+        saveQuestionSet: vi.fn().mockResolvedValue({ rev: '2' }),
+        savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+        ...overrides,
+    }
+}
+
+describe('CreatePackingList – travellers select-all/none and validation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({ isLoggedIn: false } as ReturnType<typeof useSolidPod>)
+        mockUseToast.mockReturnValue({ showToast: vi.fn() } as ReturnType<typeof useToast>)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('shows a select all/none toggle button in the people section', async () => {
+        mockUseDatabase.mockReturnValue({ db: makeTwoPersonDb() } as ReturnType<typeof useDatabase>)
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+        expect(screen.getByRole('button', { name: /select (all|none)/i })).toBeTruthy()
+    })
+
+    it('"Select none" deselects all travellers', async () => {
+        mockUseDatabase.mockReturnValue({ db: makeTwoPersonDb() } as ReturnType<typeof useDatabase>)
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+
+        const toggle = screen.getByRole('button', { name: /select none/i })
+        fireEvent.click(toggle)
+
+        const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
+        expect(checkboxes.every(cb => !cb.checked)).toBe(true)
+    })
+
+    it('"Select all" re-selects all travellers after deselecting', async () => {
+        mockUseDatabase.mockReturnValue({ db: makeTwoPersonDb() } as ReturnType<typeof useDatabase>)
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+
+        fireEvent.click(screen.getByRole('button', { name: /select none/i }))
+        fireEvent.click(screen.getByRole('button', { name: /select all/i }))
+
+        const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
+        expect(checkboxes.every(cb => cb.checked)).toBe(true)
+    })
+
+    it('blocks submission and shows error toast when no travellers are selected', async () => {
+        const showToast = vi.fn()
+        mockUseToast.mockReturnValue({ showToast } as ReturnType<typeof useToast>)
+        const db = makeTwoPersonDb()
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+
+        fireEvent.click(screen.getByRole('button', { name: /select none/i }))
+        fireEvent.change(screen.getByPlaceholderText(/enter a name/i), { target: { value: 'My Trip' } })
+        fireEvent.click(screen.getByRole('button', { name: /create packing list/i }))
+
+        await waitFor(() => expect(showToast).toHaveBeenCalledWith(
+            expect.stringMatching(/at least one traveller/i),
+            'error'
+        ))
+        expect(db.savePackingList).not.toHaveBeenCalled()
+    })
+})

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -542,6 +542,11 @@ export function CreatePackingList() {
     const onSubmit: SubmitHandler<PackingListFormData> = async (data) => {
         if (!questionSet) return
 
+        if (selectedPeopleIds.length === 0) {
+            showToast('Please select at least one traveller.', 'error')
+            return
+        }
+
         // Get items from question answers
         const questionBasedItems = data.questionAnswers.flatMap((qa: { questionId: string; selectedOptionIds: string[] }) => {
             const questionId = qa.questionId
@@ -760,9 +765,22 @@ export function CreatePackingList() {
                 {/* Person Selection */}
                 {questionSet.people.length > 0 && (
                     <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-                        <h3 className="text-lg font-medium text-gray-900 mb-4">
-                            Who is going on this trip?
-                        </h3>
+                        <div className="flex items-center justify-between mb-4">
+                            <h3 className="text-lg font-medium text-gray-900">
+                                Who is going on this trip?
+                            </h3>
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    selectedPeopleIds.length === questionSet.people.length
+                                        ? setSelectedPeopleIds([])
+                                        : setSelectedPeopleIds(questionSet.people.map(p => p.id))
+                                }
+                                className="text-sm text-blue-600 underline hover:text-blue-800"
+                            >
+                                {selectedPeopleIds.length === questionSet.people.length ? 'Select none' : 'Select all'}
+                            </button>
+                        </div>
                         <div className="space-y-2">
                             {questionSet.people.map((person) => (
                                 <label key={person.id} className="flex items-center space-x-3">


### PR DESCRIPTION
- All known travellers are pre-selected when the create-list form opens
- A "Select none / Select all" button toggles the whole traveller group
- Submitting with zero travellers selected is blocked with a clear error toast

Closes #208