### PR TITLE
Fix category expansion logic for new items and modal centering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-packing-app",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-packing-app",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@capacitor/android": "^8.3.4",
         "@capacitor/app": "^8.1.0",

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -12,7 +12,7 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
 
     return (
         <div className="fixed inset-0 z-50 overflow-y-auto">
-            <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
                 <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={onClose} />
 
                 <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -500,12 +500,16 @@ export function ViewPackingList() {
             setValue(`items.${newItem.id}`, false)
             setNewItemInputs({ ...newItemInputs, [inputKey]: '' })
 
-            // Make sure the category the new item lands in is expanded so it's visible
+            // Make sure the category the new item lands in is expanded so it's
+            // visible. New items have no category, so they land under "Other" —
+            // keyed `${sectionKey}::Other` in person view and
+            // `Other::${personName}` in question view.
             setCollapsedCategories(prev => {
-                const categoryKey = `${section.key}::Other`
-                if (!prev.has(categoryKey)) return prev
+                const sectionKey = inputKey.split('::add::')[0]
+                const keysToExpand = [`${sectionKey}::Other`, `Other::${personName}`]
+                if (!keysToExpand.some(k => prev.has(k))) return prev
                 const next = new Set(prev)
-                next.delete(categoryKey)
+                for (const k of keysToExpand) next.delete(k)
                 return next
             })
 


### PR DESCRIPTION
## Summary
This PR fixes two UI issues: the category expansion logic when adding new items now correctly handles both person and question view layouts, and modals are now properly centered on all screen sizes.

## Key Changes
- **New item category expansion**: Updated the logic in `view-packing-list.tsx` to correctly expand the "Other" category regardless of view type (person or question). The fix accounts for the different key formats used in each view (`${sectionKey}::Other` in person view vs `Other::${personName}` in question view) by extracting the section key from the input field name and attempting to expand both possible key formats.
- **Modal centering**: Changed `Modal.tsx` to use `items-center` instead of `items-end sm:items-center`, ensuring modals are vertically centered on all screen sizes rather than bottom-aligned on mobile.

## Implementation Details
The new item expansion logic now:
1. Extracts the section key from the input field identifier (`inputKey.split('::add::')[0]`)
2. Builds an array of both possible "Other" category keys for the current context
3. Checks if either key is collapsed before attempting to expand
4. Removes both keys from the collapsed set to handle both view types correctly

https://claude.ai/code/session_011A8gYJb3Ld3NFuNm5ZK2Gv