### PR TITLE
Show empty answers as non-expandable with an inline "No items" hint

### DIFF
--- a/src/pages/questions-page.option-section.test.tsx
+++ b/src/pages/questions-page.option-section.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { OptionSection } from './questions-page'
+import type { Option, Person } from '../edit-questions/types'
+
+vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
+vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn() }))
+vi.mock('../components/ForeignPodContext', () => ({ useForeignPod: vi.fn() }))
+
+const people: Person[] = [{ id: 'p1', name: 'Alice' }]
+
+function makeOption(overrides: Partial<Option> = {}): Option {
+    return { id: 'o1', order: 0, text: 'Yes', items: [], ...overrides }
+}
+
+function renderOption(option: Option) {
+    return render(
+        <OptionSection option={option} people={people} onEdit={vi.fn()} onDelete={vi.fn()} />
+    )
+}
+
+describe('OptionSection with no items', () => {
+    it('shows an inline "No items" hint', () => {
+        renderOption(makeOption())
+        expect(screen.getByText('No items')).toBeTruthy()
+    })
+
+    it('is not expandable — no toggle button and no chevron', () => {
+        const { container } = renderOption(makeOption())
+        expect(screen.queryByRole('button', { name: /Yes/ })).toBeNull()
+        expect(container.querySelector('[data-testid="option-expand-chevron"]')).toBeNull()
+    })
+
+    it('still offers edit and delete', () => {
+        renderOption(makeOption())
+        expect(screen.getByTitle('Edit option')).toBeTruthy()
+        expect(screen.getByTitle('Delete option')).toBeTruthy()
+    })
+})
+
+describe('OptionSection with items', () => {
+    const withItems = () => makeOption({ items: [{ text: 'Toothbrush' }, { text: 'Towel' }] })
+
+    it('shows the item count rather than the "No items" hint', () => {
+        renderOption(withItems())
+        expect(screen.getByText('2 items')).toBeTruthy()
+        expect(screen.queryByText('No items')).toBeNull()
+    })
+
+    it('expands to reveal the items when clicked', () => {
+        renderOption(withItems())
+        const toggle = screen.getByRole('button', { name: /Yes/ })
+        expect(screen.queryByText('Toothbrush')).toBeNull()
+        fireEvent.click(toggle)
+        expect(screen.getByText('Toothbrush')).toBeTruthy()
+        expect(screen.getByText('Towel')).toBeTruthy()
+    })
+})

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -167,7 +167,7 @@ function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete:
     )
 }
 
-function OptionSection({ option, people, onEdit, onDelete }: {
+export function OptionSection({ option, people, onEdit, onDelete }: {
     option: Option
     people: Person[]
     onEdit: () => void
@@ -179,25 +179,50 @@ function OptionSection({ option, people, onEdit, onDelete }: {
     // sets), but stay mounted afterwards so re-expanding is instant.
     const hasExpandedRef = useRef(isExpanded)
     if (isExpanded) hasExpandedRef.current = true
+    // Nothing to reveal when an answer has no items, so drop the chevron and the
+    // toggle entirely and say so inline — an expander that opens onto nothing
+    // just reads as broken.
+    const isEmpty = option.items.length === 0
+    const heading = (
+        <>
+            {isEmpty ? (
+                // Spacer keeps the text aligned with the chevroned siblings.
+                <span className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+            ) : (
+                <svg
+                    data-testid="option-expand-chevron"
+                    className={`w-4 h-4 text-gray-400 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                    fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+            )}
+            <span className="text-sm font-medium text-gray-800 flex-1 min-w-0">
+                {option.text || <em className="text-gray-400 font-normal">Untitled option</em>}
+            </span>
+            {isEmpty ? (
+                <span className="text-xs text-gray-400 italic flex-shrink-0 mr-1">No items</span>
+            ) : (
+                <span className="hidden sm:inline text-xs text-gray-400 flex-shrink-0 mr-1">{option.items.length} items</span>
+            )}
+        </>
+    )
     return (
         <div className="bg-gray-50 rounded-lg p-3">
             <div className={`flex items-center${isExpanded ? ' mb-2' : ''}`}>
-                <button
-                    type="button"
-                    onClick={() => setIsExpanded(e => !e)}
-                    className="flex items-center gap-2 flex-1 text-left min-w-0"
-                >
-                    <svg
-                        className={`w-4 h-4 text-gray-400 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
-                        fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                {isEmpty ? (
+                    <div className="flex items-center gap-2 flex-1 text-left min-w-0">
+                        {heading}
+                    </div>
+                ) : (
+                    <button
+                        type="button"
+                        onClick={() => setIsExpanded(e => !e)}
+                        className="flex items-center gap-2 flex-1 text-left min-w-0"
                     >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                    </svg>
-                    <span className="text-sm font-medium text-gray-800 flex-1 min-w-0">
-                        {option.text || <em className="text-gray-400 font-normal">Untitled option</em>}
-                    </span>
-                    <span className="hidden sm:inline text-xs text-gray-400 flex-shrink-0 mr-1">{option.items.length} items</span>
-                </button>
+                        {heading}
+                    </button>
+                )}
                 <div className="flex items-center flex-shrink-0">
                     {/* Mobile: context menu */}
                     <div className="sm:hidden">


### PR DESCRIPTION
An answer with no items still rendered a chevron and an expander that
opened onto an empty panel. Drop the toggle for empty answers and show a
small inline "No items" label (visible at every breakpoint, unlike the
"N items" count) so the state is obvious without clicking.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UhFP1sqehSDBdMM3krD3sg