### PR TITLE
Allow in-place editing of item text in the item picker

### DIFF
--- a/src/components/CreatableSelect.test.tsx
+++ b/src/components/CreatableSelect.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { ActiveSelect } from './CreatableSelect'
+
+describe('ActiveSelect', () => {
+    it('shows the existing value as editable text so the user can edit in place', () => {
+        const { container } = render(
+            <ActiveSelect
+                value="Entertainment (books/small toys)"
+                onChange={vi.fn()}
+                options={['Entertainment (books/small toys)', 'Playing cards/Travel games']}
+            />
+        )
+
+        const input = container.querySelector('input') as HTMLInputElement
+        expect(input.value).toBe('Entertainment (books/small toys)')
+    })
+
+    it('starts blank when there is no existing value', () => {
+        const { container } = render(
+            <ActiveSelect value="" onChange={vi.fn()} options={[]} />
+        )
+
+        const input = container.querySelector('input') as HTMLInputElement
+        expect(input.value).toBe('')
+    })
+
+    it('commits an in-place edit of the existing text on blur', () => {
+        const onChange = vi.fn()
+        const { container } = render(
+            <ActiveSelect value="Entertainment" onChange={onChange} options={[]} />
+        )
+
+        const input = container.querySelector('input') as HTMLInputElement
+        // Simulate inserting text mid-string rather than clearing and retyping.
+        fireEvent.change(input, { target: { value: 'Entertainment & Travel games' } })
+        fireEvent.blur(input)
+
+        expect(onChange).toHaveBeenCalledWith('Entertainment & Travel games')
+    })
+})

--- a/src/components/CreatableSelect.tsx
+++ b/src/components/CreatableSelect.tsx
@@ -39,7 +39,9 @@ const selectStyles = {
 
 // The full react-select — only mounts when the user actually interacts with this item.
 export function ActiveSelect({ value, onChange, options, placeholder, menuPortalTarget }: CreatableSelectProps) {
-    const [inputValue, setInputValue] = useState('');
+    // Seed the search box with the existing text so the user can edit in place
+    // (place the cursor and insert/delete characters) instead of it opening blank.
+    const [inputValue, setInputValue] = useState(value);
     const [menuIsOpen, setMenuIsOpen] = useState(false);
     const justSelectedRef = useRef(false);
 
@@ -64,6 +66,7 @@ export function ActiveSelect({ value, onChange, options, placeholder, menuPortal
             isClearable
             isSearchable
             value={value ? { label: value, value } : null}
+            inputValue={inputValue}
             onChange={handleChange}
             onInputChange={setInputValue}
             onBlur={handleBlur}


### PR DESCRIPTION
The item-name field (react-select Creatable) always opened with a
blank search box, hiding the existing text behind a separate
non-editable label. Users had to clear the field and retype the whole
value instead of placing a cursor and editing it, which is what
prompted manually deleting and rewriting categories to merge them.

Seed the search input with the current value on activation so it
renders as normal editable text.