### PR TITLE
Fix TypeError when non-text element is focused during pod sync

### DIFF
--- a/src/hooks/useSyncCoordinator.test.ts
+++ b/src/hooks/useSyncCoordinator.test.ts
@@ -320,4 +320,79 @@ describe('useSyncCoordinator', () => {
       expect(updateFormAndState).toHaveBeenCalledOnce()
     })
   })
+
+  // ─────────────────────────────────────────────────────────────────
+  // Focus preservation during pod sync updates
+  // ─────────────────────────────────────────────────────────────────
+
+  describe('focus preservation during pod sync updates', () => {
+    afterEach(() => {
+      document.body.innerHTML = ''
+    })
+
+    it('does not throw when a button is focused during a sync update', async () => {
+      vi.useFakeTimers()
+      const button = document.createElement('button')
+      button.id = 'focused-button'
+      document.body.appendChild(button)
+      button.focus()
+
+      const options = makeOptions()
+      const { result } = renderHook(() => useSyncCoordinator<TestData>(options))
+
+      await act(async () => {
+        await result.current.handleSyncSuccess(
+          makeTestData({ lastModified: new Date().toISOString() })
+        )
+      })
+
+      expect(() => vi.runAllTimers()).not.toThrow()
+      expect(document.activeElement).toBe(button)
+    })
+
+    it('does not throw when a select is focused during a sync update', async () => {
+      vi.useFakeTimers()
+      const select = document.createElement('select')
+      select.id = 'focused-select'
+      document.body.appendChild(select)
+      select.focus()
+
+      const options = makeOptions()
+      const { result } = renderHook(() => useSyncCoordinator<TestData>(options))
+
+      await act(async () => {
+        await result.current.handleSyncSuccess(
+          makeTestData({ lastModified: new Date().toISOString() })
+        )
+      })
+
+      expect(() => vi.runAllTimers()).not.toThrow()
+      expect(document.activeElement).toBe(select)
+    })
+
+    it('restores focus and selection on a text input', async () => {
+      vi.useFakeTimers()
+      const input = document.createElement('input')
+      input.type = 'text'
+      input.id = 'focused-input'
+      input.value = 'hello world'
+      document.body.appendChild(input)
+      input.focus()
+      input.setSelectionRange(2, 5)
+
+      const options = makeOptions()
+      const { result } = renderHook(() => useSyncCoordinator<TestData>(options))
+
+      await act(async () => {
+        await result.current.handleSyncSuccess(
+          makeTestData({ lastModified: new Date().toISOString() })
+        )
+      })
+
+      expect(() => vi.runAllTimers()).not.toThrow()
+      expect(document.activeElement).toBe(input)
+      expect(input.selectionStart).toBe(2)
+      expect(input.selectionEnd).toBe(5)
+    })
+  })
 })

--- a/src/hooks/useSyncCoordinator.ts
+++ b/src/hooks/useSyncCoordinator.ts
@@ -151,8 +151,22 @@ export function useSyncCoordinator<T extends TimestampedData>(
     // Save the currently focused element
     const activeElement = document.activeElement as HTMLElement;
     const activeElementId = activeElement?.id;
-    const selectionStart = (activeElement as HTMLInputElement)?.selectionStart;
-    const selectionEnd = (activeElement as HTMLInputElement)?.selectionEnd;
+    // Only text controls expose a selection API; on buttons/selects the
+    // properties are undefined, and inputs like type="number" throw on access
+    // in some browsers.
+    let selectionStart: number | null = null;
+    let selectionEnd: number | null = null;
+    if (
+      activeElement instanceof HTMLInputElement ||
+      activeElement instanceof HTMLTextAreaElement
+    ) {
+      try {
+        selectionStart = activeElement.selectionStart;
+        selectionEnd = activeElement.selectionEnd;
+      } catch {
+        // Input type doesn't support selection — restore focus only
+      }
+    }
 
     // Execute the callback
     callback();
@@ -163,8 +177,16 @@ export function useSyncCoordinator<T extends TimestampedData>(
         const elementToFocus = document.getElementById(activeElementId) as HTMLInputElement;
         if (elementToFocus) {
           elementToFocus.focus();
-          if (selectionStart !== null && selectionEnd !== null) {
-            elementToFocus.setSelectionRange(selectionStart, selectionEnd);
+          if (
+            selectionStart !== null &&
+            selectionEnd !== null &&
+            typeof elementToFocus.setSelectionRange === 'function'
+          ) {
+            try {
+              elementToFocus.setSelectionRange(selectionStart, selectionEnd);
+            } catch {
+              // Element re-rendered as a type that doesn't support selection
+            }
           }
         }
       }


### PR DESCRIPTION
Sentry issue 0cfd2e8b5019456592863ee1d55089e9: preserveFocusAndSelection
read selectionStart/selectionEnd off document.activeElement without
checking the element type. On buttons and selects those properties are
undefined, and undefined !== null passed the guard, so setSelectionRange
was called on an element that doesn't have it.

Only capture selection from text controls (HTMLInputElement /
HTMLTextAreaElement), and guard the restore with a method check plus
try/catch for input types like number/date that don't support selection.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XtU7E3nR968zX86FBrDUSd