### PR TITLE
Add plan for distributing wizard template updates to existing users

### DIFF
--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -137,4 +137,17 @@ test.describe('B – Editing Questions', () => {
     // No JSON toggle button should be present
     await expect(page.getByRole('button', { name: /^json$|edit.*json/i })).not.toBeVisible()
   })
+
+  test('B6: a freshly set-up user is not shown the template-updates prompt', async ({ freshPage: page }) => {
+    // The wizard stamps the current template version, so a brand-new set is
+    // already up to date and must not nag the user with "new suggestions".
+    await setupWizardAndGoToQuestions(page)
+    await expect(page.getByRole('heading', { name: 'My Questions & Items' })).toBeVisible()
+    await expect(page.getByText(/new suggestion/i)).not.toBeVisible()
+    // Reloading (re-reading the persisted set) must not surface it either.
+    await page.waitForTimeout(500)
+    await page.reload()
+    await expect(page.getByRole('heading', { name: 'My Questions & Items' })).toBeVisible()
+    await expect(page.getByText(/new suggestion/i)).not.toBeVisible()
+  })
 })

--- a/plans/wizard-updates-distribution.md
+++ b/plans/wizard-updates-distribution.md
@@ -1,0 +1,163 @@
+# Plan: Distributing wizard template updates to existing users
+
+## Problem
+
+The setup wizard takes a one-time snapshot of the built-in template
+(`createExampleData` in `src/edit-questions/example-data.ts`) and saves it as
+the user's own editable question set. Improvements shipped to the template
+never reach existing users — their only path today is re-running the wizard,
+which **replaces** their whole question set and destroys their customisations.
+
+## Goal
+
+A simple, obvious, non-destructive way for users to pull in new template
+content ("we've added new suggested items/questions since you set up"), while
+their own edits remain untouched and authoritative.
+
+## Approach (agreed)
+
+Reuse the age-promotion pattern (`src/edit-questions/age-promotion.ts` +
+`src/components/AgePromotionCard.tsx`): regenerate the template with the
+user's current people, diff it against their saved set, and surface purely
+**additive** suggestions in a review card at the top of *My Questions & Items*
+with per-item checkboxes, **Add selected** and **Dismiss**. A template version
+stamp on the question set makes detection cheap and makes the card disappear
+once handled.
+
+Non-goals:
+
+- No automatic/silent application of updates — everything is opt-in.
+- No propagation of template deletions or renames — the user owns their copy.
+- No change to the wizard's existing destructive "start from scratch" re-run.
+
+## Design
+
+### 1. Template version stamp
+
+- New constant `WIZARD_TEMPLATE_VERSION` (start at `1`) exported from
+  `src/edit-questions/example-data.ts`, with a header comment: *bump this
+  whenever the template content changes in a way users should be offered*.
+- `PackingListQuestionSetSchema` (`src/edit-questions/types.ts`) gains
+  `templateVersion: z.number().optional()`. Absent ⇒ treated as `0`
+  (pre-versioning sets), so all existing users are offered the first update.
+- The wizard (`useWizardGeneration.ts`) stamps freshly generated sets with the
+  current version.
+- Applying **or dismissing** suggestions stamps the set to the current version
+  via the normal save path, so the decision syncs across devices through the
+  pod (unlike age-promotion's per-device localStorage dismissal — a deliberate
+  difference: template updates are about the shared data, not this device).
+
+### 2. Stable template IDs (matching aid, forward-looking)
+
+`ACTIVITY_OPTION_IDS` already gives activity options stable IDs. Extend the
+same idea to template questions: a `TEMPLATE_QUESTION_IDS` map
+(`template-question-overnight`, `template-question-abroad`, …) used by
+`createExampleData` instead of `generateUUID()` for the five built-in
+questions. Newly generated sets then match template questions exactly by ID;
+legacy sets fall back to normalized-text matching (below).
+
+### 3. Diff engine — new module `src/edit-questions/template-updates.ts`
+
+```ts
+buildTemplateUpdateSuggestions(qs: PackingListQuestionSet): TemplateUpdateSuggestion[]
+applyTemplateUpdates(qs, accepted: TemplateUpdateSuggestion[]): PackingListQuestionSet
+```
+
+- Regenerate the reference template with `createExampleData(qs.people, [])`
+  (all activities included) so item `personSelections` and age filtering are
+  already aligned to the user's current group.
+- Matching, additive-only:
+  - **Questions**: by stable ID first, then normalized text (trim/lowercase —
+    reuse/extract `normalize` from `age-promotion.ts`). Questions the user
+    deleted (`deletedAt`) are treated as matched so they are never resurrected.
+  - **Options**: within a matched question, by stable ID
+    (`activity-option-*`) then normalized text.
+  - **Items**: within a matched option (or `alwaysNeededItems`), by
+    normalized text. Extract the `collectLocations` helper from
+    `age-promotion.ts` into a shared module rather than duplicating it.
+- Suggestion kinds (each carries a `contextLabel` for display, mirroring
+  `PromotionSuggestion`):
+  - `addItem` — template item missing from a matched location. Skip items
+    whose `personSelections` select nobody in the user's group (the `items()`
+    filter in the template already does this).
+  - `addOption` — whole new option under a matched question (e.g. a new
+    activity), inserted with its items.
+  - `addQuestion` — whole new template question, inserted with fresh UUIDs
+    for question/option IDs (except stable template IDs) and `order` appended
+    after the user's existing questions.
+- `applyTemplateUpdates` returns a new set containing only the accepted
+  additions plus `templateVersion: WIZARD_TEMPLATE_VERSION`. Saving goes
+  through the page's existing `saveData` → `saveWithSyncPrevention`, per the
+  data-access rules in CLAUDE.md.
+
+### 4. UI — new `src/components/TemplateUpdatesCard.tsx`
+
+Modeled closely on `AgePromotionCard`:
+
+- Rendered on `questions-page.tsx` next to `AgePromotionCard`, only when
+  `!isForeign`, `(data.templateVersion ?? 0) < WIZARD_TEMPLATE_VERSION`, and
+  there is at least one suggestion. (If the version is behind but the diff is
+  empty — user already has everything — render nothing; the diff is cheap and
+  the card simply never appears. The stamp catches up on their next
+  apply/dismiss or wizard run.)
+- Collapsed: one-line banner, e.g. *"✨ We've improved the starter suggestions
+  since you set up — N new suggestions available"* with **Review** and a
+  dismiss ×.
+- Expanded: checklist grouped by location (`contextLabel`), everything
+  checked by default; **Add selected** applies and stamps; **Not now**
+  collapses; **×** dismisses (stamps the version without adding anything,
+  saved through the same path).
+
+### 5. RDF serialization (`src/services/rdfSerialization.ts` + `rdfVocab.ts`)
+
+- New vocab term `PMU.templateVersion`; serialize as an integer on the
+  question-set root thing when present; deserialize to `templateVersion`,
+  omitted when absent.
+- Backward compatibility: old datasets without the term must round-trip
+  unchanged (covered by the existing schema-compat approach, suite K).
+
+## Edge cases & accepted trade-offs
+
+- **User deleted a template item, then a version bump re-suggests it**: it
+  appears once as a pre-checked box; unticking it or dismissing stamps the
+  version so it won't recur for that release. Accepted — no per-item
+  tombstone list in v1.
+- **User renamed a legacy template question** (no stable ID): text matching
+  fails and the whole question could be re-suggested. Mitigation: before
+  offering an `addQuestion`, require that the majority of its items are absent
+  from the user's entire set; otherwise treat the question as matched and
+  offer nothing. This keeps a renamed "Will you be staying overnight?" from
+  coming back while still allowing genuinely new questions through.
+- **Multi-device**: because the stamp lives in the synced data, a decision on
+  one device clears the card everywhere after sync.
+
+## Implementation steps (TDD, red-green-refactor)
+
+1. **Schema + constant**: failing unit tests for `templateVersion` on
+   `PackingListQuestionSetSchema` and for the wizard stamping it
+   (`useWizardGeneration.test.ts`); then implement. Add
+   `TEMPLATE_QUESTION_IDS` and switch `createExampleData` to use them
+   (update `example-data.test.ts` expectations).
+2. **RDF round-trip**: failing tests in `rdfSerialization.test.ts` for
+   serialize/deserialize of `templateVersion` and for absence on legacy data;
+   implement vocab term + mapping.
+3. **Shared helpers**: extract `normalize` / `collectLocations` from
+   `age-promotion.ts` into a shared module; keep age-promotion tests green.
+4. **Diff engine**: `template-updates.test.ts` first — cases: item added to
+   existing option; item user already has (no suggestion); item user deleted
+   (re-suggested once); new activity option; new question; renamed legacy
+   question (majority-items rule suppresses re-suggestion); `deletedAt`
+   question not resurrected; pet/age filtering respected; apply stamps
+   version and inserts with aligned `personSelections`. Then implement.
+5. **Card component**: `TemplateUpdatesCard.test.tsx` — hidden when
+   up-to-date or no suggestions; shows count; untick excludes; apply calls
+   `onApply` with additions + stamp; dismiss calls `onApply` with stamp only.
+   Then implement, wire into `questions-page.tsx`.
+6. **E2E**: extend `e2e/tests/b-questions.spec.ts` (local-only, no pod user
+   needed) with one happy path: seed a set with `templateVersion: 0` via the
+   app's own storage, see the card, add selected items, card disappears,
+   items present. If pod-sync coverage of the stamp is wanted later, that
+   needs a new serial suite with its own dedicated pod user per CLAUDE.md.
+7. **Docs**: header comment in `example-data.ts` describing the bump policy;
+   bump `WIZARD_TEMPLATE_VERSION` for the first time only when the next real
+   template change ships.

--- a/src/components/TemplateUpdatesCard.test.tsx
+++ b/src/components/TemplateUpdatesCard.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { TemplateUpdatesCard } from './TemplateUpdatesCard'
+import { createExampleData, WIZARD_TEMPLATE_VERSION, TEMPLATE_QUESTION_IDS } from '../edit-questions/example-data'
+import { PackingListQuestionSet, Person } from '../edit-questions/types'
+
+const adult: Person = { id: 'a1', name: 'Alice', ageRange: 'Adult', gender: 'female' }
+
+function set(templateVersion: number | undefined, mutate?: (s: PackingListQuestionSet) => void): PackingListQuestionSet {
+    const s = JSON.parse(JSON.stringify(createExampleData([adult], []))) as PackingListQuestionSet
+    s._id = '1'
+    if (templateVersion !== undefined) s.templateVersion = templateVersion
+    mutate?.(s)
+    return s
+}
+
+function removeSunscreen(s: PackingListQuestionSet) {
+    const hot = s.questions.find(q => q.id === TEMPLATE_QUESTION_IDS.weather)!.options.find(o => o.text === 'Hot')!
+    hot.items = hot.items.filter(i => i.text !== 'Sunscreen')
+}
+
+describe('TemplateUpdatesCard', () => {
+    it('renders nothing when the set is already at the current version', () => {
+        const { container } = render(
+            <TemplateUpdatesCard questionSet={set(WIZARD_TEMPLATE_VERSION, removeSunscreen)} onApply={vi.fn()} />
+        )
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('renders nothing when there are no new suggestions', () => {
+        const { container } = render(
+            <TemplateUpdatesCard questionSet={set(0)} onApply={vi.fn()} />
+        )
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('shows how many new suggestions are available', () => {
+        render(<TemplateUpdatesCard questionSet={set(0, removeSunscreen)} onApply={vi.fn()} />)
+        expect(screen.getByText(/1 new suggestion/i)).toBeTruthy()
+    })
+
+    it('applies checked suggestions and stamps the version', async () => {
+        const onApply = vi.fn()
+        render(<TemplateUpdatesCard questionSet={set(0, removeSunscreen)} onApply={onApply} />)
+
+        fireEvent.click(screen.getByText(/Review/i))
+        expect(screen.getByText('Sunscreen')).toBeTruthy()
+        fireEvent.click(screen.getByText(/Add selected/i))
+
+        await waitFor(() => expect(onApply).toHaveBeenCalledTimes(1))
+        const updated: PackingListQuestionSet = onApply.mock.calls[0][0]
+        expect(updated.templateVersion).toBe(WIZARD_TEMPLATE_VERSION)
+        const hot = updated.questions.find(q => q.id === TEMPLATE_QUESTION_IDS.weather)!.options.find(o => o.text === 'Hot')!
+        expect(hot.items.some(i => i.text === 'Sunscreen')).toBe(true)
+    })
+
+    it('excludes unticked suggestions but still stamps the version', async () => {
+        const onApply = vi.fn()
+        render(<TemplateUpdatesCard questionSet={set(0, removeSunscreen)} onApply={onApply} />)
+
+        fireEvent.click(screen.getByText(/Review/i))
+        const checkbox = screen.getByText('Sunscreen').closest('label')!.querySelector('input')!
+        fireEvent.click(checkbox) // untick
+        fireEvent.click(screen.getByText(/Add selected/i))
+
+        await waitFor(() => expect(onApply).toHaveBeenCalledTimes(1))
+        const updated: PackingListQuestionSet = onApply.mock.calls[0][0]
+        expect(updated.templateVersion).toBe(WIZARD_TEMPLATE_VERSION)
+        const hot = updated.questions.find(q => q.id === TEMPLATE_QUESTION_IDS.weather)!.options.find(o => o.text === 'Hot')!
+        expect(hot.items.some(i => i.text === 'Sunscreen')).toBe(false)
+    })
+
+    it('dismissing stamps the version without adding anything', async () => {
+        const base = set(0, removeSunscreen)
+        const onApply = vi.fn()
+        render(<TemplateUpdatesCard questionSet={base} onApply={onApply} />)
+
+        fireEvent.click(screen.getByLabelText(/Dismiss/i))
+        await waitFor(() => expect(onApply).toHaveBeenCalledTimes(1))
+        const updated: PackingListQuestionSet = onApply.mock.calls[0][0]
+        expect(updated.templateVersion).toBe(WIZARD_TEMPLATE_VERSION)
+        const hot = updated.questions.find(q => q.id === TEMPLATE_QUESTION_IDS.weather)!.options.find(o => o.text === 'Hot')!
+        expect(hot.items.some(i => i.text === 'Sunscreen')).toBe(false)
+    })
+})

--- a/src/components/TemplateUpdatesCard.tsx
+++ b/src/components/TemplateUpdatesCard.tsx
@@ -1,0 +1,153 @@
+import { useMemo, useState } from 'react'
+import { PackingListQuestionSet } from '../edit-questions/types'
+import { WIZARD_TEMPLATE_VERSION } from '../edit-questions/example-data'
+import {
+    buildTemplateUpdateSuggestions,
+    applyTemplateUpdates,
+    TemplateUpdateSuggestion,
+} from '../edit-questions/template-updates'
+
+interface TemplateUpdatesCardProps {
+    questionSet: PackingListQuestionSet
+    onApply: (updated: PackingListQuestionSet) => Promise<void> | void
+}
+
+const KIND_HINT: Record<TemplateUpdateSuggestion['kind'], string | null> = {
+    addItem: null,
+    addOption: 'new option',
+    addQuestion: 'new question',
+}
+
+/**
+ * Non-destructive prompt shown on My Questions & Items when the wizard template
+ * has gained content since the user set up. Lists the additive suggestions
+ * (new items, options, questions) grouped by where they'd land, all ticked by
+ * default. Adding or dismissing stamps the set to the current template version
+ * so the card stays hidden until the next real template change — the stamp
+ * lives in the synced data, so the decision carries across devices.
+ */
+export function TemplateUpdatesCard({ questionSet, onApply }: TemplateUpdatesCardProps) {
+    const [isExpanded, setIsExpanded] = useState(false)
+    const [isApplying, setIsApplying] = useState(false)
+    const [unchecked, setUnchecked] = useState<Set<string>>(new Set())
+
+    const isBehind = (questionSet.templateVersion ?? 0) < WIZARD_TEMPLATE_VERSION
+    const suggestions = useMemo(
+        () => (isBehind ? buildTemplateUpdateSuggestions(questionSet) : []),
+        [questionSet, isBehind],
+    )
+
+    if (!isBehind || suggestions.length === 0) return null
+
+    // Preserve first-seen order of locations for stable grouping.
+    const groups: { label: string; items: TemplateUpdateSuggestion[] }[] = []
+    for (const s of suggestions) {
+        let group = groups.find(g => g.label === s.contextLabel)
+        if (!group) {
+            group = { label: s.contextLabel, items: [] }
+            groups.push(group)
+        }
+        group.items.push(s)
+    }
+
+    const toggleChecked = (key: string) => {
+        setUnchecked(prev => {
+            const next = new Set(prev)
+            if (next.has(key)) next.delete(key)
+            else next.add(key)
+            return next
+        })
+    }
+
+    const applyAccepted = async (accepted: TemplateUpdateSuggestion[]) => {
+        setIsApplying(true)
+        try {
+            await onApply(applyTemplateUpdates(questionSet, accepted))
+            setIsExpanded(false)
+        } finally {
+            setIsApplying(false)
+        }
+    }
+
+    const handleAddSelected = () => applyAccepted(suggestions.filter(s => !unchecked.has(s.key)))
+    // Dismiss records the decision by stamping the version with no additions.
+    const handleDismiss = () => applyAccepted([])
+
+    const count = suggestions.length
+
+    return (
+        <div className="bg-emerald-50 rounded-lg border border-emerald-200 p-4">
+            <div className="flex items-start justify-between gap-4">
+                <p className="text-emerald-900 font-medium">
+                    ✨ We've added to the starter suggestions since you set up — {count} new suggestion{count === 1 ? '' : 's'} available.
+                </p>
+                <button
+                    type="button"
+                    aria-label="Dismiss suggestions"
+                    title="No thanks — don't show these again"
+                    disabled={isApplying}
+                    onClick={handleDismiss}
+                    className="text-emerald-600 hover:text-emerald-900 text-xl leading-none flex-shrink-0 disabled:opacity-50"
+                >
+                    ×
+                </button>
+            </div>
+
+            {!isExpanded ? (
+                <button
+                    type="button"
+                    onClick={() => setIsExpanded(true)}
+                    className="mt-2 text-sm text-emerald-700 underline"
+                >
+                    Review suggestions
+                </button>
+            ) : (
+                <div className="mt-4 space-y-4">
+                    {groups.map(group => (
+                        <div key={group.label}>
+                            <p className="text-xs uppercase tracking-wide text-emerald-600 font-semibold mb-1">{group.label}</p>
+                            <div className="space-y-1.5">
+                                {group.items.map(s => (
+                                    <label
+                                        key={s.key}
+                                        className="flex items-start gap-2 text-sm text-gray-700 bg-white rounded border border-emerald-200 px-3 py-2"
+                                    >
+                                        <input
+                                            type="checkbox"
+                                            checked={!unchecked.has(s.key)}
+                                            onChange={() => toggleChecked(s.key)}
+                                            className="mt-0.5 h-4 w-4 text-emerald-600 rounded focus:ring-2 focus:ring-emerald-500"
+                                        />
+                                        <span>
+                                            <span className="font-medium text-gray-900">{s.label}</span>
+                                            {KIND_HINT[s.kind] && (
+                                                <span className="ml-2 text-xs text-emerald-600">{KIND_HINT[s.kind]}</span>
+                                            )}
+                                        </span>
+                                    </label>
+                                ))}
+                            </div>
+                        </div>
+                    ))}
+                    <div className="flex gap-2 justify-end">
+                        <button
+                            type="button"
+                            onClick={() => setIsExpanded(false)}
+                            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-emerald-100"
+                        >
+                            Not now
+                        </button>
+                        <button
+                            type="button"
+                            disabled={isApplying}
+                            onClick={handleAddSelected}
+                            className="px-4 py-2 text-sm bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50"
+                        >
+                            {isApplying ? 'Adding…' : 'Add selected'}
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/edit-questions/age-promotion.ts
+++ b/src/edit-questions/age-promotion.ts
@@ -2,10 +2,9 @@ import { PackingListQuestionSet, Person, Item, Question, Option } from './types'
 import { AgeTransition } from './age-derivation'
 import { createExampleData } from './example-data'
 import { generateUUID } from '../utils/uuid'
+import { ItemLocation, LocatedItems, locationKey, normalize, collectLocations } from './item-locations'
 
-export type ItemLocation =
-    | { kind: 'always' }
-    | { kind: 'option'; questionId: string; optionId: string }
+export type { ItemLocation }
 
 export interface PromotionSuggestion {
     /** Stable key for UI checkbox state */
@@ -21,37 +20,6 @@ export interface PromotionSuggestion {
     itemIndex?: number
     /** For addItem: the ready-to-insert catalog item (selections aligned to active people) */
     newItem?: Item
-}
-
-function locationKey(location: ItemLocation): string {
-    return location.kind === 'always' ? 'always' : `option:${location.questionId}:${location.optionId}`
-}
-
-function normalize(text: string): string {
-    return text.trim().toLowerCase()
-}
-
-interface LocatedItems {
-    location: ItemLocation
-    contextLabel: string
-    items: Item[]
-}
-
-function collectLocations(qs: PackingListQuestionSet): LocatedItems[] {
-    const locations: LocatedItems[] = [
-        { location: { kind: 'always' }, contextLabel: 'Always needed', items: qs.alwaysNeededItems ?? [] },
-    ]
-    for (const question of qs.questions) {
-        if (question.deletedAt) continue
-        for (const option of question.options) {
-            locations.push({
-                location: { kind: 'option', questionId: question.id, optionId: option.id },
-                contextLabel: `${question.text} — ${option.text}`,
-                items: option.items,
-            })
-        }
-    }
-    return locations
 }
 
 function toggleSuggestions(qs: PackingListQuestionSet, transitions: AgeTransition[]): PromotionSuggestion[] {

--- a/src/edit-questions/example-data.test.ts
+++ b/src/edit-questions/example-data.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { createExampleData, ACTIVITY_OPTION_IDS } from './example-data'
+import { createExampleData, ACTIVITY_OPTION_IDS, TEMPLATE_QUESTION_IDS, WIZARD_TEMPLATE_VERSION } from './example-data'
 import { Person } from './types'
 
 const people: Person[] = [{ id: 'person-1', name: 'Alice', ageRange: 'Adult' }]
@@ -21,7 +21,34 @@ describe('ACTIVITY_OPTION_IDS', () => {
     })
 })
 
+describe('TEMPLATE_QUESTION_IDS', () => {
+    it('exports stable non-UUID string IDs for each built-in question', () => {
+        expect(TEMPLATE_QUESTION_IDS.overnight).toBe('template-question-overnight')
+        expect(TEMPLATE_QUESTION_IDS.abroad).toBe('template-question-abroad')
+        expect(TEMPLATE_QUESTION_IDS.selfCatering).toBe('template-question-self-catering')
+        expect(TEMPLATE_QUESTION_IDS.activities).toBe('template-question-activities')
+        expect(TEMPLATE_QUESTION_IDS.weather).toBe('template-question-weather')
+    })
+})
+
+describe('WIZARD_TEMPLATE_VERSION', () => {
+    it('is a positive integer', () => {
+        expect(Number.isInteger(WIZARD_TEMPLATE_VERSION)).toBe(true)
+        expect(WIZARD_TEMPLATE_VERSION).toBeGreaterThan(0)
+    })
+})
+
 describe('createExampleData', () => {
+    it('uses stable IDs for the built-in questions', () => {
+        const result = createExampleData(people)
+        const ids = result.questions.map(q => q.id)
+        expect(ids).toContain(TEMPLATE_QUESTION_IDS.overnight)
+        expect(ids).toContain(TEMPLATE_QUESTION_IDS.abroad)
+        expect(ids).toContain(TEMPLATE_QUESTION_IDS.selfCatering)
+        expect(ids).toContain(TEMPLATE_QUESTION_IDS.activities)
+        expect(ids).toContain(TEMPLATE_QUESTION_IDS.weather)
+    })
+
     it('uses stable IDs for activity question options', () => {
         const result = createExampleData(people)
         const activitiesQuestion = result.questions.find(q => q.text === 'What activities will you be doing?')!

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -11,6 +11,25 @@ export const ACTIVITY_OPTION_IDS = {
     formalOccasions: 'activity-option-formal-occasions',
     religiousSites: 'activity-option-religious-sites',
 } as const
+
+// Stable IDs for the built-in wizard questions. Using fixed IDs (rather than
+// fresh UUIDs) lets template-update detection match a user's saved question
+// back to its template origin exactly, even after the question text is edited.
+export const TEMPLATE_QUESTION_IDS = {
+    overnight: 'template-question-overnight',
+    abroad: 'template-question-abroad',
+    selfCatering: 'template-question-self-catering',
+    activities: 'template-question-activities',
+    weather: 'template-question-weather',
+} as const
+
+// Version of the wizard template content. Bump this whenever `createExampleData`
+// changes in a way existing users should be offered (new items, options, or
+// questions). A saved question set stamped with an older version triggers the
+// "new suggestions" review card on My Questions & Items; the stamp is updated
+// once the user reviews (applies or dismisses) the suggestions. Purely
+// additive detection — bumping never removes or rewrites a user's own edits.
+export const WIZARD_TEMPLATE_VERSION = 1
 import {
     getBabies,
     getToddlers,
@@ -77,7 +96,7 @@ function items(...args: Item[]): Item[] {
 export function createExampleData(people: Person[], selectedActivityIds: string[] = []): PackingListQuestionSet {
     const validActivityIds = Object.values(ACTIVITY_OPTION_IDS) as string[]
     const validSelectedIds = selectedActivityIds.filter(id => validActivityIds.includes(id))
-    const activitiesQuestionId = generateUUID()
+    const activitiesQuestionId = TEMPLATE_QUESTION_IDS.activities
 
     const allActivityOptions = [
         {
@@ -240,7 +259,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
         ),
         questions: [
             {
-                id: generateUUID(),
+                id: TEMPLATE_QUESTION_IDS.overnight,
                 type: "saved",
                 text: "Will you be staying overnight?",
                 order: 0,
@@ -287,7 +306,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                 ]
             },
             {
-                id: generateUUID(),
+                id: TEMPLATE_QUESTION_IDS.abroad,
                 type: "saved",
                 text: "Are you travelling abroad?",
                 order: 1,
@@ -317,7 +336,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                 ]
             },
             {
-                id: generateUUID(),
+                id: TEMPLATE_QUESTION_IDS.selfCatering,
                 type: "saved",
                 text: "Are you self-catering?",
                 order: 2,
@@ -351,7 +370,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                 options: activityOptions
             },
             {
-                id: generateUUID(),
+                id: TEMPLATE_QUESTION_IDS.weather,
                 type: "saved",
                 text: "What weather do you expect?",
                 order: 4,

--- a/src/edit-questions/item-locations.ts
+++ b/src/edit-questions/item-locations.ts
@@ -1,0 +1,49 @@
+import { PackingListQuestionSet, Item } from './types'
+
+/**
+ * Where an item lives inside a question set: either the always-needed list, or
+ * a specific option under a specific question. Shared by the age-promotion and
+ * template-update diff engines so both address items the same way.
+ */
+export type ItemLocation =
+    | { kind: 'always' }
+    | { kind: 'option'; questionId: string; optionId: string }
+
+export interface LocatedItems {
+    location: ItemLocation
+    /** Human-readable label for display, e.g. "Always needed" or "Hiking — Walking poles" */
+    contextLabel: string
+    items: Item[]
+}
+
+/** Stable string key for a location, used to group/dedupe suggestions. */
+export function locationKey(location: ItemLocation): string {
+    return location.kind === 'always' ? 'always' : `option:${location.questionId}:${location.optionId}`
+}
+
+/** Compare item/question/option text ignoring surrounding whitespace and case. */
+export function normalize(text: string): string {
+    return text.trim().toLowerCase()
+}
+
+/**
+ * Flatten a question set into its item-bearing locations (always-needed list
+ * plus every option of every non-deleted question), each tagged with a
+ * display label.
+ */
+export function collectLocations(qs: PackingListQuestionSet): LocatedItems[] {
+    const locations: LocatedItems[] = [
+        { location: { kind: 'always' }, contextLabel: 'Always needed', items: qs.alwaysNeededItems ?? [] },
+    ]
+    for (const question of qs.questions) {
+        if (question.deletedAt) continue
+        for (const option of question.options) {
+            locations.push({
+                location: { kind: 'option', questionId: question.id, optionId: option.id },
+                contextLabel: `${question.text} — ${option.text}`,
+                items: option.items,
+            })
+        }
+    }
+    return locations
+}

--- a/src/edit-questions/template-updates.test.ts
+++ b/src/edit-questions/template-updates.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest'
+import { createExampleData, WIZARD_TEMPLATE_VERSION, TEMPLATE_QUESTION_IDS, ACTIVITY_OPTION_IDS } from './example-data'
+import { buildTemplateUpdateSuggestions, applyTemplateUpdates } from './template-updates'
+import { PackingListQuestionSet, Person } from './types'
+
+const adult: Person = { id: 'a1', name: 'Alice', ageRange: 'Adult', gender: 'female' }
+
+// A saved set identical to the current template but stamped as an older
+// version, so it represents a user who set up before the latest updates.
+function baseSet(people: Person[] = [adult]): PackingListQuestionSet {
+    const generated = JSON.parse(JSON.stringify(createExampleData(people, []))) as PackingListQuestionSet
+    return { ...generated, _id: '1', templateVersion: 0 }
+}
+
+function findQuestion(set: PackingListQuestionSet, id: string) {
+    return set.questions.find(q => q.id === id)!
+}
+
+describe('buildTemplateUpdateSuggestions', () => {
+    it('returns nothing when the set already matches the template', () => {
+        expect(buildTemplateUpdateSuggestions(baseSet())).toEqual([])
+    })
+
+    it('suggests an item missing from an existing option', () => {
+        const set = baseSet()
+        const hot = findQuestion(set, TEMPLATE_QUESTION_IDS.weather).options.find(o => o.text === 'Hot')!
+        hot.items = hot.items.filter(i => i.text !== 'Sunscreen')
+
+        const suggestions = buildTemplateUpdateSuggestions(set)
+        expect(suggestions).toHaveLength(1)
+        expect(suggestions[0].kind).toBe('addItem')
+        expect(suggestions[0].label).toBe('Sunscreen')
+        expect(suggestions[0]).toMatchObject({
+            location: { kind: 'option', questionId: TEMPLATE_QUESTION_IDS.weather, optionId: hot.id },
+        })
+    })
+
+    it('suggests a missing always-needed item', () => {
+        const set = baseSet()
+        set.alwaysNeededItems = set.alwaysNeededItems.filter(i => i.text !== 'Snacks')
+
+        const suggestions = buildTemplateUpdateSuggestions(set)
+        expect(suggestions.map(s => s.label)).toContain('Snacks')
+        const snacks = suggestions.find(s => s.label === 'Snacks')!
+        expect(snacks).toMatchObject({ kind: 'addItem', location: { kind: 'always' } })
+    })
+
+    it('matches a question by text when its id differs (legacy set)', () => {
+        const set = baseSet()
+        const weather = findQuestion(set, TEMPLATE_QUESTION_IDS.weather)
+        weather.id = 'legacy-weather-uuid'
+        const hot = weather.options.find(o => o.text === 'Hot')!
+        hot.items = hot.items.filter(i => i.text !== 'Sunscreen')
+
+        const suggestions = buildTemplateUpdateSuggestions(set)
+        expect(suggestions.map(s => s.label)).toEqual(['Sunscreen'])
+        expect(suggestions[0]).toMatchObject({
+            location: { kind: 'option', questionId: 'legacy-weather-uuid', optionId: hot.id },
+        })
+    })
+
+    it('does not resurrect items from a question the user deleted', () => {
+        const set = baseSet()
+        findQuestion(set, TEMPLATE_QUESTION_IDS.selfCatering).deletedAt = '2026-01-01T00:00:00.000Z'
+        expect(buildTemplateUpdateSuggestions(set)).toEqual([])
+    })
+
+    it('suggests a whole new option under an existing question', () => {
+        const set = baseSet()
+        const activities = findQuestion(set, TEMPLATE_QUESTION_IDS.activities)
+        activities.options = activities.options.filter(o => o.id !== ACTIVITY_OPTION_IDS.hiking)
+
+        const suggestions = buildTemplateUpdateSuggestions(set)
+        expect(suggestions).toHaveLength(1)
+        expect(suggestions[0]).toMatchObject({
+            kind: 'addOption',
+            label: 'Hiking',
+            questionId: TEMPLATE_QUESTION_IDS.activities,
+        })
+    })
+
+    it('suggests a whole new question when the user has none like it', () => {
+        const set = baseSet()
+        set.questions = set.questions.filter(q => q.id !== TEMPLATE_QUESTION_IDS.abroad)
+
+        const suggestions = buildTemplateUpdateSuggestions(set)
+        expect(suggestions).toHaveLength(1)
+        expect(suggestions[0]).toMatchObject({ kind: 'addQuestion', label: 'Are you travelling abroad?' })
+    })
+
+    it('does not re-suggest a renamed legacy question whose items already exist', () => {
+        const set = baseSet()
+        const overnight = findQuestion(set, TEMPLATE_QUESTION_IDS.overnight)
+        overnight.id = 'legacy-overnight-uuid'
+        overnight.text = 'Sleeping over somewhere?'
+
+        expect(buildTemplateUpdateSuggestions(set)).toEqual([])
+    })
+
+    it('ignores deleted people when regenerating the reference template', () => {
+        const set = baseSet()
+        set.people = [adult, { id: 'baby1', name: 'Baby', ageRange: 'Baby', deletedAt: '2026-01-01T00:00:00.000Z' }]
+        set.alwaysNeededItems = set.alwaysNeededItems.filter(i => i.text !== 'Snacks')
+
+        const suggestions = buildTemplateUpdateSuggestions(set)
+        expect(suggestions.map(s => s.label)).toEqual(['Snacks'])
+    })
+})
+
+describe('applyTemplateUpdates', () => {
+    it('stamps the current template version even when nothing is accepted (dismiss)', () => {
+        const set = baseSet()
+        const updated = applyTemplateUpdates(set, [])
+        expect(updated.templateVersion).toBe(WIZARD_TEMPLATE_VERSION)
+        expect(updated.questions).toHaveLength(set.questions.length)
+        expect(updated.alwaysNeededItems).toHaveLength(set.alwaysNeededItems.length)
+    })
+
+    it('inserts an accepted item with a fresh id and stamps the version', () => {
+        const set = baseSet()
+        const hot = findQuestion(set, TEMPLATE_QUESTION_IDS.weather).options.find(o => o.text === 'Hot')!
+        hot.items = hot.items.filter(i => i.text !== 'Sunscreen')
+
+        const suggestions = buildTemplateUpdateSuggestions(set)
+        const updated = applyTemplateUpdates(set, suggestions)
+
+        expect(updated.templateVersion).toBe(WIZARD_TEMPLATE_VERSION)
+        const updatedHot = findQuestion(updated, TEMPLATE_QUESTION_IDS.weather).options.find(o => o.text === 'Hot')!
+        const inserted = updatedHot.items.find(i => i.text === 'Sunscreen')!
+        expect(inserted).toBeTruthy()
+        expect(inserted.id).toBeTruthy()
+        expect(inserted.lastModified).toBeTruthy()
+        expect(inserted.personSelections.some(ps => ps.personId === adult.id && ps.selected)).toBe(true)
+    })
+
+    it('only inserts the accepted subset', () => {
+        const set = baseSet()
+        const hot = findQuestion(set, TEMPLATE_QUESTION_IDS.weather).options.find(o => o.text === 'Hot')!
+        hot.items = hot.items.filter(i => i.text !== 'Sunscreen' && i.text !== 'Sun hat')
+
+        const suggestions = buildTemplateUpdateSuggestions(set)
+        const onlySunscreen = suggestions.filter(s => s.label === 'Sunscreen')
+        const updated = applyTemplateUpdates(set, onlySunscreen)
+
+        const updatedHot = findQuestion(updated, TEMPLATE_QUESTION_IDS.weather).options.find(o => o.text === 'Hot')!
+        expect(updatedHot.items.some(i => i.text === 'Sunscreen')).toBe(true)
+        expect(updatedHot.items.some(i => i.text === 'Sun hat')).toBe(false)
+    })
+
+    it('inserts a new option with fresh item ids', () => {
+        const set = baseSet()
+        const activities = findQuestion(set, TEMPLATE_QUESTION_IDS.activities)
+        activities.options = activities.options.filter(o => o.id !== ACTIVITY_OPTION_IDS.hiking)
+
+        const suggestions = buildTemplateUpdateSuggestions(set)
+        const updated = applyTemplateUpdates(set, suggestions)
+
+        const hiking = findQuestion(updated, TEMPLATE_QUESTION_IDS.activities).options.find(o => o.text === 'Hiking')
+        expect(hiking).toBeTruthy()
+        expect(hiking!.items.length).toBeGreaterThan(0)
+        expect(hiking!.items.every(i => i.id)).toBe(true)
+    })
+
+    it('appends a new question after the existing ones', () => {
+        const set = baseSet()
+        set.questions = set.questions.filter(q => q.id !== TEMPLATE_QUESTION_IDS.abroad)
+        const maxOrderBefore = Math.max(...set.questions.map(q => q.order))
+
+        const suggestions = buildTemplateUpdateSuggestions(set)
+        const updated = applyTemplateUpdates(set, suggestions)
+
+        const abroad = updated.questions.find(q => q.text === 'Are you travelling abroad?')!
+        expect(abroad).toBeTruthy()
+        expect(abroad.order).toBeGreaterThan(maxOrderBefore)
+        expect(abroad.type).toBe('saved')
+        expect(abroad.options.flatMap(o => o.items).every(i => i.id)).toBe(true)
+    })
+})

--- a/src/edit-questions/template-updates.ts
+++ b/src/edit-questions/template-updates.ts
@@ -1,0 +1,234 @@
+import { PackingListQuestionSet, Item, Question, Option, SavedQuestion } from './types'
+import { createExampleData, WIZARD_TEMPLATE_VERSION } from './example-data'
+import { generateUUID } from '../utils/uuid'
+import { ItemLocation, locationKey, normalize } from './item-locations'
+
+/**
+ * A single additive change the current wizard template offers over what the
+ * user already has. Purely additive by design — nothing here ever removes or
+ * rewrites a user's own questions, options, or items.
+ */
+export type TemplateUpdateSuggestion =
+    | {
+        kind: 'addItem'
+        /** Stable key for UI checkbox state and de-duplication */
+        key: string
+        /** The item text being offered */
+        label: string
+        /** Where it will land, for display (e.g. "Hiking — Walking poles") */
+        contextLabel: string
+        location: ItemLocation
+        item: Item
+    }
+    | {
+        kind: 'addOption'
+        key: string
+        /** The new option text */
+        label: string
+        /** The existing question it will be added to, for display */
+        contextLabel: string
+        questionId: string
+        option: Option
+    }
+    | {
+        kind: 'addQuestion'
+        key: string
+        /** The new question text */
+        label: string
+        contextLabel: string
+        question: Question
+    }
+
+type AddItemSuggestion = Extract<TemplateUpdateSuggestion, { kind: 'addItem' }>
+type AddOptionSuggestion = Extract<TemplateUpdateSuggestion, { kind: 'addOption' }>
+type AddQuestionSuggestion = Extract<TemplateUpdateSuggestion, { kind: 'addQuestion' }>
+
+function isRelevant(item: Item): boolean {
+    // Template items are already filtered to those selecting at least one
+    // person; this is a defensive backstop.
+    return item.personSelections.some(ps => ps.selected)
+}
+
+/**
+ * Diff the current wizard template (regenerated for the user's active people)
+ * against a saved question set and return the additions the user is missing:
+ * new items in existing options/always-needed, whole new options under an
+ * existing question, and whole new questions.
+ *
+ * Matching is additive-only and conservative:
+ * - Questions match by stable id first, then normalized text. A matched but
+ *   deleted question is respected (nothing is resurrected from it).
+ * - A template question with no match is offered as a new question only when
+ *   most of its items are absent from the user's set, so a renamed legacy
+ *   question isn't re-suggested wholesale.
+ * - Options match by id then normalized text; items match by normalized text.
+ *   An item the user removed is simply absent, so it may be re-offered once
+ *   (the version stamp stops it recurring after the user reviews).
+ */
+export function buildTemplateUpdateSuggestions(qs: PackingListQuestionSet): TemplateUpdateSuggestion[] {
+    const activePeople = (qs.people ?? []).filter(p => !p.deletedAt)
+    const template = createExampleData(activePeople, [])
+
+    const suggestions: TemplateUpdateSuggestion[] = []
+
+    // Every item text anywhere in the user's set (including deleted questions'
+    // items), used to tell a genuinely new question from a renamed one.
+    const allUserItemTexts = new Set<string>()
+    for (const item of qs.alwaysNeededItems ?? []) allUserItemTexts.add(normalize(item.text))
+    for (const q of qs.questions) {
+        for (const o of q.options) for (const i of o.items) allUserItemTexts.add(normalize(i.text))
+    }
+
+    const findUserQuestion = (tq: Question): Question | undefined => {
+        const byId = qs.questions.find(q => q.id === tq.id)
+        if (byId) return byId
+        return qs.questions.find(q => normalize(q.text) === normalize(tq.text))
+    }
+
+    for (const tq of template.questions) {
+        const uq = findUserQuestion(tq)
+
+        if (!uq) {
+            const templateItems = tq.options.flatMap(o => o.items)
+            if (templateItems.length === 0) continue
+            const presentCount = templateItems.filter(i => allUserItemTexts.has(normalize(i.text))).length
+            // Majority already present ⇒ almost certainly the same question
+            // under a different name; don't offer it again.
+            if (presentCount * 2 >= templateItems.length) continue
+            suggestions.push({
+                kind: 'addQuestion',
+                key: `addQuestion:${tq.id}`,
+                label: tq.text,
+                contextLabel: 'New question',
+                question: tq,
+            })
+            continue
+        }
+
+        if (uq.deletedAt) continue // user removed this question — respect it
+
+        for (const to of tq.options) {
+            const uo = uq.options.find(o => o.id === to.id)
+                ?? uq.options.find(o => normalize(o.text) === normalize(to.text))
+            if (!uo) {
+                if (to.items.length === 0) continue
+                suggestions.push({
+                    kind: 'addOption',
+                    key: `addOption:${uq.id}:${to.id}`,
+                    label: to.text,
+                    contextLabel: uq.text,
+                    questionId: uq.id,
+                    option: to,
+                })
+                continue
+            }
+            const existing = new Set(uo.items.map(i => normalize(i.text)))
+            const location: ItemLocation = { kind: 'option', questionId: uq.id, optionId: uo.id }
+            for (const ti of to.items) {
+                if (!isRelevant(ti) || existing.has(normalize(ti.text))) continue
+                suggestions.push({
+                    kind: 'addItem',
+                    key: `addItem:${locationKey(location)}:${normalize(ti.text)}`,
+                    label: ti.text,
+                    contextLabel: `${uq.text} — ${uo.text}`,
+                    location,
+                    item: ti,
+                })
+            }
+        }
+    }
+
+    const existingAlways = new Set((qs.alwaysNeededItems ?? []).map(i => normalize(i.text)))
+    for (const ti of template.alwaysNeededItems) {
+        if (!isRelevant(ti) || existingAlways.has(normalize(ti.text))) continue
+        const location: ItemLocation = { kind: 'always' }
+        suggestions.push({
+            kind: 'addItem',
+            key: `addItem:always:${normalize(ti.text)}`,
+            label: ti.text,
+            contextLabel: 'Always needed',
+            location,
+            item: ti,
+        })
+    }
+
+    return suggestions
+}
+
+/**
+ * Apply the accepted additions and stamp the set to the current template
+ * version. Passing an empty list still stamps the version — that's how a
+ * "dismiss" is recorded, so the review card doesn't reappear until the next
+ * template change. Inserted items get fresh ids and a `lastModified` so the
+ * pod merge stays fine-grained.
+ */
+export function applyTemplateUpdates(
+    qs: PackingListQuestionSet,
+    accepted: TemplateUpdateSuggestion[],
+    now: string = new Date().toISOString(),
+): PackingListQuestionSet {
+    const addItems = accepted.filter((s): s is AddItemSuggestion => s.kind === 'addItem')
+    const addOptions = accepted.filter((s): s is AddOptionSuggestion => s.kind === 'addOption')
+    const addQuestions = accepted.filter((s): s is AddQuestionSuggestion => s.kind === 'addQuestion')
+
+    const stampItem = (i: Item): Item => ({ ...i, id: generateUUID(), lastModified: now })
+
+    const addItemsToLocation = (location: ItemLocation, items: Item[]): Item[] => {
+        const key = locationKey(location)
+        const here = addItems.filter(s => locationKey(s.location) === key)
+        if (here.length === 0) return items
+        return [...items, ...here.map(s => stampItem(s.item))]
+    }
+
+    let questions: Question[] = qs.questions.map(question => {
+        const newOptions = addOptions.filter(s => s.questionId === question.id)
+        const maxOrder = question.options.reduce((m, o) => Math.max(m, o.order), -1)
+        const insertedOptions: Option[] = newOptions.map((s, idx) => ({
+            ...s.option,
+            order: maxOrder + 1 + idx,
+            items: s.option.items.map(stampItem),
+        }))
+        return {
+            ...question,
+            options: [
+                ...question.options.map(option => ({
+                    ...option,
+                    items: addItemsToLocation(
+                        { kind: 'option', questionId: question.id, optionId: option.id },
+                        option.items,
+                    ),
+                })),
+                ...insertedOptions,
+            ],
+        }
+    })
+
+    const maxQuestionOrder = questions.reduce((m, q) => Math.max(m, q.order), -1)
+    const insertedQuestions: SavedQuestion[] = addQuestions.map((s, idx) => ({
+        ...s.question,
+        type: 'saved',
+        order: maxQuestionOrder + 1 + idx,
+        lastModified: now,
+        options: s.question.options.map(option => ({
+            ...option,
+            items: option.items.map(stampItem),
+        })),
+    }))
+    questions = [...questions, ...insertedQuestions]
+
+    return {
+        ...qs,
+        questions,
+        alwaysNeededItems: addItemsToLocation({ kind: 'always' }, qs.alwaysNeededItems ?? []),
+        templateVersion: WIZARD_TEMPLATE_VERSION,
+    }
+}
+
+/**
+ * True when the saved set predates the current template version and there is
+ * at least one real addition to offer. Cheap enough to call on render.
+ */
+export function hasTemplateUpdates(qs: PackingListQuestionSet): boolean {
+    if ((qs.templateVersion ?? 0) >= WIZARD_TEMPLATE_VERSION) return false
+    return buildTemplateUpdateSuggestions(qs).length > 0
+}

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -119,7 +119,12 @@ export const PackingListQuestionSetSchema = z.object({
   people: z.array(PersonSchema),
   alwaysNeededItems: z.array(ItemSchema),
   questions: z.array(QuestionSchema),
-  lastModified: z.string().optional() // ISO timestamp for sync conflict resolution
+  lastModified: z.string().optional(), // ISO timestamp for sync conflict resolution
+  // Version of the wizard template this set was generated from / last
+  // reconciled against. Absent means pre-versioning (treated as 0), so the
+  // first template update is offered to every existing user. See
+  // WIZARD_TEMPLATE_VERSION in example-data.ts.
+  templateVersion: z.number().optional(),
 })
 
 // TypeScript Types (inferred from schemas)

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -13,6 +13,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { useForeignPod } from '../components/ForeignPodContext'
 import { CustomCreatableSelect } from '../components/CreatableSelect'
 import { AgePromotionCard } from '../components/AgePromotionCard'
+import { TemplateUpdatesCard } from '../components/TemplateUpdatesCard'
 import { AgeTransition } from '../edit-questions/age-derivation'
 
 // One distinct colour per person slot (by index). Tailwind classes must be literal strings.
@@ -1284,6 +1285,7 @@ export function QuestionsPage() {
                         onManualHandled={() => setManualPromotions([])}
                     />
                 )}
+                {!isForeign && <TemplateUpdatesCard questionSet={data} onApply={saveData} />}
                 <PersonLegend people={people} onEdit={() => setPeopleModal(true)} />
                 <AlwaysSection items={activeAlwaysNeededItems} people={people} onEdit={() => setAlwaysModal(true)} />
                 {activeQuestions.map((q, qi) => (

--- a/src/pages/useWizardGeneration.test.ts
+++ b/src/pages/useWizardGeneration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useWizardGeneration } from './useWizardGeneration'
+import { WIZARD_TEMPLATE_VERSION } from '../edit-questions/example-data'
 
 vi.mock('../components/DatabaseContext', () => ({
     useDatabase: vi.fn(),
@@ -111,6 +112,21 @@ describe('useWizardGeneration', () => {
         const savedData = saveQuestionSet.mock.calls[0][0]
         expect(savedData.people[0].ageRange).toBe('Child')
         expect(savedData.people[0].dateOfBirth).toBe('2024-01-10')
+    })
+
+    it('stamps the generated set with the current template version', async () => {
+        const saveQuestionSet = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+        mockUseDatabase.mockReturnValue({ db: { saveQuestionSet } as unknown as PackingAppDatabase })
+
+        const { result } = renderHook(() => useWizardGeneration())
+        await act(async () => {
+            await result.current.generateAndSave({
+                people: [{ name: 'Alice', ageRange: 'Adult' }],
+            })
+        })
+
+        const savedData = saveQuestionSet.mock.calls[0][0]
+        expect(savedData.templateVersion).toBe(WIZARD_TEMPLATE_VERSION)
     })
 
     it('syncs the question set to the pod after saving locally', async () => {

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useToast } from '../components/ToastContext'
 import { reportError } from '../errorReporting'
 import { useDatabase } from '../components/DatabaseContext'
-import { createExampleData } from '../edit-questions/example-data'
+import { createExampleData, WIZARD_TEMPLATE_VERSION } from '../edit-questions/example-data'
 import { QUESTION_SET_ID } from '../constants'
 import { WizardFormData } from './wizard-types'
 import { generateUUID } from '../utils/uuid'
@@ -48,7 +48,7 @@ export function useWizardGeneration() {
                     ...(entry.dateOfBirth ? { dateOfBirth: entry.dateOfBirth } : {}),
                 }
         )
-        return createExampleData(people, [])
+        return { ...createExampleData(people, []), templateVersion: WIZARD_TEMPLATE_VERSION }
     }
 
     const generateAndSave = async (data: WizardFormData) => {

--- a/src/services/database.test.ts
+++ b/src/services/database.test.ts
@@ -175,6 +175,18 @@ describe('PackingAppDatabase', () => {
       expect(retrieved.people[2].name).toBe('Charlie')
     })
 
+    it('should persist templateVersion', async () => {
+      await db.saveQuestionSet({ ...mockQuestionSet, templateVersion: 2 })
+      const retrieved = await db.getQuestionSet()
+      expect(retrieved.templateVersion).toBe(2)
+    })
+
+    it('should omit templateVersion when not set', async () => {
+      await db.saveQuestionSet(mockQuestionSet)
+      const retrieved = await db.getQuestionSet()
+      expect(retrieved.templateVersion).toBeUndefined()
+    })
+
     it('should throw not_found error when question set does not exist', async () => {
       await expect(db.getQuestionSet()).rejects.toEqual({
         name: 'not_found',

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -134,7 +134,12 @@ export class PackingAppDatabase {
                     data: {
                         people: questionSet.people,
                         alwaysNeededItems: questionSet.alwaysNeededItems,
-                        questions: questionSet.questions
+                        questions: questionSet.questions,
+                        // Persisted so the "new template suggestions" prompt can
+                        // tell whether this set predates the latest template.
+                        ...(questionSet.templateVersion !== undefined
+                            ? { templateVersion: questionSet.templateVersion }
+                            : {}),
                     }
                 }
 

--- a/src/services/rdfSerialization.test.ts
+++ b/src/services/rdfSerialization.test.ts
@@ -213,6 +213,21 @@ describe('questionSetToDataset / datasetToQuestionSet', () => {
         expect(result.lastModified).toBeUndefined()
     })
 
+    it('round-trips templateVersion', () => {
+        const result = roundTripQs(makeQuestionSet({ templateVersion: 3 }))
+        expect(result.templateVersion).toBe(3)
+    })
+
+    it('round-trips templateVersion of 0', () => {
+        const result = roundTripQs(makeQuestionSet({ templateVersion: 0 }))
+        expect(result.templateVersion).toBe(0)
+    })
+
+    it('omits templateVersion when not set (legacy data)', () => {
+        const result = roundTripQs(makeQuestionSet())
+        expect(result.templateVersion).toBeUndefined()
+    })
+
     it('does NOT store _rev', () => {
         const result = roundTripQs(makeQuestionSet({ _rev: '1-xyz' } as PackingListQuestionSet))
         expect(result._rev).toBeUndefined()

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -172,6 +172,10 @@ export function questionSetToDataset(qs: PackingListQuestionSet, datasetUrl: str
         rootBuilder = rootBuilder.addDatetime(DCTERMS.modified, new Date(qs.lastModified))
     }
 
+    if (qs.templateVersion !== undefined) {
+        rootBuilder = rootBuilder.addInteger(PMU.templateVersion, qs.templateVersion)
+    }
+
     for (const person of qs.people) {
         const personUrl = `${datasetUrl}#person-${person.id}`
         rootBuilder = rootBuilder.addUrl(PMU.hasPerson, personUrl)
@@ -204,6 +208,9 @@ export function datasetToQuestionSet(dataset: SolidDataset, datasetUrl: string):
     const lastModifiedDate = getDatetime(rootThing, DCTERMS.modified)
     const lastModified = lastModifiedDate?.toISOString()
 
+    const templateVersionValue = getInteger(rootThing, PMU.templateVersion)
+    const templateVersion = templateVersionValue === null ? undefined : templateVersionValue
+
     const people = getUrlAll(rootThing, PMU.hasPerson)
         .map(url => thingToPerson(getThing(dataset, url), url))
         .filter((p): p is Person => p !== null)
@@ -229,6 +236,7 @@ export function datasetToQuestionSet(dataset: SolidDataset, datasetUrl: string):
         questions,
         alwaysNeededItems,
         ...(lastModified !== undefined ? { lastModified } : {}),
+        ...(templateVersion !== undefined ? { templateVersion } : {}),
     }
 }
 

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -38,6 +38,8 @@ export const PMU = {
     hasPerson: `${PMU_NS}hasPerson`,
     hasQuestion: `${PMU_NS}hasQuestion`,
     hasAlwaysNeededItem: `${PMU_NS}hasAlwaysNeededItem`,
+    // Wizard template version this set was last reconciled against
+    templateVersion: `${PMU_NS}templateVersion`,
 
     // Person predicates
     ageRange: `${PMU_NS}ageRange`,

--- a/src/utils/mergeQuestionSets.test.ts
+++ b/src/utils/mergeQuestionSets.test.ts
@@ -58,6 +58,21 @@ describe('concurrent question adds', () => {
   })
 })
 
+describe('templateVersion', () => {
+  it('keeps the higher template version regardless of which side is newer', () => {
+    // Pod is newer at the doc level but was written by an older-app device
+    // still on version 0; the reconciled version must not regress.
+    const local = makeQS({ templateVersion: 1, lastModified: '2024-01-01T10:00:00.000Z' })
+    const pod   = makeQS({ templateVersion: 0, lastModified: '2024-01-01T11:00:00.000Z' })
+    expect(mergeQuestionSets(local, pod).templateVersion).toBe(1)
+  })
+
+  it('omits templateVersion when neither side has one', () => {
+    const result = mergeQuestionSets(makeQS(), makeQS())
+    expect(result.templateVersion).toBeUndefined()
+  })
+})
+
 describe('concurrent person adds', () => {
   it('preserves both people when each side added a unique one', () => {
     const p1 = makePerson({ id: 'p1', name: 'Alice', lastModified: '2024-01-01T10:00:00.000Z' })

--- a/src/utils/mergeQuestionSets.ts
+++ b/src/utils/mergeQuestionSets.ts
@@ -151,10 +151,19 @@ export function mergeQuestionSets(
     ? mergeItemsById(localItems, podItems, docLevelNewerIsLocal)
     : newer.alwaysNeededItems ?? []
 
+  // Template version is monotonic and additive: once a device has reconciled
+  // to a newer template, a merge with an older-app copy must not regress it, so
+  // take the max rather than following doc-level LWW.
+  const maxTemplateVersion = Math.max(local.templateVersion ?? 0, pod.templateVersion ?? 0)
+  const templateVersion = local.templateVersion === undefined && pod.templateVersion === undefined
+    ? undefined
+    : maxTemplateVersion
+
   return {
     ...newer,
     questions,
     people,
     alwaysNeededItems,
+    ...(templateVersion !== undefined ? { templateVersion } : {}),
   }
 }


### PR DESCRIPTION
Non-destructive 'new suggestions' review card on My Questions & Items,
driven by a template version stamp and an additive diff against the
regenerated template, reusing the age-promotion pattern.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TciJbLAcdzvafGiuHmZ8cD