### PR TITLE
Match Android launcher icon to website logo

### DIFF
--- a/android/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
@@ -1,34 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:aapt="http://schemas.android.com/aapt"
     android:width="108dp"
     android:height="108dp"
-    android:viewportHeight="108"
-    android:viewportWidth="108">
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <!-- Main bag body -->
     <path
-        android:fillType="evenOdd"
-        android:pathData="M32,64C32,64 38.39,52.99 44.13,50.95C51.37,48.37 70.14,49.57 70.14,49.57L108.26,87.69L108,109.01L75.97,107.97L32,64Z"
-        android:strokeColor="#00000000"
-        android:strokeWidth="1">
-        <aapt:attr name="android:fillColor">
-            <gradient
-                android:endX="78.5885"
-                android:endY="90.9159"
-                android:startX="48.7653"
-                android:startY="61.0927"
-                android:type="linear">
-                <item
-                    android:color="#44000000"
-                    android:offset="0.0" />
-                <item
-                    android:color="#00000000"
-                    android:offset="1.0" />
-            </gradient>
-        </aapt:attr>
-    </path>
+        android:fillColor="#14b8a6"
+        android:pathData="M30.375,37.125 L77.625,37.125 Q91.125,37.125 91.125,50.625 L91.125,79.3125 Q91.125,92.8125 77.625,92.8125 L30.375,92.8125 Q16.875,92.8125 16.875,79.3125 L16.875,50.625 Q16.875,37.125 30.375,37.125 Z" />
+
+    <!-- Front pocket -->
     <path
-        android:fillColor="#FFFFFF"
-        android:fillType="nonZero"
-        android:pathData="M66.94,46.02L66.94,46.02C72.44,50.07 76,56.61 76,64L32,64C32,56.61 35.56,50.11 40.98,46.06L36.18,41.19C35.45,40.45 35.45,39.3 36.18,38.56C36.91,37.81 38.05,37.81 38.78,38.56L44.25,44.05C47.18,42.57 50.48,41.71 54,41.71C57.48,41.71 60.78,42.57 63.68,44.05L69.11,38.56C69.84,37.81 70.98,37.81 71.71,38.56C72.44,39.3 72.44,40.45 71.71,41.19L66.94,46.02ZM62.94,56.92C64.08,56.92 65,56.01 65,54.88C65,53.76 64.08,52.85 62.94,52.85C61.8,52.85 60.88,53.76 60.88,54.88C60.88,56.01 61.8,56.92 62.94,56.92ZM45.06,56.92C46.2,56.92 47.13,56.01 47.13,54.88C47.13,53.76 46.2,52.85 45.06,52.85C43.92,52.85 43,53.76 43,54.88C43,56.01 43.92,56.92 45.06,56.92Z"
-        android:strokeColor="#00000000"
-        android:strokeWidth="1" />
+        android:fillColor="#0d9488"
+        android:pathData="M35.4375,57.375 L72.5625,57.375 Q81,57.375 81,65.8125 L81,77.625 Q81,86.0625 72.5625,86.0625 L35.4375,86.0625 Q27,86.0625 27,77.625 L27,65.8125 Q27,57.375 35.4375,57.375 Z" />
+
+    <!-- Zipper pull -->
+    <path
+        android:fillColor="#2dd4bf"
+        android:pathData="M49.781,57.375 A4.219,4.219 0 1 0 58.219,57.375 A4.219,4.219 0 1 0 49.781,57.375 Z" />
+
+    <!-- Carry handle -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#2dd4bf"
+        android:strokeWidth="6.75"
+        android:strokeLineCap="round"
+        android:pathData="M37.125,37.125 L37.125,27 A16.875,16.875 0 0 1 70.875,27 L70.875,37.125" />
+
 </vector>

--- a/android/app/src/main/res/values/ic_launcher_background.xml
+++ b/android/app/src/main/res/values/ic_launcher_background.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#FFFFFF</color>
+    <color name="ic_launcher_background">#134e4a</color>
 </resources>


### PR DESCRIPTION
Updates the adaptive icon background colour to #134e4a and replaces the
foreground drawable with the bag SVG (handle, body, pocket, zipper pull)
converted to Android vector format.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KEZboVJYDd2S7zJQKFr7yM