### PR TITLE
Hide Shared Items section when all its items are packed and hidden

### DIFF
--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -376,7 +376,9 @@ describe('CreatePackingList – suggestion card', () => {
                 ]),
             })
         ))
-        expect(screen.queryByText('Sunscreen SPF50')).toBeNull()
+        // The card removal re-renders after the awaited save resolves — poll
+        // rather than asserting synchronously (flaked on slower CI runners)
+        await waitFor(() => expect(screen.queryByText('Sunscreen SPF50')).toBeNull())
     })
 
     it('"Add" calls db.saveQuestionSet and db.savePackingList with reviewed:true', async () => {
@@ -405,7 +407,7 @@ describe('CreatePackingList – suggestion card', () => {
                 })
             )
         })
-        expect(screen.queryByText('Sunscreen SPF50')).toBeNull()
+        await waitFor(() => expect(screen.queryByText('Sunscreen SPF50')).toBeNull())
     })
 
     it('"Add" sets selected:true for the matching person in personSelections', async () => {

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -865,6 +865,22 @@ describe('ViewPackingList shared (communal) section', () => {
         expect(screen.getByText('Sleeping bag')).toBeTruthy()
     })
 
+    it('hides the Shared Items section when all communal items are packed and packed items are hidden', async () => {
+        renderCommunal({
+            ...communalPackingList,
+            items: communalPackingList.items.map(i => i.communal ? { ...i, packed: true } : i),
+        })
+        await waitFor(() => expect(screen.getByText('Sleeping bag')).toBeTruthy())
+        // Packed items are hidden by default, so the fully-packed shared section
+        // should disappear just like a fully-packed person's section does
+        expect(screen.queryByText('Shared Items')).toBeNull()
+
+        // Showing packed items brings the section back
+        fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
+        expect(screen.getByText('Shared Items')).toBeTruthy()
+        expect(screen.getByText('Tent')).toBeTruthy()
+    })
+
     it('does not render a Shared Items section when there are no communal items', async () => {
         renderCommunal({ ...communalPackingList, items: communalPackingList.items.filter(i => !i.communal) })
         await waitFor(() => expect(screen.getByText('Sleeping bag')).toBeTruthy())

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -566,16 +566,19 @@ export function ViewPackingList() {
         groupedItems[item.personName].push(item)
     }
 
-    // Shared section first (when the list has communal items), then regular
-    // people (from question set) alphabetically, then guests in add-order
+    // Shared section first (when the list has visible communal items), then
+    // regular people (from question set) alphabetically, then guests in
+    // add-order. Like person sections, the shared section disappears when all
+    // its items are packed and packed items are hidden.
     const hasCommunalItems = packingList.items.some(i => i.communal)
-    const sharedSections: ListSection[] = (hasCommunalItems || showSharedSection)
+    const visibleCommunalItems = filteredItems.filter(i => i.communal)
+    const sharedSections: ListSection[] = (visibleCommunalItems.length > 0 || showSharedSection)
         ? [{
             key: SHARED_SECTION_KEY,
             title: 'Shared Items',
             name: '',
             communal: true,
-            items: filteredItems.filter(i => i.communal),
+            items: visibleCommunalItems,
         }]
         : []
     const regularSections: ListSection[] = Object.entries(groupedItems)


### PR DESCRIPTION
Follow-up to #221. With "Hide Packed" active (the default) and every shared item packed, the Shared Items section lingered as an empty card, while a fully-packed person's section disappears.

The section's visibility was based on the unfiltered item list; it now uses the packed-filtered communal items, matching person-section behaviour:

- Section disappears when all shared items are packed and packed items are hidden
- Toggling **Show Packed** (or unpacking a shared item) brings it back
- The "+ Add Shared Items" reveal behaviour for lists with no communal items is unchanged

Written test-first; new unit test covers both the hidden and Show-Packed states (584 tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnxMdwsXDwmwZUD3boQH1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnxMdwsXDwmwZUD3boQH1a)_