### PR TITLE
Add pets to the setup wizard

### DIFF
--- a/src/edit-questions/example-data.test.ts
+++ b/src/edit-questions/example-data.test.ts
@@ -125,6 +125,77 @@ describe('createExampleData - unassigned items excluded', () => {
     })
 })
 
+describe('createExampleData - pets', () => {
+    const adult: Person = { id: 'a1', name: 'Alice', ageRange: 'Adult' }
+    const dog: Person = { id: 'd1', name: 'Rex', species: 'dog' }
+    const cat: Person = { id: 'c1', name: 'Whiskers', species: 'cat' }
+
+    const petItem = (result: ReturnType<typeof createExampleData>, text: string) =>
+        result.alwaysNeededItems.find(i => i.text === text)
+
+    it('excludes all pet items when no pets are in the group', () => {
+        const result = createExampleData([adult])
+        for (const text of ['Pet food', 'Lead/Leash', 'Poop bags', 'Litter tray & litter', 'Cat carrier']) {
+            expect(petItem(result, text), `"${text}" should not appear`).toBeUndefined()
+        }
+    })
+
+    it('includes dog-specific items selected for the dog only', () => {
+        const result = createExampleData([adult, dog])
+        const lead = petItem(result, 'Lead/Leash')
+        expect(lead).toBeTruthy()
+        expect(lead!.personSelections.find(ps => ps.personId === dog.id)?.selected).toBe(true)
+        expect(lead!.personSelections.find(ps => ps.personId === adult.id)?.selected).toBe(false)
+    })
+
+    it('includes generic pet items (Pet food) selected for the dog', () => {
+        const result = createExampleData([adult, dog])
+        const food = petItem(result, 'Pet food')
+        expect(food).toBeTruthy()
+        expect(food!.personSelections.find(ps => ps.personId === dog.id)?.selected).toBe(true)
+    })
+
+    it('does not select the dog for human items (Snacks)', () => {
+        const result = createExampleData([adult, dog])
+        const snacks = result.alwaysNeededItems.find(i => i.text === 'Snacks')!
+        expect(snacks.personSelections.find(ps => ps.personId === dog.id)?.selected).toBe(false)
+        expect(snacks.personSelections.find(ps => ps.personId === adult.id)?.selected).toBe(true)
+    })
+
+    it('does not select the dog for unfiltered weather items (Sunscreen)', () => {
+        const result = createExampleData([adult, dog])
+        const weather = result.questions.find(q => q.text === 'What weather do you expect?')!
+        const hotItems = weather.options.find(o => o.text === 'Hot')!.items
+        const sunscreen = hotItems.find(i => i.text === 'Sunscreen')!
+        expect(sunscreen.personSelections.find(ps => ps.personId === dog.id)?.selected).toBe(false)
+    })
+
+    it('includes cat-specific items for a cat but no dog items', () => {
+        const result = createExampleData([adult, cat])
+        const litter = petItem(result, 'Litter tray & litter')
+        expect(litter).toBeTruthy()
+        expect(litter!.personSelections.find(ps => ps.personId === cat.id)?.selected).toBe(true)
+        expect(petItem(result, 'Lead/Leash')).toBeUndefined()
+    })
+
+    it('does not select humans for pet items', () => {
+        const result = createExampleData([adult, dog])
+        const food = petItem(result, 'Pet food')!
+        expect(food.personSelections.find(ps => ps.personId === adult.id)?.selected).toBe(false)
+    })
+
+    it('produces no item that has all personSelections unselected (with a mixed group)', () => {
+        const result = createExampleData([adult, dog, cat])
+        const allItems = [
+            ...result.alwaysNeededItems,
+            ...result.questions.flatMap(q => q.options.flatMap(o => o.items)),
+        ]
+        for (const item of allItems) {
+            expect(item.personSelections.some(ps => ps.selected), `Item "${item.text}" has no one assigned`).toBe(true)
+        }
+    })
+})
+
 describe('createExampleData - gender-specific items', () => {
     function getOvernightYesItems(result: ReturnType<typeof createExampleData>) {
         const overnight = result.questions.find(q => q.text === 'Will you be staying overnight?')!

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -22,15 +22,18 @@ import {
     getFemaleTeenagersAndAdults,
     getMaleTeenagersAndAdults,
 } from './age-specific-items';
+import { getDogs, getCats, getPets, getHumans } from './pet-specific-items';
 
 /**
  * Helper function to create an item with age-appropriate person selections
  * @param text - The item text/name
  * @param people - All people in the group
- * @param ageFilter - Optional function to filter people by age range (defaults to everyone)
+ * @param ageFilter - Optional function to filter people (defaults to all humans).
+ *   Defaulting to humans (rather than everyone) keeps pets from inheriting
+ *   human items; it's a no-op for groups with no pets.
  */
 function item(text: string, people: Person[], ageFilter?: (p: Person[]) => Person[]): Item {
-    const selectedPeople = ageFilter ? ageFilter(people) : people;
+    const selectedPeople = ageFilter ? ageFilter(people) : getHumans(people);
     return {
         text,
         personSelections: people.map(p => ({
@@ -182,6 +185,19 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             item("First aid kit", people),
             item("Plasters / Band-aids", people),
             item("Pain relief (paracetamol / ibuprofen)", people, getAdults),
+            // Pet items — only appear when a matching pet is in the group
+            item("Pet food", people, getPets),
+            item("Food & water bowls", people, getPets),
+            item("Pet bed/blanket", people, getPets),
+            item("Pet medication", people, getPets),
+            item("Vaccination/health records", people, getPets),
+            item("Lead/Leash", people, getDogs),
+            item("Collar & ID tag", people, getDogs),
+            item("Poop bags", people, getDogs),
+            item("Dog toy", people, getDogs),
+            item("Litter tray & litter", people, getCats),
+            item("Cat carrier", people, getCats),
+            item("Scratching pad", people, getCats),
         ),
         questions: [
             {

--- a/src/edit-questions/pet-specific-items.test.ts
+++ b/src/edit-questions/pet-specific-items.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { getDogs, getCats, getPets, getHumans } from './pet-specific-items'
+import { Person } from './types'
+
+const adult: Person = { id: 'a1', name: 'Alice', ageRange: 'Adult' }
+const baby: Person = { id: 'b1', name: 'Baby', ageRange: 'Baby' }
+const dog: Person = { id: 'd1', name: 'Rex', species: 'dog' }
+const dog2: Person = { id: 'd2', name: 'Fido', species: 'dog' }
+const cat: Person = { id: 'c1', name: 'Whiskers', species: 'cat' }
+const other: Person = { id: 'o1', name: 'Hoppy', species: 'other' }
+
+const all = [adult, baby, dog, dog2, cat, other]
+
+describe('getDogs', () => {
+    it('returns only people with species dog', () => {
+        expect(getDogs(all).map(p => p.id)).toEqual(['d1', 'd2'])
+    })
+
+    it('ignores humans and other species', () => {
+        expect(getDogs([adult, cat, other])).toEqual([])
+    })
+})
+
+describe('getCats', () => {
+    it('returns only people with species cat', () => {
+        expect(getCats(all).map(p => p.id)).toEqual(['c1'])
+    })
+
+    it('ignores humans and other species', () => {
+        expect(getCats([adult, dog, other])).toEqual([])
+    })
+})
+
+describe('getPets', () => {
+    it('returns everyone with a species set (any pet)', () => {
+        expect(getPets(all).map(p => p.id)).toEqual(['d1', 'd2', 'c1', 'o1'])
+    })
+
+    it('excludes humans (no species)', () => {
+        expect(getPets([adult, baby])).toEqual([])
+    })
+})
+
+describe('getHumans', () => {
+    it('returns only people without a species', () => {
+        expect(getHumans(all).map(p => p.id)).toEqual(['a1', 'b1'])
+    })
+
+    it('returns everyone when there are no pets', () => {
+        expect(getHumans([adult, baby]).map(p => p.id)).toEqual(['a1', 'b1'])
+    })
+
+    it('returns empty array for a pets-only group', () => {
+        expect(getHumans([dog, cat])).toEqual([])
+    })
+})

--- a/src/edit-questions/pet-specific-items.ts
+++ b/src/edit-questions/pet-specific-items.ts
@@ -1,0 +1,37 @@
+import { Person, PetSpecies } from './types'
+
+/**
+ * Helper to filter people by pet species
+ */
+function filterBySpecies(people: Person[], species: PetSpecies): Person[] {
+    return people.filter(p => p.species === species)
+}
+
+/**
+ * Get dogs only
+ */
+export function getDogs(people: Person[]): Person[] {
+    return filterBySpecies(people, 'dog')
+}
+
+/**
+ * Get cats only
+ */
+export function getCats(people: Person[]): Person[] {
+    return filterBySpecies(people, 'cat')
+}
+
+/**
+ * Get all pets (anyone with a species set, regardless of which)
+ */
+export function getPets(people: Person[]): Person[] {
+    return people.filter(p => p.species != null)
+}
+
+/**
+ * Get all humans (anyone without a species). Used as the default audience for
+ * items that aren't otherwise filtered, so pets don't inherit human items.
+ */
+export function getHumans(people: Person[]): Person[] {
+    return people.filter(p => p.species == null)
+}

--- a/src/edit-questions/types.test.ts
+++ b/src/edit-questions/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { AGE_RANGE_OPTIONS } from './types'
+import { AGE_RANGE_OPTIONS, PET_SPECIES_OPTIONS, PersonSchema } from './types'
 
 describe('AGE_RANGE_OPTIONS', () => {
   it('all option labels fit within 40 characters for mobile display', () => {
@@ -16,5 +16,33 @@ describe('AGE_RANGE_OPTIONS', () => {
   it('Baby label still mentions nappies', () => {
     const baby = AGE_RANGE_OPTIONS.find(o => o.value === 'Baby')!
     expect(baby.label).toContain('nappies')
+  })
+})
+
+describe('PET_SPECIES_OPTIONS', () => {
+  it('offers dog, cat, and other', () => {
+    expect(PET_SPECIES_OPTIONS.map(o => o.value)).toEqual(['dog', 'cat', 'other'])
+  })
+
+  it('all option labels fit within 40 characters for mobile display', () => {
+    PET_SPECIES_OPTIONS.forEach(opt => {
+      expect(opt.label.length).toBeLessThanOrEqual(40)
+    })
+  })
+})
+
+describe('PersonSchema - species (backward compatible)', () => {
+  it('accepts a person record with a species', () => {
+    const parsed = PersonSchema.parse({ id: 'p1', name: 'Rex', species: 'dog' })
+    expect(parsed.species).toBe('dog')
+  })
+
+  it('accepts a legacy person record without a species', () => {
+    const parsed = PersonSchema.parse({ id: 'p1', name: 'Alice', ageRange: 'Adult', gender: 'female' })
+    expect(parsed.species).toBeUndefined()
+  })
+
+  it('rejects an invalid species value', () => {
+    expect(() => PersonSchema.parse({ id: 'p1', name: 'X', species: 'dragon' })).toThrow()
   })
 })

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -24,12 +24,26 @@ export const GENDER_OPTIONS = [
   { value: 'prefer-not-to-say' as const, label: 'Prefer not to say' },
 ] as const
 
+// Pet Species Type
+export const PetSpeciesSchema = z.enum(['dog', 'cat', 'other'])
+export type PetSpecies = z.infer<typeof PetSpeciesSchema>
+
+export const PET_SPECIES_OPTIONS = [
+  { value: 'dog' as const, label: '🐕 Dog' },
+  { value: 'cat' as const, label: '🐈 Cat' },
+  { value: 'other' as const, label: '🐾 Other pet' },
+] as const
+
 // Zod Schemas
+// `species` is optional and additive: a Person without it is a human (existing
+// data loads unchanged); a Person with it is a pet, modelled as just another
+// person once the question set is generated.
 export const PersonSchema = z.object({
   id: z.string(),
   name: z.string(),
   ageRange: AgeRangeSchema.optional(),
   gender: GenderSchema.optional(),
+  species: PetSpeciesSchema.optional(),
   lastModified: z.string().optional(),
   deletedAt: z.string().optional(),
 })

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -32,12 +32,11 @@ export function useWizardGeneration() {
     })
 
     const generateQuestionSet = (data: WizardFormData) => {
-        const people: Person[] = data.people.map(p => ({
-            id: generateUUID(),
-            name: p.name,
-            ageRange: p.ageRange,
-            gender: p.gender
-        }))
+        const people: Person[] = data.people.map(entry =>
+            entry.kind === 'pet'
+                ? { id: generateUUID(), name: entry.name, species: entry.species }
+                : { id: generateUUID(), name: entry.name, ageRange: entry.ageRange, gender: entry.gender }
+        )
         return createExampleData(people, [])
     }
 

--- a/src/pages/wizard-types.ts
+++ b/src/pages/wizard-types.ts
@@ -1,12 +1,30 @@
 import { z } from 'zod'
-import { AgeRangeSchema, GenderSchema } from '../edit-questions/types'
+import { AgeRangeSchema, GenderSchema, PetSpeciesSchema } from '../edit-questions/types'
 
-export const wizardSchema = z.object({
-    people: z.array(z.object({
-        name: z.string().min(1, 'Name is required'),
-        ageRange: AgeRangeSchema,
-        gender: GenderSchema
-    })).min(1, 'At least 1 person required').max(10, 'Maximum 10 people allowed'),
+// A person entry keeps age range + gender.
+export const wizardPersonSchema = z.object({
+    kind: z.literal('person'),
+    name: z.string().min(1, 'Name is required'),
+    ageRange: AgeRangeSchema,
+    gender: GenderSchema,
 })
 
+// A pet entry captures a species instead of age/gender.
+export const wizardPetSchema = z.object({
+    kind: z.literal('pet'),
+    name: z.string().min(1, 'Name is required'),
+    species: PetSpeciesSchema,
+})
+
+export const wizardEntrySchema = z.discriminatedUnion('kind', [wizardPersonSchema, wizardPetSchema])
+
+export const wizardSchema = z.object({
+    people: z.array(wizardEntrySchema)
+        .min(1, 'At least 1 person or pet required')
+        .max(10, 'Maximum of 10 reached'),
+})
+
+export type WizardPersonEntry = z.infer<typeof wizardPersonSchema>
+export type WizardPetEntry = z.infer<typeof wizardPetSchema>
+export type WizardEntry = z.infer<typeof wizardEntrySchema>
 export type WizardFormData = z.infer<typeof wizardSchema>

--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -306,6 +306,41 @@ describe('Wizard', () => {
     })
 
 
+    describe("Who's Packing? - pets", () => {
+        function renderWizard() {
+            const db = makeDb()
+            mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+            return render(
+                <MemoryRouter>
+                    <Wizard />
+                </MemoryRouter>
+            )
+        }
+
+        it('shows an "Add a Pet" button', async () => {
+            renderWizard()
+            expect(await screen.findByRole('button', { name: /add a pet/i })).toBeTruthy()
+        })
+
+        it('adds a pet row with a species select when "Add a Pet" is clicked', async () => {
+            renderWizard()
+            const addPetBtn = await screen.findByRole('button', { name: /add a pet/i })
+            addPetBtn.click()
+            await waitFor(() => expect(screen.getByText('Select species...')).toBeTruthy())
+        })
+
+        it('a pet row does not render an age range select', async () => {
+            renderWizard()
+            // Only the initial person row exists: one age range placeholder
+            await waitFor(() => expect(screen.getAllByText('Select age range...')).toHaveLength(1))
+            const addPetBtn = await screen.findByRole('button', { name: /add a pet/i })
+            addPetBtn.click()
+            // Adding a pet must not add another age range select
+            await waitFor(() => expect(screen.getByText('Select species...')).toBeTruthy())
+            expect(screen.getAllByText('Select age range...')).toHaveLength(1)
+        })
+    })
+
     describe("Who's Packing? - remove person", () => {
         function renderWizard() {
             const db = makeDb()

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -8,9 +8,9 @@ import { Modal } from '../components/Modal'
 import { SolidPodPrompt } from '../components/SolidPodPrompt'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useDatabase } from '../components/DatabaseContext'
-import { wizardSchema, WizardFormData } from './wizard-types'
+import { wizardSchema, WizardFormData, WizardEntry } from './wizard-types'
 import { useWizardGeneration } from './useWizardGeneration'
-import { AGE_RANGE_OPTIONS, GENDER_OPTIONS } from '../edit-questions/types'
+import { AGE_RANGE_OPTIONS, GENDER_OPTIONS, PET_SPECIES_OPTIONS } from '../edit-questions/types'
 
 const SOLID_POD_UPSELL_SHOWN_KEY = 'solid-pod-upsell-shown'
 
@@ -28,7 +28,7 @@ export const Wizard = () => {
     const { register, control, handleSubmit, watch, formState: { errors } } = useForm<WizardFormData>({
         resolver: zodResolver(wizardSchema),
         defaultValues: {
-            people: [{ name: 'Me', ageRange: undefined }],
+            people: [{ kind: 'person', name: 'Me', ageRange: undefined, gender: undefined }],
         }
     })
 
@@ -94,17 +94,21 @@ export const Wizard = () => {
         await generateAndSave(data)
     }
 
+    // Cast through unknown: react-hook-form seeds rows with empty (undefined)
+    // selects, which the strict discriminated union doesn't model.
     const handleAddPerson = () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        append({ name: `Person ${fields.length + 1}` } as any)
+        append({ kind: 'person', name: `Person ${fields.length + 1}`, ageRange: undefined, gender: undefined } as unknown as WizardEntry)
+    }
+
+    const handleAddPet = () => {
+        append({ kind: 'pet', name: `Pet ${fields.length + 1}`, species: undefined } as unknown as WizardEntry)
     }
 
     const handleRemovePerson = (index: number) => {
         if (fields.length > 1) {
             remove(index)
         } else {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            update(0, { name: '' } as any)
+            update(0, { kind: 'person', name: '', ageRange: undefined, gender: undefined } as unknown as WizardEntry)
         }
     }
 
@@ -140,7 +144,7 @@ export const Wizard = () => {
                     <div className="flex items-center justify-between mb-4">
                         <h2 className="text-2xl font-bold text-primary-900">👥 Who's Packing?</h2>
                         <span className="text-sm text-gray-600 font-medium">
-                            {fields.length} {fields.length === 1 ? 'person' : 'people'}
+                            {fields.length} in your group
                         </span>
                     </div>
 
@@ -163,47 +167,71 @@ export const Wizard = () => {
                                                 <p className="text-danger-500 text-sm mt-1">{errors.people[index]?.name?.message}</p>
                                             )}
                                         </div>
-                                        <div>
-                                            <label className="block text-sm font-semibold text-gray-700 mb-2">
-                                                Age Range
-                                            </label>
-                                            <select
-                                                {...register(`people.${index}.ageRange`)}
-                                                className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
-                                            >
-                                                <option value="">Select age range...</option>
-                                                {AGE_RANGE_OPTIONS.map(option => (
-                                                    <option key={option.value} value={option.value}>
-                                                        {option.label}
-                                                    </option>
-                                                ))}
-                                            </select>
-                                            {errors.people?.[index]?.ageRange && (
-                                                <p className="text-danger-500 text-sm mt-1">{errors.people[index]?.ageRange?.message}</p>
-                                            )}
-                                        </div>
-                                        <div>
-                                            <label className="block text-sm font-semibold text-gray-700 mb-2">
-                                                Gender
-                                            </label>
-                                            <select
-                                                {...register(`people.${index}.gender`)}
-                                                className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
-                                            >
-                                                <option value="">Select gender...</option>
-                                                {GENDER_OPTIONS.map(option => (
-                                                    <option key={option.value} value={option.value}>
-                                                        {option.label}
-                                                    </option>
-                                                ))}
-                                            </select>
-                                        </div>
+                                        {field.kind === 'pet' ? (
+                                            <div>
+                                                <label className="block text-sm font-semibold text-gray-700 mb-2">
+                                                    Species
+                                                </label>
+                                                <select
+                                                    {...register(`people.${index}.species`)}
+                                                    className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                >
+                                                    <option value="">Select species...</option>
+                                                    {PET_SPECIES_OPTIONS.map(option => (
+                                                        <option key={option.value} value={option.value}>
+                                                            {option.label}
+                                                        </option>
+                                                    ))}
+                                                </select>
+                                                {errors.people?.[index] && 'species' in errors.people[index]! && (
+                                                    <p className="text-danger-500 text-sm mt-1">Species is required</p>
+                                                )}
+                                            </div>
+                                        ) : (
+                                            <>
+                                                <div>
+                                                    <label className="block text-sm font-semibold text-gray-700 mb-2">
+                                                        Age Range
+                                                    </label>
+                                                    <select
+                                                        {...register(`people.${index}.ageRange`)}
+                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                    >
+                                                        <option value="">Select age range...</option>
+                                                        {AGE_RANGE_OPTIONS.map(option => (
+                                                            <option key={option.value} value={option.value}>
+                                                                {option.label}
+                                                            </option>
+                                                        ))}
+                                                    </select>
+                                                    {errors.people?.[index] && 'ageRange' in errors.people[index]! && (
+                                                        <p className="text-danger-500 text-sm mt-1">{(errors.people[index] as { ageRange?: { message?: string } }).ageRange?.message}</p>
+                                                    )}
+                                                </div>
+                                                <div>
+                                                    <label className="block text-sm font-semibold text-gray-700 mb-2">
+                                                        Gender
+                                                    </label>
+                                                    <select
+                                                        {...register(`people.${index}.gender`)}
+                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                    >
+                                                        <option value="">Select gender...</option>
+                                                        {GENDER_OPTIONS.map(option => (
+                                                            <option key={option.value} value={option.value}>
+                                                                {option.label}
+                                                            </option>
+                                                        ))}
+                                                    </select>
+                                                </div>
+                                            </>
+                                        )}
                                     </div>
                                     <button
                                         type="button"
                                         onClick={() => handleRemovePerson(index)}
                                         className="mt-8 p-2 text-danger-500 hover:bg-danger-50 rounded-lg transition-colors"
-                                        title="Remove person"
+                                        title={field.kind === 'pet' ? 'Remove pet' : 'Remove person'}
                                     >
                                         <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                             <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
@@ -215,7 +243,7 @@ export const Wizard = () => {
                     </div>
 
                     {fields.length < 10 && (
-                        <div className="mt-4">
+                        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
                             <button
                                 type="button"
                                 onClick={handleAddPerson}
@@ -226,12 +254,20 @@ export const Wizard = () => {
                                 </svg>
                                 Add Another Person
                             </button>
+                            <button
+                                type="button"
+                                onClick={handleAddPet}
+                                className="w-full py-3 px-4 border-2 border-dashed border-primary-300 rounded-xl text-primary-700 font-semibold hover:border-primary-500 hover:bg-primary-50 transition-all duration-200 flex items-center justify-center gap-2"
+                            >
+                                <span className="text-lg leading-none">🐾</span>
+                                Add a Pet
+                            </button>
                         </div>
                     )}
 
                     {fields.length >= 10 && (
                         <p className="mt-4 text-sm text-gray-600 text-center">
-                            Maximum of 10 people reached
+                            Maximum of 10 reached
                         </p>
                     )}
 

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -223,6 +223,7 @@ function personToThing(person: Person, personUrl: string): Thing {
 
     if (person.ageRange) t = t.addStringNoLocale(PMU.ageRange, person.ageRange)
     if (person.gender) t = t.addStringNoLocale(PMU.gender, person.gender)
+    if (person.species) t = t.addStringNoLocale(PMU.species, person.species)
     if (person.lastModified) t = t.addDatetime(PMU.personLastModified, new Date(person.lastModified))
     if (person.deletedAt) t = t.addDatetime(PMU.personDeletedAt, new Date(person.deletedAt))
 
@@ -235,6 +236,7 @@ function thingToPerson(thing: Thing | null, url: string): Person | null {
     const name = getStringNoLocale(thing, PMU.name) ?? ''
     const ageRange = getStringNoLocale(thing, PMU.ageRange) ?? undefined
     const gender = getStringNoLocale(thing, PMU.gender) ?? undefined
+    const species = getStringNoLocale(thing, PMU.species) ?? undefined
     const lastModified = getDatetime(thing, PMU.personLastModified)?.toISOString()
     const deletedAt = getDatetime(thing, PMU.personDeletedAt)?.toISOString()
     return {
@@ -242,6 +244,7 @@ function thingToPerson(thing: Thing | null, url: string): Person | null {
         name,
         ...(ageRange !== undefined ? { ageRange: ageRange as Person['ageRange'] } : {}),
         ...(gender !== undefined ? { gender: gender as Person['gender'] } : {}),
+        ...(species !== undefined ? { species: species as Person['species'] } : {}),
         ...(lastModified !== undefined ? { lastModified } : {}),
         ...(deletedAt !== undefined ? { deletedAt } : {}),
     }

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -37,6 +37,7 @@ export const PMU = {
     // Person predicates
     ageRange: `${PMU_NS}ageRange`,
     gender: `${PMU_NS}gender`,
+    species: `${PMU_NS}species`,
     personLastModified: `${PMU_NS}personLastModified`,
     personDeletedAt: `${PMU_NS}personDeletedAt`,
 


### PR DESCRIPTION
Add an "Add a Pet" button to the wizard alongside "Add Another Person".
A pet is captured with a name and species (dog/cat/other) instead of
age/gender, and is modelled as just another Person carrying an optional
`species` once the question set is generated — so no downstream flow
needs to change.

- types: optional `species` on PersonSchema (additive, backward
  compatible) plus PetSpeciesSchema / PET_SPECIES_OPTIONS
- wizard form: discriminated union (person | pet) so pet rows require a
  species and person rows keep age/gender
- generation: new pet-specific-items filters (getDogs/getCats/getPets/
  getHumans) and species-appropriate items seeded into alwaysNeededItems
- fix: the item() helper now defaults unfiltered items to humans rather
  than everyone, so pets don't inherit human items (no-op for pet-free
  groups)
- pod sync: serialize `species` in the RDF round-trip

Existing stored data (no species) loads unchanged; a pet-free wizard run
produces identical output to before.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJ6iEwtgjRX1jMifzX8Uhi