### PR TITLE
Persist every field of a list, not a hand-kept allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,25 @@ Never call `db.*` (local PouchDB) and pod storage functions directly in the same
 - **Write** (local + pod together): `useSyncCoordinator.saveWithSyncPrevention(data, saveToPod)` — stamps a `lastModified` timestamp, saves locally first, then best-effort pod push with sync-loop prevention.
 - **Pod path config**: use `usePodSync` to get `saveToPod` / `syncFromPod` for a given resource path.
 - **Login sync** (pod → local on login): handled automatically by `DatabaseContext` via `syncAllDataFromPod` — no per-page code needed.
+
+### Persistence: adding a field to `PackingList` or `PackingListQuestionSet`
+
+Never persist a type by listing the fields to keep. `database.ts` builds each PouchDB
+document with `toDocumentData(entity, [...keys the document owns])` — an omit-list, so a
+new field is stored by default. Reads spread the whole stored payload for the same reason.
+An allowlist is how `nights`, `questionAnswers` and `selectedPeopleIds` were silently
+dropped for every locally stored list (#260) with no type error and no failing test.
+
+Two guards catch a repeat, and both are wired into CI (`npm run typecheck`, `npm test`):
+
+1. `src/test-utils/fullyPopulatedFixtures.ts` holds `Required<...>` fixtures with **every**
+   field of these types populated. Adding an optional field to the type breaks the type
+   check until the fixture covers it. (The fixtures live in `src`, not in a `.test.ts`,
+   because `tsconfig.app.json` excludes test files from type checking.)
+2. Round-trip tests assert those fixtures survive intact — through PouchDB
+   (`database.test.ts` → "Field fidelity") and through the pod's RDF serialisation
+   (`rdfSerialization.test.ts` → "Field fidelity").
+
+So when the type check sends you to the fixtures, add the field with a distinctive value
+and run the tests — don't reach for `as` or a partial fixture. A field that genuinely must
+not leave the device belongs in `packingListLocalOnlyFields` with a comment saying why.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,9 @@
 ## Testing
 
 Use TDD (red-green-refactor) when implementing new features.
-Run tests: `npm test`
+Run tests: `npm test` — type checks first (`npm run typecheck`), then runs vitest, so the
+persistence guard below fails the same command locally and in CI. `npm run test:watch`
+skips the type check.
 
 ### E2E pod isolation
 
@@ -40,7 +42,7 @@ new field is stored by default. Reads spread the whole stored payload for the sa
 An allowlist is how `nights`, `questionAnswers` and `selectedPeopleIds` were silently
 dropped for every locally stored list (#260) with no type error and no failing test.
 
-Two guards catch a repeat, and both are wired into CI (`npm run typecheck`, `npm test`):
+Two guards catch a repeat, and `npm test` runs both (CI included):
 
 1. `src/test-utils/fullyPopulatedFixtures.ts` holds `Required<...>` fixtures with **every**
    field of these types populated. Adding an optional field to the type breaks the type

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "typecheck": "tsc -b",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "typecheck": "tsc -b",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "npm run typecheck && vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:e2e": "npm run build && playwright test",

--- a/src/create-packing-list/updateFromQuestions.test.ts
+++ b/src/create-packing-list/updateFromQuestions.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import PouchDB from 'pouchdb'
+import PouchDBMemoryAdapter from 'pouchdb-adapter-memory'
+import { PackingAppDatabase } from '../services/database'
 import { computeQuestionSetAdditions, reconstructGenerationInputs } from './updateFromQuestions'
 import { PackingList, PackingListItem } from './types'
 import { PackingListQuestionSet, Question, Person, Item } from '../edit-questions/types'
+
+PouchDB.plugin(PouchDBMemoryAdapter)
 
 const alice: Person = { id: 'p1', name: 'Alice' }
 const bob: Person = { id: 'p2', name: 'Bob' }
@@ -307,5 +312,72 @@ describe('reconstructGenerationInputs', () => {
         expect(questionAnswers).toEqual([])
         // always-needed item still contributes its personId as a traveller
         expect(selectedPeopleIds).toEqual(['p1'])
+    })
+})
+
+// End-to-end guard for #260: the generation inputs were persisted by the
+// creation flow but stripped by savePackingList, so "Update from questions"
+// always fell back to reconstructing them from the list's items — missing
+// additions for options that had generated nothing, and losing the per-night
+// quantities that `nights` drives.
+describe('after a save/load round-trip through the local database', () => {
+    let db: PackingAppDatabase
+
+    beforeEach(async () => {
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+        // @ts-expect-error - Accessing private static property for testing
+        const instances = PackingAppDatabase.instances as Map<string, PackingAppDatabase>
+        for (const instance of instances.values()) {
+            // @ts-expect-error - Accessing private property for testing
+            await instance.db.destroy()
+        }
+        instances.clear()
+        db = PackingAppDatabase.getInstance('update-from-questions')
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    // 'opt-rainy' was answered at creation time but had no items then, so it
+    // leaves no trace in the list's items: only the stored questionAnswers can
+    // reveal it.
+    const questionSet = makeQuestionSet({
+        questions: [makeQuestion({
+            options: [
+                { id: 'opt-swimming', text: 'Swimming', order: 0, items: [makeItem('Goggles', ['p1'])] },
+                { id: 'opt-rainy', text: 'Rainy', order: 1, items: [makeItem('Socks', ['p1'], { perNight: 1 })] },
+            ],
+        })],
+    })
+
+    const savedList: PackingList = makeList({
+        nights: 3,
+        selectedPeopleIds: ['p1'],
+        questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming', 'opt-rainy'] }],
+        items: [listItem({ itemText: 'Goggles', personId: 'p1', optionId: 'opt-swimming' })],
+    })
+
+    it('uses the stored generation inputs and nights, not the reconstruction fallback', async () => {
+        await db.savePackingList(savedList)
+        const reloaded = await db.getPackingList(savedList.id)
+
+        const additions = computeQuestionSetAdditions(reloaded, questionSet)
+
+        // Reconstruction cannot see 'opt-rainy' — no item on the list points at it.
+        expect(additions.map(a => a.itemText)).toEqual(['Socks'])
+        // 1 per night × 3 nights, from the stored `nights`.
+        expect(additions[0].quantity).toBe(3)
+    })
+
+    it('finds nothing when the generation inputs are missing (the pre-fix behaviour)', () => {
+        const withoutStoredInputs: PackingList = {
+            ...savedList,
+            nights: undefined,
+            questionAnswers: undefined,
+            selectedPeopleIds: undefined,
+        }
+
+        expect(computeQuestionSetAdditions(withoutStoredInputs, questionSet)).toEqual([])
     })
 })

--- a/src/services/database.test.ts
+++ b/src/services/database.test.ts
@@ -4,6 +4,7 @@ import PouchDBMemoryAdapter from 'pouchdb-adapter-memory'
 import { PackingAppDatabase } from './database'
 import type { PackingListQuestionSet } from '../edit-questions/types'
 import type { PackingList } from '../create-packing-list/types'
+import { fullyPopulatedPackingList, fullyPopulatedQuestionSet } from '../test-utils/fullyPopulatedFixtures'
 
 // Setup PouchDB with memory adapter for testing
 PouchDB.plugin(PouchDBMemoryAdapter)
@@ -370,6 +371,90 @@ describe('PackingAppDatabase', () => {
 
     it('should throw error when deleting non-existent packing list', async () => {
       await expect(db.deletePackingList('nonexistent')).rejects.toThrow()
+    })
+  })
+
+  // Regression guard for #260: savePackingList built its PouchDB document from a
+  // hand-maintained field allowlist, so `nights`, `questionAnswers` and
+  // `selectedPeopleIds` never reached local storage — no type error, no test
+  // failure. These tests fail if any field of the type is dropped on the way in
+  // or out, and the `Required<...>` fixtures they use fail the type check if a
+  // newly added field is not covered. See src/test-utils/fullyPopulatedFixtures.ts.
+  describe('Field fidelity', () => {
+    it('savePackingList/getPackingList persist every field of PackingList', async () => {
+      await db.savePackingList(fullyPopulatedPackingList)
+
+      const retrieved = await db.getPackingList(fullyPopulatedPackingList.id)
+
+      expect(retrieved).toEqual({ ...fullyPopulatedPackingList, _rev: expect.any(String) })
+    })
+
+    it('getAllPackingLists returns every field of PackingList', async () => {
+      await db.savePackingList(fullyPopulatedPackingList)
+
+      const [retrieved] = await db.getAllPackingLists()
+
+      expect(retrieved).toEqual({ ...fullyPopulatedPackingList, _rev: expect.any(String) })
+    })
+
+    it('saveQuestionSet/getQuestionSet persist every field of PackingListQuestionSet', async () => {
+      await db.saveQuestionSet(fullyPopulatedQuestionSet)
+
+      const retrieved = await db.getQuestionSet()
+
+      expect(retrieved).toEqual({ ...fullyPopulatedQuestionSet, _id: '1', _rev: expect.any(String) })
+    })
+
+    it('persists nights, questionAnswers and selectedPeopleIds (#260)', async () => {
+      const list: PackingList = {
+        id: 'pl-260',
+        name: 'Trip',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        nights: 3,
+        questionAnswers: [{ questionId: 'q1', selectedOptionIds: ['opt1'] }],
+        selectedPeopleIds: ['person-1'],
+        items: [],
+      }
+
+      await db.savePackingList(list)
+
+      const retrieved = await db.getPackingList('pl-260')
+      expect(retrieved.nights).toBe(3)
+      expect(retrieved.questionAnswers).toEqual([{ questionId: 'q1', selectedOptionIds: ['opt1'] }])
+      expect(retrieved.selectedPeopleIds).toEqual(['person-1'])
+
+      const [fromAll] = await db.getAllPackingLists()
+      expect(fromAll.nights).toBe(3)
+      expect(fromAll.questionAnswers).toEqual([{ questionId: 'q1', selectedOptionIds: ['opt1'] }])
+      expect(fromAll.selectedPeopleIds).toEqual(['person-1'])
+    })
+
+    it('does not persist id or _rev inside the document data', async () => {
+      await db.savePackingList(fullyPopulatedPackingList)
+
+      // @ts-expect-error - Accessing private property for testing
+      const rawDoc = await db.db.get(`packing-list:${fullyPopulatedPackingList.id}`)
+      expect(rawDoc.data).not.toHaveProperty('id')
+      expect(rawDoc.data).not.toHaveProperty('_rev')
+
+      await db.saveQuestionSet({ ...fullyPopulatedQuestionSet, _id: '1' })
+      // @ts-expect-error - Accessing private property for testing
+      const rawQsDoc = await db.db.get('question-set:1')
+      expect(rawQsDoc.data).not.toHaveProperty('_id')
+      expect(rawQsDoc.data).not.toHaveProperty('_rev')
+    })
+
+    it('omits fields that are absent rather than storing undefined', async () => {
+      await db.savePackingList({
+        id: 'pl-sparse',
+        name: 'Sparse',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        items: [],
+      })
+
+      // @ts-expect-error - Accessing private property for testing
+      const rawDoc = await db.db.get('packing-list:pl-sparse')
+      expect(Object.keys(rawDoc.data).sort()).toEqual(['createdAt', 'items', 'name'])
     })
   })
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -20,7 +20,7 @@ export interface QuestionSetDocument extends BaseDocument {
 
 export interface PackingListDocument extends BaseDocument {
     docType: 'packing-list'
-    data: Omit<PackingList, 'id'>
+    data: Omit<PackingList, 'id' | '_rev'>
 }
 
 export interface SharedWithMeDocument extends BaseDocument {
@@ -43,6 +43,30 @@ export const LOCAL_NAMESPACE = 'local'
 
 function hasName(err: unknown): err is { name: string } {
     return typeof err === 'object' && err !== null && 'name' in err
+}
+
+/**
+ * Builds a document's `data` payload from an entity by *omitting* the keys the
+ * document itself owns (`id` / `_id` / `_rev`), plus any explicitly-undefined
+ * values so absent fields stay absent in PouchDB.
+ *
+ * Deliberately an omit-list rather than an allowlist: an allowlist has to be
+ * remembered every time a field is added to the type, and forgetting it drops
+ * the field silently, with no type error. That is exactly what happened to
+ * `nights`, `questionAnswers` and `selectedPeopleIds` (#260). Derived this way,
+ * new fields are persisted by default.
+ */
+function toDocumentData<T extends object, K extends keyof T & string>(
+    entity: T,
+    omitKeys: readonly K[]
+): Omit<T, K> {
+    const data: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(entity)) {
+        if ((omitKeys as readonly string[]).includes(key)) continue
+        if (value === undefined) continue
+        data[key] = value
+    }
+    return data as Omit<T, K>
 }
 
 export class PackingAppDatabase {
@@ -91,9 +115,9 @@ export class PackingAppDatabase {
                 throw new Error('Invalid document type for question set')
             }
             return {
+                ...doc.data,
                 _id: '1',
                 _rev: doc._rev,
-                ...doc.data
             }
         } catch (err: unknown) {
             if (hasName(err) && err.name === 'not_found') {
@@ -131,16 +155,7 @@ export class PackingAppDatabase {
                     docType: 'question-set',
                     createdAt: existingDoc?.createdAt || now,
                     updatedAt: now,
-                    data: {
-                        people: questionSet.people,
-                        alwaysNeededItems: questionSet.alwaysNeededItems,
-                        questions: questionSet.questions,
-                        // Persisted so the "new template suggestions" prompt can
-                        // tell whether this set predates the latest template.
-                        ...(questionSet.templateVersion !== undefined
-                            ? { templateVersion: questionSet.templateVersion }
-                            : {}),
-                    }
+                    data: toDocumentData(questionSet, ['_id', '_rev'])
                 }
 
                 const result = await this.db.put(docToSave)
@@ -163,9 +178,9 @@ export class PackingAppDatabase {
                 throw new Error('Invalid document type for packing list')
             }
             return {
+                ...doc.data,
                 id,
                 _rev: doc._rev,
-                ...doc.data
             }
         } catch (err: unknown) {
             if (hasName(err) && err.name === 'not_found') {
@@ -203,19 +218,7 @@ export class PackingAppDatabase {
                     docType: 'packing-list',
                     createdAt: existingDoc?.createdAt || now,
                     updatedAt: now,
-                    data: {
-                        name: packingList.name,
-                        createdAt: packingList.createdAt,
-                        lastModified: packingList.lastModified,
-                        sharedFromPodUrl: packingList.sharedFromPodUrl,
-                        ownerWebId: packingList.ownerWebId,
-                        destination: packingList.destination,
-                        startDate: packingList.startDate,
-                        endDate: packingList.endDate,
-                        items: packingList.items,
-                        deletedItems: packingList.deletedItems,
-                        guests: packingList.guests,
-                    }
+                    data: toDocumentData(packingList, ['id', '_rev'])
                 }
 
                 const result = await this.db.put(docToSave)
@@ -244,20 +247,12 @@ export class PackingAppDatabase {
             for (const row of result.rows) {
                 if (row.doc && row.doc.docType === 'packing-list') {
                     const packingListId = row.id.replace('packing-list:', '')
+                    // Spread the whole stored payload — see toDocumentData — so
+                    // reading can't drop a field the write kept (#260).
                     const packingList: PackingList = {
+                        ...row.doc.data,
                         id: packingListId,
                         _rev: row.doc._rev,
-                        name: row.doc.data.name,
-                        createdAt: row.doc.data.createdAt,
-                        lastModified: row.doc.data.lastModified,
-                        sharedFromPodUrl: row.doc.data.sharedFromPodUrl,
-                        ownerWebId: row.doc.data.ownerWebId,
-                        destination: row.doc.data.destination,
-                        startDate: row.doc.data.startDate,
-                        endDate: row.doc.data.endDate,
-                        items: row.doc.data.items,
-                        deletedItems: row.doc.data.deletedItems,
-                        guests: row.doc.data.guests,
                     }
                     packingLists.push(packingList)
                 }

--- a/src/services/rdfSerialization.test.ts
+++ b/src/services/rdfSerialization.test.ts
@@ -11,6 +11,11 @@ import {
 import type { PackingList, PackingListItem } from '../create-packing-list/types'
 import type { PackingListQuestionSet, Person, Question, Option } from '../edit-questions/types'
 import type { SharedListsWithMe } from './rdfSerialization'
+import {
+    fullyPopulatedPackingList,
+    fullyPopulatedQuestionSet,
+    withoutLocalOnlyFields,
+} from '../test-utils/fullyPopulatedFixtures'
 
 const DATASET_URL = 'https://pod.example.com/pack-me-up/packing-lists/list-abc.ttl'
 const QS_DATASET_URL = 'https://pod.example.com/pack-me-up/packing-list-questions.ttl'
@@ -72,6 +77,29 @@ function roundTripList(list: PackingList): PackingList {
 function roundTripQs(qs: PackingListQuestionSet): PackingListQuestionSet {
     return datasetToQuestionSet(questionSetToDataset(qs, QS_DATASET_URL) as SolidDataset, QS_DATASET_URL)
 }
+
+// ── Field fidelity ────────────────────────────────────────────────────────────
+
+// Same guard as the PouchDB round-trip in database.test.ts, applied to the pod
+// copy: the serialisers are written field-by-field, so a new field on the type
+// is silently not written unless someone remembers to add it. The
+// `Required<...>` fixtures make that a type error first, and this a test
+// failure second. See src/test-utils/fullyPopulatedFixtures.ts.
+describe('Field fidelity', () => {
+    it('round-trips every pod-serialisable field of PackingList', () => {
+        const list: PackingList = { ...fullyPopulatedPackingList, id: 'list-abc' }
+
+        const result = roundTripList(list)
+
+        expect(result).toEqual(withoutLocalOnlyFields(list))
+    })
+
+    it('round-trips every field of PackingListQuestionSet', () => {
+        const result = roundTripQs({ ...fullyPopulatedQuestionSet, _id: '1' })
+
+        expect(result).toEqual({ ...fullyPopulatedQuestionSet, _id: '1' })
+    })
+})
 
 // ── PackingList round-trip ────────────────────────────────────────────────────
 

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import PouchDB from 'pouchdb'
+import PouchDBMemoryAdapter from 'pouchdb-adapter-memory'
 import type { AppSession as Session } from '../types/AppSession'
 import type { SolidDataset, WithServerResourceInfo } from '@inrupt/solid-client'
 import {
@@ -19,10 +21,15 @@ import {
     friendlyPodName,
 } from './solidPod'
 import { AuthenticationError } from './solidPod'
-import type { PackingAppDatabase } from './database'
+import { PackingAppDatabase } from './database'
 import type { PackingListQuestionSet } from '../edit-questions/types'
 import type { PackingList } from '../create-packing-list/types'
 import { packingListToDataset, questionSetToDataset } from './rdfSerialization'
+import { fullyPopulatedPackingList, withoutLocalOnlyFields } from '../test-utils/fullyPopulatedFixtures'
+
+// Most tests here use a stubbed db (see makeDb); the field-fidelity test uses a
+// real PouchDB-backed one.
+PouchDB.plugin(PouchDBMemoryAdapter)
 
 vi.mock('@inrupt/solid-client', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@inrupt/solid-client')>()
@@ -422,6 +429,26 @@ describe('syncAllDataFromPod', () => {
 
             expect(result.packingListsSynced).toBe(1)
             expect(result.packingListsUploaded).toBe(1)
+        })
+
+        // #260: login sync writes pod lists through savePackingList, whose field
+        // allowlist stripped nights / questionAnswers / selectedPeopleIds — so
+        // data that was safe in the pod was lost on its way into PouchDB.
+        it('keeps every pod-serialisable field of a synced list in the local DB', async () => {
+            const podList: PackingList = { ...fullyPopulatedPackingList, id: 'pod-full' }
+            const realDb = PackingAppDatabase.getInstance('sync-field-fidelity')
+            const podListUrl = `${LISTS_CONTAINER_URL}pod-full.ttl`
+
+            mockGetSolidDataset
+                .mockRejectedValueOnce({ statusCode: 404 }) // no question set
+                .mockResolvedValueOnce(makeContainerDataset([podListUrl]))
+                .mockResolvedValueOnce(makeRdfListDataset(podList))
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, realDb)
+
+            expect(result.packingListsSynced).toBe(1)
+            const stored = await realDb.getPackingList('pod-full')
+            expect(stored).toEqual({ ...withoutLocalOnlyFields(podList), _rev: expect.any(String) })
         })
     })
 })

--- a/src/services/solidPodBackup.test.ts
+++ b/src/services/solidPodBackup.test.ts
@@ -8,6 +8,7 @@ import { AuthenticationError } from './solidPod'
 import { createBackup, listBackups, deleteBackup, restoreBackup } from './solidPodBackup'
 import type { PackingListQuestionSet } from '../edit-questions/types'
 import type { PackingList } from '../create-packing-list/types'
+import { fullyPopulatedPackingList, fullyPopulatedQuestionSet } from '../test-utils/fullyPopulatedFixtures'
 
 // Setup PouchDB with memory adapter for testing
 PouchDB.plugin(PouchDBMemoryAdapter)
@@ -343,6 +344,29 @@ describe('restoreBackup', () => {
         const lists = await db.getAllPackingLists()
         expect(lists.map(l => l.id)).not.toContain('old-list')
         expect(lists.map(l => l.id)).toContain('new-list')
+    })
+
+    // #260: restoring went through savePackingList, whose field allowlist
+    // stripped nights / questionAnswers / selectedPeopleIds on the way in, so a
+    // backup could not fully restore a list.
+    it('keeps every field of a restored packing list', async () => {
+        const backupFile = {
+            version: 1 as const,
+            createdAt: '2025-01-01T00:00:00.000Z',
+            questionSet: fullyPopulatedQuestionSet,
+            packingLists: [fullyPopulatedPackingList]
+        }
+        mockLoadFileFromPod.mockResolvedValue(backupFile)
+        mockSaveRdfToPod.mockResolvedValue(undefined)
+        mockSaveMultipleRdfToPod.mockResolvedValue({ success: true, successCount: 1, failCount: 0, totalCount: 1 })
+
+        await restoreBackup(mockSession, POD_URL, db, backupUrl)
+
+        const restored = await db.getPackingList(fullyPopulatedPackingList.id)
+        expect(restored).toEqual({ ...fullyPopulatedPackingList, _rev: expect.any(String) })
+
+        const restoredQs = await db.getQuestionSet()
+        expect(restoredQs).toEqual({ ...fullyPopulatedQuestionSet, _id: '1', _rev: expect.any(String) })
     })
 
     it('saves restored packing lists to local DB', async () => {

--- a/src/test-utils/fullyPopulatedFixtures.ts
+++ b/src/test-utils/fullyPopulatedFixtures.ts
@@ -1,0 +1,146 @@
+import type { PackingList, PackingListItem } from '../create-packing-list/types'
+import type { PackingListQuestionSet, Person, Item, SavedQuestion, Option } from '../edit-questions/types'
+
+/**
+ * Fixtures with **every** field of their type populated, used by the
+ * persistence round-trip tests (see `database.test.ts` →
+ * "persists every field of the type").
+ *
+ * Why they live here (in `src`, not in a `.test.ts` file): `tsconfig.app.json`
+ * excludes test files from type checking, so a fixture defined inside a test
+ * would not be checked. Here it is, which is the whole point:
+ *
+ *   `Required<...>` means adding a new optional field to `PackingList` or
+ *   `PackingListQuestionSet` **breaks the type check** (`npm run typecheck`,
+ *   run in CI) until the field is added below — and once it is added, the
+ *   round-trip tests fail unless the field actually survives being saved and
+ *   read back.
+ *
+ * That pair is the automatic guard against the class of bug in #260, where
+ * `savePackingList` built its document from a hand-maintained field allowlist
+ * and silently dropped `nights`, `questionAnswers` and `selectedPeopleIds`.
+ *
+ * So: when the type check points you here, add the new field with a
+ * distinctive value. Don't reach for `as` or a partial fixture.
+ */
+
+const fullyPopulatedItem: Required<PackingListItem> = {
+    id: 'item-1',
+    itemText: 'Sunscreen',
+    personId: 'person-1',
+    personName: 'Alice',
+    questionId: 'q1',
+    optionId: 'opt1',
+    packed: true,
+    communal: false,
+    quantity: 3,
+    category: 'Toiletries',
+    order: 2,
+    reviewed: true,
+    lastModified: '2025-01-02T00:00:00.000Z',
+}
+
+const fullyPopulatedDeletedItem: Required<PackingListItem> = {
+    ...fullyPopulatedItem,
+    id: 'item-2',
+    itemText: 'Umbrella',
+    packed: false,
+    communal: true,
+    personId: '',
+    personName: '',
+    order: 5,
+}
+
+/** Every field of `PackingList` populated, except `_rev` (assigned by PouchDB). */
+export const fullyPopulatedPackingList: Required<Omit<PackingList, '_rev'>> = {
+    id: 'pl-full',
+    name: 'Fully populated trip',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    lastModified: '2025-01-02T00:00:00.000Z',
+    sharedFromPodUrl: 'https://alice.example/pod/',
+    ownerWebId: 'https://alice.example/profile/card#me',
+    nights: 4,
+    destination: 'Lisbon, Portugal',
+    startDate: '2025-06-01',
+    endDate: '2025-06-05',
+    items: [fullyPopulatedItem],
+    deletedItems: [fullyPopulatedDeletedItem],
+    guests: [{ id: 'guest-1', name: 'Zoe' }],
+    questionAnswers: [{ questionId: 'q1', selectedOptionIds: ['opt1', 'opt2'] }],
+    selectedPeopleIds: ['person-1', 'person-2'],
+}
+
+/**
+ * Fields of `PackingList` that are deliberately local-only and are not written
+ * to the pod (see the comments on the type). The RDF round-trip test excludes
+ * them; everything else must survive a trip through the pod serialisation.
+ */
+export const packingListLocalOnlyFields = ['_rev', 'sharedFromPodUrl', 'ownerWebId'] as const
+
+type PackingListLocalOnlyField = typeof packingListLocalOnlyFields[number]
+
+/** The fields of a list that a pod copy is expected to carry. */
+export function withoutLocalOnlyFields<T extends Partial<PackingList>>(
+    list: T
+): Omit<T, PackingListLocalOnlyField> {
+    const copy = { ...list } as Record<string, unknown>
+    for (const field of packingListLocalOnlyFields) delete copy[field]
+    return copy as Omit<T, PackingListLocalOnlyField>
+}
+
+const fullyPopulatedPerson: Required<Person> = {
+    id: 'person-1',
+    name: 'Alice',
+    ageRange: 'Adult',
+    dateOfBirth: '1990-05-04',
+    gender: 'female',
+    species: 'dog',
+    lastModified: '2025-01-02T00:00:00.000Z',
+    deletedAt: '2025-01-03T00:00:00.000Z',
+}
+
+const fullyPopulatedQuestionSetItem: Required<Item> = {
+    id: 'qs-item-1',
+    text: 'Sunscreen',
+    personSelections: [{ personId: 'person-1', selected: true }],
+    communal: true,
+    // Single value on purpose: RDF multi-values are an unordered set, so a
+    // longer list would make the pod round-trip assertion order-dependent.
+    ageRanges: ['Adult'],
+    order: 1,
+    perNight: 2,
+    perNights: 3,
+    maxQuantity: 7,
+    lastModified: '2025-01-02T00:00:00.000Z',
+    deletedAt: '2025-01-03T00:00:00.000Z',
+}
+
+const fullyPopulatedOption: Required<Option> = {
+    id: 'opt1',
+    text: 'Sunny',
+    items: [fullyPopulatedQuestionSetItem],
+    order: 0,
+}
+
+const fullyPopulatedQuestion: Required<SavedQuestion> = {
+    id: 'q1',
+    type: 'saved',
+    text: 'What is the weather?',
+    options: [fullyPopulatedOption],
+    order: 0,
+    questionType: 'multiple-choice',
+    lastModified: '2025-01-02T00:00:00.000Z',
+    deletedAt: '2025-01-03T00:00:00.000Z',
+}
+
+/**
+ * Every field of `PackingListQuestionSet` populated, except the PouchDB-assigned
+ * `_id` / `_rev`.
+ */
+export const fullyPopulatedQuestionSet: Required<Omit<PackingListQuestionSet, '_id' | '_rev'>> = {
+    people: [fullyPopulatedPerson],
+    alwaysNeededItems: [fullyPopulatedQuestionSetItem],
+    questions: [fullyPopulatedQuestion],
+    lastModified: '2025-01-02T00:00:00.000Z',
+    templateVersion: 3,
+}

--- a/src/test-utils/fullyPopulatedFixtures.ts
+++ b/src/test-utils/fullyPopulatedFixtures.ts
@@ -11,8 +11,8 @@ import type { PackingListQuestionSet, Person, Item, SavedQuestion, Option } from
  * would not be checked. Here it is, which is the whole point:
  *
  *   `Required<...>` means adding a new optional field to `PackingList` or
- *   `PackingListQuestionSet` **breaks the type check** (`npm run typecheck`,
- *   run in CI) until the field is added below — and once it is added, the
+ *   `PackingListQuestionSet` **breaks the type check** (`npm test` runs it
+ *   first) until the field is added below — and once it is added, the
  *   round-trip tests fail unless the field actually survives being saved and
  *   read back.
  *


### PR DESCRIPTION
savePackingList built its PouchDB document from an explicit list of fields
to keep, and getAllPackingLists read it back the same way. Three fields
were never on either list, so nights, questionAnswers and selectedPeopleIds
were dropped on every local write — including the pod → local login sync and
backup restore, where the pod copy held them correctly.

The visible cost was "Update from questions": with no stored generation
inputs, every list fell back to reconstructing them from its items, which
cannot see an option that generated nothing, and with no stored nights,
additions arrived without their per-night quantity.

Both document payloads are now derived by omitting the keys the document
owns (id/_id/_rev) and any undefined values, so a new field on the type is
persisted by default. saveQuestionSet had the same shape and was also
dropping lastModified, which left syncAllDataFromPod's local-vs-pod
comparison always resolving in the pod's favour; that now works as its
comment describes.

No migration: lists saved before this keep working through the
reconstruction fallback, and their pod copies still carry the real values.
nights is unrecoverable for local-only lists created earlier.

Guard against the next silent drop, in CI:

- src/test-utils/fullyPopulatedFixtures.ts holds Required<...> fixtures with
  every field of PackingList and PackingListQuestionSet populated, so adding
  an optional field to either type fails the type check until it is covered.
  They sit in src because tsconfig.app.json excludes test files from
  checking.
- Round-trip tests assert those fixtures survive intact through PouchDB and
  through the pod's RDF serialisation.
- npm run typecheck is a script now and runs in the test job, alongside the
  existing build-time check.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PDCEzCqvFeFyooCg5trLxk