### PR TITLE
Fix crypto.randomUUID crash on older Android WebViews

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -10,6 +10,7 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
+    implementation project(':sentry-capacitor')
 
 }
 

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -4,3 +4,6 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
+
+include ':sentry-capacitor'
+project(':sentry-capacitor').projectDir = new File('../node_modules/@sentry/capacitor/android')

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import './polyfills'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ErrorBoundary } from '@sentry/react'

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,16 @@
+// crypto.randomUUID was added in Chrome 92. Older Android WebViews (e.g. on
+// Android 11 devices that haven't updated their WebView) don't have it.
+// The @uvdsl/solid-oidc-client-browser library calls it during login, so we
+// need the polyfill in place before any auth code runs.
+if (typeof crypto !== 'undefined' && typeof crypto.randomUUID !== 'function') {
+  const randomUUID = (): `${string}-${string}-${string}-${string}-${string}` => {
+    const buf = new Uint8Array(16)
+    crypto.getRandomValues(buf)
+    // Set version 4 and variant bits per RFC 4122
+    buf[6] = (buf[6] & 0x0f) | 0x40
+    buf[8] = (buf[8] & 0x3f) | 0x80
+    const hex = Array.from(buf, b => b.toString(16).padStart(2, '0')).join('')
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}` as `${string}-${string}-${string}-${string}-${string}`
+  }
+  ;(crypto as Crypto & { randomUUID: typeof randomUUID }).randomUUID = randomUUID
+}


### PR DESCRIPTION
## What this PR does

Adds a polyfill for `crypto.randomUUID` to fix a login crash on Android 11 devices whose WebView predates Chrome 92 (where `randomUUID` was introduced).

The `@uvdsl/solid-oidc-client-browser` library calls `window.crypto.randomUUID()` during the OIDC login flow to generate CSRF tokens, PKCE verifiers, and JWT IDs. On devices with an older WebView, this throws a `TypeError` and login fails entirely.

The polyfill is implemented with `crypto.getRandomValues()` (widely supported), produces a spec-compliant RFC 4122 v4 UUID, and is a no-op on browsers that already have `randomUUID`.

Fixes JAVASCRIPT-REACT-7

## Manual testing steps

1. Test on an Android 11 device (or emulator) with an older WebView — login should complete successfully.
2. Test on a modern device / browser — login should still work as before (polyfill is skipped).