### PR TITLE
Add communal (shared) item type

### DIFF
--- a/e2e/tests/l-sharing.spec.ts
+++ b/e2e/tests/l-sharing.spec.ts
@@ -56,10 +56,11 @@ test.describe('L – Sharing a packing list', () => {
 
     test('L1: User A shares a list; shareable link contains expected params', async () => {
         // Share button renders immediately, enabled once pod URL resolves (~1 network round-trip)
-        await expect(pageA.getByRole('button', { name: 'Share' })).toBeEnabled({ timeout: 10_000 })
+        // exact: true — the packing list's "Collapse the shared items list" section header also matches a bare 'Share' substring
+        await expect(pageA.getByRole('button', { name: 'Share', exact: true })).toBeEnabled({ timeout: 10_000 })
 
         // Open share modal
-        await pageA.getByRole('button', { name: 'Share' }).click()
+        await pageA.getByRole('button', { name: 'Share', exact: true }).click()
         await expect(pageA.getByText('Manage sharing')).toBeVisible({ timeout: 5_000 })
 
         // Enter User B's WebID then submit via the dialog's Share button (not the toolbar one)
@@ -100,7 +101,7 @@ test.describe('L – Sharing a packing list', () => {
             await expect(pageB.getByText(listName)).toBeVisible({ timeout: 15_000 })
 
             // Share button must NOT be visible on a shared list
-            await expect(pageB.getByRole('button', { name: 'Share' })).not.toBeVisible()
+            await expect(pageB.getByRole('button', { name: 'Share', exact: true })).not.toBeVisible()
         } finally {
             await ctxB.close()
         }
@@ -148,7 +149,7 @@ test.describe('L – Sharing a packing list', () => {
             await expect(residualDialog).toHaveCount(0)
         }
         // Now the toolbar Share button is the only one visible
-        await pageA.getByRole('button', { name: 'Share' }).click()
+        await pageA.getByRole('button', { name: 'Share', exact: true }).click()
         await expect(pageA.getByText('Manage sharing')).toBeVisible({ timeout: 5_000 })
         await pageA.getByRole('button', { name: 'Anyone with the link' }).click()
         await pageA.getByRole('dialog').getByRole('button', { name: /^Share publicly/i }).click()

--- a/src/create-packing-list/generatePackingListItems.test.ts
+++ b/src/create-packing-list/generatePackingListItems.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateQuestionBasedItems } from './generatePackingListItems'
+import { generateQuestionBasedItems, generateAlwaysNeededItems } from './generatePackingListItems'
 import { Question } from '../edit-questions/types'
 
 const p1 = { id: 'p1', name: 'Alice' }
@@ -176,6 +176,190 @@ describe('generateQuestionBasedItems – selected options contribute items', () 
     it('skips a question when the questionId does not match any question', () => {
         const answers = [{ questionId: 'unknown-id', selectedOptionIds: ['opt-swimming'] }]
         const result = generateQuestionBasedItems([activitiesQuestion], answers, [p1], ['p1'])
+        expect(result).toHaveLength(0)
+    })
+})
+
+// ─── Communal items ───────────────────────────────────────────────────────────
+
+describe('generateQuestionBasedItems – communal items', () => {
+    const campingQuestion: Question = {
+        id: 'q-camping',
+        type: 'saved',
+        text: 'Are you camping?',
+        order: 0,
+        questionType: 'single-choice',
+        options: [
+            {
+                id: 'opt-yes',
+                text: 'Yes',
+                order: 0,
+                items: [
+                    {
+                        text: 'Tent',
+                        communal: true,
+                        personSelections: [
+                            { personId: 'p1', selected: true },
+                            { personId: 'p2', selected: true },
+                        ],
+                    },
+                    {
+                        text: 'Sleeping bag',
+                        personSelections: [
+                            { personId: 'p1', selected: true },
+                            { personId: 'p2', selected: true },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+    const answers = [{ questionId: 'q-camping', selectedOptionIds: ['opt-yes'] }]
+
+    it('generates a single entry for a communal item regardless of traveller count', () => {
+        const result = generateQuestionBasedItems([campingQuestion], answers, [p1, p2], ['p1', 'p2'])
+        const tents = result.filter(i => i.itemText === 'Tent')
+        expect(tents).toHaveLength(1)
+        expect(tents[0].communal).toBe(true)
+        expect(tents[0].personId).toBe('')
+        expect(tents[0].personName).toBe('')
+        // Per-person items still fan out
+        expect(result.filter(i => i.itemText === 'Sleeping bag')).toHaveLength(2)
+    })
+
+    it('includes a communal item when at least one trigger person is travelling', () => {
+        const babyGear: Question = {
+            ...campingQuestion,
+            options: [{
+                id: 'opt-yes',
+                text: 'Yes',
+                order: 0,
+                items: [{
+                    text: 'Travel cot',
+                    communal: true,
+                    personSelections: [{ personId: 'p2', selected: true }],
+                }],
+            }],
+        }
+        const withBaby = generateQuestionBasedItems([babyGear], answers, [p1, p2], ['p1', 'p2'])
+        expect(withBaby.map(i => i.itemText)).toContain('Travel cot')
+
+        const withoutBaby = generateQuestionBasedItems([babyGear], answers, [p1, p2], ['p1'])
+        expect(withoutBaby.map(i => i.itemText)).not.toContain('Travel cot')
+    })
+
+    it('excludes a communal item when no trigger people are selected on the item', () => {
+        const q: Question = {
+            ...campingQuestion,
+            options: [{
+                id: 'opt-yes',
+                text: 'Yes',
+                order: 0,
+                items: [{
+                    text: 'Tent',
+                    communal: true,
+                    personSelections: [
+                        { personId: 'p1', selected: false },
+                        { personId: 'p2', selected: false },
+                    ],
+                }],
+            }],
+        }
+        const result = generateQuestionBasedItems([q], answers, [p1, p2], ['p1', 'p2'])
+        expect(result).toHaveLength(0)
+    })
+
+    it('always includes a communal item that has no person selections', () => {
+        const q: Question = {
+            ...campingQuestion,
+            options: [{
+                id: 'opt-yes',
+                text: 'Yes',
+                order: 0,
+                items: [{ text: 'First aid kit', communal: true, personSelections: [] }],
+            }],
+        }
+        const result = generateQuestionBasedItems([q], answers, [p1, p2], ['p1'])
+        expect(result.map(i => i.itemText)).toContain('First aid kit')
+    })
+
+    it('sets the category on communal items like per-person items', () => {
+        const result = generateQuestionBasedItems([campingQuestion], answers, [p1], ['p1'])
+        const tent = result.find(i => i.itemText === 'Tent')
+        expect(tent?.category).toBe('Are you camping?')
+    })
+})
+
+// ─── Always-needed items ──────────────────────────────────────────────────────
+
+describe('generateAlwaysNeededItems', () => {
+    it('fans out per-person items to each selected traveller', () => {
+        const result = generateAlwaysNeededItems(
+            [{
+                text: 'Water bottle',
+                personSelections: [
+                    { personId: 'p1', selected: true },
+                    { personId: 'p2', selected: true },
+                ],
+            }],
+            [p1, p2],
+            ['p1', 'p2']
+        )
+        expect(result).toHaveLength(2)
+        expect(result.map(i => i.personName).sort()).toEqual(['Alice', 'Bob'])
+        result.forEach(item => {
+            expect(item.questionId).toBe('always-needed')
+            expect(item.optionId).toBe('always-needed')
+            expect(item.category).toBe('Essentials')
+        })
+    })
+
+    it('excludes people who are not travelling', () => {
+        const result = generateAlwaysNeededItems(
+            [{
+                text: 'Water bottle',
+                personSelections: [
+                    { personId: 'p1', selected: true },
+                    { personId: 'p2', selected: true },
+                ],
+            }],
+            [p1, p2],
+            ['p2']
+        )
+        expect(result).toHaveLength(1)
+        expect(result[0].personName).toBe('Bob')
+    })
+
+    it('generates a single shared entry for communal items', () => {
+        const result = generateAlwaysNeededItems(
+            [{
+                text: 'First aid kit',
+                communal: true,
+                personSelections: [
+                    { personId: 'p1', selected: true },
+                    { personId: 'p2', selected: true },
+                ],
+            }],
+            [p1, p2],
+            ['p1', 'p2']
+        )
+        expect(result).toHaveLength(1)
+        expect(result[0].communal).toBe(true)
+        expect(result[0].personId).toBe('')
+        expect(result[0].personName).toBe('')
+        expect(result[0].category).toBe('Essentials')
+    })
+
+    it('excludes a communal item when none of its trigger people are travelling', () => {
+        const result = generateAlwaysNeededItems(
+            [{
+                text: 'Litter tray',
+                communal: true,
+                personSelections: [{ personId: 'p2', selected: true }],
+            }],
+            [p1, p2],
+            ['p1']
+        )
         expect(result).toHaveLength(0)
     })
 })

--- a/src/create-packing-list/generatePackingListItems.ts
+++ b/src/create-packing-list/generatePackingListItems.ts
@@ -1,5 +1,55 @@
-import { Question, Person } from '../edit-questions/types'
+import { Question, Person, Item } from '../edit-questions/types'
 import { PackingListItem } from './types'
+
+interface ItemContext {
+    questionId: string
+    optionId: string
+    category?: string
+}
+
+function generateItemInstances(
+    item: Item,
+    people: Person[],
+    selectedPeopleIds: string[],
+    context: ItemContext
+): PackingListItem[] {
+    if (item.communal) {
+        // Person selections act as a trigger: include the single shared item
+        // when at least one selected person is travelling. No selections at
+        // all means the item is always needed.
+        const triggered = item.personSelections.length === 0
+            || item.personSelections.some(ps => ps.selected && selectedPeopleIds.includes(ps.personId))
+        if (!triggered) return []
+        return [{
+            id: crypto.randomUUID(),
+            itemText: item.text,
+            personId: '',
+            personName: '',
+            questionId: context.questionId,
+            optionId: context.optionId,
+            packed: false,
+            communal: true,
+            category: context.category,
+        }]
+    }
+
+    const selectedPeople = item.personSelections.filter(
+        ps => ps.selected && selectedPeopleIds.includes(ps.personId)
+    )
+    return selectedPeople.flatMap(ps => {
+        const person = people.find(p => p.id === ps.personId)!
+        return {
+            id: crypto.randomUUID(),
+            itemText: item.text,
+            personId: ps.personId,
+            personName: person.name,
+            questionId: context.questionId,
+            optionId: context.optionId,
+            packed: false,
+            category: context.category,
+        } satisfies PackingListItem
+    })
+}
 
 export function generateQuestionBasedItems(
     questions: Question[],
@@ -17,26 +67,29 @@ export function generateQuestionBasedItems(
             const selectedOption = question.options.find(o => o.id === selectedOptionId)
             if (!selectedOption) return []
 
-            return selectedOption.items.flatMap(item => {
-                const selectedPeople = item.personSelections.filter(
-                    ps => ps.selected && selectedPeopleIds.includes(ps.personId)
-                )
-                return selectedPeople.flatMap(ps => {
-                    const person = people.find(p => p.id === ps.personId)!
-                    return {
-                        id: crypto.randomUUID(),
-                        itemText: item.text,
-                        personId: ps.personId,
-                        personName: person.name,
-                        questionId: question.id,
-                        optionId: selectedOption.id,
-                        packed: false,
-                        category: question.questionType === 'multiple-choice'
-                            ? selectedOption.text
-                            : question.text,
-                    } satisfies PackingListItem
+            return selectedOption.items.flatMap(item =>
+                generateItemInstances(item, people, selectedPeopleIds, {
+                    questionId: question.id,
+                    optionId: selectedOption.id,
+                    category: question.questionType === 'multiple-choice'
+                        ? selectedOption.text
+                        : question.text,
                 })
-            })
+            )
         })
     })
+}
+
+export function generateAlwaysNeededItems(
+    alwaysNeededItems: Item[],
+    people: Person[],
+    selectedPeopleIds: string[]
+): PackingListItem[] {
+    return alwaysNeededItems.flatMap(item =>
+        generateItemInstances(item, people, selectedPeopleIds, {
+            questionId: 'always-needed',
+            optionId: 'always-needed',
+            category: 'Essentials',
+        })
+    )
 }

--- a/src/create-packing-list/types.ts
+++ b/src/create-packing-list/types.ts
@@ -14,11 +14,12 @@ export interface PackingList {
 export interface PackingListItem {
     id: string
     itemText: string
-    personId: string
-    personName: string
+    personId: string   // '' for communal and custom items
+    personName: string // '' for communal items
     questionId: string
     optionId: string
     packed: boolean
+    communal?: boolean // packed once for the whole group; absent = per-person
     category?: string
     reviewed?: boolean
     lastModified?: string // ISO timestamp; absent on legacy items

--- a/src/edit-questions/example-data.test.ts
+++ b/src/edit-questions/example-data.test.ts
@@ -340,3 +340,43 @@ describe('createExampleData - gender-specific items', () => {
         expect(item!.personSelections.find(ps => ps.personId === femaleAdult.id)?.selected).toBe(false)
     })
 })
+
+describe('createExampleData communal items', () => {
+    const family: Person[] = [
+        { id: 'a1', name: 'Alice', ageRange: 'Adult', gender: 'female' },
+        { id: 'c1', name: 'Charlie', ageRange: 'Child' },
+        { id: 'cat1', name: 'Whiskers', species: 'cat' },
+    ]
+
+    function allItems(result: ReturnType<typeof createExampleData>) {
+        return [
+            ...result.alwaysNeededItems,
+            ...result.questions.flatMap(q => q.options.flatMap(o => o.items)),
+        ]
+    }
+
+    it('marks group kit as communal with existing filters kept as triggers', () => {
+        const result = createExampleData(family)
+        const items = allItems(result)
+
+        const firstAid = result.alwaysNeededItems.find(i => i.text === 'First aid kit')!
+        expect(firstAid.communal).toBe(true)
+
+        const litterTray = result.alwaysNeededItems.find(i => i.text === 'Litter tray & litter')!
+        expect(litterTray.communal).toBe(true)
+        // Trigger selections preserved: only the cat is selected
+        expect(litterTray.personSelections.find(ps => ps.personId === 'cat1')?.selected).toBe(true)
+        expect(litterTray.personSelections.find(ps => ps.personId === 'a1')?.selected).toBe(false)
+
+        const travelAdapter = items.find(i => i.text === 'Travel adapter')!
+        expect(travelAdapter.communal).toBe(true)
+    })
+
+    it('keeps personal items per-person', () => {
+        const result = createExampleData(family)
+        const items = allItems(result)
+        expect(result.alwaysNeededItems.find(i => i.text === 'Snacks')?.communal).toBeUndefined()
+        expect(items.find(i => i.text === 'Toothbrush')?.communal).toBeUndefined()
+        expect(items.find(i => i.text === 'Passport')?.communal).toBeUndefined()
+    })
+})

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -43,6 +43,15 @@ function item(text: string, people: Person[], ageFilter?: (p: Person[]) => Perso
     };
 }
 
+/**
+ * Like `item`, but packed once for the whole group. The person selections
+ * become a trigger: the item is included when at least one selected person
+ * is on the trip (e.g. a litter tray only when the cat is coming).
+ */
+function communalItem(text: string, people: Person[], ageFilter?: (p: Person[]) => Person[]): Item {
+    return { ...item(text, people, ageFilter), communal: true };
+}
+
 function items(...args: Item[]): Item[] {
     return args.filter(i => i.personSelections.some(ps => ps.selected));
 }
@@ -131,7 +140,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                 item("Daypack/Backpack", people, getTeenagersAndAdults),
                 item("Walking poles", people, getAdults),
                 item("Trail map", people, getAdults),
-                item("First aid kit", people, getAdults),
+                communalItem("First aid kit", people, getAdults),
                 item("Baby carrier/Sling", people, getBabies),
                 item("Toddler reins/Backpack harness", people, getToddlers),
                 item("Lightweight buggy/Stroller", people, getToddlers),
@@ -179,15 +188,15 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             item("Toddler snacks", people, getToddlers),
             item("Comfort item (teddy/blanket)", people, getToddlers),
             item("Entertainment (books/small toys)", people, getChildren),
-            item("Playing cards/Travel games", people, getChildren),
+            communalItem("Playing cards/Travel games", people, getChildren),
             item("Headphones", people, getTeenagers),
             item("Phone charger", people, getTeenagers),
-            item("First aid kit", people),
-            item("Plasters / Band-aids", people),
-            item("Pain relief (paracetamol / ibuprofen)", people, getAdults),
+            communalItem("First aid kit", people),
+            communalItem("Plasters / Band-aids", people),
+            communalItem("Pain relief (paracetamol / ibuprofen)", people, getAdults),
             // Pet items — only appear when a matching pet is in the group
-            item("Pet food", people, getPets),
-            item("Food & water bowls", people, getPets),
+            communalItem("Pet food", people, getPets),
+            communalItem("Food & water bowls", people, getPets),
             item("Pet bed/blanket", people, getPets),
             item("Pet medication", people, getPets),
             item("Vaccination/health records", people, getPets),
@@ -195,7 +204,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             item("Collar & ID tag", people, getDogs),
             item("Poop bags", people, getDogs),
             item("Dog toy", people, getDogs),
-            item("Litter tray & litter", people, getCats),
+            communalItem("Litter tray & litter", people, getCats),
             item("Cat carrier", people, getCats),
             item("Scratching pad", people, getCats),
         ),
@@ -213,7 +222,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         order: 0,
                         items: items(
                             item("Toothbrush", people, getToddlersAndOlder),
-                            item("Toothpaste", people, getAdults),
+                            communalItem("Toothpaste", people, getAdults),
                             item("Deodorant", people, getTeenagersAndAdults),
                             item("Phone Charger", people, getTeenagersAndAdults),
                             item("Passport/ID", people, getAdults),
@@ -260,10 +269,10 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         order: 0,
                         items: items(
                             item("Passport", people),
-                            item("Travel insurance documents", people, getAdults),
+                            communalItem("Travel insurance documents", people, getAdults),
                             item("Visa", people, getAdults),
                             item("Local currency", people, getAdults),
-                            item("Travel adapter", people, getAdults),
+                            communalItem("Travel adapter", people, getAdults),
                             item("Copies of important documents", people, getAdults),
                             item("EHIC/GHIC card", people, getAdults),
                             item("Pet passport/Animal health certificate", people, getPets),

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -53,10 +53,15 @@ export const PersonSelectionSchema = z.object({
   selected: z.boolean()
 })
 
+// `communal` is optional and additive: absent means the item fans out
+// per-person as before. When true, the item is packed once for the whole
+// group and `personSelections` become a trigger — the item is included when
+// at least one selected person is on the trip.
 export const ItemSchema = z.object({
   id: z.string().optional(),
   text: z.string(),
   personSelections: z.array(PersonSelectionSchema),
+  communal: z.boolean().optional(),
   lastModified: z.string().optional(),
   deletedAt: z.string().optional(),
 })

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -424,6 +424,75 @@ describe('CreatePackingList – suggestion card', () => {
         expect(newItem?.personSelections).toContainEqual({ personId: 'p1', selected: true })
     })
 
+    it('"Add" saves a communal custom item as a shared question-set item', async () => {
+        const communalCustom: PackingListItem = {
+            id: 'custom-shared-1',
+            itemText: 'Camping stove',
+            personName: '',
+            personId: '',
+            questionId: '',
+            optionId: '',
+            packed: false,
+            communal: true,
+        }
+        const db = makeDb({
+            getAllPackingLists: vi.fn().mockResolvedValue([{ ...pastList, items: [communalCustom] }]),
+        })
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/past trips you added items/i))
+        fireEvent.click(screen.getByRole('button', { name: /review/i }))
+
+        // The shared checkbox is pre-checked for items that were communal on the list
+        const checkbox = screen.getByRole('checkbox', { name: /shared/i }) as HTMLInputElement
+        expect(checkbox.checked).toBe(true)
+
+        fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+        await waitFor(() => expect(db.saveQuestionSet).toHaveBeenCalled())
+        const savedQs = db.saveQuestionSet.mock.calls[0][0] as PackingListQuestionSet
+        const newItem = savedQs.alwaysNeededItems.find(i => i.text === 'Camping stove')
+        expect(newItem?.communal).toBe(true)
+        // Everyone selected so the shared item always triggers
+        expect(newItem?.personSelections).toContainEqual({ personId: 'p1', selected: true })
+    })
+
+    it('checking Shared on a regular suggestion saves it as communal', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/past trips you added items/i))
+        fireEvent.click(screen.getByRole('button', { name: /review/i }))
+
+        const checkbox = screen.getByRole('checkbox', { name: /shared/i }) as HTMLInputElement
+        expect(checkbox.checked).toBe(false)
+        fireEvent.click(checkbox)
+        fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+        await waitFor(() => expect(db.saveQuestionSet).toHaveBeenCalled())
+        const savedQs = db.saveQuestionSet.mock.calls[0][0] as PackingListQuestionSet
+        const newItem = savedQs.alwaysNeededItems.find(i => i.text === 'Sunscreen SPF50')
+        expect(newItem?.communal).toBe(true)
+    })
+
+    it('leaving Shared unchecked keeps the per-person save behaviour', async () => {
+        const db = makeDb()
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/past trips you added items/i))
+        fireEvent.click(screen.getByRole('button', { name: /review/i }))
+        fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+        await waitFor(() => expect(db.saveQuestionSet).toHaveBeenCalled())
+        const savedQs = db.saveQuestionSet.mock.calls[0][0] as PackingListQuestionSet
+        const newItem = savedQs.alwaysNeededItems.find(i => i.text === 'Sunscreen SPF50')
+        expect(newItem?.communal).toBeUndefined()
+        expect(newItem?.personSelections).toContainEqual({ personId: 'p1', selected: true })
+    })
+
     it('uses updated _rev from first save when processing second item', async () => {
         const secondItem: PackingListItem = {
             ...customItem,

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -13,7 +13,7 @@ import { getPrimaryPodUrl, saveRdfToPod, POD_CONTAINERS, loadMultipleRdfFromPod 
 import { usePodSync } from '../hooks/usePodSync'
 import { questionSetToDataset, datasetToQuestionSet, packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { useForeignPod } from '../components/ForeignPodContext'
-import { generateQuestionBasedItems } from '../create-packing-list/generatePackingListItems'
+import { generateQuestionBasedItems, generateAlwaysNeededItems } from '../create-packing-list/generatePackingListItems'
 
 export function deduplicateItems(items: PackingListItem[]): PackingListItem[] {
     const seen = new Set<string>()
@@ -95,7 +95,7 @@ type SaveDestination =
 interface SuggestionCardProps {
     suggestions: Array<{ listId: string; listName: string; item: PackingListItem }>
     questionSet: PackingListQuestionSet
-    onSaveToQuestionSet: (listId: string, item: PackingListItem, destination: SaveDestination) => void
+    onSaveToQuestionSet: (listId: string, item: PackingListItem, destination: SaveDestination, communal: boolean) => void
     onSkip: (listId: string, item: PackingListItem) => void
     onDismiss: () => void
 }
@@ -103,6 +103,7 @@ interface SuggestionCardProps {
 function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip, onDismiss }: SuggestionCardProps) {
     const [isExpanded, setIsExpanded] = useState(false)
     const [destinations, setDestinations] = useState<Record<string, string>>({})
+    const [communalFlags, setCommunalFlags] = useState<Record<string, boolean>>({})
 
     // Group by list
     const grouped = useMemo(() => {
@@ -154,6 +155,7 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                             const [questionId, optionId] = destValue.split('::')
                                             return { type: 'option', questionId, optionId }
                                         })()
+                                    const isShared = communalFlags[item.id] ?? item.communal ?? false
                                     return (
                                     <div key={item.id} className="flex flex-col gap-2 bg-white rounded border border-amber-200 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
                                         <div>
@@ -178,11 +180,21 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                                     ))
                                                 )}
                                             </select>
+                                            <label className="flex items-center gap-1.5 text-sm text-gray-600 shrink-0" title="Packed once for the whole group instead of per person">
+                                                <input
+                                                    type="checkbox"
+                                                    aria-label={`Save ${item.itemText} as a shared item`}
+                                                    checked={isShared}
+                                                    onChange={(e) => setCommunalFlags(prev => ({ ...prev, [item.id]: e.target.checked }))}
+                                                    className="h-4 w-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+                                                />
+                                                👥 Shared
+                                            </label>
                                             <div className="flex gap-2">
                                                 <Button
                                                     type="button"
                                                     variant="primary"
-                                                    onClick={() => onSaveToQuestionSet(listId, item, destination)}
+                                                    onClick={() => onSaveToQuestionSet(listId, item, destination, isShared)}
                                                 >
                                                     Add
                                                 </Button>
@@ -402,14 +414,16 @@ export function CreatePackingList() {
         [allPackingLists, questionSet]
     )
 
-    const handleSaveToQuestionSet = async (listId: string, item: PackingListItem, destination: SaveDestination) => {
+    const handleSaveToQuestionSet = async (listId: string, item: PackingListItem, destination: SaveDestination, communal: boolean) => {
         if (!questionSet) return
 
+        // Shared items select everyone so the trigger always fires; per-person
+        // items select just the person the custom item belonged to.
         const personSelections = questionSet.people.map(p => ({
             personId: p.id,
-            selected: p.name.toLowerCase() === item.personName.toLowerCase(),
+            selected: communal || p.name.toLowerCase() === item.personName.toLowerCase(),
         }))
-        const newItem = { text: item.itemText, personSelections }
+        const newItem = { text: item.itemText, personSelections, ...(communal ? { communal: true } : {}) }
 
         let updatedQs: PackingListQuestionSet
         if (destination.type === 'always') {
@@ -557,24 +571,11 @@ export function CreatePackingList() {
         )
 
         // Get always needed items
-        const alwaysNeededItems = questionSet.alwaysNeededItems.flatMap((item) => {
-            const selectedPeople = item.personSelections.filter((person) => (
-                person.selected && selectedPeopleIds.includes(person.personId)
-            ))
-            return selectedPeople.flatMap((person) => {
-                const personName = questionSet.people.find((p) => p.id === person.personId)!.name
-                return {
-                    id: crypto.randomUUID(),
-                    itemText: item.text,
-                    personId: person.personId,
-                    personName,
-                    questionId: 'always-needed',
-                    optionId: 'always-needed',
-                    packed: false,
-                    category: 'Essentials',
-                }
-            })
-        })
+        const alwaysNeededItems = generateAlwaysNeededItems(
+            questionSet.alwaysNeededItems,
+            questionSet.people,
+            selectedPeopleIds
+        )
 
         const packingList: PackingList = {
             id: crypto.randomUUID(),

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -73,6 +73,14 @@ function ItemRow({ item, people }: { item: Item; people: Person[] }) {
             <span className={`flex-1 min-w-0 ${item.text ? 'text-gray-700' : 'text-gray-400 italic'}`}>
                 {item.text || 'no text'}
             </span>
+            {item.communal && (
+                <span
+                    title="Shared — packed once for the whole group"
+                    className="inline-flex items-center justify-center h-5 rounded-full px-1.5 text-[10px] font-medium bg-blue-100 text-blue-700 select-none shrink-0"
+                >
+                    👥
+                </span>
+            )}
             {showDots && (
                 <div className="flex gap-0.5 shrink-0">
                     {people.map((person, i) => (
@@ -493,6 +501,11 @@ function useItemListState(initialItems: Item[], people: Person[]) {
             return { ...item, personSelections: selections }
         }))
 
+    const toggleCommunal = (itemIdx: number) =>
+        setItems(prev => prev.map((item, i) =>
+            i === itemIdx ? { ...item, communal: item.communal ? undefined : true } : item
+        ))
+
     const removeItem = (idx: number) =>
         setItems(prev => prev.filter((_, i) => i !== idx))
 
@@ -502,16 +515,17 @@ function useItemListState(initialItems: Item[], people: Person[]) {
             personSelections: people.map(p => ({ personId: p.id, selected: true })),
         }])
 
-    return { items, scrollRef, updateItemText, togglePerson, removeItem, addItem }
+    return { items, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, addItem }
 }
 
-function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText, togglePerson, removeItem, addItem }: {
+function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, addItem }: {
     items: Item[]
     people: Person[]
     allItemNames: string[]
     scrollRef: React.RefObject<HTMLDivElement | null>
     updateItemText: (idx: number, text: string) => void
     togglePerson: (itemIdx: number, personIdx: number) => void
+    toggleCommunal: (itemIdx: number) => void
     removeItem: (idx: number) => void
     addItem: () => void
 }) {
@@ -521,7 +535,15 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
                 <div className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2">Items</div>
             )}
             <div className="space-y-2">
-                {items.map((item, itemIdx) => (
+                {items.map((item, itemIdx) => {
+                    const isCommunal = item.communal === true
+                    const communalTitle = isCommunal
+                        ? 'Shared item — packed once for the group. Click to make per-person.'
+                        : 'Make this a shared item, packed once for the group'
+                    const personTitle = (name: string) => isCommunal
+                        ? `Needed when ${name} is on the trip`
+                        : name
+                    return (
                     <div key={itemIdx} className="sm:flex sm:items-center sm:gap-2 rounded-lg border border-gray-200 sm:border-transparent p-2 sm:p-0">
                         {/* Item name + desktop people + remove */}
                         <div className="flex items-center gap-2 sm:flex-1 sm:min-w-0">
@@ -534,25 +556,33 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
                                     menuPortalTarget={document.body}
                                 />
                             </div>
-                            {/* Desktop: inline avatars */}
-                            {people.length > 1 && (
-                                <div className="hidden sm:flex gap-0.5 shrink-0">
-                                    {people.map((person, personIdx) => {
-                                        const selected = item.personSelections?.[personIdx]?.selected ?? false
-                                        return (
-                                            <button
-                                                key={person.id}
-                                                type="button"
-                                                onClick={() => togglePerson(itemIdx, personIdx)}
-                                                title={person.name}
-                                                className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold transition-colors ${selected ? AVATAR_ON[personIdx % AVATAR_ON.length] : AVATAR_OFF}`}
-                                            >
-                                                {person.name.charAt(0).toUpperCase()}
-                                            </button>
-                                        )
-                                    })}
-                                </div>
-                            )}
+                            {/* Desktop: shared toggle + inline avatars */}
+                            <div className="hidden sm:flex gap-0.5 shrink-0 items-center">
+                                <button
+                                    type="button"
+                                    onClick={() => toggleCommunal(itemIdx)}
+                                    title={communalTitle}
+                                    aria-label={`Toggle shared for ${item.text || 'item'}`}
+                                    aria-pressed={isCommunal}
+                                    className={`inline-flex items-center justify-center h-5 rounded-full px-1 text-[10px] transition-colors mr-1 ${isCommunal ? 'bg-blue-600 text-white' : AVATAR_OFF}`}
+                                >
+                                    👥
+                                </button>
+                                {people.length > 1 && people.map((person, personIdx) => {
+                                    const selected = item.personSelections?.[personIdx]?.selected ?? false
+                                    return (
+                                        <button
+                                            key={person.id}
+                                            type="button"
+                                            onClick={() => togglePerson(itemIdx, personIdx)}
+                                            title={personTitle(person.name)}
+                                            className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold transition-colors ${selected ? AVATAR_ON[personIdx % AVATAR_ON.length] : AVATAR_OFF} ${isCommunal && selected ? 'ring-2 ring-blue-300 ring-offset-1' : ''}`}
+                                        >
+                                            {person.name.charAt(0).toUpperCase()}
+                                        </button>
+                                    )
+                                })}
+                            </div>
                             <button
                                 type="button"
                                 onClick={() => removeItem(itemIdx)}
@@ -562,31 +592,48 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
                                 ×
                             </button>
                         </div>
-                        {/* Mobile: people on their own row as large labelled tiles */}
-                        {people.length > 1 && (
-                            <div className="mt-2 sm:hidden flex gap-2">
-                                {people.map((person, personIdx) => {
-                                    const selected = item.personSelections?.[personIdx]?.selected ?? false
-                                    return (
-                                        <button
-                                            key={person.id}
-                                            type="button"
-                                            onClick={() => togglePerson(itemIdx, personIdx)}
-                                            className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${selected ? `${AVATAR_ON[personIdx % AVATAR_ON.length]} border-transparent` : `bg-white border-gray-200 text-gray-400`}`}
-                                        >
-                                            <span className="text-lg font-bold leading-none">
-                                                {person.name.charAt(0).toUpperCase()}
-                                            </span>
-                                            <span className="text-[10px] font-medium leading-none truncate w-full text-center px-1">
-                                                {person.name}
-                                            </span>
-                                        </button>
-                                    )
-                                })}
+                        {/* Mobile: shared toggle + people on their own row as large labelled tiles */}
+                        <div className="mt-2 sm:hidden flex gap-2">
+                            <button
+                                type="button"
+                                onClick={() => toggleCommunal(itemIdx)}
+                                title={communalTitle}
+                                aria-pressed={isCommunal}
+                                className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${isCommunal ? 'bg-blue-600 text-white border-transparent' : 'bg-white border-gray-200 text-gray-400'}`}
+                            >
+                                <span className="text-lg font-bold leading-none">👥</span>
+                                <span className="text-[10px] font-medium leading-none truncate w-full text-center px-1">
+                                    Shared
+                                </span>
+                            </button>
+                            {people.length > 1 && people.map((person, personIdx) => {
+                                const selected = item.personSelections?.[personIdx]?.selected ?? false
+                                return (
+                                    <button
+                                        key={person.id}
+                                        type="button"
+                                        onClick={() => togglePerson(itemIdx, personIdx)}
+                                        title={personTitle(person.name)}
+                                        className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${selected ? `${AVATAR_ON[personIdx % AVATAR_ON.length]} border-transparent` : `bg-white border-gray-200 text-gray-400`}`}
+                                    >
+                                        <span className="text-lg font-bold leading-none">
+                                            {person.name.charAt(0).toUpperCase()}
+                                        </span>
+                                        <span className="text-[10px] font-medium leading-none truncate w-full text-center px-1">
+                                            {person.name}
+                                        </span>
+                                    </button>
+                                )
+                            })}
+                        </div>
+                        {isCommunal && people.length > 1 && (
+                            <div className="mt-1 sm:mt-0 sm:hidden text-[11px] text-blue-600 px-1">
+                                Packed once for the group — included when a highlighted person is going
                             </div>
                         )}
                     </div>
-                ))}
+                    )
+                })}
             </div>
             <button
                 type="button"
@@ -607,7 +654,7 @@ function OptionEditModal({ option, people, allItemNames, onSave, onClose }: {
     onClose: () => void
 }) {
     const [text, setText] = useState(option?.text ?? '')
-    const { items, scrollRef, updateItemText, togglePerson, removeItem, addItem } = useItemListState(option?.items ?? [], people)
+    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, addItem } = useItemListState(option?.items ?? [], people)
 
     const handleSave = () => onSave({
         id: option?.id ?? crypto.randomUUID(),
@@ -655,7 +702,8 @@ function OptionEditModal({ option, people, allItemNames, onSave, onClose }: {
                 <ItemListEditor
                     items={items} people={people} allItemNames={allItemNames}
                     scrollRef={scrollRef} updateItemText={updateItemText}
-                    togglePerson={togglePerson} removeItem={removeItem} addItem={addItem}
+                    togglePerson={togglePerson} toggleCommunal={toggleCommunal}
+                    removeItem={removeItem} addItem={addItem}
                 />
                 <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex gap-2 justify-end">
                     <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
@@ -677,7 +725,7 @@ function AlwaysNeededModal({ initialItems, people, allItemNames, onSave, onClose
     onSave: (items: Item[]) => void
     onClose: () => void
 }) {
-    const { items, scrollRef, updateItemText, togglePerson, removeItem, addItem } = useItemListState(initialItems, people)
+    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, addItem } = useItemListState(initialItems, people)
 
     return (
         <div
@@ -707,7 +755,8 @@ function AlwaysNeededModal({ initialItems, people, allItemNames, onSave, onClose
                 <ItemListEditor
                     items={items} people={people} allItemNames={allItemNames}
                     scrollRef={scrollRef} updateItemText={updateItemText}
-                    togglePerson={togglePerson} removeItem={removeItem} addItem={addItem}
+                    togglePerson={togglePerson} toggleCommunal={toggleCommunal}
+                    removeItem={removeItem} addItem={addItem}
                 />
                 <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex gap-2 justify-end">
                     <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -804,3 +804,103 @@ describe('ViewPackingList foreign pod (?pod= param)', () => {
         )
     })
 })
+
+const communalPackingList = {
+    id: 'test-list-3',
+    name: 'Communal Trip',
+    createdAt: '2026-01-01T00:00:00Z',
+    items: [
+        { id: 'item-c1', itemText: 'Tent', personName: '', personId: '', questionId: 'q2', optionId: 'o2', packed: false, communal: true, category: 'Camping' },
+        { id: 'item-c2', itemText: 'First aid kit', personName: '', personId: '', questionId: 'always-needed', optionId: 'always-needed', packed: false, communal: true, category: 'Essentials' },
+        { id: 'item-a1', itemText: 'Sleeping bag', personName: 'Alice', personId: 'p1', questionId: 'q2', optionId: 'o2', packed: false, category: 'Camping' },
+    ],
+}
+
+describe('ViewPackingList shared (communal) section', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...communalPackingList, _rev: '2' }),
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function renderCommunal(list = communalPackingList) {
+        const db = {
+            getPackingList: vi.fn().mockResolvedValue(list),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+        }
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        render(
+            <MemoryRouter initialEntries={[`/view-list/${list.id}`]}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+        return db
+    }
+
+    it('renders communal items in a Shared Items section', async () => {
+        renderCommunal()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+        expect(screen.getByText('Shared Items')).toBeTruthy()
+        expect(screen.getByText('First aid kit')).toBeTruthy()
+        // Per-person items still appear under the person
+        expect(screen.getByText("Alice's Items")).toBeTruthy()
+        expect(screen.getByText('Sleeping bag')).toBeTruthy()
+    })
+
+    it('does not render a Shared Items section when there are no communal items', async () => {
+        renderCommunal({ ...communalPackingList, items: communalPackingList.items.filter(i => !i.communal) })
+        await waitFor(() => expect(screen.getByText('Sleeping bag')).toBeTruthy())
+        expect(screen.queryByText('Shared Items')).toBeNull()
+    })
+
+    it('shows shared packed stats in the section header', async () => {
+        renderCommunal()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+        const header = screen.getByRole('button', { name: /collapse the shared items list/i })
+        expect(header.textContent).toContain('0 / 2')
+    })
+
+    it('collapsing the shared section hides its items but not person items', async () => {
+        renderCommunal()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: /collapse the shared items list/i }))
+        expect(screen.queryByText('Tent')).toBeNull()
+        expect(screen.getByText('Sleeping bag')).toBeTruthy()
+    })
+
+    it('adding an item in the shared section creates a communal item', async () => {
+        const db = renderCommunal()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+
+        // Shared section is rendered first
+        const inputs = screen.getAllByPlaceholderText('Add new item...')
+        fireEvent.change(inputs[0], { target: { value: 'Camping stove' } })
+        fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
+
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        const savedList = db.savePackingList.mock.calls[0][0]
+        const added = savedList.items.find((i: { itemText: string }) => i.itemText === 'Camping stove')
+        expect(added).toBeTruthy()
+        expect(added.communal).toBe(true)
+        expect(added.personId).toBe('')
+        expect(added.personName).toBe('')
+    })
+})

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -886,6 +886,33 @@ describe('ViewPackingList shared (communal) section', () => {
         expect(screen.getByText('Sleeping bag')).toBeTruthy()
     })
 
+    it('"+ Add Shared Items" reveals an empty shared section and is hidden once the section exists', async () => {
+        const db = renderCommunal({ ...communalPackingList, items: communalPackingList.items.filter(i => !i.communal) })
+        await waitFor(() => expect(screen.getByText('Sleeping bag')).toBeTruthy())
+        expect(screen.queryByText('Shared Items')).toBeNull()
+
+        fireEvent.click(screen.getByRole('button', { name: /add shared items/i }))
+
+        expect(screen.getByText('Shared Items')).toBeTruthy()
+        expect(screen.queryByRole('button', { name: /add shared items/i })).toBeNull()
+
+        // Adding an item through the revealed section creates a communal item
+        const inputs = screen.getAllByPlaceholderText('Add new item...')
+        fireEvent.change(inputs[0], { target: { value: 'Tent' } })
+        fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
+
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        const savedList = db.savePackingList.mock.calls[0][0]
+        const added = savedList.items.find((i: { itemText: string }) => i.itemText === 'Tent')
+        expect(added.communal).toBe(true)
+    })
+
+    it('does not show "+ Add Shared Items" when the list already has communal items', async () => {
+        renderCommunal()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+        expect(screen.queryByRole('button', { name: /add shared items/i })).toBeNull()
+    })
+
     it('adding an item in the shared section creates a communal item', async () => {
         const db = renderCommunal()
         await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -22,6 +22,20 @@ type FormData = {
     items: Record<string, boolean>
 }
 
+// Reserved section key for communal items — cannot collide with a person's
+// name used as a key for the other sections.
+const SHARED_SECTION_KEY = '__shared__'
+
+interface ListSection {
+    key: string
+    title: string
+    items: PackingListItem[]
+    // Name used in aria-labels and guest actions; '' for the shared section
+    name: string
+    guestId?: string
+    communal?: boolean
+}
+
 function groupByCategory(items: PackingListItem[]) {
     const map = new Map<string, PackingListItem[]>()
     for (const item of items) {
@@ -434,10 +448,10 @@ export function ViewPackingList() {
         }
     }
 
-    const handleAddItem = async (personName: string, personId: string = '') => {
+    const handleAddItem = async (section: ListSection) => {
         if (!packingList) return
 
-        const newItemText = newItemInputs[personName]?.trim()
+        const newItemText = newItemInputs[section.key]?.trim()
         if (!newItemText) return
 
         try {
@@ -446,17 +460,18 @@ export function ViewPackingList() {
             const newItem = {
                 id: `item-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
                 itemText: newItemText,
-                personName: personName,
-                personId: personId,
+                personName: section.communal ? '' : section.name,
+                personId: section.guestId ?? '',
                 questionId: '',
                 optionId: '',
                 packed: false,
+                ...(section.communal ? { communal: true } : {}),
                 lastModified: new Date().toISOString(),
             }
 
             // Add to form values and clear the input before saving
             setValue(`items.${newItem.id}`, false)
-            setNewItemInputs({ ...newItemInputs, [personName]: '' })
+            setNewItemInputs({ ...newItemInputs, [section.key]: '' })
 
             await persistPackingList({ ...packingList, items: [...packingList.items, newItem] })
 
@@ -529,33 +544,49 @@ export function ViewPackingList() {
     const percentComplete = totalCount > 0 ? Math.round((packedCount / totalCount) * 100) : 0
     const allPacked = totalCount > 0 && packedCount === totalCount
 
-    const personStats = packingList.items.reduce((acc, item) => {
-        if (!acc[item.personName]) acc[item.personName] = { packed: 0, total: 0 }
-        acc[item.personName].total++
-        if (watchedItems[item.id]) acc[item.personName].packed++
+    const sectionStats = packingList.items.reduce((acc, item) => {
+        const key = item.communal ? SHARED_SECTION_KEY : item.personName
+        if (!acc[key]) acc[key] = { packed: 0, total: 0 }
+        acc[key].total++
+        if (watchedItems[item.id]) acc[key].packed++
         return acc
     }, {} as Record<string, { packed: number; total: number }>)
 
-    const guestPersonIdByName = new Map(
-        (packingList.guests ?? []).map(g => [g.name, g.id])
-    )
     const guestNames = new Set((packingList.guests ?? []).map(g => g.name))
 
     // Build grouped item map, seeding guest names so their sections exist even when empty
     const groupedItems: Record<string, PackingListItem[]> = {}
     for (const guest of (packingList.guests ?? [])) groupedItems[guest.name] = []
     for (const item of filteredItems) {
+        if (item.communal) continue
         if (!groupedItems[item.personName]) groupedItems[item.personName] = []
         groupedItems[item.personName].push(item)
     }
 
-    // Regular people (from question set) alphabetically first, then guests in add-order
-    const regularSections = Object.entries(groupedItems)
+    // Shared section first (when the list has communal items), then regular
+    // people (from question set) alphabetically, then guests in add-order
+    const sharedSections: ListSection[] = packingList.items.some(i => i.communal)
+        ? [{
+            key: SHARED_SECTION_KEY,
+            title: 'Shared Items',
+            name: '',
+            communal: true,
+            items: filteredItems.filter(i => i.communal),
+        }]
+        : []
+    const regularSections: ListSection[] = Object.entries(groupedItems)
         .filter(([name]) => !guestNames.has(name))
         .sort(([a], [b]) => a.localeCompare(b))
-    const guestSections = (packingList.guests ?? [])
-        .map(g => [g.name, groupedItems[g.name] ?? []] as [string, PackingListItem[]])
-    const personSections = [...regularSections, ...guestSections]
+        .map(([name, items]) => ({ key: name, title: `${name}'s Items`, name, items }))
+    const guestSections: ListSection[] = (packingList.guests ?? [])
+        .map(g => ({
+            key: g.name,
+            title: `${g.name}'s Items`,
+            name: g.name,
+            guestId: g.id,
+            items: groupedItems[g.name] ?? [],
+        }))
+    const listSections = [...sharedSections, ...regularSections, ...guestSections]
 
     return (
         <>
@@ -700,12 +731,14 @@ export function ViewPackingList() {
                 )}
                 <div>
                     <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))' }}>
-                        {personSections.map(([personName, items]) => {
-                            const stats = personStats[personName] ?? { packed: 0, total: 0 }
-                            const guestId = guestPersonIdByName.get(personName)
+                        {listSections.map((section) => {
+                            const { key: sectionKey, title, items, guestId } = section
+                            const stats = sectionStats[sectionKey] ?? { packed: 0, total: 0 }
                             const isGuest = guestId !== undefined
+                            const isShared = section.communal === true
+                            const collapseLabelTarget = isShared ? 'the shared items' : `${section.name}'s`
                             return (
-                            <div key={personName} className={`border rounded-lg p-4 bg-white shadow-sm ${isGuest ? 'border-amber-200' : 'border-gray-200'}`}>
+                            <div key={sectionKey} className={`border rounded-lg p-4 bg-white shadow-sm ${isGuest ? 'border-amber-200' : isShared ? 'border-blue-200' : 'border-gray-200'}`}>
                                 <div className="mb-4 pb-2 border-b border-gray-200">
                                     <div className="flex items-center gap-1 min-h-[2rem]">
                                         {isGuest && renamingGuestId === guestId ? (
@@ -727,22 +760,27 @@ export function ViewPackingList() {
                                         ) : (
                                             <button
                                                 type="button"
-                                                aria-label={`${collapsedPersons.has(personName) ? 'Expand' : 'Collapse'} ${personName}'s list`}
-                                                onClick={() => togglePerson(personName)}
+                                                aria-label={`${collapsedPersons.has(sectionKey) ? 'Expand' : 'Collapse'} ${collapseLabelTarget} list`}
+                                                onClick={() => togglePerson(sectionKey)}
                                                 className="flex items-center gap-2 flex-1 text-left"
                                             >
-                                                <span className="text-sm text-gray-400">{collapsedPersons.has(personName) ? '▶' : '▼'}</span>
-                                                <span className="text-xl font-semibold text-gray-800">{personName}'s Items</span>
+                                                <span className="text-sm text-gray-400">{collapsedPersons.has(sectionKey) ? '▶' : '▼'}</span>
+                                                <span className="text-xl font-semibold text-gray-800">{title}</span>
                                                 <span className="ml-1 text-sm font-normal text-gray-500">{stats.packed} / {stats.total}</span>
                                             </button>
+                                        )}
+                                        {isShared && (
+                                            <span className="text-xs font-medium text-blue-700 bg-blue-100 rounded-full px-2 py-0.5 shrink-0" title="Packed once for the whole group">
+                                                👥 For everyone
+                                            </span>
                                         )}
                                         {isGuest && renamingGuestId !== guestId && (
                                             <>
                                                 <span className="text-xs font-medium text-amber-700 bg-amber-100 rounded-full px-2 py-0.5 shrink-0">Guest</span>
                                                 <button
                                                     type="button"
-                                                    aria-label={`Rename ${personName}`}
-                                                    onClick={() => { setRenamingGuestId(guestId); setRenamingGuestName(personName) }}
+                                                    aria-label={`Rename ${section.name}`}
+                                                    onClick={() => { setRenamingGuestId(guestId); setRenamingGuestName(section.name) }}
                                                     className="p-2 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-md transition-colors"
                                                 >
                                                     <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
@@ -751,7 +789,7 @@ export function ViewPackingList() {
                                                 </button>
                                                 <button
                                                     type="button"
-                                                    aria-label={`Remove ${personName}`}
+                                                    aria-label={`Remove ${section.name}`}
                                                     onClick={() => setGuestToRemove(guestId)}
                                                     className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
                                                 >
@@ -763,18 +801,18 @@ export function ViewPackingList() {
                                         )}
                                     </div>
                                 </div>
-                                {!collapsedPersons.has(personName) && <div>
+                                {!collapsedPersons.has(sectionKey) && <div>
                                     {/* Add new item input */}
                                     <div className="mb-4 pb-4 border-b border-gray-200">
                                         <div className="flex gap-2">
                                             <input
                                                 type="text"
-                                                value={newItemInputs[personName] || ''}
-                                                onChange={(e) => setNewItemInputs({ ...newItemInputs, [personName]: e.target.value })}
+                                                value={newItemInputs[sectionKey] || ''}
+                                                onChange={(e) => setNewItemInputs({ ...newItemInputs, [sectionKey]: e.target.value })}
                                                 onKeyPress={(e) => {
                                                     if (e.key === 'Enter') {
                                                         e.preventDefault()
-                                                        handleAddItem(personName, guestPersonIdByName.get(personName) ?? '')
+                                                        handleAddItem(section)
                                                     }
                                                 }}
                                                 placeholder="Add new item..."
@@ -782,7 +820,7 @@ export function ViewPackingList() {
                                             />
                                             <button
                                                 type="button"
-                                                onClick={() => handleAddItem(personName, guestPersonIdByName.get(personName) ?? '')}
+                                                onClick={() => handleAddItem(section)}
                                                 className="shrink-0 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
                                             >
                                                 Add
@@ -790,15 +828,15 @@ export function ViewPackingList() {
                                         </div>
                                     </div>
                                     {groupByCategory(items).map(({ category, items: catItems }) => {
-                                        const sectionKey = `${personName}::${category}`
-                                        const isCollapsed = collapsedCategories.has(sectionKey)
+                                        const categoryKey = `${sectionKey}::${category}`
+                                        const isCollapsed = collapsedCategories.has(categoryKey)
                                         return (
-                                            <div key={sectionKey} className="mb-3">
+                                            <div key={categoryKey} className="mb-3">
                                                 <div className="flex items-center justify-between py-1 mb-1">
                                                     <button
                                                         type="button"
                                                         aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${category}`}
-                                                        onClick={() => toggleCategory(sectionKey)}
+                                                        onClick={() => toggleCategory(categoryKey)}
                                                         className="flex items-center gap-1 text-sm font-semibold text-gray-600 hover:text-gray-900"
                                                     >
                                                         <span>{isCollapsed ? '▶' : '▼'}</span>
@@ -820,7 +858,7 @@ export function ViewPackingList() {
                                                     <div className="space-y-2">
                                                         {catItems.map((item) => (
                                                             <div
-                                                                key={`${item.id}-${personName}`}
+                                                                key={`${item.id}-${sectionKey}`}
                                                                 className="bg-gray-50 rounded-lg p-3"
                                                             >
                                                                 <div className="flex items-center justify-between">

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -86,6 +86,9 @@ export function ViewPackingList() {
     const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
     const [collapsedPersons, setCollapsedPersons] = useState<Set<string>>(new Set())
     const [showAddGuest, setShowAddGuest] = useState(false)
+    // Reveals an empty Shared Items section on lists that have no communal
+    // items yet; once an item is added the section persists from the data.
+    const [showSharedSection, setShowSharedSection] = useState(false)
     const [newGuestName, setNewGuestName] = useState('')
     const [renamingGuestId, setRenamingGuestId] = useState<string | null>(null)
     const [renamingGuestName, setRenamingGuestName] = useState('')
@@ -565,7 +568,8 @@ export function ViewPackingList() {
 
     // Shared section first (when the list has communal items), then regular
     // people (from question set) alphabetically, then guests in add-order
-    const sharedSections: ListSection[] = packingList.items.some(i => i.communal)
+    const hasCommunalItems = packingList.items.some(i => i.communal)
+    const sharedSections: ListSection[] = (hasCommunalItems || showSharedSection)
         ? [{
             key: SHARED_SECTION_KEY,
             title: 'Shared Items',
@@ -611,6 +615,15 @@ export function ViewPackingList() {
                         </div>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
+                        {!foreignPodUrl && !hasCommunalItems && !showSharedSection && (
+                            <Button
+                                type="button"
+                                variant="secondary"
+                                onClick={() => setShowSharedSection(true)}
+                            >
+                                + Add Shared Items
+                            </Button>
+                        )}
                         {!foreignPodUrl && (
                             <Button
                                 type="button"

--- a/src/services/rdfSerialization.test.ts
+++ b/src/services/rdfSerialization.test.ts
@@ -126,6 +126,15 @@ describe('packingListToDataset / datasetToPackingList', () => {
         const result = roundTripList(makePackingList({ items: [makeItem()] }))
         expect(result.items[0].category).toBeUndefined()
         expect(result.items[0].reviewed).toBeUndefined()
+        expect(result.items[0].communal).toBeUndefined()
+    })
+
+    it('round-trips a communal item', () => {
+        const item = makeItem({ communal: true, personId: '', personName: '' })
+        const result = roundTripList(makePackingList({ items: [item] }))
+        expect(result.items[0].communal).toBe(true)
+        expect(result.items[0].personId).toBe('')
+        expect(result.items[0].personName).toBe('')
     })
 
     it('round-trips multiple items', () => {
@@ -241,6 +250,27 @@ describe('questionSetToDataset / datasetToQuestionSet', () => {
         const ps2 = item.personSelections.find(ps => ps.personId === 'p2')!
         expect(ps1.selected).toBe(true)
         expect(ps2.selected).toBe(false)
+    })
+
+    it('round-trips a communal always-needed item and omits the flag otherwise', () => {
+        const qs = makeQuestionSet({
+            alwaysNeededItems: [
+                { text: 'First aid kit', communal: true, personSelections: [{ personId: 'p1', selected: true }] },
+                { text: 'Toothbrush', personSelections: [{ personId: 'p1', selected: true }] },
+            ],
+        })
+        const result = roundTripQs(qs)
+        expect(result.alwaysNeededItems[0].communal).toBe(true)
+        expect(result.alwaysNeededItems[1].communal).toBeUndefined()
+    })
+
+    it('round-trips a communal item inside a question option', () => {
+        const option = makeOption({
+            items: [{ text: 'Tent', communal: true, personSelections: [{ personId: 'p1', selected: true }] }],
+        })
+        const question = makeQuestion({ options: [option] })
+        const result = roundTripQs(makeQuestionSet({ questions: [question] }))
+        expect(result.questions[0].options[0].items[0].communal).toBe(true)
     })
 
     it('round-trips a saved question with option and items', () => {

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -108,6 +108,7 @@ function packingListItemToThing(item: PackingListItem, itemUrl: string): Thing {
         .addStringNoLocale(PMU.optionId, item.optionId)
         .addBoolean(PMU.packed, item.packed)
 
+    if (item.communal !== undefined) t = t.addBoolean(PMU.communal, item.communal)
     if (item.category !== undefined) t = t.addStringNoLocale(PMU.category, item.category)
     if (item.reviewed !== undefined) t = t.addBoolean(PMU.reviewed, item.reviewed)
     if (item.lastModified !== undefined) t = t.addDatetime(PMU.itemLastModified, new Date(item.lastModified))
@@ -126,6 +127,7 @@ function thingToPackingListItem(thing: Thing | null, url: string): PackingListIt
     const questionId = getStringNoLocale(thing, PMU.questionId) ?? ''
     const optionId = getStringNoLocale(thing, PMU.optionId) ?? ''
     const packed = getBoolean(thing, PMU.packed) ?? false
+    const communal = getBoolean(thing, PMU.communal)
     const category = getStringNoLocale(thing, PMU.category) ?? undefined
     const reviewed = getBoolean(thing, PMU.reviewed)
     const itemLastModified = getDatetime(thing, PMU.itemLastModified)?.toISOString()
@@ -138,6 +140,7 @@ function thingToPackingListItem(thing: Thing | null, url: string): PackingListIt
         questionId,
         optionId,
         packed,
+        ...(communal !== null ? { communal } : {}),
         ...(category !== undefined ? { category } : {}),
         ...(reviewed !== null ? { reviewed } : {}),
         ...(itemLastModified !== undefined ? { lastModified: itemLastModified } : {}),
@@ -368,6 +371,7 @@ function questionItemToThings(
         .addStringNoLocale(PMU.text, item.text)
 
     if (item.id) itemBuilder = itemBuilder.addStringNoLocale(PMU.questionItemId, item.id)
+    if (item.communal !== undefined) itemBuilder = itemBuilder.addBoolean(PMU.communal, item.communal)
     if (item.lastModified) itemBuilder = itemBuilder.addDatetime(PMU.questionItemLastModified, new Date(item.lastModified))
     if (item.deletedAt) itemBuilder = itemBuilder.addDatetime(PMU.questionItemDeletedAt, new Date(item.deletedAt))
 
@@ -530,6 +534,7 @@ function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
 
     const text = getStringNoLocale(thing, PMU.text) ?? ''
     const id = getStringNoLocale(thing, PMU.questionItemId) ?? undefined
+    const communal = getBoolean(thing, PMU.communal)
     const lastModified = getDatetime(thing, PMU.questionItemLastModified)?.toISOString()
     const deletedAt = getDatetime(thing, PMU.questionItemDeletedAt)?.toISOString()
 
@@ -552,6 +557,7 @@ function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
         text,
         personSelections,
         ...(id !== undefined ? { id } : {}),
+        ...(communal !== null ? { communal } : {}),
         ...(lastModified !== undefined ? { lastModified } : {}),
         ...(deletedAt !== undefined ? { deletedAt } : {}),
     }

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -28,6 +28,9 @@ export const PMU = {
     category: `${PMU_NS}category`,
     reviewed: `${PMU_NS}reviewed`,
     itemLastModified: `${PMU_NS}itemLastModified`,
+    // Shared by PackingListItem and QuestionItem: item is packed once for the
+    // whole group rather than per person
+    communal: `${PMU_NS}communal`,
 
     // QuestionSet predicates
     hasPerson: `${PMU_NS}hasPerson`,


### PR DESCRIPTION
Communal items are packed once for the whole group instead of fanning
out per person (tent, first aid kit, litter tray). An item's person
selections become a trigger: the shared item is included when at least
one selected person is on the trip, so existing age/species filters
keep working (e.g. travel cot only when the baby comes).

- Add optional `communal` flag to question-set items and packing-list
  items (additive; absent = per-person, legacy data unchanged)
- Generate a single shared entry in question-based and always-needed
  item generation; extract generateAlwaysNeededItems for reuse
- Round-trip the flag to Solid pods via a new pmu:communal predicate
- Show a pinned "Shared Items" section in the packing list view with
  its own stats, collapse state, and add-item input
- Add a shared toggle (with trigger-styled person dots) to the item
  editors on the manage-questions page
- Offer a "Shared" checkbox when saving past-trip custom items back
  into the question set
- Mark group kit communal in wizard example data (first aid kit,
  travel adapter, travel games, pet bowls, litter tray, etc.)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WnxMdwsXDwmwZUD3boQH1a