### PR TITLE
Give waiting screens a suitcase and a skeleton instead of bare text

### DIFF
--- a/src/components/LoadingState.test.tsx
+++ b/src/components/LoadingState.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { LoadingState } from './LoadingState'
+
+describe('LoadingState', () => {
+    it('announces what is loading to screen readers', () => {
+        render(<LoadingState message="Loading packing lists..." />)
+
+        const status = screen.getByRole('status')
+        expect(status.textContent).toContain('Loading packing lists...')
+        expect(status.getAttribute('aria-live')).toBe('polite')
+    })
+
+    it('shows a packing-themed suitcase that screen readers skip', () => {
+        render(<LoadingState message="Loading backups..." />)
+
+        const suitcase = screen.getByText('🧳')
+        expect(suitcase.getAttribute('aria-hidden')).toBe('true')
+        expect(suitcase.className).toContain('loading-suitcase')
+    })
+
+    it('renders a skeleton of the content to come', () => {
+        render(<LoadingState message="Loading packing lists..." />)
+
+        expect(screen.getAllByTestId('loading-skeleton-card')).toHaveLength(3)
+    })
+
+    it('lets a page choose how many skeleton cards to show', () => {
+        render(<LoadingState message="Loading questions..." rows={5} />)
+
+        expect(screen.getAllByTestId('loading-skeleton-card')).toHaveLength(5)
+    })
+
+    it('hides the decorative skeleton from screen readers, which already have the message', () => {
+        render(<LoadingState message="Loading packing list..." />)
+
+        const skeleton = screen.getByTestId('loading-skeleton')
+        expect(skeleton.getAttribute('aria-hidden')).toBe('true')
+    })
+
+    it('holds still for anyone who asked for reduced motion', () => {
+        const css = readFileSync(resolve(__dirname, '../index.css'), 'utf-8')
+        const reducedMotionBlocks = css
+            .split('@media (prefers-reduced-motion: reduce) {')
+            .slice(1)
+            .join('\n')
+
+        expect(reducedMotionBlocks).toContain('.loading-suitcase')
+        expect(reducedMotionBlocks).toContain('.loading-skeleton-bar')
+    })
+})

--- a/src/components/LoadingState.tsx
+++ b/src/components/LoadingState.tsx
@@ -1,0 +1,36 @@
+interface LoadingStateProps {
+    /** What is being waited for, e.g. "Loading packing lists..." — read out to screen readers. */
+    message: string;
+    /** How many placeholder cards to stand in for the content to come. */
+    rows?: number;
+}
+
+/**
+ * The app's one waiting treatment: a suitcase rocking above a skeleton of the
+ * content on its way. Sized to sit in the same space the real content will
+ * take, so nothing jumps when it arrives.
+ */
+export function LoadingState({ message, rows = 3 }: LoadingStateProps) {
+    return (
+        <div role="status" aria-live="polite">
+            <div className="flex flex-col items-center gap-3 py-6">
+                <span aria-hidden="true" className="loading-suitcase text-5xl leading-none">🧳</span>
+                <p className="text-lg font-semibold text-gray-700">{message}</p>
+            </div>
+
+            <div data-testid="loading-skeleton" aria-hidden="true" className="space-y-4">
+                {Array.from({ length: rows }, (_, index) => (
+                    <div
+                        key={index}
+                        data-testid="loading-skeleton-card"
+                        className="rounded-2xl border-2 border-primary-100 bg-white p-5 shadow-soft"
+                    >
+                        <div className="loading-skeleton-bar h-5 w-1/2 rounded-full" />
+                        <div className="loading-skeleton-bar mt-3 h-4 w-1/3 rounded-full" />
+                        <div className="loading-skeleton-bar mt-5 h-3 w-full rounded-full" />
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -244,7 +244,33 @@ body {
   transition: width 0.5s ease;
 }
 
-/* Celebrations are decorative — hold still for anyone who asked us to. */
+/* Waiting should still feel like the app: a suitcase rocking on its corner
+   above a skeleton of the content that's on its way. */
+@keyframes loading-suitcase-rock {
+  0%, 100% { transform: translateY(0) rotate(-7deg); }
+  50% { transform: translateY(-6px) rotate(7deg); }
+}
+
+.loading-suitcase {
+  display: inline-block;
+  animation: loading-suitcase-rock 1.5s ease-in-out infinite;
+}
+
+@keyframes loading-skeleton-sweep {
+  0% { background-position: 150% 0; }
+  100% { background-position: -50% 0; }
+}
+
+.loading-skeleton-bar {
+  background-color: #e2e8f0;
+  background-image: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.85) 50%, transparent 100%);
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  animation: loading-skeleton-sweep 1.6s ease-in-out infinite;
+}
+
+/* Celebrations and waiting states are decorative — hold still for anyone who
+   asked us to. */
 @media (prefers-reduced-motion: reduce) {
   .celebration-banner,
   .celebration-banner-rising,
@@ -269,6 +295,16 @@ body {
   /* The bar still has to reach the right width — it just gets there at once */
   .progress-bar-fill {
     transition: none;
+  }
+
+  .loading-suitcase {
+    animation: none;
+  }
+
+  /* The placeholder bars stay — they just stop sweeping */
+  .loading-skeleton-bar {
+    animation: none;
+    background-image: none;
   }
 }
 

--- a/src/pages/backups.test.tsx
+++ b/src/pages/backups.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import React from 'react'
+import type { AppSession as Session } from '../types/AppSession'
+import type { PackingAppDatabase } from '../services/database'
+
+vi.mock('../components/SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+vi.mock('../components/DatabaseContext', () => ({
+    useDatabase: vi.fn(),
+}))
+
+vi.mock('../components/ToastContext', () => ({
+    useToast: vi.fn(() => ({ showToast: vi.fn() })),
+}))
+
+vi.mock('../hooks/usePodErrorHandler', () => ({
+    usePodErrorHandler: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('../services/solidPod', () => ({
+    getPrimaryPodUrl: vi.fn(),
+}))
+
+vi.mock('../services/solidPodBackup', () => ({
+    createBackup: vi.fn(),
+    listBackups: vi.fn(),
+    deleteBackup: vi.fn(),
+    restoreBackup: vi.fn(),
+}))
+
+import { BackupsPage } from './backups'
+import { useSolidPod } from '../components/SolidPodContext'
+import { useDatabase } from '../components/DatabaseContext'
+import { getPrimaryPodUrl } from '../services/solidPod'
+import { listBackups } from '../services/solidPodBackup'
+
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
+const mockListBackups = vi.mocked(listBackups)
+
+describe('BackupsPage loading state', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: {} as Session,
+            webId: 'https://pod.example/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: {} as PackingAppDatabase })
+        mockGetPrimaryPodUrl.mockResolvedValue('https://pod.example/')
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('uses the shared loading treatment while backups load', async () => {
+        mockListBackups.mockReturnValue(new Promise(() => {}))
+
+        render(<BackupsPage />)
+
+        await waitFor(() => {
+            expect(screen.getByRole('status').textContent).toContain('Loading backups...')
+        })
+        expect(screen.getAllByTestId('loading-skeleton-card').length).toBeGreaterThan(0)
+    })
+
+    it('replaces the loading treatment with the real content once backups arrive', async () => {
+        mockListBackups.mockResolvedValue([])
+
+        render(<BackupsPage />)
+
+        await waitFor(() => expect(screen.getByText('No backups yet')).toBeTruthy())
+        expect(screen.queryByRole('status')).toBeNull()
+    })
+})

--- a/src/pages/backups.tsx
+++ b/src/pages/backups.tsx
@@ -4,6 +4,7 @@ import { useDatabase } from '../components/DatabaseContext'
 import { useToast } from '../components/ToastContext'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { Button } from '../components/Button'
+import { LoadingState } from '../components/LoadingState'
 import { getPrimaryPodUrl } from '../services/solidPod'
 import {
     createBackup,
@@ -129,9 +130,7 @@ export function BackupsPage() {
             </div>
 
             {isLoadingBackups ? (
-                <div className="text-center py-12 text-gray-700 font-semibold">
-                    Loading backups...
-                </div>
+                <LoadingState message="Loading backups..." rows={2} />
             ) : backups.length === 0 ? (
                 <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
                     <p className="text-lg text-gray-800 font-semibold">No backups yet</p>

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -1431,3 +1431,35 @@ describe('CreatePackingList – nights away and suggested quantities', () => {
         savedList.items.forEach(item => expect(item.quantity).toBeUndefined())
     })
 })
+
+describe('CreatePackingList – loading state', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({ isLoggedIn: false } as ReturnType<typeof useSolidPod>)
+        mockUseToast.mockReturnValue({ showToast: vi.fn() } as ReturnType<typeof useToast>)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('uses the shared loading treatment while questions load', () => {
+        mockUseDatabase.mockReturnValue({
+            db: makeDb({ getQuestionSet: vi.fn(() => new Promise(() => {})) }),
+        } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+
+        expect(screen.getByRole('status').textContent).toContain('Loading questions...')
+        expect(screen.getAllByTestId('loading-skeleton-card').length).toBeGreaterThan(0)
+    })
+
+    it('replaces the loading treatment with the questions once they arrive', async () => {
+        mockUseDatabase.mockReturnValue({ db: makeDb() } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+        expect(screen.queryByRole('status')).toBeNull()
+    })
+})

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -16,6 +16,7 @@ import { questionSetToDataset, datasetToQuestionSet, packingListToDataset, datas
 import { useForeignPod } from '../components/ForeignPodContext'
 import { generateQuestionBasedItems, generateAlwaysNeededItems, withItemOrder } from '../create-packing-list/generatePackingListItems'
 import { AgePromotionCard } from '../components/AgePromotionCard'
+import { LoadingState } from '../components/LoadingState'
 
 export function deduplicateItems(items: PackingListItem[]): PackingListItem[] {
     const seen = new Set<string>()
@@ -650,11 +651,7 @@ export function CreatePackingList() {
     if (isLoading) {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
-                <div className="flex items-center justify-center min-h-96">
-                    <div className="text-center">
-                        <div className="text-lg text-gray-600">Loading questions...</div>
-                    </div>
-                </div>
+                <LoadingState message="Loading questions..." rows={3} />
             </div>
         )
     }

--- a/src/pages/foreign-packing-lists.test.tsx
+++ b/src/pages/foreign-packing-lists.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import type { AppSession as Session } from '../types/AppSession'
+
+vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn() }))
+vi.mock('../components/ForeignPodContext', () => ({ useForeignPod: vi.fn() }))
+
+vi.mock('../services/solidPod', () => ({
+    loadMultipleRdfFromPod: vi.fn(),
+    POD_CONTAINERS: { PACKING_LISTS: 'pack-me-up/packing-lists/' },
+}))
+
+vi.mock('../services/rdfSerialization', () => ({
+    datasetToPackingList: vi.fn(),
+}))
+
+import { ForeignPackingListsPage } from './foreign-packing-lists'
+import { useSolidPod } from '../components/SolidPodContext'
+import { useForeignPod } from '../components/ForeignPodContext'
+import { loadMultipleRdfFromPod } from '../services/solidPod'
+
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockUseForeignPod = vi.mocked(useForeignPod)
+const mockLoadMultipleRdfFromPod = vi.mocked(loadMultipleRdfFromPod)
+
+function renderPage() {
+    return render(
+        <MemoryRouter>
+            <ForeignPackingListsPage />
+        </MemoryRouter>
+    )
+}
+
+describe('ForeignPackingListsPage loading state', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: {} as Session,
+            webId: 'https://me.example/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseForeignPod.mockReturnValue({ foreignPodUrl: 'https://friend.example/' } as ReturnType<typeof useForeignPod>)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('uses the shared loading treatment while the shared lists load', async () => {
+        mockLoadMultipleRdfFromPod.mockReturnValue(new Promise(() => {}))
+
+        renderPage()
+
+        await waitFor(() => {
+            expect(screen.getByRole('status').textContent).toContain('Loading packing lists...')
+        })
+        expect(screen.getAllByTestId('loading-skeleton-card').length).toBeGreaterThan(0)
+    })
+
+    it('replaces the loading treatment with the real content once the lists arrive', async () => {
+        mockLoadMultipleRdfFromPod.mockResolvedValue({ data: [], errors: [] })
+
+        renderPage()
+
+        await waitFor(() => expect(screen.getByText(/no packing lists/i)).toBeTruthy())
+        expect(screen.queryByRole('status')).toBeNull()
+    })
+})

--- a/src/pages/foreign-packing-lists.tsx
+++ b/src/pages/foreign-packing-lists.tsx
@@ -4,6 +4,7 @@ import { useForeignPod } from '../components/ForeignPodContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { loadMultipleRdfFromPod, POD_CONTAINERS } from '../services/solidPod'
 import { datasetToPackingList } from '../services/rdfSerialization'
+import { LoadingState } from '../components/LoadingState'
 import type { PackingList } from '../create-packing-list/types'
 
 export function ForeignPackingListsPage() {
@@ -39,7 +40,11 @@ export function ForeignPackingListsPage() {
     if (isLoading) {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
-                <p className="text-gray-500">Loading packing lists…</p>
+                <div className="mb-8">
+                    <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
+                    <p className="mt-2 text-lg text-gray-700 font-medium">Shared packing lists.</p>
+                </div>
+                <LoadingState message="Loading packing lists..." rows={3} />
             </div>
         )
     }

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -114,6 +114,20 @@ describe('PackingLists', () => {
         vi.restoreAllMocks()
     })
 
+    it('uses the shared loading treatment while packing lists load', () => {
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn(() => new Promise(() => {})),
+                getSharedListsWithMe: vi.fn(() => new Promise(() => {})),
+            } as unknown as PackingAppDatabase,
+        })
+
+        renderComponent()
+
+        expect(screen.getByRole('status').textContent).toContain('Loading packing lists...')
+        expect(screen.getAllByTestId('loading-skeleton-card').length).toBeGreaterThan(0)
+    })
+
     it('does not show Protect Your Packing Lists banner for non-logged-in users with lists', async () => {
         render(
             <MemoryRouter>

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -5,6 +5,7 @@ import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
+import { LoadingState } from '../components/LoadingState'
 import { Modal } from '../components/Modal'
 import { getPrimaryPodUrl, saveRdfToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES, getCollaborators, isPubliclyAccessible, resolveOwnerDisplayName, buildSharedListPath } from '../services/solidPod'
 import { useOwnerDisplayNames } from '../hooks/useOwnerDisplayName'
@@ -154,7 +155,20 @@ export function PackingLists() {
     }, [packingLists, isLoggedIn, session])
 
     if (isLoading || loginSyncInProgress) {
-        return <div className="max-w-4xl mx-auto py-8 px-4 text-center text-gray-700 font-semibold">Loading packing lists...</div>
+        // Keep the real header in place so only the list area changes when the
+        // lists land.
+        return (
+            <div className="max-w-4xl mx-auto py-8 px-4">
+                <div className="mb-8 flex justify-between items-start">
+                    <div className="mb-2">
+                        <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
+                        <p className="mt-2 text-lg text-gray-700 font-medium">View all your created packing lists.</p>
+                    </div>
+                    <Button variant="primary" onClick={() => navigate('/create-packing-list')}>➕ New List</Button>
+                </div>
+                <LoadingState message="Loading packing lists..." rows={3} />
+            </div>
+        )
     }
 
     return (

--- a/src/pages/questions-page.loading.test.tsx
+++ b/src/pages/questions-page.loading.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import type { PackingAppDatabase } from '../services/database'
+
+vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
+vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn() }))
+vi.mock('../components/ForeignPodContext', () => ({ useForeignPod: vi.fn() }))
+
+vi.mock('../hooks/useSyncCoordinator', () => ({
+    useSyncCoordinator: vi.fn(() => ({
+        saveWithSyncPrevention: vi.fn(),
+        handleSyncSuccess: vi.fn(),
+        handleSyncError: vi.fn(),
+    })),
+}))
+
+vi.mock('../hooks/usePodSync', () => ({
+    usePodSync: vi.fn(() => ({ saveToPod: vi.fn(), syncFromPod: vi.fn() })),
+}))
+
+vi.mock('../services/migration', () => ({
+    DatabaseMigration: {
+        checkMigrationNeeded: vi.fn().mockResolvedValue({ needed: false }),
+        performMigration: vi.fn(),
+    },
+}))
+
+vi.mock('../services/solidPod', () => ({
+    POD_CONTAINERS: { ROOT: 'pack-me-up/' },
+}))
+
+vi.mock('../services/rdfSerialization', () => ({
+    questionSetToDataset: vi.fn(),
+    datasetToQuestionSet: vi.fn(),
+}))
+
+import { QuestionsPage } from './questions-page'
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+import { useForeignPod } from '../components/ForeignPodContext'
+
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockUseForeignPod = vi.mocked(useForeignPod)
+
+const emptyQuestionSet = { _id: '1', _rev: '1', questions: [], people: [], alwaysNeededItems: [] }
+
+function renderQuestionsPage(getQuestionSet: () => Promise<unknown>) {
+    mockUseDatabase.mockReturnValue({
+        db: { getQuestionSet, saveQuestionSet: vi.fn() } as unknown as PackingAppDatabase,
+    })
+    return render(
+        <MemoryRouter>
+            <QuestionsPage />
+        </MemoryRouter>
+    )
+}
+
+describe('QuestionsPage loading state', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseForeignPod.mockReturnValue(null)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('uses the shared loading treatment while the question set loads', async () => {
+        renderQuestionsPage(() => new Promise(() => {}))
+
+        await waitFor(() => {
+            expect(screen.getByRole('status').textContent).toContain('Loading questions & items...')
+        })
+        expect(screen.getAllByTestId('loading-skeleton-card').length).toBeGreaterThan(0)
+    })
+
+    it('replaces the loading treatment with the real content once the question set arrives', async () => {
+        renderQuestionsPage(() => Promise.resolve(emptyQuestionSet))
+
+        await waitFor(() => expect(screen.getByText('My Questions & Items')).toBeTruthy())
+        expect(screen.queryByRole('status')).toBeNull()
+    })
+})

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -32,6 +32,7 @@ import { useForeignPod } from '../components/ForeignPodContext'
 import { CustomCreatableSelect } from '../components/CreatableSelect'
 import { AgePromotionCard } from '../components/AgePromotionCard'
 import { TemplateUpdatesCard } from '../components/TemplateUpdatesCard'
+import { LoadingState } from '../components/LoadingState'
 import { AgeTransition } from '../edit-questions/age-derivation'
 import { useIsDesktop } from '../hooks/useIsDesktop'
 
@@ -1625,7 +1626,13 @@ export function QuestionsPage() {
     const activeAlwaysNeededItems = useMemo(() => (data?.alwaysNeededItems ?? []).filter(i => !i.deletedAt), [data])
 
     if (error) return <div className="p-8 text-red-600">Error: {error}</div>
-    if (!data) return <div className="p-8 text-gray-500">Loading…</div>
+    if (!data) return (
+        <div className="w-full flex flex-col items-center py-8 px-4">
+            <div className="w-full max-w-3xl">
+                <LoadingState message="Loading questions & items..." rows={3} />
+            </div>
+        </div>
+    )
 
     return (
         <div className="w-full flex flex-col items-center py-8 px-4">

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1200,6 +1200,19 @@ describe('ViewPackingList foreign pod (?pod= param)', () => {
         await waitFor(() => expect(screen.getByText(/loading/i)).toBeTruthy())
     })
 
+    it('uses the shared loading treatment while the packing list loads', async () => {
+        const dbWithNotFound = {
+            ...makeDb(),
+            getPackingList: vi.fn().mockRejectedValue({ name: 'not_found' }),
+        }
+        mockUseDatabase.mockReturnValue({ db: dbWithNotFound as unknown as PackingAppDatabase })
+
+        renderWithForeignPod(FOREIGN_POD_URL)
+
+        await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Loading packing list...'))
+        expect(screen.getAllByTestId('loading-skeleton-card').length).toBeGreaterThan(0)
+    })
+
     it('stops loading and shows a toast when foreign pod sync fails before data is loaded', async () => {
         const dbWithNotFound = {
             ...makeDb(),

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -5,6 +5,7 @@ import { PackingList, PackingListItem } from '../create-packing-list/types'
 import { useDatabase } from '../components/DatabaseContext'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
+import { LoadingState } from '../components/LoadingState'
 import { useForm, useWatch } from 'react-hook-form'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
@@ -735,7 +736,11 @@ export function ViewPackingList() {
     }
 
     if (isLoading) {
-        return <div className="max-w-4xl mx-auto py-8 px-4">Loading packing list...</div>
+        return (
+            <div className="max-w-4xl mx-auto py-8 px-4">
+                <LoadingState message="Loading packing list..." rows={3} />
+            </div>
+        )
     }
 
     if (!packingList) {


### PR DESCRIPTION
Four screens dropped to unstyled "Loading..." text while they fetched —
small dead moments in an otherwise colourful app, and the list view's can
run long when it's hydrating from a pod.

They now share one LoadingState: a suitcase rocking above a skeleton of the
cards on their way, sized to sit in the space the real content will take.
The message stays as text inside a role="status" region so screen readers
still hear what's happening, and both animations stop under
prefers-reduced-motion — the placeholder bars stay put rather than vanish,
since a still skeleton still says "content is coming".

The packing lists page keeps its real header while loading, so only the
list area changes when the lists land.

Closes #249

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QzQZBy4z92rFrwF5ojktEa