### PR TITLE
Add visual feedback for newly added packing list items

### DIFF
--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -560,6 +560,21 @@ describe('ViewPackingList new item feedback', () => {
         const row = span.closest('div.rounded-lg')
         expect(row?.className).not.toContain('ring-green-400')
     })
+
+    it('scrolls the newly added item into view', async () => {
+        const scrollIntoView = vi.fn()
+        Element.prototype.scrollIntoView = scrollIntoView
+
+        renderComponent()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        const input = screen.getByPlaceholderText('Add new item...')
+        fireEvent.change(input, { target: { value: 'Sunscreen' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+        await waitFor(() => expect(screen.getByText('Sunscreen')).toBeTruthy())
+        await waitFor(() => expect(scrollIntoView).toHaveBeenCalled())
+    })
 })
 
 describe('ViewPackingList inline item editing', () => {

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -511,6 +511,57 @@ describe('ViewPackingList checked item styling', () => {
     })
 })
 
+describe('ViewPackingList new item feedback', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({
+            saveToPod: vi.fn(),
+        })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('highlights a newly added item', async () => {
+        renderComponent()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        const input = screen.getByPlaceholderText('Add new item...')
+        fireEvent.change(input, { target: { value: 'Sunscreen' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+        await waitFor(() => {
+            const span = screen.getByText('Sunscreen')
+            const row = span.closest('div.rounded-lg')
+            expect(row?.className).toContain('ring-green-400')
+        })
+    })
+
+    it('does not highlight items that were not just added', async () => {
+        renderComponent()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        const span = screen.getByText('Passport')
+        const row = span.closest('div.rounded-lg')
+        expect(row?.className).not.toContain('ring-green-400')
+    })
+})
+
 describe('ViewPackingList inline item editing', () => {
     let db: ReturnType<typeof makeDb>
 

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -93,6 +93,7 @@ export function ViewPackingList() {
     const [renamingGuestId, setRenamingGuestId] = useState<string | null>(null)
     const [renamingGuestName, setRenamingGuestName] = useState('')
     const [guestToRemove, setGuestToRemove] = useState<string | null>(null)
+    const [recentlyAddedItemId, setRecentlyAddedItemId] = useState<string | null>(null)
 
 
     const toggleCategory = (key: string) =>
@@ -476,10 +477,22 @@ export function ViewPackingList() {
             setValue(`items.${newItem.id}`, false)
             setNewItemInputs({ ...newItemInputs, [section.key]: '' })
 
+            // Make sure the category the new item lands in is expanded so it's visible
+            setCollapsedCategories(prev => {
+                const categoryKey = `${section.key}::Other`
+                if (!prev.has(categoryKey)) return prev
+                const next = new Set(prev)
+                next.delete(categoryKey)
+                return next
+            })
+
             await persistPackingList({ ...packingList, items: [...packingList.items, newItem] })
 
             setAutoSaveStatus('saved')
             setTimeout(() => setAutoSaveStatus('idle'), 2000)
+
+            setRecentlyAddedItemId(newItem.id)
+            setTimeout(() => setRecentlyAddedItemId(null), 2000)
         } catch (err) {
             console.error('Error adding item:', err)
             setAutoSaveStatus('error')
@@ -875,7 +888,7 @@ export function ViewPackingList() {
                                                         {catItems.map((item) => (
                                                             <div
                                                                 key={`${item.id}-${sectionKey}`}
-                                                                className="bg-gray-50 rounded-lg p-3"
+                                                                className={`rounded-lg p-3 transition-colors duration-1000 ${item.id === recentlyAddedItemId ? 'bg-green-100 ring-2 ring-green-400' : 'bg-gray-50'}`}
                                                             >
                                                                 <div className="flex items-center justify-between">
                                                                     <label className="flex items-center space-x-3 cursor-pointer flex-1">

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -94,6 +94,7 @@ export function ViewPackingList() {
     const [renamingGuestName, setRenamingGuestName] = useState('')
     const [guestToRemove, setGuestToRemove] = useState<string | null>(null)
     const [recentlyAddedItemId, setRecentlyAddedItemId] = useState<string | null>(null)
+    const itemRowRefs = useRef<Map<string, HTMLDivElement>>(new Map())
 
 
     const toggleCategory = (key: string) =>
@@ -154,6 +155,10 @@ export function ViewPackingList() {
             .catch(() => {})
     }, [packingList?.id, foreignPodUrl, ownerWebIdFromUrl, db])
 
+    useEffect(() => {
+        if (!recentlyAddedItemId) return
+        itemRowRefs.current.get(recentlyAddedItemId)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }, [recentlyAddedItemId])
 
     const { register, setValue, getValues, control, reset } = useForm<FormData>({
         defaultValues: {
@@ -888,6 +893,10 @@ export function ViewPackingList() {
                                                         {catItems.map((item) => (
                                                             <div
                                                                 key={`${item.id}-${sectionKey}`}
+                                                                ref={(el) => {
+                                                                    if (el) itemRowRefs.current.set(item.id, el)
+                                                                    else itemRowRefs.current.delete(item.id)
+                                                                }}
                                                                 className={`rounded-lg p-3 transition-colors duration-1000 ${item.id === recentlyAddedItemId ? 'bg-green-100 ring-2 ring-green-400' : 'bg-gray-50'}`}
                                                             >
                                                                 <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
Added visual feedback to highlight items immediately after they are added to a packing list, improving user experience by making the action result more obvious.

## Key Changes
- **New state tracking**: Added `recentlyAddedItemId` state to track which item was just added (clears after 2 seconds)
- **Visual styling**: Applied green background (`bg-green-100`) and green ring (`ring-2 ring-green-400`) to newly added items with smooth color transition
- **Auto-expand category**: Automatically expands the category containing a newly added item so it's immediately visible to the user
- **Test coverage**: Added comprehensive test suite with two test cases:
  - Verifies newly added items are highlighted with the green ring styling
  - Verifies existing items are not highlighted

## Implementation Details
- The highlight effect uses a 1-second CSS transition for smooth visual feedback
- The `recentlyAddedItemId` state is automatically cleared after 2 seconds, matching the auto-save status feedback pattern
- The category expansion logic prevents the new item from being hidden in a collapsed section
- All changes follow existing patterns in the codebase for state management and styling

https://claude.ai/code/session_01FQyV1DoJtA36SEafCwWH5H