### PR TITLE
Add travelling abroad question to wizard-generated questions

### DIFF
--- a/src/edit-questions/example-data.test.ts
+++ b/src/edit-questions/example-data.test.ts
@@ -235,7 +235,7 @@ describe('createExampleData - travelling abroad', () => {
 
     it('includes travel document items selected for adults only', () => {
         const result = createExampleData([adult, baby])
-        for (const text of ['Travel insurance documents', 'Visa (if required)', 'Local currency', 'Copies of important documents']) {
+        for (const text of ['Travel insurance documents', 'Visa', 'Local currency', 'Copies of important documents']) {
             const found = getAbroadYesItems(result).find(i => i.text === text)
             expect(found, `"${text}" should appear`).toBeTruthy()
             expect(found!.personSelections.find(ps => ps.personId === adult.id)?.selected).toBe(true)

--- a/src/edit-questions/example-data.test.ts
+++ b/src/edit-questions/example-data.test.ts
@@ -196,6 +196,72 @@ describe('createExampleData - pets', () => {
     })
 })
 
+describe('createExampleData - travelling abroad', () => {
+    const adult: Person = { id: 'a1', name: 'Alice', ageRange: 'Adult' }
+    const baby: Person = { id: 'b1', name: 'Baby', ageRange: 'Baby' }
+    const dog: Person = { id: 'd1', name: 'Rex', species: 'dog' }
+
+    function getAbroadQuestion(result: ReturnType<typeof createExampleData>) {
+        return result.questions.find(q => q.text === 'Are you travelling abroad?')
+    }
+
+    function getAbroadYesItems(result: ReturnType<typeof createExampleData>) {
+        return getAbroadQuestion(result)!.options.find(o => o.text === 'Yes')!.items
+    }
+
+    it('includes a single-choice travelling abroad question with Yes/No options', () => {
+        const result = createExampleData([adult])
+        const question = getAbroadQuestion(result)
+        expect(question).toBeTruthy()
+        expect(question!.questionType).toBe('single-choice')
+        const optionTexts = question!.options.map(o => o.text)
+        expect(optionTexts).toEqual(['Yes', 'No'])
+    })
+
+    it('has no items on the No option', () => {
+        const result = createExampleData([adult])
+        const noOption = getAbroadQuestion(result)!.options.find(o => o.text === 'No')!
+        expect(noOption.items).toEqual([])
+    })
+
+    it('includes Passport selected for all humans including babies', () => {
+        const result = createExampleData([adult, baby, dog])
+        const passport = getAbroadYesItems(result).find(i => i.text === 'Passport')
+        expect(passport).toBeTruthy()
+        expect(passport!.personSelections.find(ps => ps.personId === adult.id)?.selected).toBe(true)
+        expect(passport!.personSelections.find(ps => ps.personId === baby.id)?.selected).toBe(true)
+        expect(passport!.personSelections.find(ps => ps.personId === dog.id)?.selected).toBe(false)
+    })
+
+    it('includes travel document items selected for adults only', () => {
+        const result = createExampleData([adult, baby])
+        for (const text of ['Travel insurance documents', 'Visa (if required)', 'Local currency', 'Copies of important documents']) {
+            const found = getAbroadYesItems(result).find(i => i.text === text)
+            expect(found, `"${text}" should appear`).toBeTruthy()
+            expect(found!.personSelections.find(ps => ps.personId === adult.id)?.selected).toBe(true)
+            expect(found!.personSelections.find(ps => ps.personId === baby.id)?.selected).toBe(false)
+        }
+    })
+
+    it('includes Travel adapter for adults', () => {
+        const result = createExampleData([adult])
+        const adapter = getAbroadYesItems(result).find(i => i.text === 'Travel adapter')
+        expect(adapter).toBeTruthy()
+        expect(adapter!.personSelections.find(ps => ps.personId === adult.id)?.selected).toBe(true)
+    })
+
+    it('includes pet travel documents only when pets are in the group', () => {
+        const withPet = createExampleData([adult, dog])
+        const petDocs = getAbroadYesItems(withPet).find(i => i.text === 'Pet passport/Animal health certificate')
+        expect(petDocs).toBeTruthy()
+        expect(petDocs!.personSelections.find(ps => ps.personId === dog.id)?.selected).toBe(true)
+        expect(petDocs!.personSelections.find(ps => ps.personId === adult.id)?.selected).toBe(false)
+
+        const withoutPet = createExampleData([adult])
+        expect(getAbroadYesItems(withoutPet).find(i => i.text === 'Pet passport/Animal health certificate')).toBeUndefined()
+    })
+})
+
 describe('createExampleData - gender-specific items', () => {
     function getOvernightYesItems(result: ReturnType<typeof createExampleData>) {
         const overnight = result.questions.find(q => q.text === 'Will you be staying overnight?')!

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -261,11 +261,11 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         items: items(
                             item("Passport", people),
                             item("Travel insurance documents", people, getAdults),
-                            item("Visa (if required)", people, getAdults),
+                            item("Visa", people, getAdults),
                             item("Local currency", people, getAdults),
                             item("Travel adapter", people, getAdults),
                             item("Copies of important documents", people, getAdults),
-                            item("EHIC/GHIC card (if applicable)", people, getAdults),
+                            item("EHIC/GHIC card", people, getAdults),
                             item("Pet passport/Animal health certificate", people, getPets),
                         )
                     },

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -250,8 +250,38 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             {
                 id: generateUUID(),
                 type: "saved",
-                text: "Are you self-catering?",
+                text: "Are you travelling abroad?",
                 order: 1,
+                questionType: "single-choice",
+                options: [
+                    {
+                        id: generateUUID(),
+                        text: "Yes",
+                        order: 0,
+                        items: items(
+                            item("Passport", people),
+                            item("Travel insurance documents", people, getAdults),
+                            item("Visa (if required)", people, getAdults),
+                            item("Local currency", people, getAdults),
+                            item("Travel adapter", people, getAdults),
+                            item("Copies of important documents", people, getAdults),
+                            item("EHIC/GHIC card (if applicable)", people, getAdults),
+                            item("Pet passport/Animal health certificate", people, getPets),
+                        )
+                    },
+                    {
+                        id: generateUUID(),
+                        text: "No",
+                        order: 1,
+                        items: []
+                    }
+                ]
+            },
+            {
+                id: generateUUID(),
+                type: "saved",
+                text: "Are you self-catering?",
+                order: 2,
                 questionType: "single-choice",
                 options: [
                     {
@@ -277,7 +307,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                 id: activitiesQuestionId,
                 type: "saved",
                 text: "What activities will you be doing?",
-                order: 2,
+                order: 3,
                 questionType: "multiple-choice",
                 options: activityOptions
             },
@@ -285,7 +315,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                 id: generateUUID(),
                 type: "saved",
                 text: "What weather do you expect?",
-                order: 3,
+                order: 4,
                 questionType: "multiple-choice",
                 options: [
                     {


### PR DESCRIPTION
The wizard's generated question set now includes 'Are you travelling
abroad?' with items such as passport, travel insurance documents, visa,
local currency, travel adapter, and pet travel documents. Document items
are assigned to adults, passports to all humans, and pet paperwork only
appears when pets are in the group.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HREiEDsxaJhJVayJ8E7KpV