### PR TITLE
Show progress as a bar on the packing screen, with a word of encouragement

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -214,6 +214,12 @@ body {
   animation: sections-pack-away 0.55s ease-in forwards;
 }
 
+/* Progress bars glide to their new width, so ticking an item reads as progress
+   being made rather than as the bar having always been that long. */
+.progress-bar-fill {
+  transition: width 0.5s ease;
+}
+
 /* Celebrations are decorative — hold still for anyone who asked us to. */
 @media (prefers-reduced-motion: reduce) {
   .celebration-banner,
@@ -234,6 +240,11 @@ body {
   .sections-packing-away {
     animation: none;
     opacity: 0;
+  }
+
+  /* The bar still has to reach the right width — it just gets there at once */
+  .progress-bar-fill {
+    transition: none;
   }
 }
 

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -248,7 +248,7 @@ export function PackingLists() {
                                     <div className="flex-1 bg-white/40 rounded-full h-3 overflow-hidden">
                                         <div
                                             data-testid="progress-fill"
-                                            className="bg-gradient-primary h-full transition-all duration-500 rounded-full"
+                                            className="progress-bar-fill bg-gradient-primary h-full rounded-full"
                                             style={{ width: `${displayWidth}%` }}
                                         ></div>
                                     </div>

--- a/src/pages/packing-milestones.test.ts
+++ b/src/pages/packing-milestones.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { reachedMilestone, resolveMilestone, MILESTONE_MESSAGES } from './packing-milestones'
+
+describe('reachedMilestone', () => {
+    it('gives nothing away below the first threshold', () => {
+        expect(reachedMilestone(0)).toBeNull()
+        expect(reachedMilestone(24)).toBeNull()
+    })
+
+    it('awards each milestone exactly on its threshold', () => {
+        expect(reachedMilestone(25)).toBe(25)
+        expect(reachedMilestone(50)).toBe(50)
+        expect(reachedMilestone(75)).toBe(75)
+    })
+
+    it('holds the highest milestone earned between thresholds', () => {
+        expect(reachedMilestone(49)).toBe(25)
+        expect(reachedMilestone(74)).toBe(50)
+        expect(reachedMilestone(99)).toBe(75)
+    })
+
+    it('has copy for every milestone it can award', () => {
+        for (const percent of [25, 50, 75]) {
+            expect(MILESTONE_MESSAGES[reachedMilestone(percent)!]).toBeTruthy()
+        }
+    })
+})
+
+describe('resolveMilestone', () => {
+    it('starts from whatever the current progress has earned', () => {
+        expect(resolveMilestone(null, 0, 40)).toBeNull()
+        expect(resolveMilestone(null, 10, 40)).toBe(25)
+        expect(resolveMilestone(null, 30, 40)).toBe(75)
+    })
+
+    it('upgrades immediately on crossing the next threshold', () => {
+        expect(resolveMilestone(25, 20, 40)).toBe(50)
+        expect(resolveMilestone(50, 30, 40)).toBe(75)
+    })
+
+    it('keeps the milestone when a single item is unticked past the boundary', () => {
+        // 10/40 earns 25%; dropping to 9/40 (23%) must not blink the copy away
+        expect(resolveMilestone(25, 9, 40)).toBe(25)
+        expect(resolveMilestone(50, 19, 40)).toBe(50)
+        expect(resolveMilestone(75, 29, 40)).toBe(75)
+    })
+
+    it('gives the milestone up once progress falls further than one item short', () => {
+        expect(resolveMilestone(25, 8, 40)).toBeNull()
+        expect(resolveMilestone(50, 18, 40)).toBe(25)
+        expect(resolveMilestone(75, 28, 40)).toBe(50)
+    })
+
+    it('does not flicker across repeated toggles around a boundary', () => {
+        let milestone = resolveMilestone(null, 20, 40)
+        expect(milestone).toBe(50)
+        for (let i = 0; i < 3; i++) {
+            milestone = resolveMilestone(milestone, 19, 40)
+            expect(milestone).toBe(50)
+            milestone = resolveMilestone(milestone, 20, 40)
+            expect(milestone).toBe(50)
+        }
+    })
+
+    it('drops back to nothing when the list is emptied of packed items', () => {
+        expect(resolveMilestone(75, 0, 40)).toBeNull()
+    })
+
+    it('treats an empty list as having earned nothing', () => {
+        expect(resolveMilestone(null, 0, 0)).toBeNull()
+    })
+
+    it('still awards 75% at full completion, leaving the caller to hide it', () => {
+        expect(resolveMilestone(50, 40, 40)).toBe(75)
+    })
+})

--- a/src/pages/packing-milestones.ts
+++ b/src/pages/packing-milestones.ts
@@ -1,0 +1,41 @@
+// Encouragement shown in the packing view's progress strip on the way to 100%.
+// The finished state has its own celebration, so there is no 100% milestone here.
+export const PACKING_MILESTONES = [25, 50, 75] as const
+
+export const MILESTONE_MESSAGES: Record<number, string> = {
+    25: '🌱 Good start!',
+    50: '💪 Halfway there!',
+    75: '🔥 Nearly done!',
+}
+
+/** The highest milestone a given completion percentage has earned, if any. */
+export function reachedMilestone(percentComplete: number): number | null {
+    let reached: number | null = null
+    for (const milestone of PACKING_MILESTONES) {
+        if (percentComplete >= milestone) reached = milestone
+    }
+    return reached
+}
+
+/**
+ * Milestone to display, given the one currently on screen.
+ *
+ * Unticking a single item near a boundary would otherwise make the copy blink
+ * out and straight back in again, so a milestone is only given up once progress
+ * falls more than one item short of it. Upgrades are immediate — reaching a
+ * higher milestone should feel instant.
+ */
+export function resolveMilestone(
+    current: number | null,
+    packedCount: number,
+    totalCount: number
+): number | null {
+    const percentComplete = totalCount > 0 ? Math.round((packedCount / totalCount) * 100) : 0
+    const reached = reachedMilestone(percentComplete)
+
+    if (current === null) return reached
+    if (reached !== null && reached >= current) return reached
+
+    const percentWithOneMore = totalCount > 0 ? Math.round(((packedCount + 1) / totalCount) * 100) : 0
+    return percentWithOneMore >= current ? current : reached
+}

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -540,6 +540,180 @@ describe('progress indicators', () => {
     })
 })
 
+describe('packing progress bar and milestones', () => {
+    // Eight items so a single tick moves progress by 12.5% — enough to step over
+    // a milestone boundary without landing exactly on the next one.
+    const eightItemList = {
+        id: 'test-list-milestones',
+        name: 'Milestone Trip',
+        createdAt: '2026-01-01T00:00:00Z',
+        items: Array.from({ length: 8 }, (_, i) => ({
+            id: `m${i}`,
+            itemText: `Item ${i}`,
+            personName: 'Alice',
+            personId: 'p1',
+            questionId: 'q1',
+            optionId: `o${i}`,
+            packed: false,
+        })),
+    }
+
+    function setup(list: { id: string; items: unknown[] }) {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...list, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getPackingList: vi.fn().mockResolvedValue(list),
+                savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+                getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }),
+            } as unknown as PackingAppDatabase,
+        })
+        return render(
+            <MemoryRouter initialEntries={[`/view-list/${list.id}`]}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+    }
+
+    /** Packed items are hidden by default, which reshuffles checkbox order as you tick. */
+    function keepPackedItemsVisible() {
+        fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
+    }
+
+    /** Toggles the items in [fromIndex, toIndex) — ticking or unticking, as they stand. */
+    function toggleItems(fromIndex: number, toIndex: number) {
+        const checkboxes = screen.getAllByRole('checkbox')
+        for (let i = fromIndex; i < toIndex; i++) fireEvent.click(checkboxes[i])
+    }
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('shows a progress bar filled to the packed proportion', async () => {
+        setup(testPackingListWithProgress)
+        await waitFor(() => expect(screen.getByText('Sunscreen')).toBeTruthy())
+
+        const fill = await screen.findByTestId('packing-progress-fill')
+        expect(fill.style.width).toBe('50%')
+    })
+
+    it('leaves the bar empty when nothing is packed', async () => {
+        setup(eightItemList)
+        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+
+        expect(screen.getByTestId('packing-progress-fill').style.width).toBe('0%')
+    })
+
+    it('exposes progress to assistive tech', async () => {
+        setup(testPackingListWithProgress)
+        await waitFor(() => expect(screen.getByText('Sunscreen')).toBeTruthy())
+
+        const bar = screen.getByRole('progressbar')
+        expect(bar.getAttribute('aria-valuenow')).toBe('50')
+        expect(bar.getAttribute('aria-valuemin')).toBe('0')
+        expect(bar.getAttribute('aria-valuemax')).toBe('100')
+    })
+
+    it('grows the bar as items are packed', async () => {
+        setup(eightItemList)
+        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        keepPackedItemsVisible()
+
+        toggleItems(0, 4)
+
+        await waitFor(() => expect(screen.getByTestId('packing-progress-fill').style.width).toBe('50%'))
+    })
+
+    it('says nothing encouraging before the first milestone', async () => {
+        setup(eightItemList)
+        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        keepPackedItemsVisible()
+
+        toggleItems(0, 1)
+
+        await waitFor(() => expect(screen.getByTestId('packing-progress-fill').style.width).toBe('13%'))
+        expect(screen.queryByTestId('progress-milestone')).toBeNull()
+    })
+
+    it('cheers the user on at each milestone', async () => {
+        setup(eightItemList)
+        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        keepPackedItemsVisible()
+
+        toggleItems(0, 2)
+        await waitFor(() => expect(screen.getByTestId('progress-milestone').textContent).toMatch(/good start/i))
+
+        toggleItems(2, 4)
+        await waitFor(() => expect(screen.getByTestId('progress-milestone').textContent).toMatch(/halfway/i))
+
+        toggleItems(4, 6)
+        await waitFor(() => expect(screen.getByTestId('progress-milestone').textContent).toMatch(/nearly done/i))
+    })
+
+    it('does not flicker the milestone when a single item is toggled around the boundary', async () => {
+        setup(eightItemList)
+        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        keepPackedItemsVisible()
+
+        toggleItems(0, 2)
+        await waitFor(() => expect(screen.getByTestId('progress-milestone')).toBeTruthy())
+
+        const secondItem = screen.getAllByRole('checkbox')[1]
+        for (let i = 0; i < 3; i++) {
+            fireEvent.click(secondItem)
+            await waitFor(() => expect(screen.getByTestId('packing-progress-fill').style.width).toBe('13%'))
+            expect(screen.getByTestId('progress-milestone').textContent).toMatch(/good start/i)
+
+            fireEvent.click(secondItem)
+            await waitFor(() => expect(screen.getByTestId('packing-progress-fill').style.width).toBe('25%'))
+            expect(screen.getByTestId('progress-milestone').textContent).toMatch(/good start/i)
+        }
+    })
+
+    it('drops the milestone once progress falls well below it', async () => {
+        setup(eightItemList)
+        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        keepPackedItemsVisible()
+
+        toggleItems(0, 2)
+        await waitFor(() => expect(screen.getByTestId('progress-milestone')).toBeTruthy())
+
+        toggleItems(0, 2)
+
+        await waitFor(() => expect(screen.getByTestId('packing-progress-fill').style.width).toBe('0%'))
+        expect(screen.queryByTestId('progress-milestone')).toBeNull()
+    })
+
+    it('hands over to the all-packed treatment at 100%', async () => {
+        setup(eightItemList)
+        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        keepPackedItemsVisible()
+
+        toggleItems(0, 8)
+
+        // The section header celebrates too, so the strip is one of several
+        await waitFor(() => expect(screen.getAllByText('🎉 All packed!').length).toBeGreaterThan(0))
+        expect(screen.queryByTestId('progress-milestone')).toBeNull()
+        expect(screen.getByTestId('packing-progress-fill').style.width).toBe('100%')
+    })
+})
+
 describe('ViewPackingList checked item styling', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -20,6 +20,7 @@ import { useForeignPod } from '../components/ForeignPodContext'
 import { useSharedListsSync } from '../hooks/useSharedListsSync'
 import { mergePackingLists } from '../utils/mergePackingLists'
 import { computeQuestionSetAdditions } from '../create-packing-list/updateFromQuestions'
+import { MILESTONE_MESSAGES, resolveMilestone } from './packing-milestones'
 
 type FormData = {
     items: Record<string, boolean>
@@ -161,6 +162,9 @@ export function ViewPackingList() {
     const [justCelebrated, setJustCelebrated] = useState(false)
     // null means "haven't looked yet", so the first read is only a baseline
     const wasAllPackedRef = useRef<boolean | null>(null)
+    // Encouragement in the progress strip. Held as state rather than derived so
+    // it can lag behind a boundary — see resolveMilestone.
+    const [milestone, setMilestone] = useState<number | null>(null)
 
 
     const toggleCategory = (key: string) =>
@@ -283,6 +287,16 @@ export function ViewPackingList() {
             setCompletionStage('exiting')
             setJustCelebrated(true)
         }
+    }, [packingList, watchedItems])
+
+    useEffect(() => {
+        if (!packingList) return
+        const total = packingList.items.length
+        // Same hydration guard as above: until the form fills in, every item looks
+        // unpacked and a list opened mid-way would start with no milestone.
+        if (total > 0 && Object.keys(watchedItems).length === 0) return
+        const packed = packingList.items.filter(item => watchedItems[item.id]).length
+        setMilestone(prev => resolveMilestone(prev, packed, total))
     }, [packingList, watchedItems])
 
     useEffect(() => {
@@ -743,6 +757,11 @@ export function ViewPackingList() {
     const packedCount = packingList.items.filter(item => watchedItems[item.id]).length
     const percentComplete = totalCount > 0 ? Math.round((packedCount / totalCount) * 100) : 0
     const allPacked = totalCount > 0 && packedCount === totalCount
+    // A sliver of fill so the first item packed is visibly worth something, but
+    // nothing at all while the list is untouched
+    const progressWidth = packedCount === 0 ? 0 : Math.max(percentComplete, 4)
+    // The finished state has its own celebration; milestones step aside for it
+    const milestoneMessage = !allPacked && milestone !== null ? MILESTONE_MESSAGES[milestone] : null
     // Asking to see packed items always wins — otherwise a finished list would
     // offer no way back to its own contents.
     const sectionsExiting = completionStage === 'exiting' && !showPacked
@@ -929,36 +948,62 @@ export function ViewPackingList() {
             {/* Slim sticky progress strip */}
             <div className="sticky top-0 z-50 w-full mb-4 flex justify-center">
                 <div className="w-full max-w-screen-2xl">
-                    <div className="backdrop-blur-md bg-white/90 border border-gray-200 shadow-sm rounded-lg px-4 py-2 flex items-center justify-between gap-3">
-                        <span className={`text-sm font-medium ${allPacked ? 'text-emerald-600' : 'text-gray-600'}`}>
-                            {allPacked ? '🎉 All packed!' : `${packedCount} / ${totalCount} packed (${percentComplete}%)`}
-                        </span>
-                        <div className="flex items-center gap-2">
-                            <div className="flex items-center rounded-md border border-gray-300 overflow-hidden" role="group" aria-label="View mode">
-                                <button
-                                    type="button"
-                                    aria-pressed={viewMode === 'person'}
-                                    onClick={() => setViewMode('person')}
-                                    className={`px-3 py-1.5 text-sm font-medium transition-colors ${viewMode === 'person' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                    <div className="backdrop-blur-md bg-white/90 border border-gray-200 shadow-sm rounded-lg px-4 py-2">
+                        {/* Counts and bar share a line with the controls where there is
+                            room; at 390px the controls drop to a line of their own
+                            rather than squeezing everything into wrapped fragments. */}
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+                            <span className={`text-sm font-medium whitespace-nowrap ${allPacked ? 'text-emerald-600' : 'text-gray-600'}`}>
+                                {allPacked ? '🎉 All packed!' : `${packedCount} / ${totalCount} packed (${percentComplete}%)`}
+                            </span>
+                            <div className="flex-1 min-w-0 flex items-center gap-2">
+                                <div
+                                    role="progressbar"
+                                    aria-label="Packing progress"
+                                    aria-valuenow={percentComplete}
+                                    aria-valuemin={0}
+                                    aria-valuemax={100}
+                                    className="flex-1 min-w-8 bg-gray-200 rounded-full h-1.5 overflow-hidden"
                                 >
-                                    Person View
-                                </button>
-                                <button
-                                    type="button"
-                                    aria-pressed={viewMode === 'question'}
-                                    onClick={() => setViewMode('question')}
-                                    className={`px-3 py-1.5 text-sm font-medium transition-colors border-l border-gray-300 ${viewMode === 'question' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
-                                >
-                                    Question View
-                                </button>
+                                    <div
+                                        data-testid="packing-progress-fill"
+                                        className={`progress-bar-fill h-full rounded-full ${allPacked ? 'bg-emerald-500' : 'bg-gradient-primary'}`}
+                                        style={{ width: `${progressWidth}%` }}
+                                    ></div>
+                                </div>
+                                {milestoneMessage && (
+                                    <span data-testid="progress-milestone" className="text-xs font-semibold text-primary-700 whitespace-nowrap">
+                                        {milestoneMessage}
+                                    </span>
+                                )}
                             </div>
-                            <Button
-                                type="button"
-                                variant={hiddenPackedCount > 0 ? 'primary' : 'secondary'}
-                                onClick={() => setShowPacked(!showPacked)}
-                            >
-                                {showPacked ? 'Hide Packed' : 'Show Packed'}
-                            </Button>
+                            <div className="w-full sm:w-auto flex items-center justify-end gap-2">
+                                <div className="flex items-center rounded-md border border-gray-300 overflow-hidden" role="group" aria-label="View mode">
+                                    <button
+                                        type="button"
+                                        aria-pressed={viewMode === 'person'}
+                                        onClick={() => setViewMode('person')}
+                                        className={`px-3 py-1.5 text-sm font-medium transition-colors ${viewMode === 'person' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                                    >
+                                        Person View
+                                    </button>
+                                    <button
+                                        type="button"
+                                        aria-pressed={viewMode === 'question'}
+                                        onClick={() => setViewMode('question')}
+                                        className={`px-3 py-1.5 text-sm font-medium transition-colors border-l border-gray-300 ${viewMode === 'question' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                                    >
+                                        Question View
+                                    </button>
+                                </div>
+                                <Button
+                                    type="button"
+                                    variant={hiddenPackedCount > 0 ? 'primary' : 'secondary'}
+                                    onClick={() => setShowPacked(!showPacked)}
+                                >
+                                    {showPacked ? 'Hide Packed' : 'Show Packed'}
+                                </Button>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The packing screen is where you stare at the number all evening, and it only
ever showed one — the lists index had the actual bar. It now has the same bar,
plus microcopy at a quarter, half and three quarters, handing over to the
existing all-packed celebration at 100%.

Milestone copy holds steady when a single item is toggled around a threshold:
unticking the item that earned a milestone shouldn't blink the copy away and
straight back in, so the milestone is only given up once progress falls more
than one item short of it. Upgrades still land immediately.

The bar goes on the line the counts already occupied rather than a new one, so
the sticky strip keeps its height on desktop. At 390px the view-mode toggle and
Show Packed now drop to their own line instead of squeezing the counts into
three wrapped fragments — the strip ends up 2px taller than before and reads
considerably better.

Both progress bars share a `.progress-bar-fill` class whose width transition is
dropped under prefers-reduced-motion.

Closes #245