### PR TITLE
Let question-set item order flow through to the packing list view

### DIFF
--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -130,7 +130,7 @@ test.describe('B – Editing Questions', () => {
     await expect(page.getByText('WaterBottleTest')).toBeVisible({ timeout: 5_000 })
   })
 
-  test('B6: reorder always-needed items with the move buttons', async ({ freshPage: page }) => {
+  test('B6: reorder always-needed items via reorder mode', async ({ freshPage: page }) => {
     await setupWizardAndGoToQuestions(page)
     await openAlwaysNeededModal(page)
 
@@ -141,8 +141,13 @@ test.describe('B – Editing Questions', () => {
     const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
     expect(first).not.toEqual(second)
 
-    // Move the first item down one position and save
+    // Enter reorder mode — rows collapse to name + large move buttons
+    await page.getByRole('button', { name: 'Reorder items' }).click()
+    await expect(page.locator('.cursor-text')).toHaveCount(0)
+
+    // Move the first item down one position, leave reorder mode, save
     await page.locator('button[title="Move item down"]').first().click()
+    await page.getByRole('button', { name: 'Finish reordering' }).click()
     await expect(itemTexts.first()).toContainText(second)
     await expect(itemTexts.nth(1)).toContainText(first)
     await page.getByRole('button', { name: 'Save changes' }).click()

--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -130,6 +130,30 @@ test.describe('B – Editing Questions', () => {
     await expect(page.getByText('WaterBottleTest')).toBeVisible({ timeout: 5_000 })
   })
 
+  test('B6: reorder always-needed items with the move buttons', async ({ freshPage: page }) => {
+    await setupWizardAndGoToQuestions(page)
+    await openAlwaysNeededModal(page)
+
+    // Item names render in inactive CustomCreatableSelect mode (.cursor-text)
+    const itemTexts = page.locator('.cursor-text')
+    // First line only — the row also renders a "×" clear glyph on its own line
+    const first = (await itemTexts.first().innerText()).split('\n')[0].trim()
+    const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
+    expect(first).not.toEqual(second)
+
+    // Move the first item down one position and save
+    await page.locator('button[title="Move item down"]').first().click()
+    await expect(itemTexts.first()).toContainText(second)
+    await expect(itemTexts.nth(1)).toContainText(first)
+    await page.getByRole('button', { name: 'Save changes' }).click()
+    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
+
+    // Reopen the modal — the swapped order must have persisted
+    await openAlwaysNeededModal(page)
+    await expect(itemTexts.first()).toContainText(second)
+    await expect(itemTexts.nth(1)).toContainText(first)
+  })
+
   test('B5: JSON editor mode toggle is not available (editor is always visual)', async ({ freshPage: page }) => {
     await setupWizardAndGoToQuestions(page)
     // The JSON editor toggle does not exist in the current UI

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -27,6 +27,32 @@ test.describe('C – Packing Lists', () => {
     await expect(page.getByText('Beach Holiday')).toBeVisible()
   })
 
+  test('C7: reordered question-set items flow through to the view list page', async ({ freshPage: page }) => {
+    await runWizard(page)
+
+    // Reorder the always-needed items: move the first item down one position
+    await page.goto('/#/manage-questions')
+    await page.locator('button[title="Edit always needed items"]').click()
+    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).toBeVisible({ timeout: 3_000 })
+    const itemTexts = page.locator('.cursor-text')
+    // First line only — the row also renders a "×" clear glyph on its own line
+    const first = (await itemTexts.first().innerText()).split('\n')[0].trim()
+    const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
+    await page.locator('button[title="Move item down"]').first().click()
+    await page.getByRole('button', { name: 'Save changes' }).click()
+    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
+
+    // Create a list and check the view page shows the swapped order
+    await page.goto('/#/create-packing-list')
+    await createList(page, 'Ordered Trip')
+    const body = page.locator('body')
+    await expect(body).toContainText(first)
+    await expect(body).toContainText(second)
+    const content = await body.innerText()
+    expect(content.indexOf(second)).toBeGreaterThanOrEqual(0)
+    expect(content.indexOf(second)).toBeLessThan(content.indexOf(first))
+  })
+
   test('C2: check item as packed persists on reload', async ({ freshPage: page }) => {
     await runWizard(page)
     await createList(page, 'Test Trip')

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -38,7 +38,9 @@ test.describe('C – Packing Lists', () => {
     // First line only — the row also renders a "×" clear glyph on its own line
     const first = (await itemTexts.first().innerText()).split('\n')[0].trim()
     const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
+    await page.getByRole('button', { name: 'Reorder items' }).click()
     await page.locator('button[title="Move item down"]').first().click()
+    await page.getByRole('button', { name: 'Finish reordering' }).click()
     await page.getByRole('button', { name: 'Save changes' }).click()
     await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
 

--- a/src/create-packing-list/generatePackingListItems.test.ts
+++ b/src/create-packing-list/generatePackingListItems.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateQuestionBasedItems, generateAlwaysNeededItems } from './generatePackingListItems'
+import { generateQuestionBasedItems, generateAlwaysNeededItems, withItemOrder } from './generatePackingListItems'
 import { Question } from '../edit-questions/types'
 
 const p1 = { id: 'p1', name: 'Alice' }
@@ -361,5 +361,71 @@ describe('generateAlwaysNeededItems', () => {
             ['p1']
         )
         expect(result).toHaveLength(0)
+    })
+})
+
+// ─── Ordering: generated items follow the question set's order ───────────────
+
+describe('generateQuestionBasedItems – ordering', () => {
+    it('follows question order even when answers arrive in a different order', () => {
+        const answers = [
+            { questionId: 'q-overnight', selectedOptionIds: ['opt-yes'] },
+            { questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] },
+        ]
+        const result = generateQuestionBasedItems(
+            [activitiesQuestion, overnightQuestion],
+            answers,
+            [p1],
+            ['p1']
+        )
+        expect(result.map(i => i.itemText)).toEqual(['Swimsuit', 'Goggles', 'Toothbrush'])
+    })
+
+    it('follows option order regardless of the order options were selected in', () => {
+        const answers = [
+            { questionId: 'q-activities', selectedOptionIds: ['opt-hiking', 'opt-swimming'] },
+        ]
+        const result = generateQuestionBasedItems(
+            [activitiesQuestion],
+            answers,
+            [p1],
+            ['p1']
+        )
+        expect(result.map(i => i.itemText)).toEqual(['Swimsuit', 'Goggles', 'Hiking boots'])
+    })
+
+    it('follows item order fields within an option when present', () => {
+        const question: Question = {
+            id: 'q-1',
+            type: 'saved',
+            text: 'Camping?',
+            order: 0,
+            options: [{
+                id: 'opt-yes',
+                text: 'Yes',
+                order: 0,
+                items: [
+                    { text: 'Sleeping bag', order: 1, personSelections: [{ personId: 'p1', selected: true }] },
+                    { text: 'Tent', order: 0, personSelections: [{ personId: 'p1', selected: true }] },
+                ],
+            }],
+        }
+        const result = generateQuestionBasedItems(
+            [question],
+            [{ questionId: 'q-1', selectedOptionIds: ['opt-yes'] }],
+            [p1],
+            ['p1']
+        )
+        expect(result.map(i => i.itemText)).toEqual(['Tent', 'Sleeping bag'])
+    })
+})
+
+describe('withItemOrder', () => {
+    it('stamps a sequential order onto assembled list items', () => {
+        const items = [
+            { id: '1', itemText: 'Tent', personId: '', personName: '', questionId: 'q', optionId: 'o', packed: false },
+            { id: '2', itemText: 'Map', personId: '', personName: '', questionId: 'q', optionId: 'o', packed: false },
+        ]
+        expect(withItemOrder(items).map(i => i.order)).toEqual([0, 1])
     })
 })

--- a/src/create-packing-list/generatePackingListItems.ts
+++ b/src/create-packing-list/generatePackingListItems.ts
@@ -57,27 +57,32 @@ export function generateQuestionBasedItems(
     people: Person[],
     selectedPeopleIds: string[]
 ): PackingListItem[] {
-    return questionAnswers.flatMap(qa => {
-        const selectedOptionIds = qa.selectedOptionIds ?? []
-        const question = questions.find(q => q.id === qa.questionId)
-        if (!question) return []
+    // Walk the question set in its own order (questions, then options, then
+    // items) rather than answer order, so the generated list mirrors how the
+    // user arranged their questions.
+    const answersByQuestionId = new Map(questionAnswers.map(qa => [qa.questionId, qa]))
+    return [...questions]
+        .sort((a, b) => a.order - b.order)
+        .flatMap(question => {
+            const qa = answersByQuestionId.get(question.id)
+            if (!qa) return []
+            const selectedOptionIds = new Set((qa.selectedOptionIds ?? []).filter(Boolean))
 
-        return selectedOptionIds.flatMap(selectedOptionId => {
-            if (!selectedOptionId) return []
-            const selectedOption = question.options.find(o => o.id === selectedOptionId)
-            if (!selectedOption) return []
-
-            return selectedOption.items.flatMap(item =>
-                generateItemInstances(item, people, selectedPeopleIds, {
-                    questionId: question.id,
-                    optionId: selectedOption.id,
-                    category: question.questionType === 'multiple-choice'
-                        ? selectedOption.text
-                        : question.text,
-                })
-            )
+            return [...question.options]
+                .sort((a, b) => a.order - b.order)
+                .filter(option => selectedOptionIds.has(option.id))
+                .flatMap(selectedOption =>
+                    sortItemsByOrder(selectedOption.items).flatMap(item =>
+                        generateItemInstances(item, people, selectedPeopleIds, {
+                            questionId: question.id,
+                            optionId: selectedOption.id,
+                            category: question.questionType === 'multiple-choice'
+                                ? selectedOption.text
+                                : question.text,
+                        })
+                    )
+                )
         })
-    })
 }
 
 export function generateAlwaysNeededItems(
@@ -85,11 +90,26 @@ export function generateAlwaysNeededItems(
     people: Person[],
     selectedPeopleIds: string[]
 ): PackingListItem[] {
-    return alwaysNeededItems.flatMap(item =>
+    return sortItemsByOrder(alwaysNeededItems).flatMap(item =>
         generateItemInstances(item, people, selectedPeopleIds, {
             questionId: 'always-needed',
             optionId: 'always-needed',
             category: 'Essentials',
         })
     )
+}
+
+// Explicit order wins where present; items without one keep their array
+// position (question sets written before items carried an order field).
+function sortItemsByOrder(items: Item[]): Item[] {
+    return items
+        .map((item, index) => ({ item, key: item.order ?? index }))
+        .sort((a, b) => a.key - b.key)
+        .map(({ item }) => item)
+}
+
+// Stamped onto the final assembled list so the view page can show items in
+// question-set order without needing access to the owner's question set.
+export function withItemOrder(items: PackingListItem[]): PackingListItem[] {
+    return items.map((item, index) => ({ ...item, order: index }))
 }

--- a/src/create-packing-list/types.ts
+++ b/src/create-packing-list/types.ts
@@ -21,6 +21,7 @@ export interface PackingListItem {
     packed: boolean
     communal?: boolean // packed once for the whole group; absent = per-person
     category?: string
+    order?: number     // position in the question set at generation time; absent on legacy items (sorted alphabetically)
     reviewed?: boolean
     lastModified?: string // ISO timestamp; absent on legacy items
 }

--- a/src/edit-questions/types.test.ts
+++ b/src/edit-questions/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { AGE_RANGE_OPTIONS, PET_SPECIES_OPTIONS, PersonSchema } from './types'
+import { AGE_RANGE_OPTIONS, PET_SPECIES_OPTIONS, PersonSchema, ItemSchema, renumberItemOrder } from './types'
 
 describe('AGE_RANGE_OPTIONS', () => {
   it('all option labels fit within 40 characters for mobile display', () => {
@@ -44,5 +44,48 @@ describe('PersonSchema - species (backward compatible)', () => {
 
   it('rejects an invalid species value', () => {
     expect(() => PersonSchema.parse({ id: 'p1', name: 'X', species: 'dragon' })).toThrow()
+  })
+})
+
+describe('ItemSchema - order (backward compatible)', () => {
+  it('accepts an item with an order', () => {
+    const parsed = ItemSchema.parse({ text: 'Towel', personSelections: [], order: 3 })
+    expect(parsed.order).toBe(3)
+  })
+
+  it('accepts a legacy item without an order', () => {
+    const parsed = ItemSchema.parse({ text: 'Towel', personSelections: [] })
+    expect(parsed.order).toBeUndefined()
+  })
+})
+
+describe('renumberItemOrder', () => {
+  const now = '2024-06-01T00:00:00.000Z'
+
+  it('stamps sequential order and lastModified on items whose position changed', () => {
+    const items = [
+      { text: 'B', personSelections: [], order: 1, lastModified: '2024-01-01T00:00:00.000Z' },
+      { text: 'A', personSelections: [], order: 0, lastModified: '2024-01-01T00:00:00.000Z' },
+    ]
+    const result = renumberItemOrder(items, now)
+    expect(result.map(i => i.order)).toEqual([0, 1])
+    expect(result.every(i => i.lastModified === now)).toBe(true)
+  })
+
+  it('leaves untouched items alone so sync LWW does not see phantom edits', () => {
+    const items = [
+      { text: 'A', personSelections: [], order: 0, lastModified: '2024-01-01T00:00:00.000Z' },
+      { text: 'B', personSelections: [], order: 1, lastModified: '2024-01-01T00:00:00.000Z' },
+    ]
+    const result = renumberItemOrder(items, now)
+    expect(result[0].lastModified).toBe('2024-01-01T00:00:00.000Z')
+    expect(result[1].lastModified).toBe('2024-01-01T00:00:00.000Z')
+  })
+
+  it('stamps order on legacy items that had none', () => {
+    const items = [{ text: 'A', personSelections: [] }]
+    const result = renumberItemOrder(items, now)
+    expect(result[0].order).toBe(0)
+    expect(result[0].lastModified).toBe(now)
   })
 })

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -65,12 +65,15 @@ export const PersonSelectionSchema = z.object({
 // filter record which brackets they apply to, so age-up transitions can
 // suggest selecting/deselecting a person. User-created items have no tag and
 // are never touched by those suggestions.
+// `order` is optional and additive: items without it sort after ordered ones
+// in their original position, so legacy data keeps its array order.
 export const ItemSchema = z.object({
   id: z.string().optional(),
   text: z.string(),
   personSelections: z.array(PersonSelectionSchema),
   communal: z.boolean().optional(),
   ageRanges: z.array(AgeRangeSchema).optional(),
+  order: z.number().optional(),
   lastModified: z.string().optional(),
   deletedAt: z.string().optional(),
 })
@@ -134,6 +137,15 @@ export function newDraftQuestion(order: number): DraftQuestion {
     order,
     questionType: "single-choice"
   }
+}
+
+// Renumber items to match their array position after an edit or reorder.
+// Only moved items get a fresh lastModified, so sync's per-item LWW carries
+// the new positions without phantom edits on untouched items.
+export function renumberItemOrder(items: Item[], now: string): Item[] {
+  return items.map((item, i) =>
+    item.order === i ? item : { ...item, order: i, lastModified: now }
+  )
 }
 
 export function newOption(order: number): Option {

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -14,7 +14,7 @@ import { getPrimaryPodUrl, saveRdfToPod, POD_CONTAINERS, loadMultipleRdfFromPod 
 import { usePodSync } from '../hooks/usePodSync'
 import { questionSetToDataset, datasetToQuestionSet, packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { useForeignPod } from '../components/ForeignPodContext'
-import { generateQuestionBasedItems, generateAlwaysNeededItems } from '../create-packing-list/generatePackingListItems'
+import { generateQuestionBasedItems, generateAlwaysNeededItems, withItemOrder } from '../create-packing-list/generatePackingListItems'
 import { AgePromotionCard } from '../components/AgePromotionCard'
 
 export function deduplicateItems(items: PackingListItem[]): PackingListItem[] {
@@ -595,7 +595,7 @@ export function CreatePackingList() {
             name: data.name,
             createdAt: new Date().toISOString(),
             lastModified: new Date().toISOString(),
-            items: deduplicateItems([...questionBasedItems, ...alwaysNeededItems])
+            items: withItemOrder(deduplicateItems([...questionBasedItems, ...alwaysNeededItems]))
         }
         try {
             if (foreignPodUrl) {

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useDatabase } from '../components/DatabaseContext'
 import { DatabaseMigration } from '../services/migration'
-import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, newDraftQuestion, AGE_RANGE_OPTIONS } from '../edit-questions/types'
+import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, newDraftQuestion, renumberItemOrder, AGE_RANGE_OPTIONS } from '../edit-questions/types'
 import { Link } from 'react-router-dom'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 import { usePodSync } from '../hooks/usePodSync'
@@ -511,16 +511,25 @@ function useItemListState(initialItems: Item[], people: Person[]) {
     const removeItem = (idx: number) =>
         setItems(prev => prev.filter((_, i) => i !== idx))
 
+    const moveItem = (idx: number, direction: 'up' | 'down') =>
+        setItems(prev => {
+            const swapIdx = direction === 'up' ? idx - 1 : idx + 1
+            if (swapIdx < 0 || swapIdx >= prev.length) return prev
+            const next = [...prev]
+            ;[next[idx], next[swapIdx]] = [next[swapIdx], next[idx]]
+            return next
+        })
+
     const addItem = () =>
         setItems(prev => [...prev, {
             text: '',
             personSelections: people.map(p => ({ personId: p.id, selected: true })),
         }])
 
-    return { items, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, addItem }
+    return { items, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, moveItem, addItem }
 }
 
-function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, addItem }: {
+function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, moveItem, addItem }: {
     items: Item[]
     people: Person[]
     allItemNames: string[]
@@ -529,6 +538,7 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
     togglePerson: (itemIdx: number, personIdx: number) => void
     toggleCommunal: (itemIdx: number) => void
     removeItem: (idx: number) => void
+    moveItem: (idx: number, direction: 'up' | 'down') => void
     addItem: () => void
 }) {
     return (
@@ -584,6 +594,32 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
                                         </button>
                                     )
                                 })}
+                            </div>
+                            <div className="shrink-0 flex flex-col -my-1">
+                                <button
+                                    type="button"
+                                    onClick={() => moveItem(itemIdx, 'up')}
+                                    disabled={itemIdx === 0}
+                                    className={`px-1 leading-none ${itemIdx === 0 ? 'text-gray-100 cursor-not-allowed' : 'text-gray-300 hover:text-gray-600'}`}
+                                    title="Move item up"
+                                    aria-label={`Move ${item.text || 'item'} up`}
+                                >
+                                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                                    </svg>
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => moveItem(itemIdx, 'down')}
+                                    disabled={itemIdx === items.length - 1}
+                                    className={`px-1 leading-none ${itemIdx === items.length - 1 ? 'text-gray-100 cursor-not-allowed' : 'text-gray-300 hover:text-gray-600'}`}
+                                    title="Move item down"
+                                    aria-label={`Move ${item.text || 'item'} down`}
+                                >
+                                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                                    </svg>
+                                </button>
                             </div>
                             <button
                                 type="button"
@@ -656,13 +692,13 @@ function OptionEditModal({ option, people, allItemNames, onSave, onClose }: {
     onClose: () => void
 }) {
     const [text, setText] = useState(option?.text ?? '')
-    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, addItem } = useItemListState(option?.items ?? [], people)
+    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, moveItem, addItem } = useItemListState(option?.items ?? [], people)
 
     const handleSave = () => onSave({
         id: option?.id ?? crypto.randomUUID(),
         order: option?.order ?? 0,
         text: text.trim(),
-        items,
+        items: renumberItemOrder(items, new Date().toISOString()),
     })
 
     return (
@@ -705,7 +741,7 @@ function OptionEditModal({ option, people, allItemNames, onSave, onClose }: {
                     items={items} people={people} allItemNames={allItemNames}
                     scrollRef={scrollRef} updateItemText={updateItemText}
                     togglePerson={togglePerson} toggleCommunal={toggleCommunal}
-                    removeItem={removeItem} addItem={addItem}
+                    removeItem={removeItem} moveItem={moveItem} addItem={addItem}
                 />
                 <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex gap-2 justify-end">
                     <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
@@ -727,7 +763,7 @@ function AlwaysNeededModal({ initialItems, people, allItemNames, onSave, onClose
     onSave: (items: Item[]) => void
     onClose: () => void
 }) {
-    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, addItem } = useItemListState(initialItems, people)
+    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, removeItem, moveItem, addItem } = useItemListState(initialItems, people)
 
     return (
         <div
@@ -758,13 +794,13 @@ function AlwaysNeededModal({ initialItems, people, allItemNames, onSave, onClose
                     items={items} people={people} allItemNames={allItemNames}
                     scrollRef={scrollRef} updateItemText={updateItemText}
                     togglePerson={togglePerson} toggleCommunal={toggleCommunal}
-                    removeItem={removeItem} addItem={addItem}
+                    removeItem={removeItem} moveItem={moveItem} addItem={addItem}
                 />
                 <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex gap-2 justify-end">
                     <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
                         Cancel
                     </button>
-                    <button type="button" onClick={() => onSave(items)} className="px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700">
+                    <button type="button" onClick={() => onSave(renumberItemOrder(items, new Date().toISOString()))} className="px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700">
                         Save changes
                     </button>
                 </div>
@@ -1068,9 +1104,16 @@ export function QuestionsPage() {
         if (swapIdx < 0 || swapIdx >= active.length) return
         const newActive = [...active]
         ;[newActive[idx], newActive[swapIdx]] = [newActive[swapIdx], newActive[idx]]
+        // Renumber order to match the new positions and stamp lastModified on
+        // moved questions, so the reorder survives pod round-trips (deserialize
+        // sorts by order) and wins per-question LWW during sync merges.
+        const now = new Date().toISOString()
+        const renumbered = newActive.map((q, i) =>
+            q.order === i ? q : { ...q, order: i, lastModified: now }
+        )
         // Rebuild full questions array preserving deleted ones
         const deletedQuestions = data.questions.filter(q => q.deletedAt)
-        await saveData({ ...data, questions: [...newActive, ...deletedQuestions] })
+        await saveData({ ...data, questions: [...renumbered, ...deletedQuestions] })
     }, [data, saveData])
 
     const handleOptionModalSave = useCallback(async (updatedOption: Option) => {

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -574,6 +574,11 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
     addItem: () => void
 }) {
     const [openQuantityIdx, setOpenQuantityIdx] = useState<number | null>(null)
+    const [reorderMode, setReorderMode] = useState(false)
+    // Reorder mode only makes sense with something to reorder; if there aren't
+    // at least two items the toggle is hidden and we render the normal editor.
+    const canReorder = items.length > 1
+    const inReorder = reorderMode && canReorder
     const parseQty = (raw: string): number | undefined => {
         const n = parseInt(raw, 10)
         return Number.isFinite(n) && n > 0 ? n : undefined
@@ -581,10 +586,63 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
     return (
         <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
             {items.length > 0 && (
-                <div className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2">Items</div>
+                <div className="flex items-center justify-between mb-2">
+                    <div className="text-xs font-medium text-gray-400 uppercase tracking-wide">Items</div>
+                    {canReorder && (
+                        <button
+                            type="button"
+                            onClick={() => setReorderMode(m => !m)}
+                            aria-pressed={reorderMode}
+                            className={`inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 transition-colors ${reorderMode ? 'bg-primary-600 text-white' : 'text-primary-600 hover:bg-primary-50'}`}
+                        >
+                            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
+                            </svg>
+                            {reorderMode ? 'Finish reordering' : 'Reorder items'}
+                        </button>
+                    )}
+                </div>
+            )}
+            {inReorder && (
+                <div className="text-[11px] text-gray-400 mb-2 px-0.5">
+                    Use the arrows to change the order, then tap Finish reordering.
+                </div>
             )}
             <div className="space-y-2">
-                {items.map((item, itemIdx) => {
+                {inReorder && items.map((item, itemIdx) => (
+                    <div key={itemIdx} className="flex items-center gap-2 rounded-lg border border-gray-200 p-2">
+                        <span className="flex-1 min-w-0 truncate text-sm text-gray-800 px-1">
+                            {item.text || <span className="text-gray-400 italic">Unnamed item</span>}
+                        </span>
+                        <div className="flex gap-1 shrink-0">
+                            <button
+                                type="button"
+                                onClick={() => moveItem(itemIdx, 'up')}
+                                disabled={itemIdx === 0}
+                                className={`inline-flex items-center justify-center w-11 h-11 rounded-lg border transition-colors ${itemIdx === 0 ? 'text-gray-200 border-gray-100 cursor-not-allowed' : 'text-gray-600 border-gray-200 hover:bg-gray-50 active:bg-gray-100'}`}
+                                title="Move item up"
+                                aria-label={`Move ${item.text || 'item'} up`}
+                            >
+                                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                                </svg>
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => moveItem(itemIdx, 'down')}
+                                disabled={itemIdx === items.length - 1}
+                                className={`inline-flex items-center justify-center w-11 h-11 rounded-lg border transition-colors ${itemIdx === items.length - 1 ? 'text-gray-200 border-gray-100 cursor-not-allowed' : 'text-gray-600 border-gray-200 hover:bg-gray-50 active:bg-gray-100'}`}
+                                title="Move item down"
+                                aria-label={`Move ${item.text || 'item'} down`}
+                            >
+                                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                ))}
+                {!inReorder && items.map((item, itemIdx) => {
                     const isCommunal = item.communal === true
                     const communalTitle = isCommunal
                         ? 'Shared item — packed once for the group. Click to make per-person.'
@@ -636,32 +694,6 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
                                         </button>
                                     )
                                 })}
-                            </div>
-                            <div className="shrink-0 flex flex-col -my-1">
-                                <button
-                                    type="button"
-                                    onClick={() => moveItem(itemIdx, 'up')}
-                                    disabled={itemIdx === 0}
-                                    className={`px-1 leading-none ${itemIdx === 0 ? 'text-gray-100 cursor-not-allowed' : 'text-gray-300 hover:text-gray-600'}`}
-                                    title="Move item up"
-                                    aria-label={`Move ${item.text || 'item'} up`}
-                                >
-                                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
-                                    </svg>
-                                </button>
-                                <button
-                                    type="button"
-                                    onClick={() => moveItem(itemIdx, 'down')}
-                                    disabled={itemIdx === items.length - 1}
-                                    className={`px-1 leading-none ${itemIdx === items.length - 1 ? 'text-gray-100 cursor-not-allowed' : 'text-gray-300 hover:text-gray-600'}`}
-                                    title="Move item down"
-                                    aria-label={`Move ${item.text || 'item'} down`}
-                                >
-                                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                                    </svg>
-                                </button>
                             </div>
                             <button
                                 type="button"
@@ -770,13 +802,15 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
                     )
                 })}
             </div>
-            <button
-                type="button"
-                onClick={addItem}
-                className="mt-3 w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
-            >
-                + Add Item
-            </button>
+            {!inReorder && (
+                <button
+                    type="button"
+                    onClick={addItem}
+                    className="mt-3 w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
+                >
+                    + Add Item
+                </button>
+            )}
         </div>
     )
 }

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import { ViewPackingList } from './view-packing-list'
+import { ViewPackingList, groupByCategory, groupByPerson } from './view-packing-list'
 import type { PackingAppDatabase } from '../services/database'
+import type { PackingListItem } from '../create-packing-list/types'
 
 vi.mock('../components/DatabaseContext', () => ({
     useDatabase: vi.fn(),
@@ -1075,5 +1076,69 @@ describe('ViewPackingList shared (communal) section', () => {
         expect(added.communal).toBe(true)
         expect(added.personId).toBe('')
         expect(added.personName).toBe('')
+    })
+})
+
+describe('grouping honours generated item order', () => {
+    const mk = (over: Partial<PackingListItem>): PackingListItem => ({
+        id: Math.random().toString(36).slice(2),
+        itemText: 'Item',
+        personId: 'p1',
+        personName: 'Alice',
+        questionId: 'q1',
+        optionId: 'o1',
+        packed: false,
+        ...over,
+    })
+
+    it('sorts items within a category by order, not alphabetically', () => {
+        const groups = groupByCategory([
+            mk({ itemText: 'Zebra print towel', category: 'Beach', order: 0 }),
+            mk({ itemText: 'Armbands', category: 'Beach', order: 1 }),
+        ])
+        expect(groups[0].items.map(i => i.itemText)).toEqual(['Zebra print towel', 'Armbands'])
+    })
+
+    it('keeps legacy items (no order) alphabetical', () => {
+        const groups = groupByCategory([
+            mk({ itemText: 'Zebra print towel', category: 'Beach' }),
+            mk({ itemText: 'Armbands', category: 'Beach' }),
+        ])
+        expect(groups[0].items.map(i => i.itemText)).toEqual(['Armbands', 'Zebra print towel'])
+    })
+
+    it('places items without order after ordered ones in the same category', () => {
+        const groups = groupByCategory([
+            mk({ itemText: 'Custom addition', category: 'Beach' }),
+            mk({ itemText: 'Towel', category: 'Beach', order: 0 }),
+        ])
+        expect(groups[0].items.map(i => i.itemText)).toEqual(['Towel', 'Custom addition'])
+    })
+
+    it('orders categories by their first item, keeping Essentials first and Other last', () => {
+        const groups = groupByCategory([
+            mk({ itemText: 'Sunscreen', category: 'Essentials', order: 5 }),
+            mk({ itemText: 'Towel', category: 'Beach', order: 2 }),
+            mk({ itemText: 'Boots', category: 'Hiking', order: 0 }),
+            mk({ itemText: 'Mystery', category: undefined, order: 1 }),
+        ])
+        expect(groups.map(g => g.label)).toEqual(['Essentials', 'Hiking', 'Beach', 'Other'])
+    })
+
+    it('keeps legacy category ordering alphabetical when no items carry order', () => {
+        const groups = groupByCategory([
+            mk({ itemText: 'Towel', category: 'Beach' }),
+            mk({ itemText: 'Boots', category: 'Hiking' }),
+            mk({ itemText: 'Sunscreen', category: 'Essentials' }),
+        ])
+        expect(groups.map(g => g.label)).toEqual(['Essentials', 'Beach', 'Hiking'])
+    })
+
+    it('sorts items within a person by order in person view', () => {
+        const groups = groupByPerson([
+            mk({ itemText: 'Zebra print towel', order: 0 }),
+            mk({ itemText: 'Armbands', order: 1 }),
+        ])
+        expect(groups[0].items.map(i => i.itemText)).toEqual(['Zebra print towel', 'Armbands'])
     })
 })

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -39,28 +39,40 @@ interface ListSection {
     isCategory?: boolean
 }
 
-function groupByCategory(items: PackingListItem[]) {
+// Generated items carry an `order` stamped from the question set; sort by it so
+// the list mirrors how the user arranged their questions. Items without one
+// (legacy lists, custom additions) fall back to alphabetical at the end.
+function sortByItemOrder(items: PackingListItem[]): PackingListItem[] {
+    return items.sort((a, b) =>
+        ((a.order ?? Infinity) - (b.order ?? Infinity)) || a.itemText.localeCompare(b.itemText)
+    )
+}
+
+export function groupByCategory(items: PackingListItem[]) {
     const map = new Map<string, PackingListItem[]>()
     for (const item of items) {
         const cat = item.category ?? 'Other'
         if (!map.has(cat)) map.set(cat, [])
         map.get(cat)!.push(item)
     }
+    // Categories follow their earliest item; ties (all-legacy) stay alphabetical
+    const minOrder = (catItems: PackingListItem[]) =>
+        Math.min(...catItems.map(i => i.order ?? Infinity))
     return [...map.entries()]
-        .sort(([a], [b]) => {
+        .sort(([a, aItems], [b, bItems]) => {
             if (a === 'Essentials') return -1
             if (b === 'Essentials') return 1
             if (a === 'Other') return 1
             if (b === 'Other') return -1
-            return a.localeCompare(b)
+            return (minOrder(aItems) - minOrder(bItems)) || a.localeCompare(b)
         })
         .map(([category, catItems]) => ({
             label: category,
-            items: catItems.sort((a, b) => a.itemText.localeCompare(b.itemText)),
+            items: sortByItemOrder(catItems),
         }))
 }
 
-function groupByPerson(items: PackingListItem[]) {
+export function groupByPerson(items: PackingListItem[]) {
     const map = new Map<string, PackingListItem[]>()
     for (const item of items) {
         const person = item.personName || 'Unassigned'
@@ -71,7 +83,7 @@ function groupByPerson(items: PackingListItem[]) {
         .sort(([a], [b]) => a.localeCompare(b))
         .map(([person, personItems]) => ({
             label: person,
-            items: personItems.sort((a, b) => a.itemText.localeCompare(b.itemText)),
+            items: sortByItemOrder(personItems),
         }))
 }
 
@@ -486,6 +498,7 @@ export function ViewPackingList() {
         try {
             setAutoSaveStatus('saving')
 
+            const maxOrder = Math.max(-1, ...packingList.items.map(i => i.order ?? -1))
             const newItem = {
                 id: `item-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
                 itemText: newItemText,
@@ -495,6 +508,7 @@ export function ViewPackingList() {
                 optionId: '',
                 packed: false,
                 ...(communal ? { communal: true } : {}),
+                order: maxOrder + 1,
                 lastModified: new Date().toISOString(),
             }
 

--- a/src/services/rdfSerialization.test.ts
+++ b/src/services/rdfSerialization.test.ts
@@ -478,3 +478,69 @@ describe('questionSet dateOfBirth and ageRanges round-trip', () => {
         expect(result.questions[0].options[0].items[1].ageRanges).toBeUndefined()
     })
 })
+
+describe('item order round-trip', () => {
+    function roundTripQS(qs: PackingListQuestionSet): PackingListQuestionSet {
+        return datasetToQuestionSet(questionSetToDataset(qs, QS_DATASET_URL), QS_DATASET_URL)
+    }
+
+    it('round-trips order on option items and sorts by it on read', () => {
+        const qs = makeQuestionSet({
+            questions: [makeQuestion({
+                options: [makeOption({
+                    items: [
+                        { id: 'i-b', text: 'B item', personSelections: [], order: 1 },
+                        { id: 'i-a', text: 'A item', personSelections: [], order: 0 },
+                    ],
+                })],
+            })],
+        })
+        const result = roundTripQS(qs)
+        const items = result.questions[0].options[0].items
+        expect(items.map(i => i.text)).toEqual(['A item', 'B item'])
+        expect(items.map(i => i.order)).toEqual([0, 1])
+    })
+
+    it('round-trips order on alwaysNeededItems and sorts by it on read', () => {
+        const qs = makeQuestionSet({
+            alwaysNeededItems: [
+                { id: 'i-b', text: 'Torch', personSelections: [], order: 1 },
+                { id: 'i-a', text: 'Map', personSelections: [], order: 0 },
+            ],
+        })
+        const result = roundTripQS(qs)
+        expect(result.alwaysNeededItems.map(i => i.text)).toEqual(['Map', 'Torch'])
+        expect(result.alwaysNeededItems.map(i => i.order)).toEqual([0, 1])
+    })
+
+    it('leaves order undefined for legacy items and keeps array order', () => {
+        const qs = makeQuestionSet({
+            alwaysNeededItems: [
+                { id: 'i-b', text: 'Torch', personSelections: [] },
+                { id: 'i-a', text: 'Map', personSelections: [] },
+            ],
+        })
+        const result = roundTripQS(qs)
+        expect(result.alwaysNeededItems.map(i => i.text)).toEqual(['Torch', 'Map'])
+        expect(result.alwaysNeededItems.every(i => i.order === undefined)).toBe(true)
+    })
+
+    it('round-trips order on packing list items', () => {
+        const list = makePackingList({
+            items: [
+                makeItem({ id: 'item-1', itemText: 'Passport', order: 0 }),
+                makeItem({ id: 'item-2', itemText: 'Sunscreen', order: 1 }),
+            ],
+        })
+        const result = roundTripList(list)
+        const byId = new Map(result.items.map(i => [i.id, i]))
+        expect(byId.get('item-1')?.order).toBe(0)
+        expect(byId.get('item-2')?.order).toBe(1)
+    })
+
+    it('leaves order undefined for legacy packing list items', () => {
+        const list = makePackingList({ items: [makeItem({ id: 'item-1' })] })
+        const result = roundTripList(list)
+        expect(result.items[0].order).toBeUndefined()
+    })
+})

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -114,6 +114,7 @@ function packingListItemToThing(item: PackingListItem, itemUrl: string): Thing {
     if (item.communal !== undefined) t = t.addBoolean(PMU.communal, item.communal)
     if (item.category !== undefined) t = t.addStringNoLocale(PMU.category, item.category)
     if (item.reviewed !== undefined) t = t.addBoolean(PMU.reviewed, item.reviewed)
+    if (item.order !== undefined) t = t.addInteger(PMU.order, item.order)
     if (item.lastModified !== undefined) t = t.addDatetime(PMU.itemLastModified, new Date(item.lastModified))
 
     return t.build()
@@ -133,6 +134,7 @@ function thingToPackingListItem(thing: Thing | null, url: string): PackingListIt
     const communal = getBoolean(thing, PMU.communal)
     const category = getStringNoLocale(thing, PMU.category) ?? undefined
     const reviewed = getBoolean(thing, PMU.reviewed)
+    const order = getInteger(thing, PMU.order)
     const itemLastModified = getDatetime(thing, PMU.itemLastModified)?.toISOString()
 
     return {
@@ -146,6 +148,7 @@ function thingToPackingListItem(thing: Thing | null, url: string): PackingListIt
         ...(communal !== null ? { communal } : {}),
         ...(category !== undefined ? { category } : {}),
         ...(reviewed !== null ? { reviewed } : {}),
+        ...(order !== null ? { order } : {}),
         ...(itemLastModified !== undefined ? { lastModified: itemLastModified } : {}),
     }
 }
@@ -209,9 +212,9 @@ export function datasetToQuestionSet(dataset: SolidDataset, datasetUrl: string):
         const ib = parseInt(b.split('#always-item-')[1] ?? '0')
         return ia - ib
     })
-    const alwaysNeededItems = alwaysItemUrls
+    const alwaysNeededItems = sortItemsByOrder(alwaysItemUrls
         .map(url => thingToQuestionItem(dataset, url))
-        .filter((item): item is Item => item !== null)
+        .filter((item): item is Item => item !== null))
 
     return {
         _id: '1',
@@ -359,11 +362,20 @@ function thingToOption(dataset: SolidDataset, url: string): Option | null {
         const ib = parseInt(b.split('-').pop() ?? '0')
         return ia - ib
     })
-    const items = itemUrls
+    const items = sortItemsByOrder(itemUrls
         .map(itemUrl => thingToQuestionItem(dataset, itemUrl))
-        .filter((item): item is Item => item !== null)
+        .filter((item): item is Item => item !== null))
 
     return { id, text, order, items }
+}
+
+// Explicit order wins where present; items without one keep their URL-index
+// position (legacy data written before items carried an order field).
+function sortItemsByOrder(items: Item[]): Item[] {
+    return items
+        .map((item, index) => ({ item, key: item.order ?? index }))
+        .sort((a, b) => a.key - b.key)
+        .map(({ item }) => item)
 }
 
 function questionItemToThings(
@@ -377,6 +389,7 @@ function questionItemToThings(
         .addStringNoLocale(PMU.text, item.text)
 
     if (item.id) itemBuilder = itemBuilder.addStringNoLocale(PMU.questionItemId, item.id)
+    if (item.order !== undefined) itemBuilder = itemBuilder.addInteger(PMU.order, item.order)
     if (item.communal !== undefined) itemBuilder = itemBuilder.addBoolean(PMU.communal, item.communal)
     for (const ageRange of item.ageRanges ?? []) {
         itemBuilder = itemBuilder.addStringNoLocale(PMU.hasAgeRange, ageRange)
@@ -544,6 +557,7 @@ function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
     const text = getStringNoLocale(thing, PMU.text) ?? ''
     const id = getStringNoLocale(thing, PMU.questionItemId) ?? undefined
     const communal = getBoolean(thing, PMU.communal)
+    const order = getInteger(thing, PMU.order)
     const lastModified = getDatetime(thing, PMU.questionItemLastModified)?.toISOString()
     const deletedAt = getDatetime(thing, PMU.questionItemDeletedAt)?.toISOString()
 
@@ -574,6 +588,7 @@ function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
         ...(id !== undefined ? { id } : {}),
         ...(communal !== null ? { communal } : {}),
         ...(ageRanges.length > 0 ? { ageRanges } : {}),
+        ...(order !== null ? { order } : {}),
         ...(lastModified !== undefined ? { lastModified } : {}),
         ...(deletedAt !== undefined ? { deletedAt } : {}),
     }

--- a/src/utils/mergeQuestionSets.test.ts
+++ b/src/utils/mergeQuestionSets.test.ts
@@ -307,3 +307,47 @@ describe('edge cases', () => {
     expect(ids).toContain('q2')
   })
 })
+
+// ── Ordering ──────────────────────────────────────────────────────────────────
+
+describe('ordering flows through merge', () => {
+  it('sorts merged questions by order so a reorder on one side wins', () => {
+    const q1 = makeQuestion({ id: 'q1', text: 'Q1', order: 0, lastModified: '2024-01-01T10:00:00.000Z' })
+    const q2 = makeQuestion({ id: 'q2', text: 'Q2', order: 1, lastModified: '2024-01-01T10:00:00.000Z' })
+    // Pod reordered: q2 now first
+    const podQ2 = { ...q2, order: 0, lastModified: '2024-01-01T12:00:00.000Z' }
+    const podQ1 = { ...q1, order: 1, lastModified: '2024-01-01T12:00:00.000Z' }
+
+    const local = makeQS({ questions: [q1, q2], lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ questions: [podQ2, podQ1], lastModified: '2024-01-01T12:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    expect(result.questions.map(q => q.id)).toEqual(['q2', 'q1'])
+  })
+
+  it('sorts merged alwaysNeededItems by order so a reorder on the pod side wins', () => {
+    const a = makeItem({ id: 'a', text: 'Torch', order: 0, lastModified: '2024-01-01T10:00:00.000Z' })
+    const b = makeItem({ id: 'b', text: 'Map', order: 1, lastModified: '2024-01-01T10:00:00.000Z' })
+    // Pod reordered: b now first
+    const podB = { ...b, order: 0, lastModified: '2024-01-01T12:00:00.000Z' }
+    const podA = { ...a, order: 1, lastModified: '2024-01-01T12:00:00.000Z' }
+
+    const local = makeQS({ alwaysNeededItems: [a, b], lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ alwaysNeededItems: [podB, podA], lastModified: '2024-01-01T12:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    expect(result.alwaysNeededItems.map(i => i.id)).toEqual(['b', 'a'])
+  })
+
+  it('keeps items without order after ordered ones, preserving legacy relative order', () => {
+    const a = makeItem({ id: 'a', text: 'Torch', lastModified: '2024-01-01T10:00:00.000Z' })
+    const b = makeItem({ id: 'b', text: 'Map', order: 0, lastModified: '2024-01-01T10:00:00.000Z' })
+    const c = makeItem({ id: 'c', text: 'Compass', lastModified: '2024-01-01T10:00:00.000Z' })
+
+    const local = makeQS({ alwaysNeededItems: [a, b, c], lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ alwaysNeededItems: [a, b, c], lastModified: '2024-01-01T10:00:00.000Z' })
+
+    const result = mergeQuestionSets(local, pod)
+    expect(result.alwaysNeededItems.map(i => i.id)).toEqual(['b', 'a', 'c'])
+  })
+})

--- a/src/utils/mergeQuestionSets.ts
+++ b/src/utils/mergeQuestionSets.ts
@@ -76,7 +76,9 @@ function mergeItemsById(
       result.push((localItem ?? podItem)!)
     }
   }
-  return result
+  // Ordered items first by their order; legacy items (no order) keep their
+  // relative position at the end. Sort is stable so ties preserve insertion.
+  return result.sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity))
 }
 
 export function mergeQuestionSets(
@@ -113,6 +115,9 @@ export function mergeQuestionSets(
       questions.push((localQ ?? podQ)!)
     }
   }
+  // A reorder bumps the moved questions' order + lastModified, so per-question
+  // LWW carries the new positions — sorting here makes them take effect.
+  questions.sort((a, b) => a.order - b.order)
 
   // ── People ─────────────────────────────────────────────────────────────────
   const localPMap = new Map(local.people.map(p => [p.id, p]))


### PR DESCRIPTION
Items in the question set can now be reordered with move up/down buttons
in the option and always-needed item editors, and generated packing
lists preserve that order instead of sorting alphabetically.

- Add optional `order` to question-set items (additive: legacy data
  keeps its array order), serialized to RDF and honoured on read.
- Renumber item order + stamp lastModified on save so reorders win
  per-item LWW during sync merges; sort merged items and questions by
  order so a reorder on either device flows through.
- Fix question move buttons to renumber `order` too — previously a
  question reorder was lost on pod round-trip since deserialization
  sorts by order.
- Walk the question set in its own order (questions → options → items)
  during generation and stamp a sequential `order` onto generated
  packing list items.
- Sort view-list items by that order (alphabetical fallback for legacy
  lists) and order categories by their earliest item, keeping
  Essentials first and Other last. Custom items append at the end.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QWifzCrYsz1DNKATZTf3L2