### PR TITLE
Let users copy full error details from error toasts

### DIFF
--- a/src/components/Toast.test.tsx
+++ b/src/components/Toast.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { Toast } from './Toast'
+
+describe('Toast', () => {
+    beforeEach(() => {
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText: vi.fn().mockResolvedValue(undefined) },
+            configurable: true,
+        })
+    })
+
+    it('does not show a copy button when no details are given', () => {
+        render(<Toast message="Saved!" type="success" onClose={vi.fn()} />)
+
+        expect(screen.queryByLabelText('Copy error details')).toBeNull()
+    })
+
+    it('copies the error details to the clipboard when the copy button is clicked', async () => {
+        const details = 'Time: 2026-07-18T00:00:00.000Z\nError saving packing list\nError: boom'
+        render(
+            <Toast
+                message="Failed to create packing list. Please try again."
+                type="error"
+                details={details}
+                onClose={vi.fn()}
+            />
+        )
+
+        fireEvent.click(screen.getByLabelText('Copy error details'))
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(details)
+    })
+
+    it('calls onClose when the dismiss button is clicked', () => {
+        const onClose = vi.fn()
+        render(<Toast message="Saved!" type="success" onClose={onClose} />)
+
+        fireEvent.click(screen.getByLabelText('Dismiss'))
+
+        expect(onClose).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { XMarkIcon } from '@heroicons/react/24/outline';
+import { useEffect, useState } from 'react';
+import { XMarkIcon, ClipboardDocumentIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
 
 export type ToastType = 'success' | 'error';
 
@@ -8,9 +8,12 @@ interface ToastProps {
     type: ToastType;
     onClose: () => void;
     duration?: number;
+    details?: string;
 }
 
-export function Toast({ message, type, onClose, duration = 3000 }: ToastProps) {
+export function Toast({ message, type, onClose, duration = 3000, details }: ToastProps) {
+    const [copied, setCopied] = useState(false);
+
     useEffect(() => {
         const timer = setTimeout(() => {
             onClose();
@@ -23,15 +26,36 @@ export function Toast({ message, type, onClose, duration = 3000 }: ToastProps) {
         ? 'bg-gradient-to-r from-success-500 to-success-600 shadow-glow-primary'
         : 'bg-gradient-to-r from-danger-500 to-danger-600 shadow-lg';
 
+    const handleCopy = () => {
+        if (!details) return;
+        navigator.clipboard.writeText(details).then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        });
+    };
+
     return (
         <div className={`fixed top-4 right-4 ${styles} text-white px-6 py-4 rounded-2xl flex items-center gap-3 min-w-[250px] animate-slide-down backdrop-blur-sm`}>
             <span className="flex-1 font-semibold">{message}</span>
+            {details && (
+                <button
+                    onClick={handleCopy}
+                    aria-label={copied ? 'Error details copied' : 'Copy error details'}
+                    title={copied ? 'Copied!' : 'Copy error details'}
+                    className="hover:scale-110 transition-transform duration-200"
+                >
+                    {copied
+                        ? <ClipboardDocumentCheckIcon className="h-5 w-5" />
+                        : <ClipboardDocumentIcon className="h-5 w-5" />}
+                </button>
+            )}
             <button
                 onClick={onClose}
+                aria-label="Dismiss"
                 className="hover:scale-110 transition-transform duration-200"
             >
                 <XMarkIcon className="h-5 w-5" />
             </button>
         </div>
     );
-} 
+}

--- a/src/components/ToastContext.tsx
+++ b/src/components/ToastContext.tsx
@@ -2,16 +2,16 @@ import { createContext, useContext, useState, ReactNode } from 'react';
 import { Toast, ToastType } from './Toast';
 
 interface ToastContextType {
-    showToast: (message: string, type: ToastType) => void;
+    showToast: (message: string, type: ToastType, details?: string) => void;
 }
 
 const ToastContext = createContext<ToastContextType | undefined>(undefined);
 
 export function ToastProvider({ children }: { children: ReactNode }) {
-    const [toast, setToast] = useState<{ message: string; type: ToastType } | null>(null);
+    const [toast, setToast] = useState<{ message: string; type: ToastType; details?: string } | null>(null);
 
-    const showToast = (message: string, type: ToastType) => {
-        setToast({ message, type });
+    const showToast = (message: string, type: ToastType, details?: string) => {
+        setToast({ message, type, details });
     };
 
     return (
@@ -21,6 +21,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
                 <Toast
                     message={toast.message}
                     type={toast.type}
+                    details={toast.details}
                     onClose={() => setToast(null)}
                 />
             )}
@@ -35,4 +36,4 @@ export function useToast() {
         throw new Error('useToast must be used within a ToastProvider');
     }
     return context;
-} 
+}

--- a/src/errorReporting.test.ts
+++ b/src/errorReporting.test.ts
@@ -25,4 +25,19 @@ describe('reportError', () => {
 
         expect(console.error).toHaveBeenCalledWith('Unhandled error', error)
     })
+
+    it('returns copyable details including the context and error message', () => {
+        const error = new Error('boom')
+        const details = reportError(error, 'Failed to create packing list')
+
+        expect(details).toContain('Failed to create packing list')
+        expect(details).toContain('boom')
+    })
+
+    it('formats non-Error values as their string representation', () => {
+        const details = reportError('a plain string error', 'Save to Pod error')
+
+        expect(details).toContain('Save to Pod error')
+        expect(details).toContain('a plain string error')
+    })
 })

--- a/src/errorReporting.ts
+++ b/src/errorReporting.ts
@@ -1,6 +1,14 @@
 import * as Sentry from '@sentry/capacitor'
 
-export function reportError(error: unknown, context?: string) {
+export function reportError(error: unknown, context?: string): string {
     console.error(context ?? 'Unhandled error', error)
     Sentry.captureException(error)
+    return formatErrorDetails(error, context)
+}
+
+function formatErrorDetails(error: unknown, context?: string): string {
+    const lines = [`Time: ${new Date().toISOString()}`]
+    if (context) lines.push(context)
+    lines.push(error instanceof Error ? (error.stack ?? `${error.name}: ${error.message}`) : String(error))
+    return lines.join('\n')
 }

--- a/src/hooks/usePodErrorHandler.test.ts
+++ b/src/hooks/usePodErrorHandler.test.ts
@@ -6,7 +6,7 @@ vi.mock('../components/ToastContext', () => ({
   useToast: () => ({ showToast }),
 }))
 
-const reportError = vi.fn()
+const reportError = vi.fn(() => 'formatted error details')
 vi.mock('../errorReporting', () => ({
   reportError: (...args: unknown[]) => reportError(...args),
 }))
@@ -27,7 +27,7 @@ describe('usePodErrorHandler', () => {
     result.current(error, 'Failed to create backup.')
 
     expect(reportError).toHaveBeenCalledWith(error, 'Pod operation error')
-    expect(showToast).toHaveBeenCalledWith('Failed to create backup.', 'error')
+    expect(showToast).toHaveBeenCalledWith('Failed to create backup.', 'error', 'formatted error details')
   })
 
   it('shows the authentication error message instead of the fallback', () => {
@@ -37,6 +37,6 @@ describe('usePodErrorHandler', () => {
     result.current(error, 'Failed to create backup.')
 
     expect(reportError).toHaveBeenCalledWith(error, 'Pod operation error')
-    expect(showToast).toHaveBeenCalledWith('Session expired', 'error')
+    expect(showToast).toHaveBeenCalledWith('Session expired', 'error', 'formatted error details')
   })
 })

--- a/src/hooks/usePodErrorHandler.ts
+++ b/src/hooks/usePodErrorHandler.ts
@@ -20,14 +20,14 @@ export function usePodErrorHandler() {
   const { showToast } = useToast();
 
   return useCallback((error: unknown, fallbackMessage: string) => {
-    reportError(error, 'Pod operation error');
+    const details = reportError(error, 'Pod operation error');
 
     if (error instanceof AuthenticationError) {
       // Use the specific authentication error message
-      showToast(error.message, 'error');
+      showToast(error.message, 'error', details);
     } else {
       // Use the fallback message for other errors
-      showToast(fallbackMessage, 'error');
+      showToast(fallbackMessage, 'error', details);
     }
   }, [showToast]);
 }

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -396,8 +396,8 @@ export function CreatePackingList() {
                     console.log('No question set found')
                     setNoQuestionsFound(true)
                 } else {
-                    reportError(err, 'Error fetching question set')
-                    showToast('Failed to load questions', 'error')
+                    const details = reportError(err, 'Error fetching question set')
+                    showToast('Failed to load questions', 'error', details)
                 }
             } finally {
                 setIsLoading(false)
@@ -624,8 +624,8 @@ export function CreatePackingList() {
                 navigate(`/view-lists/${packingList.id}`)
             }
         } catch (err) {
-            reportError(err, 'Error saving packing list')
-            showToast('Failed to create packing list. Please try again.', 'error')
+            const details = reportError(err, 'Error saving packing list')
+            showToast('Failed to create packing list. Please try again.', 'error', details)
         }
     }
 

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -145,8 +145,8 @@ export function SharingSettingsPage() {
             showToast('Access granted successfully', 'success')
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err)
-            reportError(err, 'SharingSettingsPage: failed to grant access')
-            showToast(`Failed to grant access: ${msg}`, 'error')
+            const details = reportError(err, 'SharingSettingsPage: failed to grant access')
+            showToast(`Failed to grant access: ${msg}`, 'error', details)
         } finally {
             setIsGranting(false)
         }
@@ -162,8 +162,8 @@ export function SharingSettingsPage() {
             })
             showToast('Removed', 'success')
         } catch (err) {
-            reportError(err, 'SharingSettingsPage: failed to remove shared context')
-            showToast('Failed to remove. Please try again.', 'error')
+            const details = reportError(err, 'SharingSettingsPage: failed to remove shared context')
+            showToast('Failed to remove. Please try again.', 'error', details)
         } finally {
             setRemovingPodUrl(null)
         }
@@ -177,8 +177,8 @@ export function SharingSettingsPage() {
             await loadCollaborators()
             showToast('Access revoked', 'success')
         } catch (err) {
-            reportError(err, 'SharingSettingsPage: failed to revoke access')
-            showToast('Failed to revoke access. Please try again.', 'error')
+            const details = reportError(err, 'SharingSettingsPage: failed to revoke access')
+            showToast('Failed to revoke access. Please try again.', 'error', details)
         } finally {
             setRevokingWebId(null)
         }
@@ -195,8 +195,8 @@ export function SharingSettingsPage() {
             await db.deletePackingList(listId).catch(() => {})
             showToast('Removed', 'success')
         } catch (err) {
-            reportError(err, 'SharingSettingsPage: failed to remove shared list')
-            showToast('Failed to remove. Please try again.', 'error')
+            const details = reportError(err, 'SharingSettingsPage: failed to remove shared list')
+            showToast('Failed to remove. Please try again.', 'error', details)
         } finally {
             setRemovingListId(null)
         }

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -65,8 +65,8 @@ export function useWizardGeneration() {
             showToast('Packing list questions generated successfully!', 'success')
             setIsSuccess(true)
         } catch (err) {
-            reportError(err, 'Error generating question set')
-            showToast('Failed to generate question set', 'error')
+            const details = reportError(err, 'Error generating question set')
+            showToast('Failed to generate question set', 'error', details)
         } finally {
             setIsLoading(false)
         }

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -929,7 +929,8 @@ describe('ViewPackingList foreign pod (?pod= param)', () => {
         // Toast should have been shown
         expect(mockShowToast).toHaveBeenCalledWith(
             expect.stringContaining('Could not load shared list'),
-            'error'
+            'error',
+            expect.any(String)
         )
     })
 })

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -225,8 +225,8 @@ export function ViewPackingList() {
         if (foreignPodUrl && !hasLoadedRef.current) {
             hasLoadedRef.current = true
             setIsLoading(false)
-            reportError(error, 'Could not load shared list')
-            showToast(`Could not load shared list: ${error}`, 'error')
+            const details = reportError(error, 'Could not load shared list')
+            showToast(`Could not load shared list: ${error}`, 'error', details)
         }
     }, [handleSyncError, foreignPodUrl, showToast])
 
@@ -237,8 +237,8 @@ export function ViewPackingList() {
 
     // Callback when save to Pod fails
     const handleSaveError = useCallback((error: string) => {
-        reportError(error, 'Save to Pod error');
-        showToast(`Failed to save to Pod: ${error}`, 'error');
+        const details = reportError(error, 'Save to Pod error');
+        showToast(`Failed to save to Pod: ${error}`, 'error', details);
     }, [showToast]);
 
     // Set up automatic Pod sync with polling


### PR DESCRIPTION
## Summary
- `reportError()` now returns a formatted details string (timestamp, context, error message/stack) in addition to logging and sending it to Sentry.
- Error toasts can carry these details; when present, `Toast` shows a copy-to-clipboard button next to the dismiss button, with a brief checkmark confirmation on click.
- Wired the details through every error-toast site that has real error info: `usePodErrorHandler` (covers backups + packing lists), `create-packing-list.tsx`, `useWizardGeneration.ts`, `sharing-settings.tsx`, and `view-packing-list.tsx`.

This lets someone hitting a failure grab the exact error and paste it into a bug report or email, without digging through devtools.

## Test plan
- [x] `npm test` — 644/644 passing (added coverage for the copy button and the new `reportError` return value)
- [x] `npm run build` (via a clean `npm ci`, matching CI)
- [x] `npm run lint` — only pre-existing warnings
- [x] Manual smoke test of the app in a headless browser — no console errors


---
_Generated by [Claude Code](https://claude.ai/code/session_0172kU3tpwRkXuDfFvP9EybH)_