### PR TITLE
Reveal what the wizard generated instead of an instant modal

### DIFF
--- a/e2e/tests/a-onboarding.spec.ts
+++ b/e2e/tests/a-onboarding.spec.ts
@@ -22,6 +22,9 @@ test.describe('A – Onboarding & Wizard', () => {
     await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
     // Success modal (use role heading to distinguish from toast)
     await waitForWizardSuccess(page)
+    // The reveal names the actual person, and the summary states what was built
+    await expect(page.getByText(/Thinking about Me/i)).toBeVisible()
+    await expect(page.getByText(/\d+ questions and \d+ items across 1 person/i)).toBeVisible({ timeout: 5_000 })
     await page.getByRole('button', { name: /Create My First Packing List/i }).click()
     // Pod prompt appears for non-logged-in users
     await expect(page.getByText("Great! Your Questions Are Ready")).toBeVisible({ timeout: 5_000 })

--- a/src/edit-questions/age-derivation.ts
+++ b/src/edit-questions/age-derivation.ts
@@ -6,7 +6,7 @@ import { AgeRange, Person } from './types'
  * brackets flip exactly on birthdays; a Feb 29 birthday counts from Mar 1 in
  * non-leap years.
  */
-function ageInYears(dateOfBirth: string, today: Date): number | null {
+export function ageInYears(dateOfBirth: string, today: Date): number | null {
     const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateOfBirth.trim())
     if (!match) return null
     const [, y, m, d] = match.map(Number)

--- a/src/index.css
+++ b/src/index.css
@@ -95,6 +95,30 @@ body {
   overscroll-behavior: none;
 }
 
+/* Wizard generation reveal: each line eases in as it is added */
+@keyframes reveal-line-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.reveal-line {
+  animation: reveal-line-in 0.35s ease-out both;
+}
+
+/* Motion guard: decorative animation is neutralised for users who ask for
+   reduced motion. Anything that reveals content over time must additionally
+   check prefersReducedMotion() and skip to the end state. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* Celebration animations */
 @keyframes celebration-float {
   0%, 100% { transform: translateY(0px) rotate(-5deg); }

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -18,6 +18,8 @@ export function useWizardGeneration() {
     const { db } = useDatabase()
     const [isLoading, setIsLoading] = useState(false)
     const [isSuccess, setIsSuccess] = useState(false)
+    // The set we just built, so the success screen can show what was generated
+    const [generatedSet, setGeneratedSet] = useState<PackingListQuestionSet | null>(null)
 
     const { saveToPod } = usePodSync<PackingListQuestionSet>({
         pathConfig: {
@@ -54,6 +56,7 @@ export function useWizardGeneration() {
     const generateAndSave = async (data: WizardFormData) => {
         setIsLoading(true)
         setIsSuccess(false)
+        setGeneratedSet(null)
         try {
             const questionSet = generateQuestionSet(data)
 
@@ -63,6 +66,7 @@ export function useWizardGeneration() {
             )
 
             showToast('Packing list questions generated successfully!', 'success')
+            setGeneratedSet(questionSet)
             setIsSuccess(true)
         } catch (err) {
             const details = reportError(err, 'Error generating question set')
@@ -75,6 +79,7 @@ export function useWizardGeneration() {
     return {
         isLoading,
         isSuccess,
+        generatedSet,
         generateAndSave
     }
 }

--- a/src/pages/wizard-reveal.test.ts
+++ b/src/pages/wizard-reveal.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import { buildRevealSteps, buildGenerationSummary, MAX_REVEAL_STEPS } from './wizard-reveal'
+import { createExampleData } from '../edit-questions/example-data'
+import { Person, PackingListQuestionSet } from '../edit-questions/types'
+
+function person(overrides: Partial<Person> & { id: string; name: string }): Person {
+    return { ageRange: 'Adult', ...overrides }
+}
+
+function setFor(people: Person[]): PackingListQuestionSet {
+    return createExampleData(people, [])
+}
+
+describe('buildRevealSteps', () => {
+    it('names each person from the generated set', () => {
+        const steps = buildRevealSteps(setFor([
+            person({ id: '1', name: 'Sam' }),
+            person({ id: '2', name: 'Ellie', ageRange: 'Toddler' }),
+        ]))
+
+        expect(steps.map(s => s.name)).toEqual(['Sam', 'Ellie'])
+    })
+
+    it('describes a person by their age bracket when no birthday is known', () => {
+        const [step] = buildRevealSteps(setFor([person({ id: '1', name: 'Ellie', ageRange: 'Toddler' })]))
+
+        expect(step.descriptor).toBe('toddler')
+        expect(step.text).toContain('Ellie (toddler)')
+    })
+
+    it('describes a person by their age in years when a birthday is known', () => {
+        const today = new Date('2026-07-25T00:00:00Z')
+        const [step] = buildRevealSteps(
+            setFor([person({ id: '1', name: 'Ellie', ageRange: 'Child', dateOfBirth: '2022-01-10' })]),
+            today
+        )
+
+        expect(step.descriptor).toBe('4')
+        expect(step.text).toContain('Ellie (4)')
+    })
+
+    it('describes a pet by its species', () => {
+        const [, step] = buildRevealSteps(setFor([
+            person({ id: '1', name: 'Sam' }),
+            { id: '2', name: 'Rex', species: 'dog' },
+        ]))
+
+        expect(step.descriptor).toBe('dog')
+        expect(step.text).toContain('Rex (dog)')
+    })
+
+    it('names the items that are specific to that person', () => {
+        const steps = buildRevealSteps(setFor([
+            person({ id: '1', name: 'Sam' }),
+            person({ id: '2', name: 'Ellie', ageRange: 'Baby' }),
+        ]))
+
+        const ellie = steps.find(s => s.name === 'Ellie')!
+        expect(ellie.items.join(' ').toLowerCase()).toContain('nappies')
+        expect(ellie.text).toMatch(/adding .*nappies/i)
+    })
+
+    it('picks different items for people in different age brackets', () => {
+        const steps = buildRevealSteps(setFor([
+            person({ id: '1', name: 'Sam' }),
+            person({ id: '2', name: 'Ellie', ageRange: 'Baby' }),
+        ]))
+
+        const sam = steps.find(s => s.name === 'Sam')!
+        const ellie = steps.find(s => s.name === 'Ellie')!
+        expect(sam.items).not.toEqual(ellie.items)
+    })
+
+    it('strips parenthetical qualifiers from item names', () => {
+        const steps = buildRevealSteps(setFor([person({ id: '1', name: 'Ellie', ageRange: 'Baby' })]))
+
+        expect(steps[0].items.some(i => i.includes('('))).toBe(false)
+    })
+
+    it('caps the number of steps so the reveal stays short', () => {
+        const people = Array.from({ length: 8 }, (_, i) => person({ id: String(i), name: `P${i}` }))
+
+        expect(buildRevealSteps(setFor(people))).toHaveLength(MAX_REVEAL_STEPS)
+    })
+
+    it('returns no steps for a set with no people', () => {
+        expect(buildRevealSteps(setFor([]))).toEqual([])
+    })
+
+    it('still produces readable text for a person with no distinctive items', () => {
+        const questionSet: PackingListQuestionSet = {
+            people: [person({ id: '1', name: 'Sam' })],
+            alwaysNeededItems: [],
+            questions: [],
+        }
+        const [step] = buildRevealSteps(questionSet)
+
+        expect(step.items).toEqual([])
+        expect(step.text).toContain('Sam')
+        expect(step.text).not.toContain('adding')
+    })
+})
+
+describe('buildGenerationSummary', () => {
+    it('counts questions, people and pets', () => {
+        const summary = buildGenerationSummary(setFor([
+            person({ id: '1', name: 'Sam' }),
+            person({ id: '2', name: 'Ali' }),
+            { id: '3', name: 'Rex', species: 'dog' },
+        ]))
+
+        expect(summary.peopleCount).toBe(2)
+        expect(summary.petCount).toBe(1)
+        expect(summary.questionCount).toBeGreaterThan(0)
+        expect(summary.itemCount).toBeGreaterThan(0)
+        expect(summary.text).toContain('2 people and 1 pet')
+    })
+
+    it('uses singular wording for a single person and no pets', () => {
+        const summary = buildGenerationSummary(setFor([person({ id: '1', name: 'Sam' })]))
+
+        expect(summary.text).toContain('1 person')
+        expect(summary.text).not.toContain('pet')
+    })
+
+    it('pluralises pets', () => {
+        const summary = buildGenerationSummary(setFor([
+            person({ id: '1', name: 'Sam' }),
+            { id: '2', name: 'Rex', species: 'dog' },
+            { id: '3', name: 'Mog', species: 'cat' },
+        ]))
+
+        expect(summary.text).toContain('2 pets')
+    })
+
+    it('counts every generated question and item', () => {
+        const questionSet: PackingListQuestionSet = {
+            people: [person({ id: '1', name: 'Sam' })],
+            alwaysNeededItems: [{ text: 'Snacks', personSelections: [] }],
+            questions: [
+                {
+                    id: 'q1',
+                    type: 'saved',
+                    text: 'Overnight?',
+                    order: 0,
+                    options: [
+                        { id: 'o1', text: 'Yes', order: 0, items: [{ text: 'Toothbrush', personSelections: [] }] },
+                        { id: 'o2', text: 'No', order: 1, items: [] },
+                    ],
+                },
+            ],
+        }
+
+        const summary = buildGenerationSummary(questionSet)
+        expect(summary.questionCount).toBe(1)
+        expect(summary.itemCount).toBe(2)
+        expect(summary.text).toContain('1 question and 2 items')
+    })
+})

--- a/src/pages/wizard-reveal.ts
+++ b/src/pages/wizard-reveal.ts
@@ -1,0 +1,151 @@
+import { Item, PackingListQuestionSet, Person } from '../edit-questions/types'
+import { ageInYears, currentAgeRange } from '../edit-questions/age-derivation'
+
+/** Longest the staged reveal is allowed to run: steps × REVEAL_STEP_MS. */
+export const MAX_REVEAL_STEPS = 4
+export const REVEAL_STEP_MS = 700
+
+/** How many item names each reveal line mentions. */
+const ITEMS_PER_STEP = 2
+
+export interface RevealStep {
+    personId: string
+    name: string
+    /** Age in years, age bracket or pet species — whatever we actually know. */
+    descriptor?: string
+    items: string[]
+    text: string
+}
+
+export interface GenerationSummary {
+    questionCount: number
+    itemCount: number
+    peopleCount: number
+    petCount: number
+    text: string
+}
+
+function allItems(questionSet: PackingListQuestionSet): Item[] {
+    return [
+        ...questionSet.alwaysNeededItems,
+        ...questionSet.questions.flatMap(q => q.options.flatMap(o => o.items)),
+    ]
+}
+
+function livePeople(questionSet: PackingListQuestionSet): Person[] {
+    return questionSet.people.filter(p => !p.deletedAt)
+}
+
+const SPECIES_LABELS: Record<string, string> = { dog: 'dog', cat: 'cat', other: 'pet' }
+
+/**
+ * How to refer to someone in the reveal: a pet by species, a person by their
+ * age in whole years when a birthday is known (an infant reads better as
+ * "baby" than "0"), otherwise by their bracket.
+ */
+export function describePerson(person: Person, today: Date = new Date()): string | undefined {
+    if (person.species) return SPECIES_LABELS[person.species] ?? 'pet'
+    if (person.dateOfBirth) {
+        const years = ageInYears(person.dateOfBirth, today)
+        if (years !== null && years >= 1) return String(years)
+    }
+    const bracket = currentAgeRange(person, today)
+    return bracket ? bracket.toLowerCase() : undefined
+}
+
+/**
+ * Item text as it reads mid-sentence: parenthetical qualifiers dropped
+ * ("Nappies (pack/supply)" → "Nappies"), and the leading capital dropped only
+ * when nothing else in the name is capitalised — so "Nappies" becomes
+ * "nappies" while "Lead/Leash" and "EHIC/GHIC card" keep their shape.
+ */
+function readableItemText(text: string): string {
+    const stripped = text.replace(/\s*\([^)]*\)/g, '').trim() || text.trim()
+    const hasOtherCapitals = /[A-Z]/.test(stripped.slice(1))
+    return hasOtherCapitals ? stripped : stripped.charAt(0).toLowerCase() + stripped.slice(1)
+}
+
+function joinWithAnd(parts: string[]): string {
+    if (parts.length <= 1) return parts[0] ?? ''
+    return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`
+}
+
+/**
+ * The items that say the most about this person: the ones fewest others share,
+ * which is exactly what the age/species filters produce (nappies for the baby,
+ * a lead for the dog). Ties keep template order, so the headline items in
+ * `alwaysNeededItems` come first.
+ */
+function distinctiveItemsFor(personId: string, items: Item[]): string[] {
+    const scored = items
+        .map((item, index) => ({ item, index }))
+        .filter(({ item }) => item.personSelections.some(ps => ps.personId === personId && ps.selected))
+        .map(({ item, index }) => ({
+            text: readableItemText(item.text),
+            sharedBy: item.personSelections.filter(ps => ps.selected).length,
+            index,
+        }))
+        .sort((a, b) => a.sharedBy - b.sharedBy || a.index - b.index)
+
+    const seen = new Set<string>()
+    const picked: string[] = []
+    for (const { text } of scored) {
+        const key = text.toLowerCase()
+        if (seen.has(key)) continue
+        seen.add(key)
+        picked.push(text)
+        if (picked.length === ITEMS_PER_STEP) break
+    }
+    return picked
+}
+
+/**
+ * One line per person naming what the wizard just built for them, e.g.
+ * "Thinking about Ellie (4)… adding nappies and baby wipes". Capped at
+ * MAX_REVEAL_STEPS so the reveal never becomes a wait.
+ */
+export function buildRevealSteps(
+    questionSet: PackingListQuestionSet,
+    today: Date = new Date()
+): RevealStep[] {
+    const items = allItems(questionSet)
+
+    return livePeople(questionSet)
+        .slice(0, MAX_REVEAL_STEPS)
+        .map(person => {
+            const descriptor = describePerson(person, today)
+            const pickedItems = distinctiveItemsFor(person.id, items)
+            const who = descriptor ? `${person.name} (${descriptor})` : person.name
+            const text = pickedItems.length > 0
+                ? `Thinking about ${who}… adding ${joinWithAnd(pickedItems)}`
+                : `Thinking about ${who}…`
+            return { personId: person.id, name: person.name, descriptor, items: pickedItems, text }
+        })
+}
+
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+    return `${count} ${count === 1 ? singular : pluralForm}`
+}
+
+/** Concrete proof of what was generated, for the success screen. */
+export function buildGenerationSummary(questionSet: PackingListQuestionSet): GenerationSummary {
+    const people = livePeople(questionSet)
+    const peopleCount = people.filter(p => !p.species).length
+    const petCount = people.filter(p => p.species).length
+    const questionCount = questionSet.questions.filter(q => !q.deletedAt).length
+    const itemCount = allItems(questionSet).length
+
+    const who = [
+        peopleCount > 0 ? plural(peopleCount, 'person', 'people') : null,
+        petCount > 0 ? plural(petCount, 'pet') : null,
+    ].filter((part): part is string => part !== null)
+
+    const what = `${plural(questionCount, 'question')} and ${plural(itemCount, 'item')}`
+    return {
+        questionCount,
+        itemCount,
+        peopleCount,
+        petCount,
+        text: who.length > 0 ? `${what} across ${who.join(' and ')}` : what,
+    }
+}

--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -24,6 +24,7 @@ vi.mock('../components/ToastContext', () => ({
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useWizardGeneration } from './useWizardGeneration'
+import { createExampleData } from '../edit-questions/example-data'
 
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockUseSolidPod = vi.mocked(useSolidPod)
@@ -33,6 +34,14 @@ function makeDb(overrides: { getQuestionSet?: ReturnType<typeof vi.fn> } = {}) {
     return {
         getQuestionSet: overrides.getQuestionSet ?? vi.fn().mockRejectedValue({ name: 'not_found' }),
     }
+}
+
+function makeGeneratedSet() {
+    return createExampleData([
+        { id: '1', name: 'Sam', ageRange: 'Adult' },
+        { id: '2', name: 'Ellie', ageRange: 'Baby' },
+        { id: '3', name: 'Rex', species: 'dog' },
+    ], [])
 }
 
 describe('Wizard', () => {
@@ -51,6 +60,7 @@ describe('Wizard', () => {
         mockUseWizardGeneration.mockReturnValue({
             isLoading: false,
             isSuccess: false,
+            generatedSet: null,
             generateAndSave: vi.fn(),
         })
     })
@@ -94,6 +104,7 @@ describe('Wizard', () => {
         mockUseWizardGeneration.mockReturnValue({
             isLoading: false,
             isSuccess: true,
+            generatedSet: null,
             generateAndSave: vi.fn(),
         })
 
@@ -115,6 +126,7 @@ describe('Wizard', () => {
         mockUseWizardGeneration.mockReturnValue({
             isLoading: false,
             isSuccess: true,
+            generatedSet: null,
             generateAndSave: vi.fn(),
         })
 
@@ -142,6 +154,7 @@ describe('Wizard', () => {
         mockUseWizardGeneration.mockReturnValue({
             isLoading: false,
             isSuccess: true,
+            generatedSet: null,
             generateAndSave: vi.fn(),
         })
         localStorage.removeItem('solid-pod-upsell-shown')
@@ -171,6 +184,7 @@ describe('Wizard', () => {
         mockUseWizardGeneration.mockReturnValue({
             isLoading: false,
             isSuccess: true,
+            generatedSet: null,
             generateAndSave: vi.fn(),
         })
         localStorage.removeItem('solid-pod-upsell-shown')
@@ -368,12 +382,106 @@ describe('Wizard', () => {
         })
     })
 
+    describe('generation reveal', () => {
+        function renderAfterGeneration() {
+            const db = makeDb()
+            mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+            mockUseWizardGeneration.mockReturnValue({
+                isLoading: false,
+                isSuccess: true,
+                generatedSet: makeGeneratedSet(),
+                generateAndSave: vi.fn(),
+            })
+            localStorage.setItem('solid-pod-upsell-shown', 'true')
+            return render(
+                <MemoryRouter>
+                    <Wizard />
+                </MemoryRouter>
+            )
+        }
+
+        it('names real people from the generated set, one line at a time', async () => {
+            renderAfterGeneration()
+
+            await waitFor(() => expect(screen.getByText(/thinking about Sam/i)).toBeTruthy())
+            expect(screen.queryByText(/thinking about Ellie/i)).toBeNull()
+
+            await waitFor(() => expect(screen.getByText(/thinking about Ellie/i)).toBeTruthy(), { timeout: 3000 })
+            await waitFor(() => expect(screen.getByText(/thinking about Rex/i)).toBeTruthy(), { timeout: 3000 })
+        })
+
+        it('names what was added for each person', async () => {
+            renderAfterGeneration()
+
+            await waitFor(
+                () => expect(screen.getByText(/thinking about Ellie.*adding .*nappies/i)).toBeTruthy(),
+                { timeout: 3000 }
+            )
+        })
+
+        it('shows a summary of what was generated once the reveal finishes', async () => {
+            renderAfterGeneration()
+
+            await waitFor(
+                () => expect(screen.getByText(/\d+ questions and \d+ items across 2 people and 1 pet/i)).toBeTruthy(),
+                { timeout: 4000 }
+            )
+        })
+
+        it('only offers the CTAs once the reveal has finished', async () => {
+            renderAfterGeneration()
+
+            expect(screen.queryByRole('button', { name: /create my first packing list/i })).toBeNull()
+
+            await waitFor(
+                () => expect(screen.getByRole('button', { name: /create my first packing list/i })).toBeTruthy(),
+                { timeout: 4000 }
+            )
+        })
+
+        it('lets the user skip straight to the summary', async () => {
+            renderAfterGeneration()
+
+            const skip = await screen.findByRole('button', { name: /skip/i })
+            skip.click()
+
+            await waitFor(() =>
+                expect(screen.getByRole('button', { name: /create my first packing list/i })).toBeTruthy()
+            )
+            expect(screen.queryByRole('button', { name: /skip/i })).toBeNull()
+            // Skipping still shows every person that was generated for
+            expect(screen.getByText(/thinking about Rex/i)).toBeTruthy()
+        })
+
+        it('skips the staged reveal when the user prefers reduced motion', async () => {
+            vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+                matches: query.includes('prefers-reduced-motion'),
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+            }) as unknown as MediaQueryList)
+
+            renderAfterGeneration()
+
+            await waitFor(() =>
+                expect(screen.getByRole('button', { name: /create my first packing list/i })).toBeTruthy()
+            )
+            expect(screen.queryByRole('button', { name: /skip/i })).toBeNull()
+            expect(screen.getByText(/\d+ questions and \d+ items across 2 people and 1 pet/i)).toBeTruthy()
+        })
+    })
+
     it('does not show pod prompt when solid-pod-upsell-shown is already set', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
         mockUseWizardGeneration.mockReturnValue({
             isLoading: false,
             isSuccess: true,
+            generatedSet: null,
             generateAndSave: vi.fn(),
         })
         localStorage.setItem('solid-pod-upsell-shown', 'true')

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useForm, useFieldArray } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useNavigate, Link } from 'react-router-dom'
@@ -12,6 +12,8 @@ import { wizardSchema, WizardFormData, WizardEntry } from './wizard-types'
 import { useWizardGeneration } from './useWizardGeneration'
 import { AGE_RANGE_OPTIONS, GENDER_OPTIONS, PET_SPECIES_OPTIONS } from '../edit-questions/types'
 import { deriveAgeRange } from '../edit-questions/age-derivation'
+import { buildRevealSteps, buildGenerationSummary, REVEAL_STEP_MS } from './wizard-reveal'
+import { prefersReducedMotion } from '../utils/prefersReducedMotion'
 
 const SOLID_POD_UPSELL_SHOWN_KEY = 'solid-pod-upsell-shown'
 
@@ -22,9 +24,20 @@ export const Wizard = () => {
     const [showSuccessModal, setShowSuccessModal] = useState(false)
     const [pendingNavRoute, setPendingNavRoute] = useState<string | null>(null)
     const [hasExistingData, setHasExistingData] = useState(false)
+    const [revealedCount, setRevealedCount] = useState(0)
+    const [isRevealComplete, setIsRevealComplete] = useState(false)
     const { isLoggedIn } = useSolidPod()
     const { db } = useDatabase()
-    const { isLoading, isSuccess, generateAndSave } = useWizardGeneration()
+    const { isLoading, isSuccess, generatedSet, generateAndSave } = useWizardGeneration()
+
+    const revealSteps = useMemo(
+        () => (generatedSet ? buildRevealSteps(generatedSet) : []),
+        [generatedSet]
+    )
+    const summary = useMemo(
+        () => (generatedSet ? buildGenerationSummary(generatedSet) : null),
+        [generatedSet]
+    )
 
     const { register, control, handleSubmit, watch, setValue, formState: { errors } } = useForm<WizardFormData>({
         resolver: zodResolver(wizardSchema),
@@ -55,10 +68,36 @@ export const Wizard = () => {
         checkExistingData()
     }, [db])
 
-    // Open success modal when generation completes
+    // Open success modal when generation completes, starting the reveal at the
+    // first person. Users who prefer reduced motion get the whole thing at once.
     useEffect(() => {
-        if (isSuccess) setShowSuccessModal(true)
-    }, [isSuccess])
+        if (!isSuccess) return
+        setShowSuccessModal(true)
+        if (revealSteps.length === 0 || prefersReducedMotion()) {
+            setRevealedCount(revealSteps.length)
+            setIsRevealComplete(true)
+        } else {
+            setRevealedCount(1)
+            setIsRevealComplete(false)
+        }
+    }, [isSuccess, revealSteps])
+
+    // Reveal one person per tick, then hand over to the summary. Bounded by
+    // MAX_REVEAL_STEPS, and the Skip button jumps to the end at any point.
+    useEffect(() => {
+        if (!showSuccessModal || isRevealComplete) return
+        if (revealedCount >= revealSteps.length) {
+            setIsRevealComplete(true)
+            return
+        }
+        const timer = setTimeout(() => setRevealedCount(count => count + 1), REVEAL_STEP_MS)
+        return () => clearTimeout(timer)
+    }, [showSuccessModal, isRevealComplete, revealedCount, revealSteps.length])
+
+    const handleSkipReveal = () => {
+        setRevealedCount(revealSteps.length)
+        setIsRevealComplete(true)
+    }
 
     const handleSuccessAction = (route: string) => {
         setShowSuccessModal(false)
@@ -333,29 +372,64 @@ Are you sure you want to continue?"
                 title="🎉 Questions Generated Successfully!"
             >
                 <div className="space-y-6">
-                    <p className="text-gray-700 text-center">
-                        Your starter questions are ready! Head to 'My Questions &amp; Items' to add, remove, or tweak them to match how you travel — then create your first list.
-                    </p>
+                    {revealSteps.length > 0 && (
+                        <ul aria-live="polite" className="space-y-2 text-left">
+                            {revealSteps.slice(0, revealedCount).map(step => (
+                                <li
+                                    key={step.personId}
+                                    className="reveal-line flex gap-2 text-gray-700 break-words"
+                                >
+                                    <span aria-hidden="true">✨</span>
+                                    <span className="flex-1 min-w-0">{step.text}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
 
-                    <div className="space-y-4">
-                        <button
-                            onClick={() => handleSuccessAction('/create-packing-list')}
-                            className="w-full bg-gradient-primary text-white px-6 py-4 rounded-xl font-bold text-lg hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
-                        >
-                            🚀 Create My First Packing List
-                        </button>
+                    {!isRevealComplete && (
+                        <div className="flex justify-center">
+                            <button
+                                onClick={handleSkipReveal}
+                                className="text-sm font-semibold text-primary-700 underline hover:text-primary-900"
+                            >
+                                Skip ›
+                            </button>
+                        </div>
+                    )}
 
-                        <button
-                            onClick={() => handleSuccessAction('/manage-questions')}
-                            className="w-full bg-gradient-secondary text-white px-6 py-4 rounded-xl font-bold text-lg hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-secondary"
-                        >
-                            ✏️ Refine My Packing List Questions
-                        </button>
-                    </div>
+                    {isRevealComplete && (
+                        <>
+                            {summary && (
+                                <p className="text-center font-bold text-primary-900 break-words">
+                                    {summary.text}
+                                </p>
+                            )}
 
-                    <p className="text-sm text-gray-500 text-center mt-4">
-                        You can always access these options from the navigation menu above
-                    </p>
+                            <p className="text-gray-700 text-center">
+                                Your starter questions are ready! Head to 'My Questions &amp; Items' to add, remove, or tweak them to match how you travel — then create your first list.
+                            </p>
+
+                            <div className="space-y-4">
+                                <button
+                                    onClick={() => handleSuccessAction('/create-packing-list')}
+                                    className="w-full bg-gradient-primary text-white px-6 py-4 rounded-xl font-bold text-lg hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
+                                >
+                                    🚀 Create My First Packing List
+                                </button>
+
+                                <button
+                                    onClick={() => handleSuccessAction('/manage-questions')}
+                                    className="w-full bg-gradient-secondary text-white px-6 py-4 rounded-xl font-bold text-lg hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-secondary"
+                                >
+                                    ✏️ Refine My Packing List Questions
+                                </button>
+                            </div>
+
+                            <p className="text-sm text-gray-500 text-center mt-4">
+                                You can always access these options from the navigation menu above
+                            </p>
+                        </>
+                    )}
                 </div>
             </Modal>
 

--- a/src/utils/prefersReducedMotion.ts
+++ b/src/utils/prefersReducedMotion.ts
@@ -1,0 +1,10 @@
+/**
+ * Whether the user has asked for reduced motion. Anything that reveals content
+ * over time (rather than just decorating it) should check this and jump
+ * straight to the end state — the CSS guard in index.css only neutralises
+ * animation/transition durations.
+ */
+export function prefersReducedMotion(): boolean {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}


### PR DESCRIPTION
Completing the wizard flashed a success modal that said nothing about what
had just been built. The success moment now walks through the group one
person at a time — "Thinking about Ellie (4)… adding nappies and baby
wipes" — and finishes with a concrete summary of the generated set.

The reveal is driven by the generated question set, not fixed copy: each
line names the person (age in years when a birthday is known, bracket
otherwise, species for pets) and the items fewest others share, which is
exactly what the age/species filters produced for them.

It stays inside the existing success modal rather than adding a screen, is
capped at 4 lines (~2.1s), has a Skip link, and jumps straight to the
summary for users who prefer reduced motion. Also adds the CSS
reduced-motion guard that neutralises decorative animation.

Closes #246

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R4qnbHSZCjWB2xfM3BSUqp