### PR TITLE
Give ticking an item a moment of its own

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -10,6 +10,7 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
+    implementation project(':capacitor-haptics')
     implementation project(':sentry-capacitor')
 
 }

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -5,5 +5,8 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
 
+include ':capacitor-haptics'
+project(':capacitor-haptics').projectDir = new File('../node_modules/@capacitor/haptics/android')
+
 include ':sentry-capacitor'
 project(':sentry-capacitor').projectDir = new File('../node_modules/@sentry/capacitor/android')

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -12,7 +12,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.4"),
-        .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app")
+        .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
+        .package(name: "CapacitorHaptics", path: "../../../node_modules/@capacitor/haptics"),
+        .package(name: "SentryCapacitor", path: "../../../node_modules/@sentry/capacitor")
     ],
     targets: [
         .target(
@@ -20,7 +22,9 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
-                .product(name: "CapacitorApp", package: "CapacitorApp")
+                .product(name: "CapacitorApp", package: "CapacitorApp"),
+                .product(name: "CapacitorHaptics", package: "CapacitorHaptics"),
+                .product(name: "SentryCapacitor", package: "SentryCapacitor")
             ]
         )
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/app": "^8.1.0",
         "@capacitor/cli": "^8.3.4",
         "@capacitor/core": "^8.3.4",
+        "@capacitor/haptics": "^8.0.2",
         "@capacitor/ios": "^8.3.4",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -432,6 +433,15 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/haptics": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/haptics/-/haptics-8.0.2.tgz",
+      "integrity": "sha512-c2hZzRR5Fk1tbTvhG1jhh2XBAf3EhnIerMIb2sl7Mt41Gxx1fhBJFDa0/BI1IbY4loVepyyuqNC9820/GZuoWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/ios": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@capacitor/app": "^8.1.0",
     "@capacitor/cli": "^8.3.4",
     "@capacitor/core": "^8.3.4",
+    "@capacitor/haptics": "^8.0.2",
     "@capacitor/ios": "^8.3.4",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/src/index.css
+++ b/src/index.css
@@ -269,6 +269,34 @@ body {
   animation: loading-skeleton-sweep 1.6s ease-in-out infinite;
 }
 
+/* Ticking an item is the move the user repeats hundreds of times a trip, so it
+   gets a beat of acknowledgement — a green swell and a tick lifting out of the
+   checkbox — before the row is whisked out of the unpacked list. Kept in step
+   with ITEM_FLOURISH_MS. Nothing here is `forwards`: with packed items shown
+   the row stays put and must settle back to looking ordinary. */
+@keyframes item-packed-swell {
+  0% { transform: scale(1); background-color: rgb(249 250 251); }
+  30% { transform: scale(1.02); background-color: rgb(220 252 231); }
+  70% { transform: scale(1); background-color: rgb(220 252 231); }
+  100% { transform: scale(1); background-color: rgb(249 250 251); }
+}
+
+/* The tick starts where the checkbox is — which is exactly where the checkbox's
+   own mark now sits — so it has to lift clear of it to be seen at all. */
+@keyframes item-packed-tick {
+  0% { transform: translate(-50%, -50%) scale(0.4); opacity: 0; }
+  35% { transform: translate(-50%, -95%) scale(1.25); opacity: 1; }
+  100% { transform: translate(-50%, -135%) scale(1); opacity: 0; }
+}
+
+.item-row-packed {
+  animation: item-packed-swell 0.45s ease-out;
+}
+
+.item-packed-tick {
+  animation: item-packed-tick 0.45s ease-out;
+}
+
 /* Celebrations and waiting states are decorative — hold still for anyone who
    asked us to. */
 @media (prefers-reduced-motion: reduce) {
@@ -305,6 +333,13 @@ body {
   .loading-skeleton-bar {
     animation: none;
     background-image: none;
+  }
+
+  /* The check-off flourish is pure decoration. The component skips rendering the
+     tick entirely in this mode; this is the belt to that pair of braces. */
+  .item-row-packed,
+  .item-packed-tick {
+    animation: none;
   }
 }
 

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -58,6 +58,11 @@ vi.mock('../hooks/useSharedListsSync', () => ({
     })),
 }))
 
+const mockTapFeedback = vi.fn()
+vi.mock('../utils/haptics', () => ({
+    tapFeedback: () => mockTapFeedback(),
+}))
+
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockUsePodSync = vi.mocked(usePodSync)
@@ -1949,5 +1954,174 @@ describe('ViewPackingList trip destination and dates', () => {
 
         await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
         expect(screen.queryByTestId('trip-details')).toBeNull()
+    })
+})
+
+describe('ViewPackingList check-off feedback', () => {
+    // Two people so the list is never finished by a single tick — the completion
+    // celebration has its own tests and would otherwise mask the per-item one.
+    const feedbackList = {
+        id: 'test-list-feedback',
+        name: 'Feedback Trip',
+        createdAt: '2026-01-01T00:00:00Z',
+        items: [
+            { id: 'a1', itemText: 'Passport', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', packed: false },
+            { id: 'a2', itemText: 'Sunhat', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', packed: false },
+            { id: 'b1', itemText: 'Wellies', personName: 'Bob', personId: 'p2', questionId: 'q1', optionId: 'o1', packed: true },
+        ],
+    }
+
+    let saveWithSyncPrevention: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+        mockTapFeedback.mockClear()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        saveWithSyncPrevention = vi.fn().mockResolvedValue({ ...feedbackList, _rev: '2' })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention,
+        })
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getPackingList: vi.fn().mockResolvedValue(feedbackList),
+                savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+                getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }),
+            } as unknown as PackingAppDatabase,
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function renderList() {
+        return render(
+            <MemoryRouter initialEntries={['/view-list/test-list-feedback']}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+    }
+
+    function checkboxFor(itemText: string) {
+        return screen.getByText(itemText).closest('label')!.querySelector('input')!
+    }
+
+    function preferReducedMotion() {
+        vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+            matches: query.includes('prefers-reduced-motion'),
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList)
+    }
+
+    it('taps back when an item is checked', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(checkboxFor('Passport'))
+
+        expect(mockTapFeedback).toHaveBeenCalledTimes(1)
+    })
+
+    it('stays silent when an item is unchecked', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
+        fireEvent.click(checkboxFor('Wellies'))
+
+        expect(mockTapFeedback).not.toHaveBeenCalled()
+    })
+
+    it('plays a flourish on the row that was just checked', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(checkboxFor('Passport'))
+
+        expect(screen.getByTestId('item-tick-a1')).toBeTruthy()
+        expect(screen.getByTestId('item-row-a1').className).toContain('item-row-packed')
+    })
+
+    it('flourishes only the row that was checked', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(checkboxFor('Passport'))
+
+        expect(screen.queryByTestId('item-tick-a2')).toBeNull()
+        expect(screen.getByTestId('item-row-a2').className).not.toContain('item-row-packed')
+    })
+
+    it('holds the row on screen for the flourish before whisking it away', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(checkboxFor('Passport'))
+
+        // Packed items are hidden, but the row waits for its moment first
+        expect(screen.getByText('Passport')).toBeTruthy()
+        await waitFor(() => expect(screen.queryByText('Passport')).toBeNull())
+    })
+
+    it('does not flourish when an item is unchecked', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
+        fireEvent.click(checkboxFor('Wellies'))
+
+        expect(screen.queryByTestId('item-tick-b1')).toBeNull()
+        expect(screen.getByTestId('item-row-b1').className).not.toContain('item-row-packed')
+    })
+
+    it('holds still for anyone who asked for reduced motion', async () => {
+        preferReducedMotion()
+        renderList()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(checkboxFor('Passport'))
+
+        expect(screen.queryByTestId('item-tick-a1')).toBeNull()
+        await waitFor(() => expect(screen.queryByText('Passport')).toBeNull())
+    })
+
+    it('still taps back when motion is reduced', async () => {
+        preferReducedMotion()
+        renderList()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(checkboxFor('Passport'))
+
+        expect(mockTapFeedback).toHaveBeenCalledTimes(1)
+    })
+
+    it('gives feedback immediately, without waiting on the debounced save', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(checkboxFor('Passport'))
+
+        // The save is 800ms of debounce away; the feedback has already happened
+        expect(saveWithSyncPrevention).not.toHaveBeenCalled()
+        expect(mockTapFeedback).toHaveBeenCalledTimes(1)
+        expect(screen.getByTestId('item-tick-a1')).toBeTruthy()
     })
 })

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -23,6 +23,8 @@ import { mergePackingLists } from '../utils/mergePackingLists'
 import { computeQuestionSetAdditions } from '../create-packing-list/updateFromQuestions'
 import { MILESTONE_MESSAGES, resolveMilestone } from './packing-milestones'
 import { formatTripDates } from '../create-packing-list/tripDetails'
+import { tapFeedback } from '../utils/haptics'
+import { prefersReducedMotion } from '../utils/prefersReducedMotion'
 
 type FormData = {
     items: Record<string, boolean>
@@ -37,6 +39,12 @@ const CONFETTI_DURATION_MS = 4000
 
 // Kept in step with the `sections-packing-away` animation in index.css
 const SECTIONS_EXIT_MS = 550
+
+// Kept in step with the `item-packed-swell` / `item-packed-tick` animations in
+// index.css. Also how long a freshly-packed row is held on screen before the
+// "hide packed items" filter takes it — long enough to see, short enough that
+// the next item is never waiting on it.
+const ITEM_FLOURISH_MS = 450
 
 // Spread across the viewport with staggered starts so the confetti doesn't fall
 // as one rank. Fixed rather than random so the effect is identical every run.
@@ -167,6 +175,27 @@ export function ViewPackingList() {
     // Encouragement in the progress strip. Held as state rather than derived so
     // it can lag behind a boundary — see resolveMilestone.
     const [milestone, setMilestone] = useState<number | null>(null)
+    // The item currently taking its bow after being checked off. The nonce rises
+    // on every tick so re-checking the same row remounts the tick and replays it,
+    // rather than the unchanged id leaving the animation half-finished.
+    const [flourish, setFlourish] = useState<{ itemId: string; nonce: number } | null>(null)
+
+    // The reward for a tick belongs to the tick, not to the save that follows it
+    // 800ms later — everything here is local and immediate, and none of it waits
+    // on the database or the pod. Unchecking is a correction rather than an
+    // achievement, so it passes in silence.
+    const handleItemToggle = useCallback((itemId: string, checked: boolean) => {
+        if (!checked) return
+        tapFeedback()
+        if (prefersReducedMotion()) return
+        setFlourish(prev => ({ itemId, nonce: (prev?.nonce ?? 0) + 1 }))
+    }, [])
+
+    useEffect(() => {
+        if (!flourish) return
+        const timer = setTimeout(() => setFlourish(null), ITEM_FLOURISH_MS)
+        return () => clearTimeout(timer)
+    }, [flourish])
 
 
     const toggleCategory = (key: string) =>
@@ -752,6 +781,10 @@ export function ViewPackingList() {
         if (showPacked) {
             return true
         }
+        // A just-ticked item keeps its place until the flourish has played —
+        // otherwise the row it belongs to vanishes in the same frame and the
+        // feedback has nothing to happen to.
+        if (item.id === flourish?.itemId) return true
         return !watchedItems[item.id]
     })
 
@@ -1283,17 +1316,36 @@ export function ViewPackingList() {
                                                         {catItems.map((item) => (
                                                             <div
                                                                 key={`${item.id}-${sectionKey}`}
+                                                                data-testid={`item-row-${item.id}`}
                                                                 ref={(el) => {
                                                                     if (el) itemRowRefs.current.set(item.id, el)
                                                                     else itemRowRefs.current.delete(item.id)
                                                                 }}
-                                                                className={`rounded-lg p-3 transition-colors duration-1000 ${item.id === recentlyAddedItemId ? 'bg-green-100 ring-2 ring-green-400' : 'bg-gray-50'}`}
+                                                                className={`relative rounded-lg p-3 transition-colors duration-1000 ${item.id === recentlyAddedItemId ? 'bg-green-100 ring-2 ring-green-400' : 'bg-gray-50'} ${item.id === flourish?.itemId ? 'item-row-packed' : ''}`}
                                                             >
+                                                                {item.id === flourish?.itemId && (
+                                                                    <span
+                                                                        key={flourish.nonce}
+                                                                        data-testid={`item-tick-${item.id}`}
+                                                                        aria-hidden="true"
+                                                                        // Themed green rather than text-green-600 — that class is the
+                                                                        // "Saved" indicator's, and the e2e suite waits on it by selector
+                                                                        // Anchored over the checkbox; the animation owns the transform,
+                                                                        // so no translate utilities here. Themed green rather than
+                                                                        // text-green-600 — that class belongs to the "Saved" indicator,
+                                                                        // which the e2e suite waits on by selector.
+                                                                        className="item-packed-tick pointer-events-none absolute left-[22px] top-1/2 z-10 text-xl font-bold text-success-600"
+                                                                    >
+                                                                        ✓
+                                                                    </span>
+                                                                )}
                                                                 <div className="flex items-center justify-between">
                                                                     <label className="flex items-center space-x-3 cursor-pointer flex-1 min-w-0">
                                                                         <input
                                                                             type="checkbox"
-                                                                            {...register(`items.${item.id}`)}
+                                                                            {...register(`items.${item.id}`, {
+                                                                                onChange: (e) => handleItemToggle(item.id, e.target.checked),
+                                                                            })}
                                                                             className="h-5 w-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
                                                                         />
                                                                         {editingItemId === item.id ? (

--- a/src/utils/haptics.test.ts
+++ b/src/utils/haptics.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ImpactStyle } from '@capacitor/haptics'
+
+const mockImpact = vi.fn()
+const mockIsNativePlatform = vi.fn()
+
+vi.mock('@capacitor/haptics', async () => {
+    const actual = await vi.importActual<typeof import('@capacitor/haptics')>('@capacitor/haptics')
+    return {
+        ImpactStyle: actual.ImpactStyle,
+        Haptics: { impact: (...args: unknown[]) => mockImpact(...args) },
+    }
+})
+
+vi.mock('@capacitor/core', () => ({
+    Capacitor: { isNativePlatform: () => mockIsNativePlatform() },
+}))
+
+import { tapFeedback } from './haptics'
+
+describe('tapFeedback', () => {
+    beforeEach(() => {
+        mockImpact.mockReset().mockResolvedValue(undefined)
+        mockIsNativePlatform.mockReset()
+    })
+
+    it('fires a light impact on a native build', () => {
+        mockIsNativePlatform.mockReturnValue(true)
+
+        tapFeedback()
+
+        expect(mockImpact).toHaveBeenCalledWith({ style: ImpactStyle.Light })
+    })
+
+    it('does nothing on the web, where there is no haptics hardware to reach', () => {
+        mockIsNativePlatform.mockReturnValue(false)
+
+        tapFeedback()
+
+        expect(mockImpact).not.toHaveBeenCalled()
+    })
+
+    it('swallows a failing haptic rather than letting it reject', async () => {
+        mockIsNativePlatform.mockReturnValue(true)
+        mockImpact.mockRejectedValue(new Error('no vibrator'))
+
+        expect(() => tapFeedback()).not.toThrow()
+        // Give the rejected promise a tick to surface as unhandled if uncaught
+        await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    it('does not throw when the plugin itself blows up synchronously', () => {
+        mockIsNativePlatform.mockReturnValue(true)
+        mockImpact.mockImplementation(() => { throw new Error('plugin missing') })
+
+        expect(() => tapFeedback()).not.toThrow()
+    })
+})

--- a/src/utils/haptics.ts
+++ b/src/utils/haptics.ts
@@ -1,0 +1,19 @@
+import { Capacitor } from '@capacitor/core'
+import { Haptics, ImpactStyle } from '@capacitor/haptics'
+
+/**
+ * A light tap of physical feedback for a small "that's done" moment.
+ *
+ * Fire-and-forget by design: the caller must never wait on it, and anywhere
+ * without haptics hardware to reach — the browser, a device with the motor
+ * disabled, a native build where the plugin failed to load — is a silent no-op
+ * rather than an error. Feedback is a bonus; it is never worth a broken tap.
+ */
+export function tapFeedback(): void {
+    if (!Capacitor.isNativePlatform()) return
+    try {
+        void Haptics.impact({ style: ImpactStyle.Light }).catch(() => { })
+    } catch {
+        // Plugin missing or misregistered — nothing to do but carry on quietly
+    }
+}


### PR DESCRIPTION
Closes #243

Checking an item off is the move a packing parent repeats hundreds of times a trip, and until now it was the flattest thing in the app: the text went grey, the row vanished, and 800ms later something quietly saved. Nothing acknowledged the tap itself.

## What changed

- **Haptics.** Added `@capacitor/haptics` and a `tapFeedback()` wrapper (`src/utils/haptics.ts`) that fires a light impact. It checks `Capacitor.isNativePlatform()` first and swallows both rejections and synchronous plugin failures, so the browser — or a device with no motor to reach — is a silent no-op rather than a broken tap.
- **A flourish on the row.** A green swell across the row plus a check mark that lifts out of the checkbox and fades (`item-packed-swell` / `item-packed-tick` in `src/index.css`). The first attempt put the tick *on* the checkbox, where the checkbox's own mark hides it completely — hence the lift.
- **The row waits for it.** With packed items hidden the row used to vanish in the same frame it was ticked, leaving the feedback nothing to happen to. A just-ticked item now keeps its place in `filteredItems` for the 450ms of the flourish, then goes.
- **Independent of the save.** Both the haptic and the flourish fire straight off the checkbox change event, via `register(name, { onChange })`. Neither touches the database, the pod, or the 800ms debounce.
- **Unchecking stays silent** — it is a correction, not an achievement — and `prefersReducedMotion()` skips the flourish while still giving the haptic. The CSS carries a matching `prefers-reduced-motion` rule as a second guard.

`npx cap sync` regenerated the native plugin manifests. The iOS `Package.swift` also picks up `SentryCapacitor`, which had drifted out of the committed file — that is the regenerator catching up, not a new dependency.

## Testing

- `src/utils/haptics.test.ts` — native fires a light impact, web does not, and neither a rejection nor a throwing plugin escapes.
- `src/pages/view-packing-list.test.tsx` — nine tests covering tap-on-check, silence on uncheck, the flourish landing only on the row that was ticked, the row being held then whisked away, reduced motion, and feedback arriving before `saveWithSyncPrevention` has been called.
- `npm test`: 885 passing. `npm run lint`: no new warnings. Full Playwright suite: 59 passing.

One e2e casualty worth noting: the tick was originally styled `text-green-600`, which is also the "Saved" indicator's class that `c-packing-lists.spec.ts` waits on by CSS selector — the flourish satisfied that wait instantly and the test reloaded before the debounce had saved. The tick now uses the theme's `text-success-600` and the suite is green.

## Verification

- Desktop verified in a real browser via Playwright: the swell and rising tick play, the row is held then removed, and the only console error is the pre-existing `_vercel/insights/script.js` 404 that local preview always produces.
- **Not** verified on a native build — no device or emulator available in this environment, so the haptic firing for real is still unticked on the issue's checklist.

## Rebase note

Rebased onto `main` at 85e0550 (destination/dates, loading states). Three files conflicted, all additive collisions rather than competing logic:

- `src/index.css` — both branches appended keyframes and both added a clause to the `prefers-reduced-motion` block. Kept both, under main's broadened "Celebrations and waiting states are decorative" heading.
- `src/pages/view-packing-list.tsx` — adjacent import lines. Kept both.
- `src/pages/view-packing-list.test.tsx` — both branches appended a `describe` at the end of the file. Kept both, plus the `../utils/haptics` mock this branch adds near the top.

Full suite re-run green after the rebase.