### PR TITLE
Add Sentry error reporting with crash dialog and feedback widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@inrupt/vocab-solid": "^1.0.4",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@sentry/capacitor": "^4.2.0",
-        "@sentry/react": "^10.60.0",
+        "@sentry/react": "10.60.0",
         "@tailwindcss/vite": "^4.1.4",
         "@types/pouchdb": "^6.4.2",
         "@types/react-select": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@inrupt/vocab-common-rdf": "^1.0.5",
         "@inrupt/vocab-solid": "^1.0.4",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@sentry/capacitor": "^4.2.0",
+        "@sentry/react": "^10.60.0",
         "@tailwindcss/vite": "^4.1.4",
         "@types/pouchdb": "^6.4.2",
         "@types/react-select": "^5.0.1",
@@ -5595,6 +5597,138 @@
       },
       "engines": {
         "node": ">=v12.22.12"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.60.0.tgz",
+      "integrity": "sha512-20vzPKGrmupJPCaWd+soCOLkZRwKZxt0AVF4XGPNoGp7D7wVPRlHf+FWwVMx+rRRkahKupFefM2D9YoiUiBeag==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.60.0",
+        "@sentry/core": "10.60.0",
+        "@sentry/feedback": "10.60.0",
+        "@sentry/replay": "10.60.0",
+        "@sentry/replay-canvas": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.60.0.tgz",
+      "integrity": "sha512-YhdPeMJnMaKVi5NQ2tD9RJ2AxU7cav5khmiMHFppmbP3I3Os2EHVaQjAVb6/ePAINr/d5mj5SxpnWmFX17iXsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/capacitor": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/capacitor/-/capacitor-4.2.0.tgz",
+      "integrity": "sha512-ygK4EY0nwf+Uxm86kwvA231GM13yal0om5NbF9Ay+TxijK9NvyhMC571LDyWe5cS+Wxcbba1w++rUc0YumxJQA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.60.0",
+        "@sentry/core": "10.60.0",
+        "@sentry/types": "10.60.0"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=3.0.0",
+        "@sentry/angular": "10.60.0",
+        "@sentry/react": "10.60.0",
+        "@sentry/vue": "10.60.0"
+      },
+      "peerDependenciesMeta": {
+        "@sentry/angular": {
+          "optional": true
+        },
+        "@sentry/react": {
+          "optional": true
+        },
+        "@sentry/vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.60.0.tgz",
+      "integrity": "sha512-szN7ccOJAEaLb1BBQzCQhABGMTJmKNUk0G2sc7rWhajeXoZoMKIbNkI9RvJrFuV69cbad/d/BKGBjbpJhySAzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.60.0.tgz",
+      "integrity": "sha512-RcGUgaI8yrIXunhNLpdNLsBUJIDvnEGDRmFhC5v0oMltoGtovrIqrEhPXEiSWQvNB0x4q33ejkLeJRJoSDOp2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.60.0.tgz",
+      "integrity": "sha512-ALRIDOj7T1Vk9t9IyI12Tq2t3MKoV2F/mKn140AiUBk3WzQhq2gXQUFpcsaDYA2FBsrYoYc6qdqrny6mMbA0Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.60.0",
+        "@sentry/core": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.60.0.tgz",
+      "integrity": "sha512-j+w774BP1p+v/ga1hJAJSn0cXgTiB2VWwQCAxukF7AEXscny/OCXzTTsaPxdovw9kDHI641vKV+/yixLV2nKIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.60.0",
+        "@sentry/core": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.60.0.tgz",
+      "integrity": "sha512-mYyQRJbhRRaqUkRvkJZyqt9AWdomh4108LOAph1YJvV1jW7tKYPPFNAUveJd7YkYCyhUOtekN0DKNJveK802qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.60.0",
+        "@sentry/replay": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.60.0.tgz",
+      "integrity": "sha512-ZGBls8tft/yCLWf72ZG+/J0v1vOrX2k5Bb+Z62q0IwohwZJgE1HB+x695wiGSu0C6bf8WKgPNyVJO7Wq1Bylaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@inrupt/vocab-common-rdf": "^1.0.5",
     "@inrupt/vocab-solid": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@sentry/capacitor": "^4.2.0",
+    "@sentry/react": "^10.60.0",
     "@tailwindcss/vite": "^4.1.4",
     "@types/pouchdb": "^6.4.2",
     "@types/react-select": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@inrupt/vocab-solid": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@sentry/capacitor": "^4.2.0",
-    "@sentry/react": "^10.60.0",
+    "@sentry/react": "10.60.0",
     "@tailwindcss/vite": "^4.1.4",
     "@types/pouchdb": "^6.4.2",
     "@types/react-select": "^5.0.1",

--- a/src/components/ErrorFallback.test.tsx
+++ b/src/components/ErrorFallback.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { ErrorFallback } from './ErrorFallback'
+
+describe('ErrorFallback', () => {
+  it('shows an apology message and calls resetError when retrying', () => {
+    const resetError = vi.fn()
+    render(<ErrorFallback resetError={resetError} />)
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(resetError).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,0 +1,20 @@
+import { Button } from './Button'
+
+interface ErrorFallbackProps {
+    resetError: () => void
+}
+
+export function ErrorFallback({ resetError }: ErrorFallbackProps) {
+    return (
+        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-50 via-white to-accent-50 px-4">
+            <div className="max-w-md w-full text-center bg-white rounded-2xl shadow-soft p-8">
+                <h1 className="text-xl font-bold text-gray-900 mb-2">Something went wrong</h1>
+                <p className="text-gray-600 mb-6">
+                    We've been notified about this error. A report dialog should appear where you can add details
+                    about what happened — that helps us fix it faster.
+                </p>
+                <Button onClick={resetError}>Try again</Button>
+            </div>
+        </div>
+    )
+}

--- a/src/errorReporting.test.ts
+++ b/src/errorReporting.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const captureException = vi.fn()
+vi.mock('@sentry/capacitor', () => ({ captureException: (...args: unknown[]) => captureException(...args) }))
+
+import { reportError } from './errorReporting'
+
+describe('reportError', () => {
+    beforeEach(() => {
+        captureException.mockClear()
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    it('logs and forwards the error to Sentry', () => {
+        const error = new Error('boom')
+        reportError(error, 'Failed to create packing list')
+
+        expect(console.error).toHaveBeenCalledWith('Failed to create packing list', error)
+        expect(captureException).toHaveBeenCalledWith(error)
+    })
+
+    it('falls back to a generic log message when no context is given', () => {
+        const error = new Error('boom')
+        reportError(error)
+
+        expect(console.error).toHaveBeenCalledWith('Unhandled error', error)
+    })
+})

--- a/src/errorReporting.ts
+++ b/src/errorReporting.ts
@@ -1,0 +1,6 @@
+import * as Sentry from '@sentry/capacitor'
+
+export function reportError(error: unknown, context?: string) {
+    console.error(context ?? 'Unhandled error', error)
+    Sentry.captureException(error)
+}

--- a/src/hooks/usePodErrorHandler.test.ts
+++ b/src/hooks/usePodErrorHandler.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const showToast = vi.fn()
+vi.mock('../components/ToastContext', () => ({
+  useToast: () => ({ showToast }),
+}))
+
+const reportError = vi.fn()
+vi.mock('../errorReporting', () => ({
+  reportError: (...args: unknown[]) => reportError(...args),
+}))
+
+import { usePodErrorHandler } from './usePodErrorHandler'
+import { AuthenticationError } from '../services/solidPod'
+
+describe('usePodErrorHandler', () => {
+  beforeEach(() => {
+    showToast.mockClear()
+    reportError.mockClear()
+  })
+
+  it('reports the error and shows the fallback message', () => {
+    const { result } = renderHook(() => usePodErrorHandler())
+    const error = new Error('network down')
+
+    result.current(error, 'Failed to create backup.')
+
+    expect(reportError).toHaveBeenCalledWith(error, 'Pod operation error')
+    expect(showToast).toHaveBeenCalledWith('Failed to create backup.', 'error')
+  })
+
+  it('shows the authentication error message instead of the fallback', () => {
+    const { result } = renderHook(() => usePodErrorHandler())
+    const error = new AuthenticationError('Session expired')
+
+    result.current(error, 'Failed to create backup.')
+
+    expect(reportError).toHaveBeenCalledWith(error, 'Pod operation error')
+    expect(showToast).toHaveBeenCalledWith('Session expired', 'error')
+  })
+})

--- a/src/hooks/usePodErrorHandler.ts
+++ b/src/hooks/usePodErrorHandler.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useToast } from '../components/ToastContext';
 import { AuthenticationError } from '../services/solidPod';
+import { reportError } from '../errorReporting';
 
 /**
  * Custom hook for handling Pod operation errors in a consistent way
@@ -19,7 +20,7 @@ export function usePodErrorHandler() {
   const { showToast } = useToast();
 
   return useCallback((error: unknown, fallbackMessage: string) => {
-    console.error('Pod operation error:', error);
+    reportError(error, 'Pod operation error');
 
     if (error instanceof AuthenticationError) {
       // Use the specific authentication error message

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,17 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { ErrorBoundary } from '@sentry/react'
 import './index.css'
 import App from './App.tsx'
+import { ErrorFallback } from './components/ErrorFallback.tsx'
+import { initSentry } from './sentry.ts'
+
+initSentry()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary fallback={ErrorFallback} showDialog>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -8,6 +8,7 @@ import { Input } from '../components/Input'
 import { Button } from '../components/Button'
 import { useToast } from '../components/ToastContext'
 import { useSolidPod } from '../components/SolidPodContext'
+import { reportError } from '../errorReporting'
 import { SolidProviderSelector } from '../components/SolidProviderSelector'
 import { getPrimaryPodUrl, saveRdfToPod, POD_CONTAINERS, loadMultipleRdfFromPod } from '../services/solidPod'
 import { usePodSync } from '../hooks/usePodSync'
@@ -394,7 +395,7 @@ export function CreatePackingList() {
                     console.log('No question set found')
                     setNoQuestionsFound(true)
                 } else {
-                    console.error('Error fetching question set:', err)
+                    reportError(err, 'Error fetching question set')
                     showToast('Failed to load questions', 'error')
                 }
             } finally {
@@ -611,7 +612,7 @@ export function CreatePackingList() {
                 navigate(`/view-lists/${packingList.id}`)
             }
         } catch (err) {
-            console.error('Error saving packing list:', err)
+            reportError(err, 'Error saving packing list')
             showToast('Failed to create packing list. Please try again.', 'error')
         }
     }

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useDatabase } from '../components/DatabaseContext'
 import { useToast } from '../components/ToastContext'
+import { reportError } from '../errorReporting'
 import {
     grantFullCollaboratorAccess,
     revokeFullCollaboratorAccess,
@@ -68,7 +69,7 @@ export function SharingSettingsPage() {
             const list = await getFullCollaborators(session, ownPodUrl)
             setCollaborators(list)
         } catch (err) {
-            console.error('SharingSettingsPage: failed to load collaborators', err)
+            reportError(err, 'SharingSettingsPage: failed to load collaborators')
         } finally {
             setIsLoadingCollaborators(false)
         }
@@ -144,7 +145,7 @@ export function SharingSettingsPage() {
             showToast('Access granted successfully', 'success')
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err)
-            console.error('SharingSettingsPage: failed to grant access', err)
+            reportError(err, 'SharingSettingsPage: failed to grant access')
             showToast(`Failed to grant access: ${msg}`, 'error')
         } finally {
             setIsGranting(false)
@@ -161,7 +162,7 @@ export function SharingSettingsPage() {
             })
             showToast('Removed', 'success')
         } catch (err) {
-            console.error('SharingSettingsPage: failed to remove shared context', err)
+            reportError(err, 'SharingSettingsPage: failed to remove shared context')
             showToast('Failed to remove. Please try again.', 'error')
         } finally {
             setRemovingPodUrl(null)
@@ -176,7 +177,7 @@ export function SharingSettingsPage() {
             await loadCollaborators()
             showToast('Access revoked', 'success')
         } catch (err) {
-            console.error('SharingSettingsPage: failed to revoke access', err)
+            reportError(err, 'SharingSettingsPage: failed to revoke access')
             showToast('Failed to revoke access. Please try again.', 'error')
         } finally {
             setRevokingWebId(null)
@@ -194,7 +195,7 @@ export function SharingSettingsPage() {
             await db.deletePackingList(listId).catch(() => {})
             showToast('Removed', 'success')
         } catch (err) {
-            console.error('SharingSettingsPage: failed to remove shared list', err)
+            reportError(err, 'SharingSettingsPage: failed to remove shared list')
             showToast('Failed to remove. Please try again.', 'error')
         } finally {
             setRemovingListId(null)

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useToast } from '../components/ToastContext'
+import { reportError } from '../errorReporting'
 import { useDatabase } from '../components/DatabaseContext'
 import { createExampleData } from '../edit-questions/example-data'
 import { QUESTION_SET_ID } from '../constants'
@@ -54,7 +55,7 @@ export function useWizardGeneration() {
             showToast('Packing list questions generated successfully!', 'success')
             setIsSuccess(true)
         } catch (err) {
-            console.error('Error generating question set:', err)
+            reportError(err, 'Error generating question set')
             showToast('Failed to generate question set', 'error')
         } finally {
             setIsLoading(false)

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -8,6 +8,7 @@ import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { useForm, useWatch } from 'react-hook-form'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
+import { reportError } from '../errorReporting'
 import { usePodSync } from '../hooks/usePodSync'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 import { POD_CONTAINERS, getPrimaryPodUrl, saveRdfToPod, resolveOwnerDisplayName, deriveWebIdFromPodUrl } from '../services/solidPod'
@@ -224,6 +225,7 @@ export function ViewPackingList() {
         if (foreignPodUrl && !hasLoadedRef.current) {
             hasLoadedRef.current = true
             setIsLoading(false)
+            reportError(error, 'Could not load shared list')
             showToast(`Could not load shared list: ${error}`, 'error')
         }
     }, [handleSyncError, foreignPodUrl, showToast])
@@ -235,7 +237,7 @@ export function ViewPackingList() {
 
     // Callback when save to Pod fails
     const handleSaveError = useCallback((error: string) => {
-        console.error('Save to Pod error:', error);
+        reportError(error, 'Save to Pod error');
         showToast(`Failed to save to Pod: ${error}`, 'error');
     }, [showToast]);
 
@@ -282,7 +284,7 @@ export function ViewPackingList() {
                 if (isNotFound && foreignPodUrl) {
                     // Leave isLoading=true — the first pod poll will hydrate via handleSyncSuccess
                 } else {
-                    console.error('Error fetching packing list:', err)
+                    reportError(err, 'Error fetching packing list')
                     setIsLoading(false)
                 }
             }
@@ -365,7 +367,7 @@ export function ViewPackingList() {
             setAutoSaveStatus('saved')
             setTimeout(() => setAutoSaveStatus('idle'), 2000) // Show "saved" for 2 seconds
         } catch (err) {
-            console.error('handleItemChange: Error saving packing list:', err)
+            reportError(err, 'handleItemChange: Error saving packing list')
             setAutoSaveStatus('error')
         }
     }, 800) // Reduced to 800ms for faster saves while still batching rapid changes
@@ -432,7 +434,7 @@ export function ViewPackingList() {
             setAutoSaveStatus('saved')
             setTimeout(() => setAutoSaveStatus('idle'), 2000)
         } catch (err) {
-            console.error('Error deleting item:', err)
+            reportError(err, 'Error deleting item')
             setAutoSaveStatus('error')
         }
     }
@@ -467,7 +469,7 @@ export function ViewPackingList() {
             setAutoSaveStatus('saved')
             setTimeout(() => setAutoSaveStatus('idle'), 2000)
         } catch (err) {
-            console.error('Error saving item name:', err)
+            reportError(err, 'Error saving item name')
             setAutoSaveStatus('error')
         } finally {
             setEditingItemId(null)
@@ -521,7 +523,7 @@ export function ViewPackingList() {
             setRecentlyAddedItemId(newItem.id)
             setTimeout(() => setRecentlyAddedItemId(null), 2000)
         } catch (err) {
-            console.error('Error adding item:', err)
+            reportError(err, 'Error adding item')
             setAutoSaveStatus('error')
         }
     }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/capacitor'
+import * as SentryReact from '@sentry/react'
+
+// Sentry DSNs are public identifiers, safe to ship in client-side code.
+const SENTRY_DSN = 'https://a331ffe142776c6dd8d5fcecfb2a4a97@o4511757730578432.ingest.de.sentry.io/4511757737525328'
+
+export function initSentry() {
+  if (import.meta.env.MODE === 'test') return
+
+  Sentry.init(
+    {
+      dsn: SENTRY_DSN,
+      environment: import.meta.env.MODE,
+      integrations: [SentryReact.feedbackIntegration({ colorScheme: 'system' })],
+    },
+    SentryReact.init,
+  )
+}


### PR DESCRIPTION
Wraps the app in a Sentry error boundary so unhandled render errors
are captured with full stack traces and device context, and prompts
the user with Sentry's built-in report dialog to add what happened.
Also enables the floating feedback widget so users can report issues
proactively, not just on a crash. Uses @sentry/capacitor so native
crashes are covered on the iOS/Android builds too.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0172kU3tpwRkXuDfFvP9EybH