### PR TITLE
Drop the toast on list creation

### DIFF
--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -25,6 +25,8 @@ test.describe('C – Packing Lists', () => {
     await runWizard(page)
     await createList(page, 'Beach Holiday')
     await expect(page.getByText('Beach Holiday')).toBeVisible()
+    // The list on screen is the confirmation; no toast repeats it
+    await expect(page.getByText('Packing list created successfully!')).not.toBeVisible()
   })
 
   test('C7: reordered question-set items flow through to the view list page', async ({ freshPage: page }) => {

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -34,6 +34,12 @@ vi.mock('../hooks/usePodSync', () => ({
     }),
 }))
 
+const mockNavigate = vi.hoisted(() => vi.fn())
+vi.mock('react-router-dom', async (importOriginal) => ({
+    ...await importOriginal<typeof import('react-router-dom')>(),
+    useNavigate: () => mockNavigate,
+}))
+
 vi.mock('../services/solidPod', () => ({
     getPrimaryPodUrl: vi.fn(),
     saveRdfToPod: vi.fn(),
@@ -1576,5 +1582,47 @@ describe('CreatePackingList – loading state', () => {
 
         await waitFor(() => screen.getByText(/Answer the questions below/i))
         expect(screen.queryByRole('status')).toBeNull()
+    })
+})
+
+// ─── CreatePackingList – landing on the new list ──────────────────────────────
+
+describe('CreatePackingList – landing on the new list', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({ isLoggedIn: false } as ReturnType<typeof useSolidPod>)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    async function createAList(showToast = vi.fn()) {
+        mockUseToast.mockReturnValue({ showToast } as ReturnType<typeof useToast>)
+        const db = makeDb({ getAllPackingLists: vi.fn().mockResolvedValue([]) })
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+
+        fireEvent.change(screen.getByPlaceholderText(/enter a name/i), { target: { value: 'Beach Holiday' } })
+        fireEvent.click(screen.getByRole('button', { name: /create packing list/i }))
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        return db
+    }
+
+    it('goes straight to the new list', async () => {
+        await createAList()
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalled())
+        expect(mockNavigate).toHaveBeenCalledWith(expect.stringMatching(/^\/view-lists\//))
+    })
+
+    it('does not announce the creation in a toast — the list itself says it', async () => {
+        const showToast = vi.fn()
+        await createAList(showToast)
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalled())
+        expect(showToast).not.toHaveBeenCalledWith(expect.stringMatching(/created successfully/i), 'success')
     })
 })

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -639,7 +639,8 @@ export function CreatePackingList() {
                     data: packingList,
                     serializer: packingListToDataset,
                 })
-                showToast('Packing list created successfully!', 'success')
+                // No toast: landing on the finished list is its own confirmation,
+                // and it says far more than "created successfully" ever did.
                 navigate(`/pod/${encodedForeignPodUrl}/view-lists/${packingList.id}`)
             } else {
                 await db.savePackingList(packingList)
@@ -654,7 +655,6 @@ export function CreatePackingList() {
                         })
                     }
                 }
-                showToast('Packing list created successfully!', 'success')
                 navigate(`/view-lists/${packingList.id}`)
             }
         } catch (err) {

--- a/src/test-utils/fullyPopulatedFixtures.ts
+++ b/src/test-utils/fullyPopulatedFixtures.ts
@@ -107,6 +107,7 @@ const fullyPopulatedQuestionSetItem: Required<Item> = {
     // Single value on purpose: RDF multi-values are an unordered set, so a
     // longer list would make the pod round-trip assertion order-dependent.
     ageRanges: ['Adult'],
+    category: 'Toiletries',
     order: 1,
     perNight: 2,
     perNights: 3,


### PR DESCRIPTION
Refs #247 — but see "Scope" below: this deliberately does **not** add the summary reveal the issue asks for, so it won't close it.

## What changed

Creating a list fired `Packing list created successfully!` and then navigated to the finished list. Landing on a page full of your own items is the confirmation — the toast said strictly less than the screen behind it. Creation behaviour is otherwise untouched: local save and pod push are unchanged.

## Scope

This PR originally implemented #247 in full: a dismissible arrival banner summarising item count, people and nights. On review the banner didn't earn its space — everything it said (`8 items for 1 person, 3 nights`) was a recap of the page directly beneath it, where the heading, the progress strip and the sections already show the name, the count and the people. It only approached being interesting on large lists, and cost vertical space above the first section on every phone-sized screen. So it's out.

It also carried a fix for `savePackingList` dropping `nights`, `selectedPeopleIds` and `questionAnswers` on local saves. #260/#261 has since fixed that on main, and more generally — an omit-list `toDocumentData` rather than my hand-patched allowlist — so that half is dropped too, along with its now-duplicate tests.

#247 stays open; its summary idea would need to reveal something the page can't already show — the per-night quantities it worked out, or the trip destination and dates from #209.

## Second commit: unbreaking main

`Give the fully-populated item its category` does not belong to this PR, and should ideally land on main directly. #261 added `Required<Item>` fixtures and #262 added `category` to `Item`; each was green alone, but together they leave the fixture missing a field the type now requires. `npm run typecheck` fails on `origin/main` as it stands, which fails the build, the test run and the pre-push hook — nothing could be pushed or built until it was fixed. One line, verified against the round-trip tests in `database.test.ts` and `rdfSerialization.test.ts`.

## Testing

- `src/pages/create-packing-list.test.tsx` — creation navigates straight to the new list, and no "created successfully" toast fires.
- `e2e/tests/c-packing-lists.spec.ts` — C1 now also asserts the toast doesn't appear.

`npm test` 965 passed, `npx playwright test` 60 passed, lint clean.