### PR TITLE
Add kids' birthdays with age-bracket promotion suggestions

### DIFF
--- a/src/components/AgePromotionCard.test.tsx
+++ b/src/components/AgePromotionCard.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { AgePromotionCard } from './AgePromotionCard'
+import { PackingListQuestionSet, Person, Item } from '../edit-questions/types'
+
+const TODAY = new Date('2026-07-18T12:00:00Z')
+
+const mum: Person = { id: 'mum', name: 'Mum', ageRange: 'Adult', gender: 'female' }
+// Turned 3 in June 2026, still stored as Toddler
+const kid: Person = { id: 'kid', name: 'Neve', ageRange: 'Toddler', dateOfBirth: '2023-06-01' }
+
+function makeItem(text: string, overrides: Partial<Item> = {}): Item {
+    return {
+        text,
+        personSelections: [
+            { personId: 'mum', selected: true },
+            { personId: 'kid', selected: false },
+        ],
+        ...overrides,
+    }
+}
+
+function makeQuestionSet(people: Person[] = [mum, kid], items: Item[] = []): PackingListQuestionSet {
+    return { _id: '1', people, questions: [], alwaysNeededItems: items }
+}
+
+describe('AgePromotionCard', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    it('renders nothing when nobody has crossed a bracket', () => {
+        const qs = makeQuestionSet([mum, { ...kid, ageRange: 'Child' }])
+        const { container } = render(<AgePromotionCard questionSet={qs} onApply={vi.fn()} today={TODAY} />)
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('shows a banner naming the person and their new bracket', () => {
+        render(<AgePromotionCard questionSet={makeQuestionSet()} onApply={vi.fn()} today={TODAY} />)
+        expect(screen.getByText(/Neve is now a child/i)).toBeTruthy()
+    })
+
+    it('applies checked suggestions and acknowledges the new bracket', async () => {
+        const potty = makeItem('Travel potty', {
+            ageRanges: ['Toddler'],
+            personSelections: [
+                { personId: 'mum', selected: false },
+                { personId: 'kid', selected: true },
+            ],
+        })
+        const onApply = vi.fn()
+        render(<AgePromotionCard questionSet={makeQuestionSet([mum, kid], [potty])} onApply={onApply} today={TODAY} />)
+
+        fireEvent.click(screen.getByText('Review changes'))
+        expect(screen.getByText('Travel potty')).toBeTruthy()
+
+        fireEvent.click(screen.getByText('Apply updates'))
+        await waitFor(() => expect(onApply).toHaveBeenCalledTimes(1))
+
+        const updated: PackingListQuestionSet = onApply.mock.calls[0][0]
+        expect(updated.people.find(p => p.id === 'kid')!.ageRange).toBe('Child')
+        expect(
+            updated.alwaysNeededItems.find(i => i.text === 'Travel potty')!
+                .personSelections.find(ps => ps.personId === 'kid')!.selected
+        ).toBe(false)
+    })
+
+    it('leaves unticked suggestions alone', async () => {
+        const potty = makeItem('Travel potty', {
+            ageRanges: ['Toddler'],
+            personSelections: [
+                { personId: 'mum', selected: false },
+                { personId: 'kid', selected: true },
+            ],
+        })
+        const onApply = vi.fn()
+        render(<AgePromotionCard questionSet={makeQuestionSet([mum, kid], [potty])} onApply={onApply} today={TODAY} />)
+
+        fireEvent.click(screen.getByText('Review changes'))
+        const pottyCheckbox = screen.getByText('Travel potty').closest('label')!.querySelector('input')!
+        fireEvent.click(pottyCheckbox)
+        fireEvent.click(screen.getByText('Apply updates'))
+        await waitFor(() => expect(onApply).toHaveBeenCalledTimes(1))
+
+        const updated: PackingListQuestionSet = onApply.mock.calls[0][0]
+        expect(updated.people.find(p => p.id === 'kid')!.ageRange).toBe('Child')
+        expect(
+            updated.alwaysNeededItems.find(i => i.text === 'Travel potty')!
+                .personSelections.find(ps => ps.personId === 'kid')!.selected
+        ).toBe(true)
+    })
+
+    it('dismissing hides the banner and remembers the person + bracket', () => {
+        render(<AgePromotionCard questionSet={makeQuestionSet()} onApply={vi.fn()} today={TODAY} />)
+        fireEvent.click(screen.getByLabelText('Dismiss age update'))
+        expect(screen.queryByText(/Neve is now/i)).toBeNull()
+        expect(localStorage.getItem('age-promotion-dismissed:kid')).toBe('Child')
+    })
+
+    it('a dismissed transition stays hidden on re-render but a later bracket shows again', () => {
+        localStorage.setItem('age-promotion-dismissed:kid', 'Child')
+        const { rerender, container } = render(
+            <AgePromotionCard questionSet={makeQuestionSet()} onApply={vi.fn()} today={TODAY} />
+        )
+        expect(container.firstChild).toBeNull()
+
+        // Years later the same kid becomes a teenager — prompt again
+        rerender(
+            <AgePromotionCard
+                questionSet={makeQuestionSet()}
+                onApply={vi.fn()}
+                today={new Date('2036-07-18T12:00:00Z')}
+            />
+        )
+        expect(screen.getByText(/Neve is now a teenager/i)).toBeTruthy()
+    })
+})

--- a/src/components/AgePromotionCard.test.tsx
+++ b/src/components/AgePromotionCard.test.tsx
@@ -41,6 +41,12 @@ describe('AgePromotionCard', () => {
         expect(screen.getByText(/Neve is now a child/i)).toBeTruthy()
     })
 
+    it('uses "an adult" phrasing for the Adult bracket', () => {
+        const almostAdult: Person = { id: 'kid2', name: 'Sam', ageRange: 'Teenager', dateOfBirth: '2008-01-01' }
+        render(<AgePromotionCard questionSet={makeQuestionSet([mum, almostAdult])} onApply={vi.fn()} today={TODAY} />)
+        expect(screen.getByText(/Sam is now an adult!/)).toBeTruthy()
+    })
+
     it('applies checked suggestions and acknowledges the new bracket', async () => {
         const potty = makeItem('Travel potty', {
             ageRanges: ['Toddler'],

--- a/src/components/AgePromotionCard.test.tsx
+++ b/src/components/AgePromotionCard.test.tsx
@@ -104,6 +104,55 @@ describe('AgePromotionCard', () => {
         expect(localStorage.getItem('age-promotion-dismissed:kid')).toBe('Child')
     })
 
+    it('shows manual transitions (no DOB needed) and reports them handled on apply', async () => {
+        const sam: Person = { id: 'sam', name: 'Sam', ageRange: 'Teenager' } // already saved with the new bracket
+        const qs = makeQuestionSet([mum, { ...kid, ageRange: 'Child' }, sam])
+        const onApply = vi.fn()
+        const onManualHandled = vi.fn()
+        render(
+            <AgePromotionCard
+                questionSet={qs}
+                onApply={onApply}
+                manualTransitions={[{ person: sam, from: 'Child', to: 'Teenager' }]}
+                onManualHandled={onManualHandled}
+                today={TODAY}
+            />
+        )
+        expect(screen.getByText(/Sam is now a teenager/)).toBeTruthy()
+
+        fireEvent.click(screen.getByText('Review changes'))
+        fireEvent.click(screen.getByText('Apply updates'))
+        await waitFor(() => expect(onManualHandled).toHaveBeenCalledTimes(1))
+        expect(onApply).toHaveBeenCalledTimes(1)
+    })
+
+    it('dismissing a manual transition does not write a localStorage marker', () => {
+        const sam: Person = { id: 'sam', name: 'Sam', ageRange: 'Teenager' }
+        const qs = makeQuestionSet([mum, { ...kid, ageRange: 'Child' }, sam])
+        const onManualHandled = vi.fn()
+        render(
+            <AgePromotionCard
+                questionSet={qs}
+                onApply={vi.fn()}
+                manualTransitions={[{ person: sam, from: 'Child', to: 'Teenager' }]}
+                onManualHandled={onManualHandled}
+                today={TODAY}
+            />
+        )
+        fireEvent.click(screen.getByLabelText('Dismiss age update'))
+        expect(onManualHandled).toHaveBeenCalledTimes(1)
+        expect(localStorage.getItem('age-promotion-dismissed:sam')).toBeNull()
+    })
+
+    it('never prompts to demote someone promoted early by hand', () => {
+        // DOB says Child, but the parent already bumped them to Teenager
+        const early: Person = { id: 'kid', name: 'Neve', ageRange: 'Teenager', dateOfBirth: '2018-01-01' }
+        const { container } = render(
+            <AgePromotionCard questionSet={makeQuestionSet([mum, early])} onApply={vi.fn()} today={TODAY} />
+        )
+        expect(container.firstChild).toBeNull()
+    })
+
     it('a dismissed transition stays hidden on re-render but a later bracket shows again', () => {
         localStorage.setItem('age-promotion-dismissed:kid', 'Child')
         const { rerender, container } = render(

--- a/src/components/AgePromotionCard.tsx
+++ b/src/components/AgePromotionCard.tsx
@@ -22,6 +22,15 @@ function isDismissed(t: AgeTransition): boolean {
 interface AgePromotionCardProps {
     questionSet: PackingListQuestionSet
     onApply: (updated: PackingListQuestionSet) => Promise<void> | void
+    /**
+     * Bracket changes the user just made by hand (e.g. promoting a kid
+     * early). Shown alongside birthday-driven transitions so they get the
+     * same item review; never dismissed via localStorage since they're
+     * one-shot.
+     */
+    manualTransitions?: AgeTransition[]
+    /** Called when manual transitions have been applied or dismissed */
+    onManualHandled?: () => void
     /** Injectable clock for tests */
     today?: Date
 }
@@ -33,16 +42,22 @@ interface AgePromotionCardProps {
  * changes the user left ticked. Dismissing remembers the person+bracket in
  * localStorage so the same transition isn't offered again on this device.
  */
-export function AgePromotionCard({ questionSet, onApply, today }: AgePromotionCardProps) {
+export function AgePromotionCard({ questionSet, onApply, manualTransitions, onManualHandled, today }: AgePromotionCardProps) {
     const [isExpanded, setIsExpanded] = useState(false)
     const [isApplying, setIsApplying] = useState(false)
     const [unchecked, setUnchecked] = useState<Set<string>>(new Set())
     const [dismissedTick, setDismissedTick] = useState(0)
 
     const transitions = useMemo(
-        () => detectAgeTransitions(questionSet.people ?? [], today).filter(t => !isDismissed(t)),
+        () => {
+            const manual = manualTransitions ?? []
+            const manualIds = new Set(manual.map(t => t.person.id))
+            const auto = detectAgeTransitions(questionSet.people ?? [], today)
+                .filter(t => !isDismissed(t) && !manualIds.has(t.person.id))
+            return [...manual, ...auto]
+        },
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [questionSet, today, dismissedTick]
+        [questionSet, manualTransitions, today, dismissedTick]
     )
 
     const suggestions = useMemo(
@@ -68,14 +83,20 @@ export function AgePromotionCard({ questionSet, onApply, today }: AgePromotionCa
     }
 
     const handleDismiss = () => {
+        const manualIds = new Set((manualTransitions ?? []).map(t => t.person.id))
         try {
+            // Manual transitions are one-shot state, not a recurring detection,
+            // so they don't need a localStorage marker.
             for (const t of transitions) {
-                localStorage.setItem(`${DISMISSED_KEY_PREFIX}${t.person.id}`, t.to)
+                if (!manualIds.has(t.person.id)) {
+                    localStorage.setItem(`${DISMISSED_KEY_PREFIX}${t.person.id}`, t.to)
+                }
             }
         } catch {
             // localStorage unavailable — banner just reappears next visit
         }
         setDismissedTick(n => n + 1)
+        onManualHandled?.()
     }
 
     const handleApply = async () => {
@@ -84,6 +105,7 @@ export function AgePromotionCard({ questionSet, onApply, today }: AgePromotionCa
             const accepted = suggestions.filter(s => !unchecked.has(s.key))
             await onApply(applyAgePromotions(questionSet, transitions, accepted))
             setIsExpanded(false)
+            onManualHandled?.()
         } finally {
             setIsApplying(false)
         }

--- a/src/components/AgePromotionCard.tsx
+++ b/src/components/AgePromotionCard.tsx
@@ -90,7 +90,7 @@ export function AgePromotionCard({ questionSet, onApply, today }: AgePromotionCa
     }
 
     const summary = transitions
-        .map(t => `${t.person.name} is now a ${t.to.toLowerCase() === 'adult' ? 'an adult' : t.to.toLowerCase()}`)
+        .map(t => `${t.person.name} is now ${t.to === 'Adult' ? 'an adult' : `a ${t.to.toLowerCase()}`}`)
         .join(', ')
 
     const renderSuggestion = (s: PromotionSuggestion) => (

--- a/src/components/AgePromotionCard.tsx
+++ b/src/components/AgePromotionCard.tsx
@@ -1,0 +1,178 @@
+import { useMemo, useState } from 'react'
+import { PackingListQuestionSet } from '../edit-questions/types'
+import { AGE_RANGE_OPTIONS } from '../edit-questions/types'
+import { detectAgeTransitions, AgeTransition } from '../edit-questions/age-derivation'
+import { buildPromotionSuggestions, applyAgePromotions, PromotionSuggestion } from '../edit-questions/age-promotion'
+
+const DISMISSED_KEY_PREFIX = 'age-promotion-dismissed:'
+
+function bracketLabel(value: string | undefined): string {
+    if (!value) return 'no age set'
+    return AGE_RANGE_OPTIONS.find(o => o.value === value)?.label ?? value
+}
+
+function isDismissed(t: AgeTransition): boolean {
+    try {
+        return localStorage.getItem(`${DISMISSED_KEY_PREFIX}${t.person.id}`) === t.to
+    } catch {
+        return false
+    }
+}
+
+interface AgePromotionCardProps {
+    questionSet: PackingListQuestionSet
+    onApply: (updated: PackingListQuestionSet) => Promise<void> | void
+    /** Injectable clock for tests */
+    today?: Date
+}
+
+/**
+ * Banner shown when someone with a date of birth has aged into a new
+ * bracket. Expands into a per-person review of suggested item changes;
+ * applying updates the stored bracket (so the prompt stops) and only the
+ * changes the user left ticked. Dismissing remembers the person+bracket in
+ * localStorage so the same transition isn't offered again on this device.
+ */
+export function AgePromotionCard({ questionSet, onApply, today }: AgePromotionCardProps) {
+    const [isExpanded, setIsExpanded] = useState(false)
+    const [isApplying, setIsApplying] = useState(false)
+    const [unchecked, setUnchecked] = useState<Set<string>>(new Set())
+    const [dismissedTick, setDismissedTick] = useState(0)
+
+    const transitions = useMemo(
+        () => detectAgeTransitions(questionSet.people ?? [], today).filter(t => !isDismissed(t)),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [questionSet, today, dismissedTick]
+    )
+
+    const suggestions = useMemo(
+        () => buildPromotionSuggestions(questionSet, transitions),
+        [questionSet, transitions]
+    )
+
+    if (transitions.length === 0) return null
+
+    const byPerson = transitions.map(t => ({
+        transition: t,
+        ageOut: suggestions.filter(s => s.personId === t.person.id && s.direction === 'ageOut'),
+        ageIn: suggestions.filter(s => s.personId === t.person.id && s.direction !== 'ageOut'),
+    }))
+
+    const toggleChecked = (key: string) => {
+        setUnchecked(prev => {
+            const next = new Set(prev)
+            if (next.has(key)) next.delete(key)
+            else next.add(key)
+            return next
+        })
+    }
+
+    const handleDismiss = () => {
+        try {
+            for (const t of transitions) {
+                localStorage.setItem(`${DISMISSED_KEY_PREFIX}${t.person.id}`, t.to)
+            }
+        } catch {
+            // localStorage unavailable — banner just reappears next visit
+        }
+        setDismissedTick(n => n + 1)
+    }
+
+    const handleApply = async () => {
+        setIsApplying(true)
+        try {
+            const accepted = suggestions.filter(s => !unchecked.has(s.key))
+            await onApply(applyAgePromotions(questionSet, transitions, accepted))
+            setIsExpanded(false)
+        } finally {
+            setIsApplying(false)
+        }
+    }
+
+    const summary = transitions
+        .map(t => `${t.person.name} is now a ${t.to.toLowerCase() === 'adult' ? 'an adult' : t.to.toLowerCase()}`)
+        .join(', ')
+
+    const renderSuggestion = (s: PromotionSuggestion) => (
+        <label key={s.key} className="flex items-start gap-2 text-sm text-gray-700 bg-white rounded border border-violet-200 px-3 py-2">
+            <input
+                type="checkbox"
+                checked={!unchecked.has(s.key)}
+                onChange={() => toggleChecked(s.key)}
+                className="mt-0.5 h-4 w-4 text-violet-600 rounded focus:ring-2 focus:ring-violet-500"
+            />
+            <span>
+                <span className="font-medium text-gray-900">{s.itemText}</span>
+                <span className="ml-2 text-xs text-gray-500">{s.contextLabel}</span>
+            </span>
+        </label>
+    )
+
+    return (
+        <div className="bg-violet-50 rounded-lg border border-violet-200 p-4">
+            <div className="flex items-start justify-between gap-4">
+                <p className="text-violet-900 font-medium">🎂 Time flies — {summary}! Want to update their packing items?</p>
+                <button
+                    type="button"
+                    aria-label="Dismiss age update"
+                    title="Don't ask again for this age change"
+                    onClick={handleDismiss}
+                    className="text-violet-600 hover:text-violet-900 text-xl leading-none flex-shrink-0"
+                >
+                    ×
+                </button>
+            </div>
+            {!isExpanded ? (
+                <button
+                    type="button"
+                    onClick={() => setIsExpanded(true)}
+                    className="mt-2 text-sm text-violet-700 underline"
+                >
+                    Review changes
+                </button>
+            ) : (
+                <div className="mt-4 space-y-5">
+                    {byPerson.map(({ transition, ageOut, ageIn }) => (
+                        <div key={transition.person.id}>
+                            <p className="text-sm text-violet-800 font-semibold">
+                                {transition.person.name}: {bracketLabel(transition.from)} → {bracketLabel(transition.to)}
+                            </p>
+                            {ageOut.length === 0 && ageIn.length === 0 && (
+                                <p className="mt-1 text-sm text-violet-700">No item changes suggested — we'll just remember the new age bracket.</p>
+                            )}
+                            {ageOut.length > 0 && (
+                                <div className="mt-2">
+                                    <p className="text-xs uppercase tracking-wide text-violet-600 font-semibold mb-1">Outgrown — untick to keep</p>
+                                    <div className="space-y-1.5">{ageOut.map(renderSuggestion)}</div>
+                                </div>
+                            )}
+                            {ageIn.length > 0 && (
+                                <div className="mt-2">
+                                    <p className="text-xs uppercase tracking-wide text-violet-600 font-semibold mb-1">Suggested for their new age</p>
+                                    <div className="space-y-1.5">{ageIn.map(renderSuggestion)}</div>
+                                </div>
+                            )}
+                        </div>
+                    ))}
+                    <div className="flex gap-2 justify-end">
+                        <button
+                            type="button"
+                            onClick={() => setIsExpanded(false)}
+                            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-violet-100"
+                        >
+                            Not now
+                        </button>
+                        <button
+                            type="button"
+                            disabled={isApplying}
+                            onClick={handleApply}
+                            className="px-4 py-2 text-sm bg-violet-600 text-white rounded-lg hover:bg-violet-700 disabled:opacity-50"
+                        >
+                            {isApplying ? 'Updating…' : 'Apply updates'}
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/edit-questions/age-derivation.test.ts
+++ b/src/edit-questions/age-derivation.test.ts
@@ -79,6 +79,12 @@ describe('detectAgeTransitions', () => {
         expect(detectAgeTransitions([kid], TODAY)).toEqual([{ person: kid, from: undefined, to: 'Toddler' }])
     })
 
+    it('never suggests a downward move when the stored bracket is ahead of the derived one', () => {
+        // Manually promoted early — derived says Child, parent already set Teenager
+        const early = person({ name: 'Sam', ageRange: 'Teenager', dateOfBirth: '2020-01-01' })
+        expect(detectAgeTransitions([early], TODAY)).toEqual([])
+    })
+
     it('ignores people whose brackets match, without a DOB, pets, and deleted people', () => {
         const matching = person({ ageRange: 'Child', dateOfBirth: '2020-01-01' })
         const noDob = person({ ageRange: 'Toddler' })

--- a/src/edit-questions/age-derivation.test.ts
+++ b/src/edit-questions/age-derivation.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { deriveAgeRange, currentAgeRange, detectAgeTransitions } from './age-derivation'
+import { Person } from './types'
+
+const TODAY = new Date('2026-07-18T12:00:00Z')
+
+describe('deriveAgeRange', () => {
+    it('returns Baby for under 1', () => {
+        expect(deriveAgeRange('2026-01-10', TODAY)).toBe('Baby')
+        expect(deriveAgeRange('2025-07-19', TODAY)).toBe('Baby') // 1st birthday tomorrow
+    })
+
+    it('returns Toddler from 1st birthday up to 3rd', () => {
+        expect(deriveAgeRange('2025-07-18', TODAY)).toBe('Toddler') // 1st birthday today
+        expect(deriveAgeRange('2023-07-19', TODAY)).toBe('Toddler') // 3rd birthday tomorrow
+    })
+
+    it('returns Child from 3rd birthday up to 12th', () => {
+        expect(deriveAgeRange('2023-07-18', TODAY)).toBe('Child') // 3rd birthday today
+        expect(deriveAgeRange('2014-07-19', TODAY)).toBe('Child') // 12th birthday tomorrow
+    })
+
+    it('returns Teenager from 12th birthday up to 18th', () => {
+        expect(deriveAgeRange('2014-07-18', TODAY)).toBe('Teenager') // 12th birthday today
+        expect(deriveAgeRange('2008-07-19', TODAY)).toBe('Teenager') // 18th birthday tomorrow
+    })
+
+    it('returns Adult from 18th birthday', () => {
+        expect(deriveAgeRange('2008-07-18', TODAY)).toBe('Adult') // 18th birthday today
+        expect(deriveAgeRange('1985-03-02', TODAY)).toBe('Adult')
+    })
+
+    it('handles a Feb 29 birthday in non-leap years (birthday counts from Mar 1)', () => {
+        // Born 2024-02-29; on 2027-02-28 they are still 2, on 2027-03-01 they turn 3
+        expect(deriveAgeRange('2024-02-29', new Date('2027-02-28T12:00:00Z'))).toBe('Toddler')
+        expect(deriveAgeRange('2024-02-29', new Date('2027-03-01T12:00:00Z'))).toBe('Child')
+    })
+
+    it('returns undefined for invalid or future dates', () => {
+        expect(deriveAgeRange('not-a-date', TODAY)).toBeUndefined()
+        expect(deriveAgeRange('', TODAY)).toBeUndefined()
+        expect(deriveAgeRange('2030-01-01', TODAY)).toBeUndefined()
+    })
+})
+
+function person(overrides: Partial<Person>): Person {
+    return { id: crypto.randomUUID(), name: 'Test', ...overrides }
+}
+
+describe('currentAgeRange', () => {
+    it('derives from dateOfBirth when present', () => {
+        const p = person({ ageRange: 'Toddler', dateOfBirth: '2020-01-01' })
+        expect(currentAgeRange(p, TODAY)).toBe('Child')
+    })
+
+    it('falls back to stored ageRange without dateOfBirth', () => {
+        expect(currentAgeRange(person({ ageRange: 'Teenager' }), TODAY)).toBe('Teenager')
+    })
+
+    it('falls back to stored ageRange when dateOfBirth is invalid', () => {
+        const p = person({ ageRange: 'Child', dateOfBirth: 'garbage' })
+        expect(currentAgeRange(p, TODAY)).toBe('Child')
+    })
+
+    it('returns undefined when neither is available', () => {
+        expect(currentAgeRange(person({}), TODAY)).toBeUndefined()
+    })
+})
+
+describe('detectAgeTransitions', () => {
+    it('reports people whose derived bracket differs from the stored one', () => {
+        const kid = person({ name: 'Neve', ageRange: 'Toddler', dateOfBirth: '2022-06-01' })
+        const transitions = detectAgeTransitions([kid], TODAY)
+        expect(transitions).toEqual([{ person: kid, from: 'Toddler', to: 'Child' }])
+    })
+
+    it('reports people with a dateOfBirth but no stored bracket yet', () => {
+        const kid = person({ name: 'Leo', dateOfBirth: '2024-01-01' })
+        expect(detectAgeTransitions([kid], TODAY)).toEqual([{ person: kid, from: undefined, to: 'Toddler' }])
+    })
+
+    it('ignores people whose brackets match, without a DOB, pets, and deleted people', () => {
+        const matching = person({ ageRange: 'Child', dateOfBirth: '2020-01-01' })
+        const noDob = person({ ageRange: 'Toddler' })
+        const pet = person({ species: 'dog', dateOfBirth: '2020-01-01' })
+        const deleted = person({ ageRange: 'Toddler', dateOfBirth: '2020-01-01', deletedAt: '2026-01-01T00:00:00Z' })
+        expect(detectAgeTransitions([matching, noDob, pet, deleted], TODAY)).toEqual([])
+    })
+})

--- a/src/edit-questions/age-derivation.ts
+++ b/src/edit-questions/age-derivation.ts
@@ -1,0 +1,71 @@
+import { AgeRange, Person } from './types'
+
+/**
+ * Whole years between a YYYY-MM-DD date of birth and `today`, or null when
+ * the date is unparseable or in the future. Calendar-based (not ms-based) so
+ * brackets flip exactly on birthdays; a Feb 29 birthday counts from Mar 1 in
+ * non-leap years.
+ */
+function ageInYears(dateOfBirth: string, today: Date): number | null {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateOfBirth.trim())
+    if (!match) return null
+    const [, y, m, d] = match.map(Number)
+    if (m < 1 || m > 12 || d < 1 || d > 31) return null
+
+    let age = today.getUTCFullYear() - y
+    const birthdayPassed =
+        today.getUTCMonth() + 1 > m ||
+        (today.getUTCMonth() + 1 === m && today.getUTCDate() >= d)
+    if (!birthdayPassed) age--
+    return age < 0 ? null : age
+}
+
+/**
+ * Map a date of birth to the app's age brackets (Baby 0-1, Toddler 1-3,
+ * Child 3-12, Teenager 12-18, Adult 18+). Returns undefined for invalid or
+ * future dates so a bad entry never triggers a transition.
+ */
+export function deriveAgeRange(dateOfBirth: string, today: Date = new Date()): AgeRange | undefined {
+    const age = ageInYears(dateOfBirth, today)
+    if (age === null) return undefined
+    if (age < 1) return 'Baby'
+    if (age < 3) return 'Toddler'
+    if (age < 12) return 'Child'
+    if (age < 18) return 'Teenager'
+    return 'Adult'
+}
+
+/**
+ * The person's effective bracket right now: derived from dateOfBirth when
+ * available, otherwise the stored ageRange.
+ */
+export function currentAgeRange(person: Person, today: Date = new Date()): AgeRange | undefined {
+    if (person.dateOfBirth) {
+        const derived = deriveAgeRange(person.dateOfBirth, today)
+        if (derived) return derived
+    }
+    return person.ageRange
+}
+
+export interface AgeTransition {
+    person: Person
+    from: AgeRange | undefined
+    to: AgeRange
+}
+
+/**
+ * People whose derived bracket no longer matches the stored one — i.e. they
+ * have aged into a new bracket since the user last acknowledged it. Pets and
+ * deleted people never transition.
+ */
+export function detectAgeTransitions(people: Person[], today: Date = new Date()): AgeTransition[] {
+    const transitions: AgeTransition[] = []
+    for (const person of people) {
+        if (person.species || person.deletedAt || !person.dateOfBirth) continue
+        const derived = deriveAgeRange(person.dateOfBirth, today)
+        if (derived && derived !== person.ageRange) {
+            transitions.push({ person, from: person.ageRange, to: derived })
+        }
+    }
+    return transitions
+}

--- a/src/edit-questions/age-derivation.ts
+++ b/src/edit-questions/age-derivation.ts
@@ -53,9 +53,13 @@ export interface AgeTransition {
     to: AgeRange
 }
 
+const BRACKET_ORDER: readonly AgeRange[] = ['Baby', 'Toddler', 'Child', 'Teenager', 'Adult']
+
 /**
- * People whose derived bracket no longer matches the stored one — i.e. they
- * have aged into a new bracket since the user last acknowledged it. Pets and
+ * People whose derived bracket has moved AHEAD of the stored one — i.e. they
+ * have aged up since the user last acknowledged it. Deliberately one-way: a
+ * stored bracket ahead of the derived one means the user promoted them early
+ * (kids mature at different speeds), and we never nag to demote. Pets and
  * deleted people never transition.
  */
 export function detectAgeTransitions(people: Person[], today: Date = new Date()): AgeTransition[] {
@@ -63,7 +67,10 @@ export function detectAgeTransitions(people: Person[], today: Date = new Date())
     for (const person of people) {
         if (person.species || person.deletedAt || !person.dateOfBirth) continue
         const derived = deriveAgeRange(person.dateOfBirth, today)
-        if (derived && derived !== person.ageRange) {
+        if (!derived) continue
+        const agedUp = !person.ageRange ||
+            BRACKET_ORDER.indexOf(derived) > BRACKET_ORDER.indexOf(person.ageRange)
+        if (agedUp) {
             transitions.push({ person, from: person.ageRange, to: derived })
         }
     }

--- a/src/edit-questions/age-promotion.test.ts
+++ b/src/edit-questions/age-promotion.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest'
+import { buildPromotionSuggestions, applyAgePromotions } from './age-promotion'
+import { AgeTransition } from './age-derivation'
+import { createExampleData } from './example-data'
+import { PackingListQuestionSet, Person, Item } from './types'
+
+const NOW = '2026-07-18T12:00:00.000Z'
+
+const mum: Person = { id: 'mum', name: 'Mum', ageRange: 'Adult', gender: 'female' }
+const kid: Person = { id: 'kid', name: 'Neve', ageRange: 'Toddler', dateOfBirth: '2023-06-01' }
+
+function transition(person: Person, to: AgeTransition['to']): AgeTransition {
+    return { person, from: person.ageRange, to }
+}
+
+function makeItem(text: string, overrides: Partial<Item> = {}): Item {
+    return {
+        text,
+        personSelections: [
+            { personId: 'mum', selected: true },
+            { personId: 'kid', selected: false },
+        ],
+        ...overrides,
+    }
+}
+
+function minimalQs(alwaysNeededItems: Item[]): PackingListQuestionSet {
+    return { _id: '1', people: [mum, kid], questions: [], alwaysNeededItems }
+}
+
+describe('buildPromotionSuggestions - toggles', () => {
+    it('suggests deselecting tagged items the person has outgrown', () => {
+        const qs = minimalQs([
+            makeItem('Custom potty', {
+                ageRanges: ['Toddler'],
+                personSelections: [
+                    { personId: 'mum', selected: false },
+                    { personId: 'kid', selected: true },
+                ],
+            }),
+        ])
+        const suggestions = buildPromotionSuggestions(qs, [transition(kid, 'Child')])
+        const ageOut = suggestions.filter(s => s.direction === 'ageOut')
+        expect(ageOut).toHaveLength(1)
+        expect(ageOut[0]).toMatchObject({
+            personId: 'kid',
+            itemText: 'Custom potty',
+            location: { kind: 'always' },
+            itemIndex: 0,
+        })
+    })
+
+    it('suggests selecting existing tagged items for the new bracket', () => {
+        const qs = minimalQs([makeItem('Custom colouring book', { ageRanges: ['Child'] })])
+        const suggestions = buildPromotionSuggestions(qs, [transition(kid, 'Child')])
+        const ageIn = suggestions.filter(s => s.direction === 'ageIn')
+        expect(ageIn).toHaveLength(1)
+        expect(ageIn[0]).toMatchObject({ personId: 'kid', itemText: 'Custom colouring book' })
+    })
+
+    it('never touches untagged items, deleted items, or other people', () => {
+        const qs = minimalQs([
+            makeItem('Custom teddy'), // untagged
+            makeItem('Custom deleted', { ageRanges: ['Child'], deletedAt: NOW }),
+        ])
+        const suggestions = buildPromotionSuggestions(qs, [transition(kid, 'Child')])
+        const toggles = suggestions.filter(s => s.direction !== 'addItem')
+        expect(toggles).toHaveLength(0)
+    })
+
+    it('skips items already in the right state', () => {
+        const qs = minimalQs([
+            makeItem('Custom already selected', {
+                ageRanges: ['Child'],
+                personSelections: [
+                    { personId: 'mum', selected: false },
+                    { personId: 'kid', selected: true },
+                ],
+            }),
+        ])
+        const suggestions = buildPromotionSuggestions(qs, [transition(kid, 'Child')])
+        expect(suggestions.filter(s => s.direction !== 'addItem' && s.itemText === 'Custom already selected')).toHaveLength(0)
+    })
+})
+
+describe('buildPromotionSuggestions - additions from the default catalog', () => {
+    it('suggests default items for the new bracket that are missing from the data', () => {
+        // Family generated with a toddler: Child-only defaults were dropped at
+        // generation time, so aging up must offer to add them back.
+        const qs = createExampleData([mum, kid])
+        expect(qs.alwaysNeededItems.find(i => i.text === 'Entertainment (books/small toys)')).toBeUndefined()
+
+        const suggestions = buildPromotionSuggestions(qs, [transition(kid, 'Child')])
+        const adds = suggestions.filter(s => s.direction === 'addItem')
+        const entertainment = adds.find(s => s.itemText === 'Entertainment (books/small toys)')
+        expect(entertainment).toBeDefined()
+        expect(entertainment!.location).toEqual({ kind: 'always' })
+        expect(entertainment!.newItem!.ageRanges).toEqual(['Child'])
+        // Selections align with the family and select the promoted kid
+        expect(entertainment!.newItem!.personSelections).toEqual([
+            { personId: 'mum', selected: false },
+            { personId: 'kid', selected: true },
+        ])
+    })
+
+    it('places option-level additions in the matching question option', () => {
+        const qs = createExampleData([mum, kid])
+        const suggestions = buildPromotionSuggestions(qs, [transition(kid, 'Child')])
+        const adds = suggestions.filter(s => s.direction === 'addItem')
+        const swimAids = adds.find(s => s.itemText === 'Swim aids (noodles, kickboard)')
+        expect(swimAids).toBeDefined()
+        expect(swimAids!.location.kind).toBe('option')
+        expect(swimAids!.contextLabel).toContain('Swimming')
+    })
+
+    it('does not re-add items the user has, or previously deleted, or that were already relevant', () => {
+        const qs = createExampleData([mum, kid])
+        // 'Water bottle' (Toddler+) exists already, and was already relevant before the transition.
+        // Simulate the user having deleted a default child item they don't want.
+        qs.alwaysNeededItems.push({ ...makeItem('Entertainment (books/small toys)'), deletedAt: NOW })
+
+        const suggestions = buildPromotionSuggestions(qs, [transition(kid, 'Child')])
+        const adds = suggestions.filter(s => s.direction === 'addItem')
+        expect(adds.find(s => s.itemText === 'Water bottle')).toBeUndefined()
+        expect(adds.find(s => s.itemText === 'Entertainment (books/small toys)')).toBeUndefined()
+    })
+
+    it('produces no suggestions when there are no transitions', () => {
+        const qs = createExampleData([mum, kid])
+        expect(buildPromotionSuggestions(qs, [])).toEqual([])
+    })
+})
+
+describe('applyAgePromotions', () => {
+    it('updates the stored bracket for every transition, even with nothing accepted', () => {
+        const qs = minimalQs([])
+        const result = applyAgePromotions(qs, [transition(kid, 'Child')], [], NOW)
+        const updatedKid = result.people.find(p => p.id === 'kid')!
+        expect(updatedKid.ageRange).toBe('Child')
+        expect(updatedKid.lastModified).toBe(NOW)
+        // untouched person is not restamped
+        expect(result.people.find(p => p.id === 'mum')).toEqual(mum)
+    })
+
+    it('flips selections for accepted toggles and stamps the item', () => {
+        const qs = minimalQs([
+            makeItem('Custom potty', {
+                ageRanges: ['Toddler'],
+                personSelections: [
+                    { personId: 'mum', selected: false },
+                    { personId: 'kid', selected: true },
+                ],
+            }),
+            makeItem('Custom colouring book', { ageRanges: ['Child'] }),
+        ])
+        const suggestions = buildPromotionSuggestions(qs, [transition(kid, 'Child')])
+            .filter(s => s.direction !== 'addItem')
+        const result = applyAgePromotions(qs, [transition(kid, 'Child')], suggestions, NOW)
+
+        const potty = result.alwaysNeededItems[0]
+        expect(potty.personSelections.find(ps => ps.personId === 'kid')!.selected).toBe(false)
+        expect(potty.lastModified).toBe(NOW)
+        const book = result.alwaysNeededItems[1]
+        expect(book.personSelections.find(ps => ps.personId === 'kid')!.selected).toBe(true)
+    })
+
+    it('inserts accepted catalog items with an id and timestamp', () => {
+        const qs = createExampleData([mum, kid])
+        const adds = buildPromotionSuggestions(qs, [transition(kid, 'Child')])
+            .filter(s => s.direction === 'addItem' && s.itemText === 'Entertainment (books/small toys)')
+        const result = applyAgePromotions(qs, [transition(kid, 'Child')], adds, NOW)
+
+        const added = result.alwaysNeededItems.find(i => i.text === 'Entertainment (books/small toys)')!
+        expect(added).toBeDefined()
+        expect(added.id).toBeTruthy()
+        expect(added.lastModified).toBe(NOW)
+        expect(added.ageRanges).toEqual(['Child'])
+    })
+
+    it('leaves rejected suggestions untouched', () => {
+        const qs = minimalQs([
+            makeItem('Custom potty', {
+                ageRanges: ['Toddler'],
+                personSelections: [
+                    { personId: 'mum', selected: false },
+                    { personId: 'kid', selected: true },
+                ],
+            }),
+        ])
+        const result = applyAgePromotions(qs, [transition(kid, 'Child')], [], NOW)
+        expect(result.alwaysNeededItems[0].personSelections.find(ps => ps.personId === 'kid')!.selected).toBe(true)
+        expect(result.alwaysNeededItems[0].lastModified).toBeUndefined()
+    })
+})

--- a/src/edit-questions/age-promotion.ts
+++ b/src/edit-questions/age-promotion.ts
@@ -1,0 +1,236 @@
+import { PackingListQuestionSet, Person, Item, Question, Option } from './types'
+import { AgeTransition } from './age-derivation'
+import { createExampleData } from './example-data'
+import { generateUUID } from '../utils/uuid'
+
+export type ItemLocation =
+    | { kind: 'always' }
+    | { kind: 'option'; questionId: string; optionId: string }
+
+export interface PromotionSuggestion {
+    /** Stable key for UI checkbox state */
+    key: string
+    personId: string
+    personName: string
+    direction: 'ageOut' | 'ageIn' | 'addItem'
+    itemText: string
+    /** Where the item lives, for display: "Always needed" or "Question — Option" */
+    contextLabel: string
+    location: ItemLocation
+    /** For toggles: index into the raw items array at `location` */
+    itemIndex?: number
+    /** For addItem: the ready-to-insert catalog item (selections aligned to active people) */
+    newItem?: Item
+}
+
+function locationKey(location: ItemLocation): string {
+    return location.kind === 'always' ? 'always' : `option:${location.questionId}:${location.optionId}`
+}
+
+function normalize(text: string): string {
+    return text.trim().toLowerCase()
+}
+
+interface LocatedItems {
+    location: ItemLocation
+    contextLabel: string
+    items: Item[]
+}
+
+function collectLocations(qs: PackingListQuestionSet): LocatedItems[] {
+    const locations: LocatedItems[] = [
+        { location: { kind: 'always' }, contextLabel: 'Always needed', items: qs.alwaysNeededItems ?? [] },
+    ]
+    for (const question of qs.questions) {
+        if (question.deletedAt) continue
+        for (const option of question.options) {
+            locations.push({
+                location: { kind: 'option', questionId: question.id, optionId: option.id },
+                contextLabel: `${question.text} — ${option.text}`,
+                items: option.items,
+            })
+        }
+    }
+    return locations
+}
+
+function toggleSuggestions(qs: PackingListQuestionSet, transitions: AgeTransition[]): PromotionSuggestion[] {
+    const suggestions: PromotionSuggestion[] = []
+    for (const { location, contextLabel, items } of collectLocations(qs)) {
+        items.forEach((item, itemIndex) => {
+            if (item.deletedAt || !item.ageRanges) return
+            for (const { person, to } of transitions) {
+                const selection = item.personSelections.find(ps => ps.personId === person.id)
+                if (!selection) continue
+                const inNewBracket = item.ageRanges!.includes(to)
+                const direction = selection.selected && !inNewBracket ? 'ageOut'
+                    : !selection.selected && inNewBracket ? 'ageIn'
+                    : null
+                if (!direction) continue
+                suggestions.push({
+                    key: `${direction}:${person.id}:${locationKey(location)}:${itemIndex}`,
+                    personId: person.id,
+                    personName: person.name,
+                    direction,
+                    itemText: item.text,
+                    contextLabel,
+                    location,
+                    itemIndex,
+                })
+            }
+        })
+    }
+    return suggestions
+}
+
+/**
+ * Default items for a newly reached bracket that are missing from the user's
+ * data entirely — they were dropped at generation time because nobody was in
+ * that bracket. Regenerates the default catalog for the post-transition
+ * family and matches locations back by question/option text (or stable
+ * option id), so renamed questions are simply skipped rather than guessed at.
+ */
+function additionSuggestions(qs: PackingListQuestionSet, transitions: AgeTransition[]): PromotionSuggestion[] {
+    const activePeople = qs.people.filter(p => !p.deletedAt)
+    const promotedBracket = new Map(transitions.map(t => [t.person.id, t.to]))
+    const postPeople: Person[] = activePeople.map(p => {
+        const to = promotedBracket.get(p.id)
+        return to ? { ...p, ageRange: to } : p
+    })
+    const catalog = createExampleData(postPeople, [])
+
+    const userLocations = collectLocations(qs)
+    const findUserLocation = (catalogLoc: LocatedItems, catalogQs: PackingListQuestionSet): LocatedItems | undefined => {
+        if (catalogLoc.location.kind === 'always') {
+            return userLocations.find(l => l.location.kind === 'always')
+        }
+        const { questionId, optionId } = catalogLoc.location
+        const catalogQuestion = catalogQs.questions.find(q => q.id === questionId)
+        const catalogOption = catalogQuestion?.options.find(o => o.id === optionId)
+        if (!catalogQuestion || !catalogOption) return undefined
+        return userLocations.find(l => {
+            if (l.location.kind !== 'option') return false
+            const userQuestion = qs.questions.find(q => q.id === (l.location as { questionId: string }).questionId)
+            const userOption = userQuestion?.options.find(o => o.id === (l.location as { optionId: string }).optionId)
+            if (!userQuestion || !userOption) return false
+            const questionMatches = normalize(userQuestion.text) === normalize(catalogQuestion.text)
+            const optionMatches = userOption.id === catalogOption.id || normalize(userOption.text) === normalize(catalogOption.text)
+            return questionMatches && optionMatches
+        })
+    }
+
+    const suggestions: PromotionSuggestion[] = []
+    const suggested = new Set<string>()
+    for (const catalogLoc of collectLocations(catalog)) {
+        const userLoc = findUserLocation(catalogLoc, catalog)
+        if (!userLoc) continue
+        // Deleted items count as present: the user chose to remove them.
+        const existingTexts = new Set(userLoc.items.map(i => normalize(i.text)))
+
+        for (const catalogItem of catalogLoc.items) {
+            if (!catalogItem.ageRanges) continue
+            for (const { person, from, to } of transitions) {
+                if (!catalogItem.ageRanges.includes(to)) continue
+                // Skip items that were already relevant before the transition —
+                // if they're missing, the user removed them on purpose.
+                if (from && catalogItem.ageRanges.includes(from)) continue
+                const selection = catalogItem.personSelections.find(ps => ps.personId === person.id)
+                if (!selection?.selected) continue
+                if (existingTexts.has(normalize(catalogItem.text))) continue
+
+                const dedupeKey = `${locationKey(userLoc.location)}:${normalize(catalogItem.text)}`
+                if (suggested.has(dedupeKey)) continue
+                suggested.add(dedupeKey)
+                suggestions.push({
+                    key: `addItem:${person.id}:${dedupeKey}`,
+                    personId: person.id,
+                    personName: person.name,
+                    direction: 'addItem',
+                    itemText: catalogItem.text,
+                    contextLabel: userLoc.contextLabel,
+                    location: userLoc.location,
+                    newItem: catalogItem,
+                })
+            }
+        }
+    }
+    return suggestions
+}
+
+/**
+ * Everything worth reviewing when the given people move into a new age
+ * bracket: existing tagged items to select/deselect, plus default items for
+ * the new bracket that don't exist in the data yet.
+ */
+export function buildPromotionSuggestions(
+    qs: PackingListQuestionSet,
+    transitions: AgeTransition[],
+): PromotionSuggestion[] {
+    if (transitions.length === 0) return []
+    return [...toggleSuggestions(qs, transitions), ...additionSuggestions(qs, transitions)]
+}
+
+/**
+ * Apply the accepted suggestions and acknowledge every transition by moving
+ * each person's stored ageRange to the new bracket (which stops the prompt
+ * recurring). Only touched items and people get a fresh lastModified so the
+ * pod merge stays fine-grained.
+ */
+export function applyAgePromotions(
+    qs: PackingListQuestionSet,
+    transitions: AgeTransition[],
+    accepted: PromotionSuggestion[],
+    now: string = new Date().toISOString(),
+): PackingListQuestionSet {
+    const promotedBracket = new Map(transitions.map(t => [t.person.id, t.to]))
+
+    const people = qs.people.map(p => {
+        const to = promotedBracket.get(p.id)
+        return to ? { ...p, ageRange: to, lastModified: now } : p
+    })
+
+    const toggles = accepted.filter(s => s.direction !== 'addItem')
+    const additions = accepted.filter(s => s.direction === 'addItem' && s.newItem)
+
+    const applyToLocation = (location: ItemLocation, items: Item[]): Item[] => {
+        const locKey = locationKey(location)
+        let result = items.map((item, idx) => {
+            const togglesHere = toggles.filter(s => locationKey(s.location) === locKey && s.itemIndex === idx)
+            if (togglesHere.length === 0) return item
+            const toggledPersonIds = new Set(togglesHere.map(s => s.personId))
+            return {
+                ...item,
+                lastModified: now,
+                personSelections: item.personSelections.map(ps =>
+                    toggledPersonIds.has(ps.personId) ? { ...ps, selected: !ps.selected } : ps
+                ),
+            }
+        })
+        const additionsHere = additions.filter(s => locationKey(s.location) === locKey)
+        if (additionsHere.length > 0) {
+            result = [
+                ...result,
+                ...additionsHere.map(s => ({ ...s.newItem!, id: generateUUID(), lastModified: now })),
+            ]
+        }
+        return result
+    }
+
+    const questions: Question[] = qs.questions.map(question => ({
+        ...question,
+        options: question.options.map((option): Option => ({
+            ...option,
+            items: applyToLocation(
+                { kind: 'option', questionId: question.id, optionId: option.id },
+                option.items,
+            ),
+        })),
+    }))
+
+    return {
+        ...qs,
+        people,
+        questions,
+        alwaysNeededItems: applyToLocation({ kind: 'always' }, qs.alwaysNeededItems ?? []),
+    }
+}

--- a/src/edit-questions/age-specific-items.ts
+++ b/src/edit-questions/age-specific-items.ts
@@ -1,13 +1,6 @@
 import { Person, AgeRange, Gender } from './types'
 
 /**
- * Helper function to filter people by age range
- */
-function filterByAgeRange(people: Person[], ageRange: AgeRange): Person[] {
-    return people.filter(p => p.ageRange === ageRange)
-}
-
-/**
  * Helper function to filter people by multiple age ranges
  */
 function filterByAgeRanges(people: Person[], ageRanges: AgeRange[]): Person[] {
@@ -15,60 +8,30 @@ function filterByAgeRanges(people: Person[], ageRanges: AgeRange[]): Person[] {
 }
 
 /**
- * Get adults only
+ * A people filter that carries the brackets it selects, so items built from
+ * it can be tagged with `ageRanges` and revisited when someone ages up.
+ * Gender-constrained filters deliberately do NOT carry the tag — bracket
+ * membership alone doesn't decide those items.
  */
-export function getAdults(people: Person[]): Person[] {
-    return filterByAgeRange(people, 'Adult')
+export interface AgeRangeFilter {
+    (people: Person[]): Person[]
+    ageRanges: AgeRange[]
 }
 
-/**
- * Get teenagers only
- */
-export function getTeenagers(people: Person[]): Person[] {
-    return filterByAgeRange(people, 'Teenager')
+function ageRangeFilter(ageRanges: AgeRange[]): AgeRangeFilter {
+    const fn = ((people: Person[]) => filterByAgeRanges(people, ageRanges)) as AgeRangeFilter
+    fn.ageRanges = ageRanges
+    return fn
 }
 
-/**
- * Get children only
- */
-export function getChildren(people: Person[]): Person[] {
-    return filterByAgeRange(people, 'Child')
-}
-
-/**
- * Get toddlers only
- */
-export function getToddlers(people: Person[]): Person[] {
-    return filterByAgeRange(people, 'Toddler')
-}
-
-/**
- * Get babies only
- */
-export function getBabies(people: Person[]): Person[] {
-    return filterByAgeRange(people, 'Baby')
-}
-
-/**
- * Get teenagers and adults
- */
-export function getTeenagersAndAdults(people: Person[]): Person[] {
-    return filterByAgeRanges(people, ['Teenager', 'Adult'])
-}
-
-/**
- * Get children and older (Child, Teenager, Adult)
- */
-export function getChildrenAndOlder(people: Person[]): Person[] {
-    return filterByAgeRanges(people, ['Child', 'Teenager', 'Adult'])
-}
-
-/**
- * Get toddlers and older (Toddler, Child, Teenager, Adult)
- */
-export function getToddlersAndOlder(people: Person[]): Person[] {
-    return filterByAgeRanges(people, ['Toddler', 'Child', 'Teenager', 'Adult'])
-}
+export const getAdults = ageRangeFilter(['Adult'])
+export const getTeenagers = ageRangeFilter(['Teenager'])
+export const getChildren = ageRangeFilter(['Child'])
+export const getToddlers = ageRangeFilter(['Toddler'])
+export const getBabies = ageRangeFilter(['Baby'])
+export const getTeenagersAndAdults = ageRangeFilter(['Teenager', 'Adult'])
+export const getChildrenAndOlder = ageRangeFilter(['Child', 'Teenager', 'Adult'])
+export const getToddlersAndOlder = ageRangeFilter(['Toddler', 'Child', 'Teenager', 'Adult'])
 
 /**
  * Helper to filter people by gender

--- a/src/edit-questions/example-data.test.ts
+++ b/src/edit-questions/example-data.test.ts
@@ -380,3 +380,34 @@ describe('createExampleData communal items', () => {
         expect(items.find(i => i.text === 'Passport')?.communal).toBeUndefined()
     })
 })
+
+describe('createExampleData - ageRanges tagging', () => {
+    const family: Person[] = [
+        { id: 'a1', name: 'Alice', ageRange: 'Adult', gender: 'female' },
+        { id: 'b1', name: 'Bea', ageRange: 'Baby' },
+    ]
+
+    it('tags age-filtered items with the brackets they apply to', () => {
+        const result = createExampleData(family)
+        const nappies = result.alwaysNeededItems.find(i => i.text === 'Nappies (pack/supply)')!
+        expect(nappies.ageRanges).toEqual(['Baby'])
+
+        const swimming = result.questions
+            .find(q => q.text === 'What activities will you be doing?')!
+            .options.find(o => o.id === ACTIVITY_OPTION_IDS.swimming)!
+        const swimsuit = swimming.items.find(i => i.text === 'Swimsuit')!
+        expect(swimsuit.ageRanges).toEqual(['Toddler', 'Child', 'Teenager', 'Adult'])
+    })
+
+    it('leaves everyone-items and gender-filtered items untagged', () => {
+        const result = createExampleData(family)
+        const snacks = result.alwaysNeededItems.find(i => i.text === 'Snacks')!
+        expect(snacks.ageRanges).toBeUndefined()
+
+        const overnightYes = result.questions
+            .find(q => q.text === 'Will you be staying overnight?')!
+            .options.find(o => o.text === 'Yes')!
+        const bra = overnightYes.items.find(i => i.text === 'Bra')!
+        expect(bra.ageRanges).toBeUndefined()
+    })
+})

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -21,6 +21,7 @@ import {
     getToddlersAndOlder,
     getFemaleTeenagersAndAdults,
     getMaleTeenagersAndAdults,
+    AgeRangeFilter,
 } from './age-specific-items';
 import { getDogs, getCats, getPets, getHumans } from './pet-specific-items';
 
@@ -34,8 +35,12 @@ import { getDogs, getCats, getPets, getHumans } from './pet-specific-items';
  */
 function item(text: string, people: Person[], ageFilter?: (p: Person[]) => Person[]): Item {
     const selectedPeople = ageFilter ? ageFilter(people) : getHumans(people);
+    const ageRanges = ageFilter && 'ageRanges' in ageFilter
+        ? [...(ageFilter as AgeRangeFilter).ageRanges]
+        : undefined;
     return {
         text,
+        ...(ageRanges ? { ageRanges } : {}),
         personSelections: people.map(p => ({
             personId: p.id,
             selected: selectedPeople.some(sp => sp.id === p.id)

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -38,10 +38,14 @@ export const PET_SPECIES_OPTIONS = [
 // `species` is optional and additive: a Person without it is a human (existing
 // data loads unchanged); a Person with it is a pet, modelled as just another
 // person once the question set is generated.
+// `dateOfBirth` (ISO date, YYYY-MM-DD) is optional and additive: when present
+// the person's bracket is derived from it and `ageRange` acts as the last
+// bracket the user acknowledged, which is how age-up transitions are detected.
 export const PersonSchema = z.object({
   id: z.string(),
   name: z.string(),
   ageRange: AgeRangeSchema.optional(),
+  dateOfBirth: z.string().optional(),
   gender: GenderSchema.optional(),
   species: PetSpeciesSchema.optional(),
   lastModified: z.string().optional(),
@@ -57,11 +61,16 @@ export const PersonSelectionSchema = z.object({
 // per-person as before. When true, the item is packed once for the whole
 // group and `personSelections` become a trigger — the item is included when
 // at least one selected person is on the trip.
+// `ageRanges` is optional and additive: default items generated from an age
+// filter record which brackets they apply to, so age-up transitions can
+// suggest selecting/deselecting a person. User-created items have no tag and
+// are never touched by those suggestions.
 export const ItemSchema = z.object({
   id: z.string().optional(),
   text: z.string(),
   personSelections: z.array(PersonSelectionSchema),
   communal: z.boolean().optional(),
+  ageRanges: z.array(AgeRangeSchema).optional(),
   lastModified: z.string().optional(),
   deletedAt: z.string().optional(),
 })

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -14,6 +14,7 @@ import { usePodSync } from '../hooks/usePodSync'
 import { questionSetToDataset, datasetToQuestionSet, packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { useForeignPod } from '../components/ForeignPodContext'
 import { generateQuestionBasedItems, generateAlwaysNeededItems } from '../create-packing-list/generatePackingListItems'
+import { AgePromotionCard } from '../components/AgePromotionCard'
 
 export function deduplicateItems(items: PackingListItem[]): PackingListItem[] {
     const seen = new Set<string>()
@@ -467,6 +468,17 @@ export function CreatePackingList() {
         await markReviewed(listId, item)
     }
 
+    const handleApplyAgePromotions = async (updated: PackingListQuestionSet) => {
+        // Stamp a lastModified so manage-questions' fallback-to-pod sync resolution
+        // won't overwrite this save with stale pod data.
+        const updatedWithTimestamp = { ...updated, lastModified: new Date().toISOString() }
+        const { rev } = await db.saveQuestionSet(updatedWithTimestamp)
+        const savedQs = { ...updatedWithTimestamp, _rev: rev }
+        setQuestionSet(savedQs)
+        await saveQuestionSetToPod(savedQs)
+        showToast('Packing items updated for their new age group', 'success')
+    }
+
     const pushListToPod = async (list: PackingList) => {
         if (!isLoggedIn || !session) return
         const podUrl = foreignPodUrl ?? await getPrimaryPodUrl(session)
@@ -707,6 +719,12 @@ export function CreatePackingList() {
                 <h1 className="text-2xl font-bold text-gray-900">Create New Packing List</h1>
                 <p className="mt-2 text-gray-600">Answer the questions below to create your packing list.</p>
             </div>
+
+            {!foreignPodUrl && (
+                <div className="mb-6 empty:hidden">
+                    <AgePromotionCard questionSet={questionSet} onApply={handleApplyAgePromotions} />
+                </div>
+            )}
 
             {suggestions.length > 0 && !isSuggestionDismissed && (
                 <div className="mb-6">

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useDatabase } from '../components/DatabaseContext'
 import { DatabaseMigration } from '../services/migration'
-import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, newDraftQuestion } from '../edit-questions/types'
+import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, newDraftQuestion, AGE_RANGE_OPTIONS } from '../edit-questions/types'
 import { Link } from 'react-router-dom'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 import { usePodSync } from '../hooks/usePodSync'
@@ -13,7 +13,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { useForeignPod } from '../components/ForeignPodContext'
 import { CustomCreatableSelect } from '../components/CreatableSelect'
 import { AgePromotionCard } from '../components/AgePromotionCard'
-import { deriveAgeRange } from '../edit-questions/age-derivation'
+import { AgeTransition } from '../edit-questions/age-derivation'
 
 // One distinct colour per person slot (by index). Tailwind classes must be literal strings.
 const AVATAR_ON = [
@@ -793,6 +793,10 @@ function PeopleModal({ people, onSave, onClose }: {
         setLocalPeople(prev => prev.map((p, i) => i === idx
             ? { ...p, dateOfBirth: dateOfBirth || undefined }
             : p))
+    const updateAgeRange = (idx: number, value: string) =>
+        setLocalPeople(prev => prev.map((p, i) => i === idx
+            ? { ...p, ageRange: value === '' ? undefined : value as Person['ageRange'] }
+            : p))
 
     return (
         <div
@@ -804,9 +808,7 @@ function PeopleModal({ people, onSave, onClose }: {
                 <div className="p-5">
                     <h2 className="text-lg font-semibold text-gray-900 mb-4">Edit People</h2>
                     <div className="space-y-2 mb-3">
-                        {localPeople.map((person, i) => {
-                            const derived = person.dateOfBirth ? deriveAgeRange(person.dateOfBirth) : undefined
-                            return (
+                        {localPeople.map((person, i) => (
                             <div key={person.id}>
                                 <div className="flex items-center gap-2">
                                     <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold shrink-0 ${AVATAR_ON[i % AVATAR_ON.length]}`}>
@@ -821,14 +823,6 @@ function PeopleModal({ people, onSave, onClose }: {
                                         className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
                                         onKeyDown={e => { if (e.key === 'Enter') addPerson() }}
                                     />
-                                    <input
-                                        type="date"
-                                        aria-label={`Birthday for ${person.name || `Person ${i + 1}`} (optional)`}
-                                        title="Birthday (optional) — used to keep age-based items up to date"
-                                        value={person.dateOfBirth ?? ''}
-                                        onChange={e => updateDob(i, e.target.value)}
-                                        className="w-36 border border-gray-300 rounded-lg px-2 py-2 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500 shrink-0"
-                                    />
                                     {localPeople.length > 1 && (
                                         <button
                                             type="button"
@@ -840,14 +834,34 @@ function PeopleModal({ people, onSave, onClose }: {
                                         </button>
                                     )}
                                 </div>
-                                {derived && derived !== person.ageRange && (
-                                    <p className="ml-9 mt-0.5 text-xs text-gray-400">Age group: {derived}</p>
+                                {!person.species && (
+                                    <div className="ml-9 mt-1 flex items-center gap-2">
+                                        <input
+                                            type="date"
+                                            aria-label={`Birthday for ${person.name || `Person ${i + 1}`} (optional)`}
+                                            title="Birthday (optional) — used to keep age-based items up to date"
+                                            value={person.dateOfBirth ?? ''}
+                                            onChange={e => updateDob(i, e.target.value)}
+                                            className="flex-1 min-w-0 border border-gray-300 rounded-lg px-2 py-1.5 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                        />
+                                        <select
+                                            aria-label={`Age group for ${person.name || `Person ${i + 1}`}`}
+                                            title="Age group — change it manually if they're ready for the next one early"
+                                            value={person.ageRange ?? ''}
+                                            onChange={e => updateAgeRange(i, e.target.value)}
+                                            className="flex-1 min-w-0 border border-gray-300 rounded-lg px-2 py-1.5 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                        >
+                                            <option value="">Age group…</option>
+                                            {AGE_RANGE_OPTIONS.map(option => (
+                                                <option key={option.value} value={option.value}>{option.label}</option>
+                                            ))}
+                                        </select>
+                                    </div>
                                 )}
                             </div>
-                            )
-                        })}
+                        ))}
                     </div>
-                    <p className="text-xs text-gray-400 mb-3">Birthdays are optional — add one and we'll suggest packing-item updates as they grow.</p>
+                    <p className="text-xs text-gray-400 mb-3">Birthdays are optional — add one and we'll suggest packing-item updates as they grow. You can also bump the age group early if they're ready for it.</p>
                     <button
                         type="button"
                         onClick={addPerson}
@@ -961,6 +975,9 @@ export function QuestionsPage() {
     const [optionModal, setOptionModal] = useState<{ questionId: string; option: Option | null } | null>(null)
     const [peopleModal, setPeopleModal] = useState(false)
     const [alwaysModal, setAlwaysModal] = useState(false)
+    // Bracket changes made by hand in the people modal; offered the same
+    // item-review flow as birthday-driven transitions, then cleared.
+    const [manualPromotions, setManualPromotions] = useState<AgeTransition[]>([])
 
     const saveToPodRef = useRef<((data: PackingListQuestionSet) => Promise<boolean>) | undefined>(undefined)
 
@@ -1104,6 +1121,16 @@ export function QuestionsPage() {
             .map(p => ({ ...p, deletedAt: now }))
         const allPeople = [...stamped, ...nowDeleted, ...previouslyDeleted]
 
+        const manual: AgeTransition[] = stamped
+            .filter(p => !p.species && p.ageRange)
+            .flatMap(p => {
+                const oldRange = oldPeopleMap.get(p.id)?.ageRange
+                return oldPeopleMap.has(p.id) && oldRange !== p.ageRange
+                    ? [{ person: p, from: oldRange, to: p.ageRange! }]
+                    : []
+            })
+        setManualPromotions(manual)
+
         const reconcile = (items: Item[]) => reconcileItems(items, oldPeople.filter(p => !p.deletedAt), stamped)
         const newData: PackingListQuestionSet = {
             ...data,
@@ -1150,7 +1177,14 @@ export function QuestionsPage() {
                     <p className="mt-1 text-gray-600 text-sm">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>
                     {!isForeign && <p className="mt-1 text-xs text-gray-400">Want to start from scratch? <Link to="/wizard" className="text-primary-600 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</p>}
                 </div>
-                {!isForeign && <AgePromotionCard questionSet={data} onApply={saveData} />}
+                {!isForeign && (
+                    <AgePromotionCard
+                        questionSet={data}
+                        onApply={saveData}
+                        manualTransitions={manualPromotions}
+                        onManualHandled={() => setManualPromotions([])}
+                    />
+                )}
                 <PersonLegend people={people} onEdit={() => setPeopleModal(true)} />
                 <AlwaysSection items={activeAlwaysNeededItems} people={people} onEdit={() => setAlwaysModal(true)} />
                 {activeQuestions.map((q, qi) => (

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -12,6 +12,8 @@ import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSeria
 import { useSolidPod } from '../components/SolidPodContext'
 import { useForeignPod } from '../components/ForeignPodContext'
 import { CustomCreatableSelect } from '../components/CreatableSelect'
+import { AgePromotionCard } from '../components/AgePromotionCard'
+import { deriveAgeRange } from '../edit-questions/age-derivation'
 
 // One distinct colour per person slot (by index). Tailwind classes must be literal strings.
 const AVATAR_ON = [
@@ -787,6 +789,10 @@ function PeopleModal({ people, onSave, onClose }: {
     }
     const updateName = (idx: number, name: string) =>
         setLocalPeople(prev => prev.map((p, i) => i === idx ? { ...p, name } : p))
+    const updateDob = (idx: number, dateOfBirth: string) =>
+        setLocalPeople(prev => prev.map((p, i) => i === idx
+            ? { ...p, dateOfBirth: dateOfBirth || undefined }
+            : p))
 
     return (
         <div
@@ -798,33 +804,50 @@ function PeopleModal({ people, onSave, onClose }: {
                 <div className="p-5">
                     <h2 className="text-lg font-semibold text-gray-900 mb-4">Edit People</h2>
                     <div className="space-y-2 mb-3">
-                        {localPeople.map((person, i) => (
-                            <div key={person.id} className="flex items-center gap-2">
-                                <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold shrink-0 ${AVATAR_ON[i % AVATAR_ON.length]}`}>
-                                    {person.name.charAt(0).toUpperCase() || '?'}
-                                </span>
-                                <input
-                                    autoFocus={i === 0}
-                                    type="text"
-                                    value={person.name}
-                                    onChange={e => updateName(i, e.target.value)}
-                                    placeholder={`Person ${i + 1}`}
-                                    className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-                                    onKeyDown={e => { if (e.key === 'Enter') addPerson() }}
-                                />
-                                {localPeople.length > 1 && (
-                                    <button
-                                        type="button"
-                                        onClick={() => removePerson(i)}
-                                        className="text-gray-300 hover:text-red-400 text-xl leading-none shrink-0"
-                                        title="Remove person"
-                                    >
-                                        ×
-                                    </button>
+                        {localPeople.map((person, i) => {
+                            const derived = person.dateOfBirth ? deriveAgeRange(person.dateOfBirth) : undefined
+                            return (
+                            <div key={person.id}>
+                                <div className="flex items-center gap-2">
+                                    <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold shrink-0 ${AVATAR_ON[i % AVATAR_ON.length]}`}>
+                                        {person.name.charAt(0).toUpperCase() || '?'}
+                                    </span>
+                                    <input
+                                        autoFocus={i === 0}
+                                        type="text"
+                                        value={person.name}
+                                        onChange={e => updateName(i, e.target.value)}
+                                        placeholder={`Person ${i + 1}`}
+                                        className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                        onKeyDown={e => { if (e.key === 'Enter') addPerson() }}
+                                    />
+                                    <input
+                                        type="date"
+                                        aria-label={`Birthday for ${person.name || `Person ${i + 1}`} (optional)`}
+                                        title="Birthday (optional) — used to keep age-based items up to date"
+                                        value={person.dateOfBirth ?? ''}
+                                        onChange={e => updateDob(i, e.target.value)}
+                                        className="w-36 border border-gray-300 rounded-lg px-2 py-2 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500 shrink-0"
+                                    />
+                                    {localPeople.length > 1 && (
+                                        <button
+                                            type="button"
+                                            onClick={() => removePerson(i)}
+                                            className="text-gray-300 hover:text-red-400 text-xl leading-none shrink-0"
+                                            title="Remove person"
+                                        >
+                                            ×
+                                        </button>
+                                    )}
+                                </div>
+                                {derived && derived !== person.ageRange && (
+                                    <p className="ml-9 mt-0.5 text-xs text-gray-400">Age group: {derived}</p>
                                 )}
                             </div>
-                        ))}
+                            )
+                        })}
                     </div>
+                    <p className="text-xs text-gray-400 mb-3">Birthdays are optional — add one and we'll suggest packing-item updates as they grow.</p>
                     <button
                         type="button"
                         onClick={addPerson}
@@ -1069,7 +1092,8 @@ export function QuestionsPage() {
         const stamped: Person[] = newPeople.map(p => {
             const existing = oldPeopleMap.get(p.id)
             const changed = !existing || existing.name !== p.name ||
-                existing.ageRange !== p.ageRange || existing.gender !== p.gender
+                existing.ageRange !== p.ageRange || existing.gender !== p.gender ||
+                existing.dateOfBirth !== p.dateOfBirth
             return changed ? { ...p, lastModified: now } : p
         })
 
@@ -1126,6 +1150,7 @@ export function QuestionsPage() {
                     <p className="mt-1 text-gray-600 text-sm">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>
                     {!isForeign && <p className="mt-1 text-xs text-gray-400">Want to start from scratch? <Link to="/wizard" className="text-primary-600 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</p>}
                 </div>
+                {!isForeign && <AgePromotionCard questionSet={data} onApply={saveData} />}
                 <PersonLegend people={people} onEdit={() => setPeopleModal(true)} />
                 <AlwaysSection items={activeAlwaysNeededItems} people={people} onEdit={() => setAlwaysModal(true)} />
                 {activeQuestions.map((q, qi) => (

--- a/src/pages/useWizardGeneration.test.ts
+++ b/src/pages/useWizardGeneration.test.ts
@@ -74,6 +74,45 @@ describe('useWizardGeneration', () => {
         expect(savedData.people[0].gender).toBeUndefined()
     })
 
+    it('derives the age bracket from a birthday when no bracket is picked', async () => {
+        const saveQuestionSet = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+        mockUseDatabase.mockReturnValue({ db: { saveQuestionSet } as unknown as PackingAppDatabase })
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-07-18T12:00:00Z'))
+
+        const { result } = renderHook(() => useWizardGeneration())
+        await act(async () => {
+            await result.current.generateAndSave({
+                people: [{ kind: 'person', name: 'Neve', dateOfBirth: '2024-01-10', gender: 'female' }],
+            })
+        })
+        vi.useRealTimers()
+
+        const savedData = saveQuestionSet.mock.calls[0][0]
+        expect(savedData.people[0].ageRange).toBe('Toddler')
+        expect(savedData.people[0].dateOfBirth).toBe('2024-01-10')
+    })
+
+    it('lets a manually picked bracket override the birthday-derived one', async () => {
+        const saveQuestionSet = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+        mockUseDatabase.mockReturnValue({ db: { saveQuestionSet } as unknown as PackingAppDatabase })
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-07-18T12:00:00Z'))
+
+        const { result } = renderHook(() => useWizardGeneration())
+        await act(async () => {
+            await result.current.generateAndSave({
+                // Birthday says Toddler, but the parent says they're ready for Child
+                people: [{ kind: 'person', name: 'Neve', dateOfBirth: '2024-01-10', ageRange: 'Child', gender: 'female' }],
+            })
+        })
+        vi.useRealTimers()
+
+        const savedData = saveQuestionSet.mock.calls[0][0]
+        expect(savedData.people[0].ageRange).toBe('Child')
+        expect(savedData.people[0].dateOfBirth).toBe('2024-01-10')
+    })
+
     it('syncs the question set to the pod after saving locally', async () => {
         const saveQuestionSet = vi.fn().mockResolvedValue({ rev: 'rev-1' })
         mockUseDatabase.mockReturnValue({

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -6,6 +6,7 @@ import { QUESTION_SET_ID } from '../constants'
 import { WizardFormData } from './wizard-types'
 import { generateUUID } from '../utils/uuid'
 import { Person, PackingListQuestionSet } from '../edit-questions/types'
+import { deriveAgeRange } from '../edit-questions/age-derivation'
 import { usePodSync } from '../hooks/usePodSync'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 import { POD_CONTAINERS } from '../services/solidPod'
@@ -35,7 +36,15 @@ export function useWizardGeneration() {
         const people: Person[] = data.people.map(entry =>
             entry.kind === 'pet'
                 ? { id: generateUUID(), name: entry.name, species: entry.species }
-                : { id: generateUUID(), name: entry.name, ageRange: entry.ageRange, gender: entry.gender }
+                : {
+                    id: generateUUID(),
+                    name: entry.name,
+                    // A birthday wins over a manually picked bracket; '' is the
+                    // untouched select
+                    ageRange: (entry.dateOfBirth ? deriveAgeRange(entry.dateOfBirth) : undefined) ?? (entry.ageRange || undefined),
+                    gender: entry.gender,
+                    ...(entry.dateOfBirth ? { dateOfBirth: entry.dateOfBirth } : {}),
+                }
         )
         return createExampleData(people, [])
     }

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -39,9 +39,10 @@ export function useWizardGeneration() {
                 : {
                     id: generateUUID(),
                     name: entry.name,
-                    // A birthday wins over a manually picked bracket; '' is the
-                    // untouched select
-                    ageRange: (entry.dateOfBirth ? deriveAgeRange(entry.dateOfBirth) : undefined) ?? (entry.ageRange || undefined),
+                    // The select is auto-filled from the birthday but stays
+                    // editable, so the (possibly overridden) selection wins;
+                    // '' is the untouched select
+                    ageRange: (entry.ageRange || undefined) ?? (entry.dateOfBirth ? deriveAgeRange(entry.dateOfBirth) : undefined),
                     gender: entry.gender,
                     ...(entry.dateOfBirth ? { dateOfBirth: entry.dateOfBirth } : {}),
                 }

--- a/src/pages/wizard-types.ts
+++ b/src/pages/wizard-types.ts
@@ -1,11 +1,16 @@
 import { z } from 'zod'
 import { AgeRangeSchema, GenderSchema, PetSpeciesSchema } from '../edit-questions/types'
 
-// A person entry keeps age range + gender.
+// A person entry keeps age range + gender, and optionally a date of birth.
+// The age-range select submits '' when untouched, so '' is allowed here and
+// treated as "not set"; requiring either an age range or a birthday is
+// enforced at the form level below (discriminated unions can't carry
+// refinements, and transforms would break react-hook-form's resolver types).
 export const wizardPersonSchema = z.object({
     kind: z.literal('person'),
     name: z.string().min(1, 'Name is required'),
-    ageRange: AgeRangeSchema,
+    dateOfBirth: z.string().optional(),
+    ageRange: AgeRangeSchema.or(z.literal('')).optional(),
     gender: GenderSchema,
 })
 
@@ -22,6 +27,16 @@ export const wizardSchema = z.object({
     people: z.array(wizardEntrySchema)
         .min(1, 'At least 1 person or pet required')
         .max(10, 'Maximum of 10 reached'),
+}).superRefine((data, ctx) => {
+    data.people.forEach((entry, index) => {
+        if (entry.kind === 'person' && !entry.ageRange && !entry.dateOfBirth) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['people', index, 'ageRange'],
+                message: 'Pick an age range or enter a birthday',
+            })
+        }
+    })
 })
 
 export type WizardPersonEntry = z.infer<typeof wizardPersonSchema>

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -11,6 +11,7 @@ import { useDatabase } from '../components/DatabaseContext'
 import { wizardSchema, WizardFormData, WizardEntry } from './wizard-types'
 import { useWizardGeneration } from './useWizardGeneration'
 import { AGE_RANGE_OPTIONS, GENDER_OPTIONS, PET_SPECIES_OPTIONS } from '../edit-questions/types'
+import { deriveAgeRange } from '../edit-questions/age-derivation'
 
 const SOLID_POD_UPSELL_SHOWN_KEY = 'solid-pod-upsell-shown'
 
@@ -189,6 +190,23 @@ export const Wizard = () => {
                                             </div>
                                         ) : (
                                             <>
+                                                <div>
+                                                    <label className="block text-sm font-semibold text-gray-700 mb-2">
+                                                        Birthday <span className="text-gray-400 font-normal">(optional)</span>
+                                                    </label>
+                                                    <input
+                                                        type="date"
+                                                        {...register(`people.${index}.dateOfBirth`)}
+                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                    />
+                                                    {(() => {
+                                                        const dob = watch(`people.${index}.dateOfBirth`)
+                                                        const derived = dob ? deriveAgeRange(dob) : undefined
+                                                        return derived
+                                                            ? <p className="text-xs text-gray-500 mt-1">Age group: {derived} — we'll suggest updates as they grow</p>
+                                                            : null
+                                                    })()}
+                                                </div>
                                                 <div>
                                                     <label className="block text-sm font-semibold text-gray-700 mb-2">
                                                         Age Range

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -26,7 +26,7 @@ export const Wizard = () => {
     const { db } = useDatabase()
     const { isLoading, isSuccess, generateAndSave } = useWizardGeneration()
 
-    const { register, control, handleSubmit, watch, formState: { errors } } = useForm<WizardFormData>({
+    const { register, control, handleSubmit, watch, setValue, formState: { errors } } = useForm<WizardFormData>({
         resolver: zodResolver(wizardSchema),
         defaultValues: {
             people: [{ kind: 'person', name: 'Me', ageRange: undefined, gender: undefined }],
@@ -150,7 +150,10 @@ export const Wizard = () => {
                     </div>
 
                     <div className="space-y-4">
-                        {fields.map((field, index) => (
+                        {fields.map((field, index) => {
+                            const dob = field.kind === 'person' ? watch(`people.${index}.dateOfBirth`) : undefined
+                            const derivedAgeRange = dob ? deriveAgeRange(dob) : undefined
+                            return (
                             <div key={field.id} className="bg-primary-50 p-4 rounded-xl border border-primary-200">
                                 <div className="flex items-start gap-4">
                                     <div className="flex-1 grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -196,16 +199,17 @@ export const Wizard = () => {
                                                     </label>
                                                     <input
                                                         type="date"
-                                                        {...register(`people.${index}.dateOfBirth`)}
+                                                        {...register(`people.${index}.dateOfBirth`, {
+                                                            onChange: (e) => {
+                                                                const derived = deriveAgeRange(e.target.value)
+                                                                if (derived) setValue(`people.${index}.ageRange`, derived)
+                                                            },
+                                                        })}
                                                         className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
                                                     />
-                                                    {(() => {
-                                                        const dob = watch(`people.${index}.dateOfBirth`)
-                                                        const derived = dob ? deriveAgeRange(dob) : undefined
-                                                        return derived
-                                                            ? <p className="text-xs text-gray-500 mt-1">Age group: {derived} — we'll suggest updates as they grow</p>
-                                                            : null
-                                                    })()}
+                                                    {derivedAgeRange && (
+                                                        <p className="text-xs text-gray-500 mt-1">We'll suggest packing updates as they grow</p>
+                                                    )}
                                                 </div>
                                                 <div>
                                                     <label className="block text-sm font-semibold text-gray-700 mb-2">
@@ -213,7 +217,9 @@ export const Wizard = () => {
                                                     </label>
                                                     <select
                                                         {...register(`people.${index}.ageRange`)}
-                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                        disabled={!!derivedAgeRange}
+                                                        title={derivedAgeRange ? 'Set automatically from their birthday' : undefined}
+                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all disabled:bg-gray-100 disabled:text-gray-500 disabled:cursor-not-allowed"
                                                     >
                                                         <option value="">Select age range...</option>
                                                         {AGE_RANGE_OPTIONS.map(option => (
@@ -257,7 +263,8 @@ export const Wizard = () => {
                                     </button>
                                 </div>
                             </div>
-                        ))}
+                            )
+                        })}
                     </div>
 
                     {fields.length < 10 && (

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -208,7 +208,7 @@ export const Wizard = () => {
                                                         className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
                                                     />
                                                     {derivedAgeRange && (
-                                                        <p className="text-xs text-gray-500 mt-1">We'll suggest packing updates as they grow</p>
+                                                        <p className="text-xs text-gray-500 mt-1">Age group filled in from birthday — adjust it if they're ahead or behind</p>
                                                     )}
                                                 </div>
                                                 <div>
@@ -217,9 +217,7 @@ export const Wizard = () => {
                                                     </label>
                                                     <select
                                                         {...register(`people.${index}.ageRange`)}
-                                                        disabled={!!derivedAgeRange}
-                                                        title={derivedAgeRange ? 'Set automatically from their birthday' : undefined}
-                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all disabled:bg-gray-100 disabled:text-gray-500 disabled:cursor-not-allowed"
+                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
                                                     >
                                                         <option value="">Select age range...</option>
                                                         {AGE_RANGE_OPTIONS.map(option => (

--- a/src/services/rdfSerialization.test.ts
+++ b/src/services/rdfSerialization.test.ts
@@ -441,3 +441,40 @@ describe('sharedListsWithMeToDataset / datasetToSharedListsWithMe', () => {
         expect(result.lists[0].label).toBeUndefined()
     })
 })
+
+describe('questionSet dateOfBirth and ageRanges round-trip', () => {
+    it('round-trips a person dateOfBirth and omits it when not set', () => {
+        const people = [
+            makePerson({ id: 'p1', name: 'Neve', dateOfBirth: '2023-06-01' }),
+            makePerson({ id: 'p2', name: 'Mum' }),
+        ]
+        const result = roundTripQs(makeQuestionSet({ people }))
+        expect(result.people.find(p => p.name === 'Neve')!.dateOfBirth).toBe('2023-06-01')
+        expect(result.people.find(p => p.name === 'Mum')!.dateOfBirth).toBeUndefined()
+    })
+
+    it('round-trips item ageRanges in canonical bracket order', () => {
+        const qs = makeQuestionSet({
+            alwaysNeededItems: [{
+                text: 'Swimsuit',
+                ageRanges: ['Adult', 'Toddler', 'Child', 'Teenager'],
+                personSelections: [{ personId: 'p1', selected: true }],
+            }],
+        })
+        const result = roundTripQs(qs)
+        expect(result.alwaysNeededItems[0].ageRanges).toEqual(['Toddler', 'Child', 'Teenager', 'Adult'])
+    })
+
+    it('omits ageRanges when not set and round-trips it inside a question option', () => {
+        const option = makeOption({
+            items: [
+                { text: 'Nappies', ageRanges: ['Baby'], personSelections: [{ personId: 'p1', selected: true }] },
+                { text: 'Snacks', personSelections: [{ personId: 'p1', selected: true }] },
+            ],
+        })
+        const question = makeQuestion({ options: [option] })
+        const result = roundTripQs(makeQuestionSet({ questions: [question] }))
+        expect(result.questions[0].options[0].items[0].ageRanges).toEqual(['Baby'])
+        expect(result.questions[0].options[0].items[1].ageRanges).toBeUndefined()
+    })
+})

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -5,6 +5,7 @@ import {
     getThing,
     getUrlAll,
     getStringNoLocale,
+    getStringNoLocaleAll,
     getBoolean,
     getInteger,
     getDatetime,
@@ -19,7 +20,9 @@ import type {
     Option,
     Item,
     PersonSelection,
+    AgeRange,
 } from '../edit-questions/types'
+import { AgeRangeSchema } from '../edit-questions/types'
 
 // ── PackingList ───────────────────────────────────────────────────────────────
 
@@ -227,6 +230,7 @@ function personToThing(person: Person, personUrl: string): Thing {
     if (person.ageRange) t = t.addStringNoLocale(PMU.ageRange, person.ageRange)
     if (person.gender) t = t.addStringNoLocale(PMU.gender, person.gender)
     if (person.species) t = t.addStringNoLocale(PMU.species, person.species)
+    if (person.dateOfBirth) t = t.addStringNoLocale(PMU.dateOfBirth, person.dateOfBirth)
     if (person.lastModified) t = t.addDatetime(PMU.personLastModified, new Date(person.lastModified))
     if (person.deletedAt) t = t.addDatetime(PMU.personDeletedAt, new Date(person.deletedAt))
 
@@ -240,6 +244,7 @@ function thingToPerson(thing: Thing | null, url: string): Person | null {
     const ageRange = getStringNoLocale(thing, PMU.ageRange) ?? undefined
     const gender = getStringNoLocale(thing, PMU.gender) ?? undefined
     const species = getStringNoLocale(thing, PMU.species) ?? undefined
+    const dateOfBirth = getStringNoLocale(thing, PMU.dateOfBirth) ?? undefined
     const lastModified = getDatetime(thing, PMU.personLastModified)?.toISOString()
     const deletedAt = getDatetime(thing, PMU.personDeletedAt)?.toISOString()
     return {
@@ -248,6 +253,7 @@ function thingToPerson(thing: Thing | null, url: string): Person | null {
         ...(ageRange !== undefined ? { ageRange: ageRange as Person['ageRange'] } : {}),
         ...(gender !== undefined ? { gender: gender as Person['gender'] } : {}),
         ...(species !== undefined ? { species: species as Person['species'] } : {}),
+        ...(dateOfBirth !== undefined ? { dateOfBirth } : {}),
         ...(lastModified !== undefined ? { lastModified } : {}),
         ...(deletedAt !== undefined ? { deletedAt } : {}),
     }
@@ -372,6 +378,9 @@ function questionItemToThings(
 
     if (item.id) itemBuilder = itemBuilder.addStringNoLocale(PMU.questionItemId, item.id)
     if (item.communal !== undefined) itemBuilder = itemBuilder.addBoolean(PMU.communal, item.communal)
+    for (const ageRange of item.ageRanges ?? []) {
+        itemBuilder = itemBuilder.addStringNoLocale(PMU.hasAgeRange, ageRange)
+    }
     if (item.lastModified) itemBuilder = itemBuilder.addDatetime(PMU.questionItemLastModified, new Date(item.lastModified))
     if (item.deletedAt) itemBuilder = itemBuilder.addDatetime(PMU.questionItemDeletedAt, new Date(item.deletedAt))
 
@@ -538,6 +547,12 @@ function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
     const lastModified = getDatetime(thing, PMU.questionItemLastModified)?.toISOString()
     const deletedAt = getDatetime(thing, PMU.questionItemDeletedAt)?.toISOString()
 
+    // RDF multi-values are unordered — restore the canonical bracket order
+    const bracketOrder = AgeRangeSchema.options
+    const ageRanges = getStringNoLocaleAll(thing, PMU.hasAgeRange)
+        .filter((r): r is AgeRange => (bracketOrder as readonly string[]).includes(r))
+        .sort((a, b) => bracketOrder.indexOf(a) - bracketOrder.indexOf(b))
+
     const psUrls = getUrlAll(thing, PMU.hasPersonSelection)
     const personSelectionsWithOrder: Array<PersonSelection & { order: number }> = psUrls
         .map(psUrl => {
@@ -558,6 +573,7 @@ function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
         personSelections,
         ...(id !== undefined ? { id } : {}),
         ...(communal !== null ? { communal } : {}),
+        ...(ageRanges.length > 0 ? { ageRanges } : {}),
         ...(lastModified !== undefined ? { lastModified } : {}),
         ...(deletedAt !== undefined ? { deletedAt } : {}),
     }

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -41,6 +41,8 @@ export const PMU = {
     ageRange: `${PMU_NS}ageRange`,
     gender: `${PMU_NS}gender`,
     species: `${PMU_NS}species`,
+    // Stored as a plain YYYY-MM-DD string (not a datetime) to avoid timezone drift
+    dateOfBirth: 'https://schema.org/birthDate',
     personLastModified: `${PMU_NS}personLastModified`,
     personDeletedAt: `${PMU_NS}personDeletedAt`,
 
@@ -58,6 +60,8 @@ export const PMU = {
 
     // Item predicates (on option items and always-needed items)
     hasPersonSelection: `${PMU_NS}hasPersonSelection`,
+    // One value per bracket the item applies to
+    hasAgeRange: `${PMU_NS}hasAgeRange`,
     questionItemId: `${PMU_NS}questionItemId`,
     questionItemLastModified: `${PMU_NS}questionItemLastModified`,
     questionItemDeletedAt: `${PMU_NS}questionItemDeletedAt`,


### PR DESCRIPTION
People can now have an optional date of birth. When a person's derived
age bracket no longer matches their stored one (they've had a birthday
that crosses a bracket boundary), a review banner appears on the
questions and create-list pages suggesting item updates:

- Deselect tagged items they've outgrown (e.g. swim nappies)
- Select existing items for their new bracket
- Add default items for the new bracket that were dropped at
  generation time because nobody was in that bracket yet

Suggestions are opt-out per item and never touch untagged
(user-created) items or items the user previously deleted. Applying
acknowledges the new bracket; dismissing remembers the person+bracket
in localStorage so the same transition isn't offered again.

Supporting changes:
- Person.dateOfBirth and Item.ageRanges are additive schema fields
  with RDF round-trip support (schema:birthDate, pmu:hasAgeRange)
- Pure age filters in age-specific-items now carry their bracket list
  so generated default items are tagged
- Wizard accepts a birthday instead of a manual age range and shows
  the derived bracket; Edit People modal gains a birthday field

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017QxySCUicKXXgDVXMrTnC5