### PR TITLE
Add plan for updating packing lists from question-set changes

### DIFF
--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -120,4 +120,61 @@ test.describe('C – Packing Lists', () => {
     // Use heading selector to avoid matching the confirmation dialog text
     await expect(page.getByRole('heading', { name: /To Delete/i })).not.toBeVisible({ timeout: 5_000 })
   })
+
+  // Add a new always-needed item to the question set via manage-questions.
+  async function addAlwaysNeededItem(page: import('@playwright/test').Page, itemName: string) {
+    await page.goto('/#/manage-questions')
+    await expect(page.getByRole('heading', { name: 'My Questions & Items' })).toBeVisible({ timeout: 8_000 })
+    await page.locator('button[title="Edit always needed items"]').click()
+    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).toBeVisible({ timeout: 3_000 })
+    await page.getByRole('button', { name: '+ Add Item' }).click()
+    await page.locator('.cursor-text').last().click()
+    const control = page.locator('.react-select__control').last()
+    await expect(control).toBeVisible({ timeout: 3_000 })
+    await control.click()
+    await page.keyboard.type(itemName)
+    const option = page.locator('.react-select__option').filter({ hasText: new RegExp(itemName, 'i') }).first()
+    await expect(option).toBeVisible({ timeout: 5_000 })
+    await option.click()
+    await page.getByRole('button', { name: 'Save changes' }).click()
+    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
+    // Give the async IndexedDB write time to commit
+    await page.waitForTimeout(800)
+  }
+
+  test('C8: update an existing list from question-set changes', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'Evolving Trip')
+    const listUrl = page.url()
+
+    // The new item is not on the list yet
+    await expect(page.getByText('GadgetTest')).not.toBeVisible()
+
+    // Add a new always-needed item to the question set, then return to the list
+    await addAlwaysNeededItem(page, 'GadgetTest')
+    await page.goto(listUrl)
+    await expect(page.getByRole('heading', { name: 'Evolving Trip' })).toBeVisible({ timeout: 8_000 })
+
+    // Update from questions surfaces the new item in a preview
+    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await expect(page.getByRole('button', { name: /Add 1 item/i })).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByLabel(/Add GadgetTest/i)).toBeVisible()
+    await page.getByRole('button', { name: /Add 1 item/i }).click()
+
+    // The item now appears on the list
+    await expect(page.getByText('GadgetTest')).toBeVisible({ timeout: 5_000 })
+
+    // Delete it, then update again — it must not be re-suggested
+    await page.getByText('GadgetTest', { exact: true })
+      .locator('xpath=ancestor::label[1]/..')
+      .getByTitle('Delete item')
+      .click()
+    await page.getByRole('button', { name: /^Remove$/ }).click()
+    await expect(page.getByText('GadgetTest')).not.toBeVisible({ timeout: 5_000 })
+
+    await page.getByRole('button', { name: /Update from questions/i }).click()
+    // No preview — the list already matches (the deleted item is not resurrected)
+    await expect(page.getByText('This list already matches your questions')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByRole('button', { name: /Add \d+ item/i })).not.toBeVisible()
+  })
 })

--- a/plans/update-packing-list-from-questions.md
+++ b/plans/update-packing-list-from-questions.md
@@ -1,0 +1,174 @@
+# Plan: Update an existing packing list from question-set changes
+
+## Problem
+
+A packing list is a one-off snapshot: `generateQuestionBasedItems` /
+`generateAlwaysNeededItems` fan the question set out into `PackingListItem`s at
+creation time and the two are disconnected afterwards. When the user later adds
+items to their question set, existing lists never see them.
+
+Auto-syncing by default would be jarring (items appearing/disappearing under
+the user) and drags in conflict UI. Instead:
+
+**A manual, one-shot "Update from questions" action on the view-packing-list
+page, with a preview of what would be added, additions only.** No setting, no
+per-list toggle, no background behaviour.
+
+### Scope for v1
+
+- **In:** adding items that the current question set would generate for this
+  trip's answers/travellers but that aren't on the list.
+- **Out (v2+):** propagating renames/edits/removals; `sourceItemId` stamping
+  and question-set `Item.id` backfill (needed for rename tracking, not for
+  additions); foreign/shared lists (`sharedFromPodUrl` set or foreign-pod
+  context — the local question set isn't theirs); any automatic behaviour.
+
+Follow TDD (red-green-refactor) throughout, per CLAUDE.md.
+
+---
+
+## Phase 1 — Persist generation inputs on `PackingList`
+
+The list must remember *how* it was generated so the update is a deterministic
+re-run of the existing generator, not a heuristic.
+
+1. **Types** (`src/create-packing-list/types.ts`) — additive optional fields on
+   `PackingList`:
+
+   ```ts
+   questionAnswers?: Array<{ questionId: string; selectedOptionIds: string[] }>
+   selectedPeopleIds?: string[]
+   ```
+
+   (`nights` is already persisted.)
+
+2. **Creation** (`src/pages/create-packing-list.tsx` `onSubmit`) — store the
+   submitted `data.questionAnswers` (normalised: drop entries with no selected
+   options, drop empty-string option ids — mirroring what the generator
+   ignores) and `selectedPeopleIds` on the new `PackingList`.
+
+3. **RDF round-trip** (`src/services/rdfVocab.ts`,
+   `src/services/rdfSerialization.ts`):
+   - New vocab terms: `PMU.hasAnswer`, `PMU.selectedOptionId`,
+     `PMU.selectedPersonId` (reuse existing `PMU.questionId` on the answer
+     Thing).
+   - `packingListToDataset`: one Thing per answer at
+     `#answer-<questionId>` with `questionId` + repeated `selectedOptionId`
+     strings; `selectedPersonId` as repeated strings on the root Thing.
+   - `datasetToPackingList`: read them back; omit the fields when absent so
+     legacy `.ttl` files parse unchanged.
+   - Unit tests: round-trip with and without the new fields
+     (`rdfSerialization.test.ts`). Fields are additive, matching the
+     schema-compat approach exercised by suite K.
+
+4. **Merge** (`src/utils/mergePackingLists.ts`) — the `...newer` spread already
+   carries top-level fields from the newer side; add a unit test pinning that
+   `questionAnswers`/`selectedPeopleIds` survive a merge.
+
+Legacy lists (created before this change) have no stored answers — see the
+fallback in Phase 2.
+
+## Phase 2 — Pure diff function (the core logic)
+
+New module `src/create-packing-list/updateFromQuestions.ts`, fully unit-tested
+before any UI work:
+
+```ts
+export function computeQuestionSetAdditions(
+  list: PackingList,
+  questionSet: PackingListQuestionSet,
+): PackingListItem[]
+```
+
+Behaviour:
+
+1. Resolve generation inputs: stored `questionAnswers` + `selectedPeopleIds`,
+   with `selectedPeopleIds` **intersected with current `questionSet.people`
+   ids** (a person deleted from the question set must not be regenerated —
+   also guards the non-null `people.find(...)!` in `generateItemInstances`).
+   Answers pointing at deleted questions/options already yield nothing in the
+   generator.
+2. Re-run the existing `generateQuestionBasedItems` +
+   `generateAlwaysNeededItems` with those inputs and `list.nights` (so new
+   items get `suggestedQuantity` and a category exactly as at creation).
+3. Filter the regenerated items down to true additions, keyed the same way as
+   the existing `deduplicateItems` (`${personId}::${itemText.trim().toLowerCase()}`),
+   dropping anything whose key matches:
+   - a current `list.items` entry (covers custom items the user already added
+     by hand), or
+   - a `list.deletedItems` entry (never resurrect a deliberate deletion).
+
+   For communal items use the same key shape (`personId` is `''`), which also
+   prevents re-adding a communal item the user deleted.
+4. Stamp each addition with a fresh `id`, `lastModified` (item-level merge in
+   `mergePackingLists` relies on it), `packed: false`.
+
+**Legacy-list fallback** — `reconstructGenerationInputs(list)`: when
+`questionAnswers` is absent, rebuild answers from the distinct
+`(questionId, optionId)` pairs across `items` **and** `deletedItems`
+(skipping the `always-needed` sentinel and custom items with `questionId === ''`),
+and `selectedPeopleIds` from the distinct non-empty `personId`s. This is lossy
+(an option whose items were all deleted-and-purged, or that generated zero
+instances, is invisible) but safe for additions-only: worst case it *misses*
+additions, it never invents wrong ones. Unit-test it separately.
+
+Test cases to cover (in `updateFromQuestions.test.ts`):
+- new item in a selected option → added for each selected traveller
+- new item in an *unselected* option → not added
+- item already on the list (incl. user-added custom item with same text) → skipped
+- item in `deletedItems` → skipped
+- communal item: trigger semantics respected; deleted communal item skipped
+- person removed from the question set → no items generated for them
+- question/option deleted → answers for it silently ignored
+- `nights` set → additions carry `suggestedQuantity`
+- legacy list without stored answers → reconstruction path
+
+## Phase 3 — UI on the view-packing-list page
+
+All in `src/pages/view-packing-list.tsx` plus one small new component:
+
+1. **Entry point:** an "Update from questions" button alongside the existing
+   header actions. Hidden when the list is foreign (`foreignPodUrl` or
+   `packingList.sharedFromPodUrl`) or when `db.getQuestionSet()` throws
+   `not_found`.
+2. **On click:** load the question set (read via `db` is fine; CLAUDE.md's
+   layering rule applies to writes), run `computeQuestionSetAdditions`.
+   - No additions → toast "This list already matches your questions", no dialog.
+   - Otherwise open a preview modal (new component
+     `src/components/UpdateFromQuestionsModal.tsx`, styled after
+     `SharePackingListModal`): additions grouped by traveller (shared items
+     first), each with a checkbox defaulting to checked, plus
+     Cancel / "Add N items".
+3. **On confirm:** append the selected additions to `packingList.items` and
+   save through the existing `persistPackingList` →
+   `saveWithSyncPrevention(updatedList, saveToPod)` path, which handles the
+   local-first write, `lastModified` stamping, and best-effort pod push per
+   the data-access rules. Success toast with the count.
+
+No settings, no badges, no auto-run. The whole surface is one button and one
+modal.
+
+## Phase 4 — Tests & verification
+
+- **Unit** (Phases 1–2 above, plus): component test for the modal flow in
+  `view-packing-list.test.tsx` — button hidden for foreign lists, preview
+  shows expected items, unchecking excludes an item, confirm persists and
+  closes.
+- **E2E:** extend `e2e/tests/c-packing-lists.spec.ts` (local-only flow, so no
+  new pod user is needed and the pod-isolation table in CLAUDE.md is
+  untouched): create a list → add an item to an answered option in
+  manage-questions → open the list → Update from questions → preview shows the
+  item → confirm → item appears in the right section; delete it, update again
+  → not re-suggested.
+- Run `npm test` and the c-suite Playwright spec; manual check via the
+  solid-dev flow that a pod-synced list round-trips the new fields.
+
+## Suggested implementation order / PRs
+
+Either one PR with commits per phase, or two PRs:
+
+1. **PR 1 (invisible plumbing):** Phase 1 — persist + serialize + merge
+   generation inputs. Ships safely on its own; new lists start recording
+   inputs immediately, which matters because lists created before Phase 3
+   ships will otherwise all be on the lossy reconstruction path.
+2. **PR 2 (feature):** Phases 2–4.

--- a/src/components/UpdateFromQuestionsModal.tsx
+++ b/src/components/UpdateFromQuestionsModal.tsx
@@ -1,0 +1,106 @@
+import { useMemo, useState } from 'react'
+import { Modal } from './Modal'
+import { Button } from './Button'
+import { PackingListItem } from '../create-packing-list/types'
+
+interface UpdateFromQuestionsModalProps {
+    isOpen: boolean
+    onClose: () => void
+    additions: PackingListItem[]
+    onConfirm: (selected: PackingListItem[]) => void
+}
+
+// Groups additions by traveller for the preview, communal ("Shared items")
+// first, then people alphabetically.
+function groupAdditions(additions: PackingListItem[]): Array<{ label: string; items: PackingListItem[] }> {
+    const shared: PackingListItem[] = []
+    const byPerson = new Map<string, PackingListItem[]>()
+    for (const item of additions) {
+        if (item.communal || item.personId === '') {
+            shared.push(item)
+        } else {
+            const key = item.personName || 'Unassigned'
+            if (!byPerson.has(key)) byPerson.set(key, [])
+            byPerson.get(key)!.push(item)
+        }
+    }
+    const groups: Array<{ label: string; items: PackingListItem[] }> = []
+    if (shared.length > 0) groups.push({ label: 'Shared items', items: shared })
+    for (const label of [...byPerson.keys()].sort((a, b) => a.localeCompare(b))) {
+        groups.push({ label, items: byPerson.get(label)! })
+    }
+    return groups
+}
+
+export function UpdateFromQuestionsModal({
+    isOpen,
+    onClose,
+    additions,
+    onConfirm,
+}: UpdateFromQuestionsModalProps) {
+    // All additions start selected; the user unchecks any they don't want.
+    const [excludedIds, setExcludedIds] = useState<Set<string>>(new Set())
+
+    const groups = useMemo(() => groupAdditions(additions), [additions])
+    const selectedCount = additions.length - excludedIds.size
+
+    const toggle = (id: string) => {
+        setExcludedIds(prev => {
+            const next = new Set(prev)
+            if (next.has(id)) next.delete(id)
+            else next.add(id)
+            return next
+        })
+    }
+
+    const handleConfirm = () => {
+        onConfirm(additions.filter(item => !excludedIds.has(item.id)))
+    }
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title="Update from questions">
+            <p className="text-sm text-gray-600 mb-4">
+                Your questions have new items that match this trip. Choose which to add.
+            </p>
+            <div className="max-h-96 overflow-y-auto space-y-4">
+                {groups.map(group => (
+                    <div key={group.label}>
+                        <p className="text-sm font-semibold text-gray-700 mb-2">{group.label}</p>
+                        <div className="space-y-1">
+                            {group.items.map(item => (
+                                <label key={item.id} className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer">
+                                    <input
+                                        type="checkbox"
+                                        aria-label={`Add ${item.itemText}${item.personName ? ` for ${item.personName}` : ''}`}
+                                        checked={!excludedIds.has(item.id)}
+                                        onChange={() => toggle(item.id)}
+                                        className="h-4 w-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+                                    />
+                                    <span className="text-gray-900">
+                                        {item.itemText}
+                                        {item.quantity !== undefined && (
+                                            <span className="ml-1.5 text-sm text-gray-500">×{item.quantity}</span>
+                                        )}
+                                    </span>
+                                </label>
+                            ))}
+                        </div>
+                    </div>
+                ))}
+            </div>
+            <div className="mt-6 flex justify-end gap-2">
+                <Button type="button" variant="secondary" onClick={onClose}>
+                    Cancel
+                </Button>
+                <Button
+                    type="button"
+                    variant="primary"
+                    onClick={handleConfirm}
+                    disabled={selectedCount === 0}
+                >
+                    {selectedCount > 0 ? `Add ${selectedCount} item${selectedCount === 1 ? '' : 's'}` : 'Add items'}
+                </Button>
+            </div>
+        </Modal>
+    )
+}

--- a/src/create-packing-list/types.ts
+++ b/src/create-packing-list/types.ts
@@ -10,6 +10,12 @@ export interface PackingList {
     items: PackingListItem[]
     deletedItems?: PackingListItem[]
     guests?: Array<{ id: string; name: string }>
+    // How this list was generated, remembered so it can later be re-run against
+    // an updated question set ("Update from questions"). Both optional and
+    // additive: legacy lists created before this existed have neither, and fall
+    // back to reconstructing the inputs from their items' question/option ids.
+    questionAnswers?: Array<{ questionId: string; selectedOptionIds: string[] }>
+    selectedPeopleIds?: string[]
 }
 
 export interface PackingListItem {

--- a/src/create-packing-list/updateFromQuestions.test.ts
+++ b/src/create-packing-list/updateFromQuestions.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from 'vitest'
+import { computeQuestionSetAdditions, reconstructGenerationInputs } from './updateFromQuestions'
+import { PackingList, PackingListItem } from './types'
+import { PackingListQuestionSet, Question, Person, Item } from '../edit-questions/types'
+
+const alice: Person = { id: 'p1', name: 'Alice' }
+const bob: Person = { id: 'p2', name: 'Bob' }
+
+function makeItem(text: string, personIds: string[], extra: Partial<Item> = {}): Item {
+    return {
+        text,
+        personSelections: personIds.map(id => ({ personId: id, selected: true })),
+        ...extra,
+    }
+}
+
+function makeQuestion(overrides: Partial<Question> = {}): Question {
+    return {
+        id: 'q-activities',
+        type: 'saved',
+        text: 'Activities?',
+        order: 0,
+        questionType: 'multiple-choice',
+        options: [],
+        ...overrides,
+    }
+}
+
+function makeQuestionSet(overrides: Partial<PackingListQuestionSet> = {}): PackingListQuestionSet {
+    return { _id: '1', people: [alice, bob], alwaysNeededItems: [], questions: [], ...overrides }
+}
+
+function makeList(overrides: Partial<PackingList> = {}): PackingList {
+    return {
+        id: 'list-1',
+        name: 'Trip',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        items: [],
+        selectedPeopleIds: ['p1', 'p2'],
+        questionAnswers: [],
+        ...overrides,
+    }
+}
+
+// A packing-list item generated from a question option
+function listItem(overrides: Partial<PackingListItem> = {}): PackingListItem {
+    return {
+        id: crypto.randomUUID(),
+        itemText: 'Existing',
+        personId: 'p1',
+        personName: 'Alice',
+        questionId: 'q-activities',
+        optionId: 'opt-swimming',
+        packed: false,
+        ...overrides,
+    }
+}
+
+describe('computeQuestionSetAdditions', () => {
+    it('adds a new item in a selected option for each selected traveller', () => {
+        const questionSet = makeQuestionSet({
+            questions: [makeQuestion({
+                options: [{
+                    id: 'opt-swimming', text: 'Swimming', order: 0,
+                    items: [makeItem('Goggles', ['p1', 'p2'])],
+                }],
+            })],
+        })
+        const list = makeList({
+            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+        })
+
+        const additions = computeQuestionSetAdditions(list, questionSet)
+
+        expect(additions.map(a => `${a.itemText}:${a.personName}`).sort())
+            .toEqual(['Goggles:Alice', 'Goggles:Bob'])
+        additions.forEach(a => {
+            expect(a.packed).toBe(false)
+            expect(a.id).toBeTruthy()
+            expect(a.lastModified).toBeTruthy()
+        })
+    })
+
+    it('does not add items from an option that was not selected', () => {
+        const questionSet = makeQuestionSet({
+            questions: [makeQuestion({
+                options: [
+                    { id: 'opt-swimming', text: 'Swimming', order: 0, items: [makeItem('Goggles', ['p1'])] },
+                    { id: 'opt-hiking', text: 'Hiking', order: 1, items: [makeItem('Boots', ['p1'])] },
+                ],
+            })],
+        })
+        const list = makeList({
+            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+        })
+
+        const additions = computeQuestionSetAdditions(list, questionSet)
+
+        expect(additions.map(a => a.itemText)).toEqual(['Goggles'])
+    })
+
+    it('skips items already on the list, including hand-added custom items with the same text', () => {
+        const questionSet = makeQuestionSet({
+            questions: [makeQuestion({
+                options: [{
+                    id: 'opt-swimming', text: 'Swimming', order: 0,
+                    items: [makeItem('Goggles', ['p1'])],
+                }],
+            })],
+        })
+        const list = makeList({
+            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+            // custom item added by hand with no questionId but same text/person
+            items: [listItem({ itemText: 'goggles', personId: 'p1', personName: 'Alice', questionId: '', optionId: '' })],
+        })
+
+        const additions = computeQuestionSetAdditions(list, questionSet)
+
+        expect(additions).toEqual([])
+    })
+
+    it('never resurrects an item the user previously deleted', () => {
+        const questionSet = makeQuestionSet({
+            questions: [makeQuestion({
+                options: [{
+                    id: 'opt-swimming', text: 'Swimming', order: 0,
+                    items: [makeItem('Goggles', ['p1'])],
+                }],
+            })],
+        })
+        const list = makeList({
+            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+            deletedItems: [listItem({ itemText: 'Goggles', personId: 'p1', personName: 'Alice' })],
+        })
+
+        const additions = computeQuestionSetAdditions(list, questionSet)
+
+        expect(additions).toEqual([])
+    })
+
+    it('respects communal trigger semantics and skips deleted communal items', () => {
+        const questionSet = makeQuestionSet({
+            questions: [makeQuestion({
+                options: [{
+                    id: 'opt-swimming', text: 'Swimming', order: 0,
+                    items: [
+                        makeItem('Beach umbrella', ['p1'], { communal: true }),
+                        makeItem('Cooler', ['p1'], { communal: true }),
+                    ],
+                }],
+            })],
+        })
+        const list = makeList({
+            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+            // Cooler was already deleted as a communal item (personId '')
+            deletedItems: [listItem({ itemText: 'Cooler', personId: '', personName: '', communal: true })],
+        })
+
+        const additions = computeQuestionSetAdditions(list, questionSet)
+
+        expect(additions.map(a => a.itemText)).toEqual(['Beach umbrella'])
+        expect(additions[0].communal).toBe(true)
+        expect(additions[0].personId).toBe('')
+    })
+
+    it('does not generate items for a person removed from the question set', () => {
+        const questionSet = makeQuestionSet({
+            people: [alice], // Bob removed
+            questions: [makeQuestion({
+                options: [{
+                    id: 'opt-swimming', text: 'Swimming', order: 0,
+                    items: [makeItem('Goggles', ['p1', 'p2'])],
+                }],
+            })],
+        })
+        const list = makeList({
+            selectedPeopleIds: ['p1', 'p2'],
+            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+        })
+
+        const additions = computeQuestionSetAdditions(list, questionSet)
+
+        expect(additions.map(a => a.personName)).toEqual(['Alice'])
+    })
+
+    it('silently ignores answers pointing at deleted questions/options', () => {
+        const questionSet = makeQuestionSet({ questions: [] })
+        const list = makeList({
+            questionAnswers: [{ questionId: 'q-gone', selectedOptionIds: ['opt-gone'] }],
+        })
+
+        expect(computeQuestionSetAdditions(list, questionSet)).toEqual([])
+    })
+
+    it('applies suggested quantities when nights is set', () => {
+        const questionSet = makeQuestionSet({
+            people: [alice],
+            questions: [makeQuestion({
+                options: [{
+                    id: 'opt-swimming', text: 'Swimming', order: 0,
+                    items: [makeItem('Socks', ['p1'], { perNight: 1 })],
+                }],
+            })],
+        })
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            nights: 3,
+            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+        })
+
+        const additions = computeQuestionSetAdditions(list, questionSet)
+
+        expect(additions).toHaveLength(1)
+        expect(additions[0].quantity).toBe(3)
+    })
+
+    it('adds new always-needed items', () => {
+        const questionSet = makeQuestionSet({
+            people: [alice],
+            alwaysNeededItems: [makeItem('Passport', ['p1'])],
+        })
+        const list = makeList({ selectedPeopleIds: ['p1'] })
+
+        const additions = computeQuestionSetAdditions(list, questionSet)
+
+        expect(additions.map(a => a.itemText)).toEqual(['Passport'])
+    })
+
+    describe('legacy lists without stored generation inputs', () => {
+        it('reconstructs answers and travellers from existing items', () => {
+            const questionSet = makeQuestionSet({
+                questions: [makeQuestion({
+                    options: [{
+                        id: 'opt-swimming', text: 'Swimming', order: 0,
+                        items: [
+                            makeItem('Swimsuit', ['p1']),
+                            makeItem('Goggles', ['p1']), // the new item
+                        ],
+                    }],
+                })],
+            })
+            // Legacy: no questionAnswers / selectedPeopleIds fields at all
+            const list: PackingList = {
+                id: 'list-1', name: 'Trip', createdAt: '2024-01-01T00:00:00.000Z',
+                items: [listItem({ itemText: 'Swimsuit', personId: 'p1', personName: 'Alice', optionId: 'opt-swimming' })],
+            }
+
+            const additions = computeQuestionSetAdditions(list, questionSet)
+
+            expect(additions.map(a => a.itemText)).toEqual(['Goggles'])
+        })
+
+        it('reconstructs travellers from deleted items too', () => {
+            const questionSet = makeQuestionSet({
+                questions: [makeQuestion({
+                    options: [{
+                        id: 'opt-swimming', text: 'Swimming', order: 0,
+                        items: [makeItem('Goggles', ['p1'])],
+                    }],
+                })],
+            })
+            const list: PackingList = {
+                id: 'list-1', name: 'Trip', createdAt: '2024-01-01T00:00:00.000Z',
+                items: [],
+                deletedItems: [listItem({ itemText: 'Swimsuit', personId: 'p1', personName: 'Alice', optionId: 'opt-swimming' })],
+            }
+
+            const additions = computeQuestionSetAdditions(list, questionSet)
+
+            // Swimsuit was deleted so it's skipped; Goggles is new for reconstructed traveller p1
+            expect(additions.map(a => a.itemText)).toEqual(['Goggles'])
+        })
+    })
+})
+
+describe('reconstructGenerationInputs', () => {
+    it('derives distinct (question, option) answers and non-empty personIds', () => {
+        const list: PackingList = {
+            id: 'list-1', name: 'Trip', createdAt: '2024-01-01T00:00:00.000Z',
+            items: [
+                listItem({ questionId: 'q1', optionId: 'o1', personId: 'p1' }),
+                listItem({ questionId: 'q1', optionId: 'o1', personId: 'p2' }),
+                listItem({ questionId: 'q1', optionId: 'o2', personId: 'p1' }),
+                listItem({ questionId: 'q2', optionId: 'o3', personId: 'p1' }),
+            ],
+        }
+
+        const { questionAnswers, selectedPeopleIds } = reconstructGenerationInputs(list)
+
+        expect(selectedPeopleIds.sort()).toEqual(['p1', 'p2'])
+        const q1 = questionAnswers.find(a => a.questionId === 'q1')!
+        expect(q1.selectedOptionIds.sort()).toEqual(['o1', 'o2'])
+        expect(questionAnswers.find(a => a.questionId === 'q2')!.selectedOptionIds).toEqual(['o3'])
+    })
+
+    it('skips always-needed and custom items and empty personIds', () => {
+        const list: PackingList = {
+            id: 'list-1', name: 'Trip', createdAt: '2024-01-01T00:00:00.000Z',
+            items: [
+                listItem({ questionId: 'always-needed', optionId: 'always-needed', personId: 'p1' }),
+                listItem({ questionId: '', optionId: '', personId: '' }),
+            ],
+        }
+
+        const { questionAnswers, selectedPeopleIds } = reconstructGenerationInputs(list)
+
+        expect(questionAnswers).toEqual([])
+        // always-needed item still contributes its personId as a traveller
+        expect(selectedPeopleIds).toEqual(['p1'])
+    })
+})

--- a/src/create-packing-list/updateFromQuestions.ts
+++ b/src/create-packing-list/updateFromQuestions.ts
@@ -1,0 +1,107 @@
+import { PackingListQuestionSet } from '../edit-questions/types'
+import { PackingList, PackingListItem } from './types'
+import { generateQuestionBasedItems, generateAlwaysNeededItems } from './generatePackingListItems'
+
+// The sentinel questionId used for always-needed items; such items carry no real
+// question/option ids to reconstruct answers from.
+const ALWAYS_NEEDED_QUESTION_ID = 'always-needed'
+
+interface GenerationInputs {
+    questionAnswers: Array<{ questionId: string; selectedOptionIds: string[] }>
+    selectedPeopleIds: string[]
+}
+
+// The same identity key the creation flow uses for deduplication:
+// `${personId}::${normalised text}`. Communal items have personId '', so a
+// communal item and a per-person item with the same text never collide.
+function itemKey(personId: string, itemText: string): string {
+    return `${personId}::${itemText.trim().toLowerCase()}`
+}
+
+// Legacy lists (created before generation inputs were persisted) have neither
+// `questionAnswers` nor `selectedPeopleIds`. Rebuild what we can from the items
+// that were generated: the distinct (questionId → optionId) pairs become the
+// answers, and the distinct non-empty personIds become the travellers. This is
+// lossy — an option that generated no instances, or whose items were all
+// deleted-and-purged, is invisible — but safe for additions: at worst it misses
+// some additions, it never invents wrong ones.
+export function reconstructGenerationInputs(list: PackingList): GenerationInputs {
+    const optionIdsByQuestion = new Map<string, Set<string>>()
+    const peopleIds = new Set<string>()
+
+    for (const item of [...list.items, ...(list.deletedItems ?? [])]) {
+        if (item.personId) peopleIds.add(item.personId)
+        if (!item.questionId || item.questionId === ALWAYS_NEEDED_QUESTION_ID) continue
+        if (!item.optionId) continue
+        if (!optionIdsByQuestion.has(item.questionId)) {
+            optionIdsByQuestion.set(item.questionId, new Set())
+        }
+        optionIdsByQuestion.get(item.questionId)!.add(item.optionId)
+    }
+
+    const questionAnswers = [...optionIdsByQuestion.entries()].map(([questionId, optionIds]) => ({
+        questionId,
+        selectedOptionIds: [...optionIds],
+    }))
+
+    return { questionAnswers, selectedPeopleIds: [...peopleIds] }
+}
+
+function resolveGenerationInputs(list: PackingList): GenerationInputs {
+    if (list.questionAnswers !== undefined || list.selectedPeopleIds !== undefined) {
+        return {
+            questionAnswers: list.questionAnswers ?? [],
+            selectedPeopleIds: list.selectedPeopleIds ?? [],
+        }
+    }
+    return reconstructGenerationInputs(list)
+}
+
+// Re-runs the generator for the list's stored (or reconstructed) inputs against
+// the current question set, and returns only the items that are genuinely new:
+// not already on the list, and not previously deleted from it. Additions carry
+// a fresh id and lastModified so the item-level merge can track them.
+export function computeQuestionSetAdditions(
+    list: PackingList,
+    questionSet: PackingListQuestionSet,
+): PackingListItem[] {
+    const { questionAnswers, selectedPeopleIds } = resolveGenerationInputs(list)
+
+    // A person removed from the question set must not be regenerated; this also
+    // guards the non-null people.find(...)! inside the generator.
+    const currentPeopleIds = new Set(questionSet.people.map(p => p.id))
+    const validPeopleIds = selectedPeopleIds.filter(id => currentPeopleIds.has(id))
+
+    const regenerated = [
+        ...generateQuestionBasedItems(
+            questionSet.questions,
+            questionAnswers,
+            questionSet.people,
+            validPeopleIds,
+            list.nights,
+        ),
+        ...generateAlwaysNeededItems(
+            questionSet.alwaysNeededItems,
+            questionSet.people,
+            validPeopleIds,
+            list.nights,
+        ),
+    ]
+
+    // Anything already present (incl. custom items the user added by hand with
+    // the same text) or previously deleted is not an addition.
+    const existingKeys = new Set<string>()
+    for (const item of list.items) existingKeys.add(itemKey(item.personId, item.itemText))
+    for (const item of (list.deletedItems ?? [])) existingKeys.add(itemKey(item.personId, item.itemText))
+
+    const additions: PackingListItem[] = []
+    const seen = new Set<string>()
+    const now = new Date().toISOString()
+    for (const item of regenerated) {
+        const key = itemKey(item.personId, item.itemText)
+        if (existingKeys.has(key) || seen.has(key)) continue
+        seen.add(key)
+        additions.push({ ...item, id: crypto.randomUUID(), packed: false, lastModified: now })
+    }
+    return additions
+}

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -594,13 +594,26 @@ export function CreatePackingList() {
             nights
         )
 
+        // Remember how the list was generated so it can later be re-run against
+        // an updated question set. Normalise the answers the same way the
+        // generator treats them: drop questions with no selected options and any
+        // empty-string option ids.
+        const questionAnswers = data.questionAnswers
+            .map(qa => ({
+                questionId: qa.questionId,
+                selectedOptionIds: (qa.selectedOptionIds ?? []).filter(id => id),
+            }))
+            .filter(qa => qa.questionId && qa.selectedOptionIds.length > 0)
+
         const packingList: PackingList = {
             id: crypto.randomUUID(),
             name: data.name,
             createdAt: new Date().toISOString(),
             lastModified: new Date().toISOString(),
             ...(nights !== undefined ? { nights } : {}),
-            items: withItemOrder(deduplicateItems([...questionBasedItems, ...alwaysNeededItems]))
+            items: withItemOrder(deduplicateItems([...questionBasedItems, ...alwaysNeededItems])),
+            selectedPeopleIds: [...selectedPeopleIds],
+            questionAnswers,
         }
         try {
             if (foreignPodUrl) {

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1247,3 +1247,160 @@ describe('grouping honours generated item order', () => {
         expect(groups[0].items.map(i => i.itemText)).toEqual(['Zebra print towel', 'Armbands'])
     })
 })
+
+const updatablePackingList = {
+    id: 'test-list-4',
+    name: 'Updatable Trip',
+    createdAt: '2026-01-01T00:00:00Z',
+    selectedPeopleIds: ['p1'],
+    questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+    items: [
+        { id: 'item-existing', itemText: 'Swimsuit', personName: 'Alice', personId: 'p1', questionId: 'q-activities', optionId: 'opt-swimming', packed: false },
+    ],
+}
+
+// Question set that now has a new item (Goggles) in the answered option
+const questionSetWithNewItem = {
+    _id: 'question-set',
+    people: [{ id: 'p1', name: 'Alice' }],
+    alwaysNeededItems: [],
+    questions: [{
+        id: 'q-activities',
+        type: 'saved',
+        text: 'Activities?',
+        order: 0,
+        questionType: 'multiple-choice',
+        options: [{
+            id: 'opt-swimming',
+            text: 'Swimming',
+            order: 0,
+            items: [
+                { text: 'Swimsuit', personSelections: [{ personId: 'p1', selected: true }] },
+                { text: 'Goggles', personSelections: [{ personId: 'p1', selected: true }] },
+            ],
+        }],
+    }],
+}
+
+describe('ViewPackingList update from questions', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...updatablePackingList, _rev: '2' }),
+        })
+        mockShowToast.mockClear()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function renderUpdatable(options: { list?: typeof updatablePackingList; getQuestionSet?: ReturnType<typeof vi.fn> } = {}) {
+        const list = options.list ?? updatablePackingList
+        const db = {
+            getPackingList: vi.fn().mockResolvedValue(list),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+            getQuestionSet: options.getQuestionSet ?? vi.fn().mockResolvedValue(questionSetWithNewItem),
+        }
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        render(
+            <MemoryRouter initialEntries={[`/view-list/${list.id}`]}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+        return db
+    }
+
+    it('hides the button when no question set exists', async () => {
+        renderUpdatable({ getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }) })
+        await waitFor(() => expect(screen.getByText('Swimsuit')).toBeTruthy())
+        expect(screen.queryByRole('button', { name: /update from questions/i })).toBeNull()
+    })
+
+    it('shows new items in a preview when the question set has additions', async () => {
+        renderUpdatable()
+        await waitFor(() => expect(screen.getByText('Swimsuit')).toBeTruthy())
+
+        fireEvent.click(await screen.findByRole('button', { name: /update from questions/i }))
+
+        // Preview modal lists the new item, not the one already on the list
+        await waitFor(() => expect(screen.getByRole('button', { name: /add 1 item/i })).toBeTruthy())
+        expect(screen.getByLabelText(/add goggles/i)).toBeTruthy()
+    })
+
+    it('toasts and shows no preview when the list already matches', async () => {
+        // Question set whose only item is already on the list
+        const matchingQs = {
+            ...questionSetWithNewItem,
+            questions: [{
+                ...questionSetWithNewItem.questions[0],
+                options: [{
+                    ...questionSetWithNewItem.questions[0].options[0],
+                    items: [{ text: 'Swimsuit', personSelections: [{ personId: 'p1', selected: true }] }],
+                }],
+            }],
+        }
+        renderUpdatable({ getQuestionSet: vi.fn().mockResolvedValue(matchingQs) })
+        await waitFor(() => expect(screen.getByText('Swimsuit')).toBeTruthy())
+
+        fireEvent.click(await screen.findByRole('button', { name: /update from questions/i }))
+
+        await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith('This list already matches your questions', 'success'))
+        expect(screen.queryByRole('button', { name: /add 1 item/i })).toBeNull()
+    })
+
+    it('excludes an unchecked item and persists only the selected additions', async () => {
+        const db = renderUpdatable({
+            list: {
+                ...updatablePackingList,
+                questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+                items: [],
+            },
+        })
+        await waitFor(() => expect(screen.getByRole('heading', { name: 'Updatable Trip' })).toBeTruthy())
+
+        fireEvent.click(await screen.findByRole('button', { name: /update from questions/i }))
+        await screen.findByRole('button', { name: /add 2 items/i })
+
+        // Uncheck Swimsuit, leaving only Goggles
+        fireEvent.click(screen.getByLabelText(/add swimsuit/i))
+        fireEvent.click(screen.getByRole('button', { name: /add 1 item/i }))
+
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        const saved = db.savePackingList.mock.calls[0][0]
+        const texts = saved.items.map((i: { itemText: string }) => i.itemText)
+        expect(texts).toContain('Goggles')
+        expect(texts).not.toContain('Swimsuit')
+    })
+
+    it('is hidden for foreign lists', async () => {
+        const db = {
+            getPackingList: vi.fn().mockResolvedValue(updatablePackingList),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+            getQuestionSet: vi.fn().mockResolvedValue(questionSetWithNewItem),
+        }
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        render(
+            <MemoryRouter initialEntries={[`/view-list/${updatablePackingList.id}?pod=${encodeURIComponent('https://foreign.example/')}`]}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+        await waitFor(() => expect(screen.getByText('Swimsuit')).toBeTruthy())
+        expect(screen.queryByRole('button', { name: /update from questions/i })).toBeNull()
+    })
+})

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -15,9 +15,11 @@ import { POD_CONTAINERS, getPrimaryPodUrl, saveRdfToPod, resolveOwnerDisplayName
 import { useOwnerDisplayName } from '../hooks/useOwnerDisplayName'
 import { packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { SharePackingListModal } from '../components/SharePackingListModal'
+import { UpdateFromQuestionsModal } from '../components/UpdateFromQuestionsModal'
 import { useForeignPod } from '../components/ForeignPodContext'
 import { useSharedListsSync } from '../hooks/useSharedListsSync'
 import { mergePackingLists } from '../utils/mergePackingLists'
+import { computeQuestionSetAdditions } from '../create-packing-list/updateFromQuestions'
 
 type FormData = {
     items: Record<string, boolean>
@@ -102,6 +104,10 @@ export function ViewPackingList() {
     const [packingList, setPackingList] = useState<PackingList | null>(null)
     const [isLoading, setIsLoading] = useState(true)
     const [shareModalOpen, setShareModalOpen] = useState(false)
+    // Additions computed from the question set; non-null opens the preview modal.
+    const [questionUpdateAdditions, setQuestionUpdateAdditions] = useState<PackingListItem[] | null>(null)
+    // Whether the question set exists locally (gates the "Update from questions" button).
+    const [hasQuestionSet, setHasQuestionSet] = useState(false)
     const [ownPodUrl, setOwnPodUrl] = useState<string | null>(null)
     // Tracks whether initial data has been loaded (local DB or pod).
     // Used to surface a real error to the user instead of hanging on "Loading…"
@@ -157,6 +163,20 @@ export function ViewPackingList() {
             getPrimaryPodUrl(session).then(url => setOwnPodUrl(url ?? null))
         }
     }, [isLoggedIn, session])
+
+    // The "Update from questions" action only applies to the user's own lists,
+    // regenerating them from their local question set. Foreign lists belong to
+    // someone else, so gate the button on a question set existing locally.
+    useEffect(() => {
+        if (foreignPodUrl || !db) {
+            setHasQuestionSet(false)
+            return
+        }
+        Promise.resolve()
+            .then(() => db.getQuestionSet())
+            .then(() => setHasQuestionSet(true))
+            .catch(() => setHasQuestionSet(false))
+    }, [db, foreignPodUrl])
 
     useEffect(() => {
         if (!packingList || !foreignPodUrl || !id || !sharedListsWithMe) return
@@ -413,6 +433,42 @@ export function ViewPackingList() {
             const dataWithTimestamp = { ...updatedPackingList, lastModified: new Date().toISOString() }
             const dbResult = await db.savePackingList(dataWithTimestamp)
             setPackingList({ ...dataWithTimestamp, _rev: dbResult.rev })
+        }
+    }
+
+    const handleOpenQuestionUpdate = async () => {
+        if (!packingList) return
+        try {
+            const questionSet = await db.getQuestionSet()
+            const additions = computeQuestionSetAdditions(packingList, questionSet)
+            if (additions.length === 0) {
+                showToast('This list already matches your questions', 'success')
+                return
+            }
+            setQuestionUpdateAdditions(additions)
+        } catch (err) {
+            const details = reportError(err, 'Error computing question updates')
+            showToast('Failed to check for question updates', 'error', details)
+        }
+    }
+
+    const handleConfirmQuestionUpdate = async (selected: PackingListItem[]) => {
+        if (!packingList || selected.length === 0) {
+            setQuestionUpdateAdditions(null)
+            return
+        }
+        try {
+            const updatedList: PackingList = {
+                ...packingList,
+                items: [...packingList.items, ...selected],
+            }
+            await persistPackingList(updatedList)
+            showToast(`Added ${selected.length} item${selected.length === 1 ? '' : 's'} from your questions`, 'success')
+        } catch (err) {
+            const details = reportError(err, 'Error adding question updates')
+            showToast('Failed to add items', 'error', details)
+        } finally {
+            setQuestionUpdateAdditions(null)
         }
     }
 
@@ -719,6 +775,15 @@ export function ViewPackingList() {
                                 onClick={() => { setShowAddGuest(v => !v); setNewGuestName('') }}
                             >
                                 + Add Guest
+                            </Button>
+                        )}
+                        {!foreignPodUrl && hasQuestionSet && (
+                            <Button
+                                type="button"
+                                variant="secondary"
+                                onClick={handleOpenQuestionUpdate}
+                            >
+                                Update from questions
                             </Button>
                         )}
                         {isLoggedIn && !foreignPodUrl && (
@@ -1150,6 +1215,12 @@ export function ViewPackingList() {
                 } : undefined}
             />
         )}
+        <UpdateFromQuestionsModal
+            isOpen={questionUpdateAdditions !== null}
+            onClose={() => setQuestionUpdateAdditions(null)}
+            additions={questionUpdateAdditions ?? []}
+            onConfirm={handleConfirmQuestionUpdate}
+        />
         </>
     )
 }

--- a/src/services/rdfSerialization.test.ts
+++ b/src/services/rdfSerialization.test.ts
@@ -191,6 +191,22 @@ describe('packingListToDataset / datasetToPackingList', () => {
         const without = roundTripList(makePackingList({ items: [makeItem()] }))
         expect(without.items[0].quantity).toBeUndefined()
     })
+
+    it('round-trips selectedPeopleIds and omits when not set', () => {
+        const result = roundTripList(makePackingList({ selectedPeopleIds: ['person-1', 'person-2'] }))
+        expect(result.selectedPeopleIds).toEqual(['person-1', 'person-2'])
+        expect(roundTripList(makePackingList()).selectedPeopleIds).toBeUndefined()
+    })
+
+    it('round-trips questionAnswers and omits when not set', () => {
+        const questionAnswers = [
+            { questionId: 'q-1', selectedOptionIds: ['opt-1', 'opt-2'] },
+            { questionId: 'q-2', selectedOptionIds: ['opt-3'] },
+        ]
+        const result = roundTripList(makePackingList({ questionAnswers }))
+        expect(result.questionAnswers).toEqual(questionAnswers)
+        expect(roundTripList(makePackingList()).questionAnswers).toBeUndefined()
+    })
 })
 
 // ── QuestionSet round-trip ────────────────────────────────────────────────────

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -63,6 +63,21 @@ export function packingListToDataset(list: PackingList, datasetUrl: string): Sol
             .build())
     }
 
+    for (const personId of (list.selectedPeopleIds ?? [])) {
+        rootBuilder = rootBuilder.addStringNoLocale(PMU.selectedPersonId, personId)
+    }
+
+    for (const answer of (list.questionAnswers ?? [])) {
+        const answerUrl = `${datasetUrl}#answer-${answer.questionId}`
+        rootBuilder = rootBuilder.addUrl(PMU.hasAnswer, answerUrl)
+        let answerBuilder = buildThing({ url: answerUrl })
+            .addStringNoLocale(PMU.questionId, answer.questionId)
+        for (const optionId of answer.selectedOptionIds) {
+            answerBuilder = answerBuilder.addStringNoLocale(PMU.selectedOptionId, optionId)
+        }
+        ds = setThing(ds, answerBuilder.build())
+    }
+
     return setThing(ds, rootBuilder.build())
 }
 
@@ -96,6 +111,18 @@ export function datasetToPackingList(dataset: SolidDataset, datasetUrl: string):
         })
         .filter((g): g is { id: string; name: string } => g !== null)
 
+    const selectedPeopleIds = getStringNoLocaleAll(rootThing, PMU.selectedPersonId)
+
+    const questionAnswers = getUrlAll(rootThing, PMU.hasAnswer)
+        .map(url => {
+            const thing = getThing(dataset, url)
+            if (!thing) return null
+            const questionId = getStringNoLocale(thing, PMU.questionId) ?? ''
+            const selectedOptionIds = getStringNoLocaleAll(thing, PMU.selectedOptionId)
+            return { questionId, selectedOptionIds }
+        })
+        .filter((a): a is { questionId: string; selectedOptionIds: string[] } => a !== null)
+
     return {
         id,
         name,
@@ -105,6 +132,8 @@ export function datasetToPackingList(dataset: SolidDataset, datasetUrl: string):
         items,
         deletedItems,
         ...(guests.length > 0 ? { guests } : {}),
+        ...(selectedPeopleIds.length > 0 ? { selectedPeopleIds } : {}),
+        ...(questionAnswers.length > 0 ? { questionAnswers } : {}),
     }
 }
 

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -19,6 +19,12 @@ export const PMU = {
     hasItem: `${PMU_NS}hasItem`,
     hasDeletedItem: `${PMU_NS}hasDeletedItem`,
     hasGuest: `${PMU_NS}hasGuest`,
+    // Generation inputs remembered on the list so it can be re-run against an
+    // updated question set. One hasAnswer Thing per answered question; the
+    // selected traveller ids are repeated strings on the root Thing.
+    hasAnswer: `${PMU_NS}hasAnswer`,
+    selectedOptionId: `${PMU_NS}selectedOptionId`,
+    selectedPersonId: `${PMU_NS}selectedPersonId`,
     itemText: `${PMU_NS}itemText`,
     personId: `${PMU_NS}personId`,
     personName: `${PMU_NS}personName`,

--- a/src/utils/mergePackingLists.test.ts
+++ b/src/utils/mergePackingLists.test.ts
@@ -321,5 +321,23 @@ describe('mergePackingLists', () => {
 
       expect(result.items.map(i => i.id)).toEqual(expect.arrayContaining(['item-P', 'item-Q']))
     })
+
+    it('carries generation inputs from the newer side', () => {
+      const local = makeList({
+        lastModified: '2024-01-01T10:00:00.000Z',
+        questionAnswers: [{ questionId: 'q-old', selectedOptionIds: ['opt-old'] }],
+        selectedPeopleIds: ['person-old'],
+      })
+      const pod = makeList({
+        lastModified: '2024-01-01T10:00:01.000Z',
+        questionAnswers: [{ questionId: 'q-new', selectedOptionIds: ['opt-new'] }],
+        selectedPeopleIds: ['person-new'],
+      })
+
+      const result = mergePackingLists(local, pod)
+
+      expect(result.questionAnswers).toEqual([{ questionId: 'q-new', selectedOptionIds: ['opt-new'] }])
+      expect(result.selectedPeopleIds).toEqual(['person-new'])
+    })
   })
 })


### PR DESCRIPTION
Manual one-shot 'Update from questions' action with a preview dialog,
additions only in v1. Covers persisting generation inputs on PackingList,
a pure diff function with a legacy-list fallback, UI on the view page,
and the test strategy.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013qxY3bFP5G7fkQxTL5ZQQd