### PR TITLE
Add Privacy Policy page and navigation links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-packing-app",
-  "version": "0.3.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-packing-app",
-      "version": "0.3.0",
+      "version": "1.7.0",
       "dependencies": {
         "@capacitor/android": "^8.3.4",
         "@capacitor/app": "^8.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { ForeignPodLayout } from './components/ForeignPodLayout'
 import { ForeignPackingListsPage } from './pages/foreign-packing-lists'
 import { SharingSettingsPage } from './pages/sharing-settings'
 import { QuestionsPage } from './pages/questions-page'
+import { PrivacyPolicyPage } from './pages/privacy-policy'
 
 function DefaultRedirect() {
   const { isLoggedIn, isLoading } = useSolidPod()
@@ -49,6 +50,7 @@ function App() {
                 <Route path="/solid-pod-handle-redirect" element={<SolidPodHandleRedirectPage />} />
                 <Route path="/backups" element={<BackupsPage />} />
                 <Route path="/sharing" element={<SharingSettingsPage />} />
+                <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
                 <Route path="/pod/:encodedPodUrl" element={<ForeignPodLayout />}>
                   <Route index element={<Navigate to="view-lists" replace />} />
                   <Route path="view-lists" element={<ForeignPackingListsPage />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -94,6 +94,12 @@ export const Navigation = () => {
                         </div>
                         {/* Solid Login/Logout section */}
                         <div className="hidden md:flex items-center gap-4">
+                            <Link
+                                to="/privacy-policy"
+                                className="px-3 py-1.5 rounded-lg text-sm font-medium text-white/70 hover:text-white transition-colors duration-200"
+                            >
+                                Privacy Policy
+                            </Link>
                             <a
                                 href="mailto:tim.packmeup@gmail.com"
                                 className="px-3 py-1.5 rounded-lg text-sm font-medium text-white/70 hover:text-white transition-colors duration-200"
@@ -223,6 +229,13 @@ export const Navigation = () => {
                                 Sharing
                             </Link>
                         )}
+                        <Link
+                            to="/privacy-policy"
+                            className="block px-3 py-3 rounded-xl text-base font-medium text-white/70 hover:text-white transition-colors duration-200"
+                            onClick={() => setIsOpen(false)}
+                        >
+                            Privacy Policy
+                        </Link>
                         <a
                             href="mailto:tim.packmeup@gmail.com"
                             className="block px-3 py-3 rounded-xl text-base font-medium text-white/70 hover:text-white transition-colors duration-200"

--- a/src/pages/privacy-policy.test.tsx
+++ b/src/pages/privacy-policy.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { PrivacyPolicyPage } from './privacy-policy'
+
+describe('PrivacyPolicyPage', () => {
+    it('renders the privacy policy heading', () => {
+        render(<PrivacyPolicyPage />)
+
+        expect(screen.getByRole('heading', { name: 'Privacy Policy', level: 1 })).toBeTruthy()
+    })
+
+    it('mentions where data is stored', () => {
+        render(<PrivacyPolicyPage />)
+
+        expect(screen.getByRole('heading', { name: 'Where your data is stored' })).toBeTruthy()
+        expect(screen.getAllByText(/Solid Pod/).length).toBeGreaterThan(0)
+    })
+
+    it('provides a contact email', () => {
+        render(<PrivacyPolicyPage />)
+
+        const link = screen.getByRole('link', { name: 'tim.packmeup@gmail.com' })
+        expect(link.getAttribute('href')).toBe('mailto:tim.packmeup@gmail.com')
+    })
+})

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -1,0 +1,96 @@
+const LAST_UPDATED = '21 July 2026'
+
+export const PrivacyPolicyPage = () => {
+    return (
+        <div className="max-w-3xl mx-auto bg-white/60 rounded-2xl shadow-soft p-6 md:p-10 space-y-6">
+            <div>
+                <h1 className="text-3xl font-bold text-primary-900 mb-1">Privacy Policy</h1>
+                <p className="text-sm text-gray-500">Last updated: {LAST_UPDATED}</p>
+            </div>
+
+            <p className="text-gray-700">
+                Pack Me Up ("the app") helps you build and manage packing lists for your trips. This
+                policy explains what information the app handles, where it is stored, and who can see it.
+            </p>
+
+            <section className="space-y-2">
+                <h2 className="text-xl font-bold text-primary-900">Information you provide</h2>
+                <p className="text-gray-700">
+                    The app stores the packing questions, items, and packing lists you create, including
+                    any trip or traveller details you choose to enter (such as names or age brackets for
+                    the people you're packing for). This information is provided directly by you and is
+                    used only to generate and display your packing lists.
+                </p>
+            </section>
+
+            <section className="space-y-2">
+                <h2 className="text-xl font-bold text-primary-900">Where your data is stored</h2>
+                <p className="text-gray-700">
+                    By default, your data is stored locally on your device, in your browser's or app's
+                    local storage. It is not sent to any server we control.
+                </p>
+                <p className="text-gray-700">
+                    If you choose to log in with a Solid Pod, your data is also saved to the personal Pod
+                    you connect — storage that you own and control, hosted by the Pod provider you select.
+                    We do not have our own servers that store your packing data; the app talks directly to
+                    your Pod. You can revoke access or delete your data from your Pod at any time through
+                    your Pod provider.
+                </p>
+                <p className="text-gray-700">
+                    If you use the sharing feature, the packing lists or questions you choose to share are
+                    made accessible to the specific people you share them with, via your Pod's access
+                    controls.
+                </p>
+            </section>
+
+            <section className="space-y-2">
+                <h2 className="text-xl font-bold text-primary-900">Analytics and error reporting</h2>
+                <p className="text-gray-700">
+                    We use privacy-friendly, cookie-free analytics to understand overall app usage (such as
+                    which pages are visited), and an error-reporting tool to help us diagnose crashes and
+                    bugs. Error reports may include technical details like error messages, stack traces,
+                    and device/browser information, but do not include the contents of your packing lists.
+                </p>
+            </section>
+
+            <section className="space-y-2">
+                <h2 className="text-xl font-bold text-primary-900">What we don't do</h2>
+                <p className="text-gray-700">
+                    We do not sell your data, and we do not use your packing list contents for advertising.
+                    We do not have accounts or passwords of our own — authentication, when used, is handled
+                    by your chosen Solid Pod provider.
+                </p>
+            </section>
+
+            <section className="space-y-2">
+                <h2 className="text-xl font-bold text-primary-900">Children's privacy</h2>
+                <p className="text-gray-700">
+                    The app is not directed at children and is not designed to knowingly collect personal
+                    information from children.
+                </p>
+            </section>
+
+            <section className="space-y-2">
+                <h2 className="text-xl font-bold text-primary-900">Changes to this policy</h2>
+                <p className="text-gray-700">
+                    We may update this policy from time to time. Changes will be posted on this page with
+                    an updated "Last updated" date.
+                </p>
+            </section>
+
+            <section className="space-y-2">
+                <h2 className="text-xl font-bold text-primary-900">Contact us</h2>
+                <p className="text-gray-700">
+                    If you have questions about this policy or your data, contact us at{' '}
+                    <a
+                        href="mailto:tim.packmeup@gmail.com"
+                        className="font-semibold text-primary-700 underline hover:text-primary-900"
+                    >
+                        tim.packmeup@gmail.com
+                    </a>
+                    .
+                </p>
+            </section>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
Adds a new Privacy Policy page to the application and integrates it into the main navigation menu for both desktop and mobile views.

## Changes
- **New Privacy Policy page** (`src/pages/privacy-policy.tsx`): Comprehensive privacy policy component covering data storage (local storage and Solid Pod), analytics, data handling practices, and contact information
- **Privacy Policy tests** (`src/pages/privacy-policy.test.tsx`): Unit tests verifying the page renders correctly, displays key sections, and includes proper contact information
- **Navigation updates** (`src/components/Navigation.tsx`): Added "Privacy Policy" links to both desktop navigation bar and mobile menu
- **App routing** (`src/App.tsx`): Registered the new `/privacy-policy` route

## Implementation Details
- The Privacy Policy page uses consistent styling with the rest of the application (Tailwind classes, primary color scheme)
- Last updated date is centralized as a constant (`LAST_UPDATED = '21 July 2026'`)
- Navigation links are positioned consistently with existing footer-style links (email contact)
- Mobile menu link includes `onClick` handler to close the menu after navigation
- Tests cover heading rendering, key content sections, and email link functionality

https://claude.ai/code/session_01R2tA8mCsKRtjLUUfsXUnBa