### PR TITLE
Add "Visiting religious/sacred sites" activity option to wizard

### DIFF
--- a/src/edit-questions/example-data.test.ts
+++ b/src/edit-questions/example-data.test.ts
@@ -17,6 +17,7 @@ describe('ACTIVITY_OPTION_IDS', () => {
         expect(ACTIVITY_OPTION_IDS.climbing).toBe('activity-option-climbing')
         expect(ACTIVITY_OPTION_IDS.hiking).toBe('activity-option-hiking')
         expect(ACTIVITY_OPTION_IDS.formalOccasions).toBe('activity-option-formal-occasions')
+        expect(ACTIVITY_OPTION_IDS.religiousSites).toBe('activity-option-religious-sites')
     })
 })
 

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -9,6 +9,7 @@ export const ACTIVITY_OPTION_IDS = {
     climbing: 'activity-option-climbing',
     hiking: 'activity-option-hiking',
     formalOccasions: 'activity-option-formal-occasions',
+    religiousSites: 'activity-option-religious-sites',
 } as const
 import {
     getBabies,
@@ -160,6 +161,18 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                 item("Dress shoes", people, getToddlersAndOlder),
                 item("Accessories (watch, jewelry, etc.)", people, getTeenagersAndAdults),
                 item("Evening bag/Clutch", people, getTeenagersAndAdults),
+            )
+        },
+        {
+            id: ACTIVITY_OPTION_IDS.religiousSites,
+            text: "Visiting religious/sacred sites",
+            order: 7,
+            items: items(
+                item("Scarf/shawl (for covering shoulders/head)", people, getChildrenAndOlder),
+                item("Top with sleeves (covers shoulders)", people, getChildrenAndOlder),
+                item("Long trousers/skirt (knee-length or longer)", people, getChildrenAndOlder),
+                item("Easy-to-remove shoes", people, getToddlersAndOlder),
+                item("Socks (for bare-shoe areas)", people, getToddlersAndOlder),
             )
         }
     ]


### PR DESCRIPTION
Covers trips involving temples, mosques, churches, etc. with dress
codes: shoulder/head covering, knee-length bottoms, and easy-to-remove
shoes for bare-shoe areas.