### PR TITLE
Add /home route and smart default redirect based on login state

### DIFF
--- a/e2e/tests/i-migration.spec.ts
+++ b/e2e/tests/i-migration.spec.ts
@@ -75,7 +75,7 @@ test.describe('I – Data Migration', () => {
     const cancelBtn = dialog.getByRole('button').filter({ hasText: /no|cancel|skip|start fresh/i }).first()
     await cancelBtn.click({ timeout: 10_000 })
     // Landing page should show "Get Started" (empty pod namespace)
-    await localPage.goto('/')
+    await localPage.goto('/#/home')
     await expect(localPage.getByRole('link', { name: /Get Started/i })).toBeVisible({ timeout: 5_000 })
     await localCtx.close()
   })

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -8,7 +8,7 @@ vi.mock('@vercel/analytics/react', () => ({
 
 vi.mock('./components/SolidPodContext', () => ({
   SolidPodProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  useSolidPod: vi.fn(),
+  useSolidPod: vi.fn(() => ({ isLoggedIn: false, isLoading: false })),
 }))
 
 vi.mock('./components/DatabaseContext', () => ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { LandingPage } from './pages/landing-page'
 import { CreatePackingList } from './pages/create-packing-list'
 import { PackingLists } from './pages/packing-lists'
 import { ViewPackingList } from './pages/view-packing-list'
-import { SolidPodProvider } from './components/SolidPodContext'
+import { SolidPodProvider, useSolidPod } from './components/SolidPodContext'
 import { DatabaseProvider } from './components/DatabaseContext'
 import { SolidPodHandleRedirectPage } from './pages/solid-pod-handle-redirect-page'
 import { Wizard } from './pages/wizard'
@@ -20,6 +20,12 @@ import { ForeignPodLayout } from './components/ForeignPodLayout'
 import { ForeignPackingListsPage } from './pages/foreign-packing-lists'
 import { SharingSettingsPage } from './pages/sharing-settings'
 import { QuestionsPage } from './pages/questions-page'
+
+function DefaultRedirect() {
+  const { isLoggedIn, isLoading } = useSolidPod()
+  if (isLoading) return null
+  return <Navigate to={isLoggedIn ? '/view-lists' : '/home'} replace />
+}
 
 function App() {
   return (
@@ -33,7 +39,8 @@ function App() {
             <SessionExpiredBanner />
             <div className="container mx-auto px-4 py-8" style={{ paddingBottom: 'calc(2rem + env(safe-area-inset-bottom))' }}>
               <Routes>
-                <Route path="/" element={<LandingPage />} />
+                <Route path="/" element={<DefaultRedirect />} />
+                <Route path="/home" element={<LandingPage />} />
                 <Route path="/wizard" element={<Wizard />} />
                 <Route path="/manage-questions" element={<QuestionsPage />} />
                 <Route path="/create-packing-list" element={<CreatePackingList />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -48,7 +48,7 @@ export const Navigation = () => {
                     <div className="flex items-center justify-between h-16">
                         <div className="flex items-center">
                             <div className="flex-shrink-0">
-                                <Link to="/" className="flex items-center gap-2 text-2xl font-bold hover:scale-105 transition-transform duration-200 drop-shadow-md">
+                                <Link to="/home" className="flex items-center gap-2 text-2xl font-bold hover:scale-105 transition-transform duration-200 drop-shadow-md">
                                     <img src="/favicon.svg" alt="" className="h-8 w-8" />
                                     Pack Me Up
                                 </Link>


### PR DESCRIPTION
## Summary

- Moves `LandingPage` from `/` to an explicit `/home` route
- `/` now uses a `DefaultRedirect` component that waits for session restore, then sends logged-in users to `/view-lists` and guests to `/home`
- Updates the nav logo link from `/` to `/home`

## Why

Having a stable `/home` URL for the landing page lets the root route act as a smart entry point that can evolve independently (e.g. redirecting returning users straight to their lists, or future onboarding flows).

## Reviewer notes

`DefaultRedirect` renders `null` while `isLoading` is true to avoid a flash-redirect to `/home` before the Solid session has been restored. Once `isLoading` settles the redirect fires and the user lands on the right page.

## Test plan

- [ ] Visit `/` logged out → should redirect to `/home` (landing page)
- [ ] Visit `/` logged in → should redirect to `/view-lists`
- [ ] Nav logo click → goes to `/home`
- [ ] Hard refresh on any route → no unintended redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)