### PR TITLE
Document PR conventions for issue linking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ Each serial suite that writes to a Solid pod **must use its own dedicated pod us
 | M (User A) | `muser` |
 | L/M (User B) | `collabuser` |
 
+## Pull Requests
+
+When raising a PR that addresses a GitHub issue, always reference the issue in the PR description using `Closes #<issue-number>` or `Fixes #<issue-number>` so GitHub automatically links and closes the issue on merge.
+
 ## Data Access
 
 Never call `db.*` (local PouchDB) and pod storage functions directly in the same place. Use the established intermediate layers:


### PR DESCRIPTION
## Summary

Added documentation to CLAUDE.md clarifying the pull request convention for linking GitHub issues.

## Changes

- Added a new "Pull Requests" section to CLAUDE.md that documents the requirement to reference issues in PR descriptions using `Closes #<issue-number>` or `Fixes #<issue-number>` syntax
- This enables GitHub's automatic issue linking and closing on merge

## Details

This is a documentation-only change that codifies an existing best practice for the project. It helps ensure that PRs addressing GitHub issues are properly tracked and automatically closed when merged.

https://claude.ai/code/session_01N9QDphMXQtyRrNjva4uZkb