### PR TITLE
Split long item lists into packing list sections

### DIFF
--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -141,13 +141,13 @@ test.describe('B – Editing Questions', () => {
     const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
     expect(first).not.toEqual(second)
 
-    // Enter reorder mode — rows collapse to name + large move buttons
-    await page.getByRole('button', { name: 'Reorder items' }).click()
+    // Enter organise mode — rows collapse to name + large move buttons
+    await page.getByRole('button', { name: 'Organise items' }).click()
     await expect(page.locator('.cursor-text')).toHaveCount(0)
 
-    // Move the first item down one position, leave reorder mode, save
+    // Move the first item down one position, leave organise mode, save
     await page.locator('button[title="Move item down"]').first().click()
-    await page.getByRole('button', { name: 'Finish reordering' }).click()
+    await page.getByRole('button', { name: 'Finish organising' }).click()
     await expect(itemTexts.first()).toContainText(second)
     await expect(itemTexts.nth(1)).toContainText(first)
     await page.getByRole('button', { name: 'Save changes' }).click()
@@ -168,7 +168,7 @@ test.describe('B – Editing Questions', () => {
     const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
     expect(first).not.toEqual(second)
 
-    await page.getByRole('button', { name: 'Reorder items' }).click()
+    await page.getByRole('button', { name: 'Organise items' }).click()
     const rows = page.locator('[data-reorder-row]')
     await expect(rows.first()).toBeVisible()
 
@@ -176,7 +176,8 @@ test.describe('B – Editing Questions', () => {
     // edge (before its midpoint) so the item lands in exactly slot 1. Aiming
     // deeper would cross the next row's midpoint and overshoot. Low-level mouse
     // moves dispatch pointer events, driving the same code path as touch.
-    const handle = page.locator('button[title="Drag to reorder"]').first()
+    // Prefix match: the handle's tooltip also mentions moving between sections
+    const handle = page.locator('button[title^="Drag to reorder"]').first()
     const hb = (await handle.boundingBox())!
     const sb = (await rows.nth(1).boundingBox())!
     await page.mouse.move(hb.x + hb.width / 2, hb.y + hb.height / 2)
@@ -184,16 +185,16 @@ test.describe('B – Editing Questions', () => {
     await page.mouse.move(hb.x + hb.width / 2, sb.y + 4, { steps: 10 })
     await page.mouse.up()
 
-    // The drag reordered the two items (still in reorder mode, rows show plain text)
+    // The drag reordered the two items (still in organise mode, rows show plain text)
     await expect(rows.first()).toContainText(second)
     await expect(rows.nth(1)).toContainText(first)
 
-    // Leave reorder mode. dnd-kit suppresses the single click that immediately
-    // follows a drop, so retry until reorder mode actually exits (a real user
+    // Leave organise mode. dnd-kit suppresses the single click that immediately
+    // follows a drop, so retry until organise mode actually exits (a real user
     // never taps this fast; the suppression is invisible in practice).
     await expect(async () => {
-      await page.getByRole('button', { name: 'Finish reordering' }).click()
-      await expect(page.getByRole('button', { name: 'Reorder items' })).toBeVisible({ timeout: 1_000 })
+      await page.getByRole('button', { name: 'Finish organising' }).click()
+      await expect(page.getByRole('button', { name: 'Organise items' })).toBeVisible({ timeout: 1_000 })
     }).toPass()
     await expect(itemTexts.first()).toContainText(second)
     await expect(itemTexts.nth(1)).toContainText(first)

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -38,9 +38,9 @@ test.describe('C – Packing Lists', () => {
     // First line only — the row also renders a "×" clear glyph on its own line
     const first = (await itemTexts.first().innerText()).split('\n')[0].trim()
     const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
-    await page.getByRole('button', { name: 'Reorder items' }).click()
+    await page.getByRole('button', { name: 'Organise items' }).click()
     await page.locator('button[title="Move item down"]').first().click()
-    await page.getByRole('button', { name: 'Finish reordering' }).click()
+    await page.getByRole('button', { name: 'Finish organising' }).click()
     await page.getByRole('button', { name: 'Save changes' }).click()
     await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
 

--- a/src/components/SectionedItemReorder.tsx
+++ b/src/components/SectionedItemReorder.tsx
@@ -1,0 +1,343 @@
+/**
+ * Reorder view for an item list, split into sections.
+ *
+ * Position is the interaction — you drag an item under a header to put it in
+ * that section — but nothing positional is stored. Every drop runs the sequence
+ * back through `applySectionLayout`, which stamps each item with the nearest
+ * header above it. See `item-sections.ts` for why the storage is stamped.
+ */
+import { useRef, useState } from 'react'
+import {
+    DndContext,
+    closestCenter,
+    KeyboardSensor,
+    MouseSensor,
+    TouchSensor,
+    useSensor,
+    useSensors,
+    type DragEndEvent,
+    type Modifier,
+} from '@dnd-kit/core'
+import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import type { Item } from '../edit-questions/types'
+import {
+    applySectionLayout,
+    buildSectionSequence,
+    type SectionSequenceEntry,
+} from '../edit-questions/item-sections'
+
+// Drags only ever move rows up and down the list.
+const restrictToVerticalAxis: Modifier = ({ transform }) => ({ ...transform, x: 0 })
+
+function SectionHeaderRow({ id, label, isDefault, onRename, onRemove }: {
+    id: string
+    label: string
+    isDefault: boolean
+    onRename: (label: string) => void
+    onRemove: () => void
+}) {
+    // Headers sit in the sortable context so items can be dropped across them,
+    // but they aren't draggable themselves — a section moves by moving its items.
+    const { setNodeRef, transform, transition } = useSortable({ id, disabled: true })
+    const [editing, setEditing] = useState(false)
+    const [draft, setDraft] = useState(label)
+
+    const commit = () => {
+        const trimmed = draft.trim()
+        if (trimmed && trimmed !== label) onRename(trimmed)
+        else setDraft(label)
+        setEditing(false)
+    }
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={{ transform: CSS.Transform.toString(transform), transition }}
+            className="flex items-center gap-2 pt-3 pb-1"
+        >
+            {editing ? (
+                <input
+                    autoFocus
+                    value={draft}
+                    onChange={e => setDraft(e.target.value)}
+                    onBlur={commit}
+                    onKeyDown={e => {
+                        if (e.key === 'Enter') commit()
+                        if (e.key === 'Escape') { setDraft(label); setEditing(false) }
+                    }}
+                    aria-label={`Rename section ${label}`}
+                    className="flex-1 min-w-0 border border-primary-300 rounded-lg px-2 py-1 text-xs font-semibold uppercase tracking-wide focus:outline-none focus:ring-2 focus:ring-primary-500"
+                />
+            ) : (
+                <>
+                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide truncate">
+                        {label}
+                    </span>
+                    <span className="flex-1 h-px bg-gray-200" />
+                    {!isDefault && (
+                        <>
+                            <button
+                                type="button"
+                                onClick={() => { setDraft(label); setEditing(true) }}
+                                aria-label={`Rename section ${label}`}
+                                className="text-[11px] text-gray-400 hover:text-primary-600 px-1"
+                            >
+                                Rename
+                            </button>
+                            <button
+                                type="button"
+                                onClick={onRemove}
+                                aria-label={`Remove section ${label}`}
+                                className="text-[11px] text-gray-400 hover:text-red-600 px-1"
+                            >
+                                Remove
+                            </button>
+                        </>
+                    )}
+                </>
+            )}
+        </div>
+    )
+}
+
+function SortableSectionItem({ id, item, canMoveUp, canMoveDown, onMove }: {
+    id: string
+    item: Item
+    canMoveUp: boolean
+    canMoveDown: boolean
+    onMove: (direction: 'up' | 'down') => void
+}) {
+    const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id })
+    return (
+        <div
+            ref={setNodeRef}
+            style={{ transform: CSS.Transform.toString(transform), transition }}
+            data-reorder-row
+            className={`flex items-center gap-1 rounded-lg border bg-white p-2 ${isDragging ? 'relative z-10 border-primary-400 shadow-md opacity-95' : 'border-gray-200'}`}
+        >
+            <button
+                type="button"
+                ref={setActivatorNodeRef}
+                {...attributes}
+                {...listeners}
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-50 cursor-grab active:cursor-grabbing touch-none"
+                title="Drag to reorder or move between sections"
+                aria-label={`Drag ${item.text || 'item'} to reorder`}
+            >
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M7 4a1 1 0 100 2 1 1 0 000-2zM7 9a1 1 0 100 2 1 1 0 000-2zM7 14a1 1 0 100 2 1 1 0 000-2zM13 4a1 1 0 100 2 1 1 0 000-2zM13 9a1 1 0 100 2 1 1 0 000-2zM13 14a1 1 0 100 2 1 1 0 000-2z" />
+                </svg>
+            </button>
+            <span className="flex-1 min-w-0 truncate text-sm text-gray-800 px-1">
+                {item.text || <span className="text-gray-400 italic">Unnamed item</span>}
+            </span>
+            <div className="flex gap-1 shrink-0">
+                <button
+                    type="button"
+                    onClick={() => onMove('up')}
+                    disabled={!canMoveUp}
+                    className={`inline-flex items-center justify-center w-11 h-11 rounded-lg border transition-colors ${!canMoveUp ? 'text-gray-200 border-gray-100 cursor-not-allowed' : 'text-gray-600 border-gray-200 hover:bg-gray-50 active:bg-gray-100'}`}
+                    title="Move item up"
+                    aria-label={`Move ${item.text || 'item'} up`}
+                >
+                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                    </svg>
+                </button>
+                <button
+                    type="button"
+                    onClick={() => onMove('down')}
+                    disabled={!canMoveDown}
+                    className={`inline-flex items-center justify-center w-11 h-11 rounded-lg border transition-colors ${!canMoveDown ? 'text-gray-200 border-gray-100 cursor-not-allowed' : 'text-gray-600 border-gray-200 hover:bg-gray-50 active:bg-gray-100'}`}
+                    title="Move item down"
+                    aria-label={`Move ${item.text || 'item'} down`}
+                >
+                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+    )
+}
+
+export function SectionedItemReorder({ items, defaultLabel, suggestedSectionNames, scrollRef, onChange }: {
+    items: Item[]
+    /** Section name for items carrying no category — what the list will call them. */
+    defaultLabel: string
+    suggestedSectionNames: string[]
+    scrollRef: React.RefObject<HTMLDivElement | null>
+    onChange: (items: Item[]) => void
+}) {
+    // Sections the user has created but not yet filled. They can't be stored
+    // (a section is only its items' stamps), so they live here until something
+    // lands in them — and are simply forgotten if nothing does.
+    const [draftSections, setDraftSections] = useState<string[]>([])
+    const [addingSection, setAddingSection] = useState(false)
+    const [newSectionName, setNewSectionName] = useState('')
+
+    const sequence = buildSectionSequence(items, defaultLabel, draftSections)
+
+    // dnd-kit needs a stable id per row across reorders. Items may have no `id`
+    // yet (defaults not saved), so map each object to a client-only drag id.
+    const dragIdMap = useRef(new WeakMap<Item, string>())
+    const dragIdSeq = useRef(0)
+    const entryId = (entry: SectionSequenceEntry): string => {
+        if (entry.kind === 'header') return `header:${entry.label}`
+        let id = dragIdMap.current.get(entry.item)
+        if (!id) {
+            id = `item-${dragIdSeq.current++}`
+            dragIdMap.current.set(entry.item, id)
+        }
+        return id
+    }
+    const entryIds = sequence.map(entryId)
+
+    const applySequence = (next: SectionSequenceEntry[]) => {
+        const updated = applySectionLayout(next, defaultLabel, new Date().toISOString())
+        // A section that still has a header but no items stays a draft, so the
+        // user can keep dragging into it; one that gained items no longer needs
+        // to be remembered here.
+        const filled = new Set(updated.map(i => i.category).filter(Boolean) as string[])
+        setDraftSections(prev => prev.filter(label => !filled.has(label)))
+        onChange(updated)
+    }
+
+    const sensors = useSensors(
+        useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+        useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    )
+
+    const handleDragEnd = (e: DragEndEvent) => {
+        const { active, over } = e
+        if (!over || active.id === over.id) return
+        const from = entryIds.indexOf(String(active.id))
+        const to = entryIds.indexOf(String(over.id))
+        if (from === -1 || to === -1) return
+        const next = [...sequence]
+        const [moved] = next.splice(from, 1)
+        next.splice(to, 0, moved)
+        applySequence(next)
+    }
+
+    // The arrows are the keyboard//no-pointer equivalent of dragging: stepping
+    // an item past a header moves it into the neighbouring section, exactly as
+    // dragging across that header would.
+    const moveEntry = (seqIndex: number, direction: 'up' | 'down') => {
+        const target = direction === 'up' ? seqIndex - 1 : seqIndex + 1
+        if (target < 0 || target >= sequence.length) return
+        const next = [...sequence]
+        ;[next[seqIndex], next[target]] = [next[target], next[seqIndex]]
+        applySequence(next)
+    }
+
+    const addSection = () => {
+        const name = newSectionName.trim()
+        setNewSectionName('')
+        setAddingSection(false)
+        if (!name) return
+        const existing = new Set(sequence.filter(e => e.kind === 'header').map(e => e.kind === 'header' && e.label))
+        if (existing.has(name)) return
+        setDraftSections(prev => [...prev, name])
+    }
+
+    const renameSectionAt = (from: string, to: string) => {
+        setDraftSections(prev => prev.map(label => label === from ? to : label))
+        onChange(items.map(item =>
+            item.category === from ? { ...item, category: to, lastModified: new Date().toISOString() } : item
+        ))
+    }
+
+    const removeSectionAt = (label: string) => {
+        setDraftSections(prev => prev.filter(l => l !== label))
+        onChange(items.map(item => {
+            if (item.category !== label) return item
+            const { category: _dropped, ...rest } = item
+            return { ...rest, lastModified: new Date().toISOString() }
+        }))
+    }
+
+    const firstItemIndex = sequence.findIndex(e => e.kind === 'item')
+    const lastItemIndex = sequence.map(e => e.kind).lastIndexOf('item')
+
+    return (
+        <>
+            <div className="text-[11px] text-gray-400 mb-2 px-0.5">
+                Drag the handle (press and hold on touch), or use the arrows, to reorder.
+                Move an item under a section heading to put it in that section.
+            </div>
+            <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                modifiers={[restrictToVerticalAxis]}
+                // Only ever auto-scroll the modal's own scroll area — see the
+                // note on the unsectioned editor for why.
+                autoScroll={{ canScroll: (el) => el === scrollRef.current }}
+                onDragEnd={handleDragEnd}
+            >
+                <SortableContext items={entryIds} strategy={verticalListSortingStrategy}>
+                    <div className="space-y-2">
+                        {sequence.map((entry, i) => entry.kind === 'header' ? (
+                            <SectionHeaderRow
+                                key={entryIds[i]}
+                                id={entryIds[i]}
+                                label={entry.label}
+                                isDefault={entry.label === defaultLabel}
+                                onRename={to => renameSectionAt(entry.label, to)}
+                                onRemove={() => removeSectionAt(entry.label)}
+                            />
+                        ) : (
+                            <SortableSectionItem
+                                key={entryIds[i]}
+                                id={entryIds[i]}
+                                item={entry.item}
+                                canMoveUp={i > firstItemIndex}
+                                canMoveDown={i < lastItemIndex}
+                                onMove={direction => moveEntry(i, direction)}
+                            />
+                        ))}
+                    </div>
+                </SortableContext>
+            </DndContext>
+            {addingSection ? (
+                <div className="mt-3 flex gap-2">
+                    <input
+                        autoFocus
+                        list="section-name-suggestions"
+                        value={newSectionName}
+                        onChange={e => setNewSectionName(e.target.value)}
+                        onKeyDown={e => {
+                            if (e.key === 'Enter') addSection()
+                            if (e.key === 'Escape') { setNewSectionName(''); setAddingSection(false) }
+                        }}
+                        placeholder="Section name (e.g. Toiletries)"
+                        aria-label="New section name"
+                        className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    />
+                    {/* Suggest names already in use so the same section spelled two
+                        ways doesn't split into two groups on the list. */}
+                    <datalist id="section-name-suggestions">
+                        {suggestedSectionNames.map(name => <option key={name} value={name} />)}
+                    </datalist>
+                    <button
+                        type="button"
+                        onClick={addSection}
+                        className="px-3 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700"
+                    >
+                        Add
+                    </button>
+                </div>
+            ) : (
+                <button
+                    type="button"
+                    onClick={() => setAddingSection(true)}
+                    className="mt-3 w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
+                >
+                    + Add section
+                </button>
+            )}
+        </>
+    )
+}

--- a/src/components/SectionedItemReorder.tsx
+++ b/src/components/SectionedItemReorder.tsx
@@ -24,6 +24,8 @@ import type { Item } from '../edit-questions/types'
 import {
     applySectionLayout,
     buildSectionSequence,
+    removeSection,
+    renameSection,
     type SectionSequenceEntry,
 } from '../edit-questions/item-sections'
 
@@ -245,22 +247,19 @@ export function SectionedItemReorder({ items, defaultLabel, suggestedSectionName
 
     const renameSectionAt = (from: string, to: string) => {
         setDraftSections(prev => prev.map(label => label === from ? to : label))
-        onChange(items.map(item =>
-            item.category === from ? { ...item, category: to, lastModified: new Date().toISOString() } : item
-        ))
+        onChange(renameSection(items, from, to, new Date().toISOString()))
     }
 
     const removeSectionAt = (label: string) => {
         setDraftSections(prev => prev.filter(l => l !== label))
-        onChange(items.map(item => {
-            if (item.category !== label) return item
-            const { category: _dropped, ...rest } = item
-            return { ...rest, lastModified: new Date().toISOString() }
-        }))
+        onChange(removeSection(items, label, new Date().toISOString()))
     }
 
+    // An item can step down onto any following entry — including a trailing
+    // section heading, which is how a newly added (still empty) section gets its
+    // first item without a drag. Stepping up above the very first heading is the
+    // only no-op, since that heading is already the default section.
     const firstItemIndex = sequence.findIndex(e => e.kind === 'item')
-    const lastItemIndex = sequence.map(e => e.kind).lastIndexOf('item')
 
     return (
         <>
@@ -294,7 +293,7 @@ export function SectionedItemReorder({ items, defaultLabel, suggestedSectionName
                                 id={entryIds[i]}
                                 item={entry.item}
                                 canMoveUp={i > firstItemIndex}
-                                canMoveDown={i < lastItemIndex}
+                                canMoveDown={i < sequence.length - 1}
                                 onMove={direction => moveEntry(i, direction)}
                             />
                         ))}

--- a/src/create-packing-list/generatePackingListItems.test.ts
+++ b/src/create-packing-list/generatePackingListItems.test.ts
@@ -152,6 +152,48 @@ describe('generateQuestionBasedItems – selected options contribute items', () 
         result.forEach(item => expect(item.category).toBe('Staying overnight?'))
     })
 
+    it("prefers an item's own category over the option text", () => {
+        const q: Question = {
+            ...activitiesQuestion,
+            options: [{
+                ...swimmingOpt,
+                items: [
+                    { text: 'Swimsuit', personSelections: [{ personId: 'p1', selected: true }], category: 'Clothes' },
+                    { text: 'Goggles', personSelections: [{ personId: 'p1', selected: true }] },
+                ],
+            }],
+        }
+        const answers = [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }]
+        const result = generateQuestionBasedItems([q], answers, [p1], ['p1'])
+        expect(result.find(i => i.itemText === 'Swimsuit')?.category).toBe('Clothes')
+        // Unstamped siblings keep falling back to the option text
+        expect(result.find(i => i.itemText === 'Goggles')?.category).toBe('Swimming')
+    })
+
+    it("prefers an item's own category over the question text on single-choice questions", () => {
+        const q: Question = {
+            ...overnightQuestion,
+            options: [
+                {
+                    id: 'opt-yes',
+                    text: 'Yes',
+                    order: 0,
+                    items: [
+                        { text: 'Toothbrush', personSelections: [{ personId: 'p1', selected: true }], category: 'Toiletries' },
+                        { text: 'Pyjamas', personSelections: [{ personId: 'p1', selected: true }], category: 'Sleep' },
+                        { text: 'Socks', personSelections: [{ personId: 'p1', selected: true }] },
+                    ],
+                },
+                { id: 'opt-no', text: 'No', order: 1, items: [] },
+            ],
+        }
+        const answers = [{ questionId: 'q-overnight', selectedOptionIds: ['opt-yes'] }]
+        const result = generateQuestionBasedItems([q], answers, [p1], ['p1'])
+        expect(result.find(i => i.itemText === 'Toothbrush')?.category).toBe('Toiletries')
+        expect(result.find(i => i.itemText === 'Pyjamas')?.category).toBe('Sleep')
+        expect(result.find(i => i.itemText === 'Socks')?.category).toBe('Staying overnight?')
+    })
+
     it('processes multiple questions and merges their items', () => {
         const answers = [
             { questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] },
@@ -430,6 +472,21 @@ describe('generateAlwaysNeededItems', () => {
             expect(item.optionId).toBe('always-needed')
             expect(item.category).toBe('Essentials')
         })
+    })
+
+    it("prefers an item's own category over Essentials", () => {
+        const result = generateAlwaysNeededItems(
+            [
+                { text: 'Nappies', personSelections: [{ personId: 'p1', selected: true }], category: 'Baby' },
+                { text: 'First aid kit', communal: true, personSelections: [], category: 'First aid' },
+                { text: 'Snacks', personSelections: [{ personId: 'p1', selected: true }] },
+            ],
+            [p1],
+            ['p1']
+        )
+        expect(result.find(i => i.itemText === 'Nappies')?.category).toBe('Baby')
+        expect(result.find(i => i.itemText === 'First aid kit')?.category).toBe('First aid')
+        expect(result.find(i => i.itemText === 'Snacks')?.category).toBe('Essentials')
     })
 
     it('excludes people who are not travelling', () => {

--- a/src/create-packing-list/generatePackingListItems.ts
+++ b/src/create-packing-list/generatePackingListItems.ts
@@ -1,11 +1,23 @@
 import { Question, Person, Item } from '../edit-questions/types'
+import { ALWAYS_NEEDED_CATEGORY, defaultCategoryFor } from '../edit-questions/item-sections'
 import { PackingListItem } from './types'
 
 interface ItemContext {
     questionId: string
     optionId: string
+    // Category to use when the item doesn't carry its own — the option text,
+    // the question text, or 'Essentials' for always-needed items.
     category?: string
     nights?: number
+}
+
+// An item's own category wins over the one derived from its question/option.
+// The category is stamped on each item rather than marking a section boundary,
+// so it is a purely local property: per-item LWW merges (mergeQuestionSets) and
+// old clients that drop the field can only ever misplace the single item they
+// touched, never scramble a whole section.
+function categoryFor(item: Item, context: ItemContext): string | undefined {
+    return item.category ?? context.category
 }
 
 // The rate is "perNight per perNights nights" (perNights defaults to 1):
@@ -43,7 +55,7 @@ function generateItemInstances(
             packed: false,
             communal: true,
             ...(quantity !== undefined ? { quantity } : {}),
-            category: context.category,
+            category: categoryFor(item, context),
         }]
     }
 
@@ -61,7 +73,7 @@ function generateItemInstances(
             optionId: context.optionId,
             packed: false,
             ...(quantity !== undefined ? { quantity } : {}),
-            category: context.category,
+            category: categoryFor(item, context),
         } satisfies PackingListItem
     })
 }
@@ -92,9 +104,7 @@ export function generateQuestionBasedItems(
                         generateItemInstances(item, people, selectedPeopleIds, {
                             questionId: question.id,
                             optionId: selectedOption.id,
-                            category: question.questionType === 'multiple-choice'
-                                ? selectedOption.text
-                                : question.text,
+                            category: defaultCategoryFor(question, selectedOption),
                             nights,
                         })
                     )
@@ -112,7 +122,7 @@ export function generateAlwaysNeededItems(
         generateItemInstances(item, people, selectedPeopleIds, {
             questionId: 'always-needed',
             optionId: 'always-needed',
-            category: 'Essentials',
+            category: ALWAYS_NEEDED_CATEGORY,
             nights,
         })
     )

--- a/src/edit-questions/item-category-compat.test.ts
+++ b/src/edit-questions/item-category-compat.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Backwards-compatibility guards for `Item.category` (packing list sections).
+ *
+ * Sections are stored by stamping a category onto each item rather than by
+ * inserting heading rows or marking section boundaries. These tests pin the
+ * two properties that choice buys us, both of which matter because old
+ * clients (notably installed mobile builds) never disappear:
+ *
+ *   1. Adding categories is *purely additive* — it introduces no new items and
+ *      changes nothing else about the serialized shape. An old client, whose
+ *      RDF reader ignores the unknown predicate, therefore sees exactly the
+ *      question set it saw before.
+ *   2. When an old client rewrites an item it drops the category, and the
+ *      damage is limited to that one item — neighbours in the same section are
+ *      untouched. A boundary marker would have lost the whole section.
+ */
+import { describe, it, expect } from 'vitest'
+import { getThingAll, getUrlAll } from '@inrupt/solid-client'
+import type { SolidDataset } from '@inrupt/solid-client'
+import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSerialization'
+import { PMU, RDF } from '../services/rdfVocab'
+import { mergeQuestionSets } from '../utils/mergeQuestionSets'
+import type { PackingListQuestionSet, Item } from './types'
+
+const QS_URL = 'https://pod.example/pack-me-up/question-set.ttl'
+
+function makeQs(alwaysNeededItems: Item[]): PackingListQuestionSet {
+    return {
+        _id: '1',
+        people: [{ id: 'p1', name: 'Alice' }],
+        questions: [],
+        alwaysNeededItems,
+        lastModified: '2024-01-01T00:00:00.000Z',
+    }
+}
+
+const baseItems: Item[] = [
+    { id: 'i1', text: 'Nappies', order: 0, personSelections: [{ personId: 'p1', selected: true }] },
+    { id: 'i2', text: 'Baby wipes', order: 1, personSelections: [{ personId: 'p1', selected: true }] },
+    { id: 'i3', text: 'First aid kit', order: 2, communal: true, personSelections: [] },
+]
+
+const sectionedItems: Item[] = [
+    { ...baseItems[0], category: 'Baby' },
+    { ...baseItems[1], category: 'Baby' },
+    { ...baseItems[2], category: 'First aid' },
+]
+
+function roundTrip(qs: PackingListQuestionSet): PackingListQuestionSet {
+    return datasetToQuestionSet(questionSetToDataset(qs, QS_URL) as SolidDataset, QS_URL)
+}
+
+function stripCategory(items: Item[]): Item[] {
+    return items.map(({ category: _category, ...rest }) => rest)
+}
+
+describe('Item.category – additive on the wire', () => {
+    it('changes nothing but the category itself, so an old reader sees the pre-section data', () => {
+        const withoutSections = roundTrip(makeQs(baseItems))
+        const withSections = roundTrip(makeQs(sectionedItems))
+
+        // Guard against this passing vacuously: the categories must have
+        // survived the round-trip for the comparison below to mean anything.
+        expect(withSections.alwaysNeededItems.map(i => i.category))
+            .toEqual(['Baby', 'Baby', 'First aid'])
+
+        // An old client ignores pmu:category on read; everything it *does* read
+        // must be byte-for-byte what it saw before sections existed.
+        expect(stripCategory(withSections.alwaysNeededItems))
+            .toEqual(withoutSections.alwaysNeededItems)
+    })
+
+    it('adds no extra items — sectioning never changes the item count', () => {
+        const withSections = roundTrip(makeQs(sectionedItems))
+        expect(withSections.alwaysNeededItems).toHaveLength(baseItems.length)
+        expect(withSections.alwaysNeededItems.map(i => i.text))
+            .toEqual(['Nappies', 'Baby wipes', 'First aid kit'])
+    })
+
+    it('emits no extra QuestionItem things in the dataset', () => {
+        const plain = questionSetToDataset(makeQs(baseItems), QS_URL) as SolidDataset
+        const sectioned = questionSetToDataset(makeQs(sectionedItems), QS_URL) as SolidDataset
+
+        const questionItemCount = (ds: SolidDataset) =>
+            getThingAll(ds).filter(t => getUrlAll(t, RDF.type).includes(PMU.QuestionItem)).length
+
+        expect(questionItemCount(sectioned)).toBe(questionItemCount(plain))
+    })
+})
+
+describe('Item.category – blast radius when an old client drops it', () => {
+    it('loses the category only on the item the old client actually rewrote', () => {
+        // Pod holds the sectioned set. Local is an old client that edited one
+        // item's text: it rewrote that item without the category it never read,
+        // and its newer lastModified wins under per-item LWW.
+        const pod = makeQs(sectionedItems.map(i => ({ ...i, lastModified: '2024-01-01T00:00:00.000Z' })))
+        const local = makeQs([
+            { ...baseItems[0], text: 'Nappies (size 4)', lastModified: '2024-06-01T00:00:00.000Z' },
+            { ...sectionedItems[1], lastModified: '2024-01-01T00:00:00.000Z' },
+            { ...sectionedItems[2], lastModified: '2024-01-01T00:00:00.000Z' },
+        ])
+
+        const merged = mergeQuestionSets(local, pod)
+        const byId = new Map(merged.alwaysNeededItems.map(i => [i.id, i]))
+
+        // The edited item wins and has lost its section...
+        expect(byId.get('i1')?.text).toBe('Nappies (size 4)')
+        expect(byId.get('i1')?.category).toBeUndefined()
+        // ...but its section-mate is untouched, and so is the rest of the set.
+        expect(byId.get('i2')?.category).toBe('Baby')
+        expect(byId.get('i3')?.category).toBe('First aid')
+    })
+
+    it('keeps the category when the new client is the one that wrote last', () => {
+        const pod = makeQs([{ ...sectionedItems[0], lastModified: '2024-06-01T00:00:00.000Z' }])
+        const local = makeQs([{ ...baseItems[0], lastModified: '2024-01-01T00:00:00.000Z' }])
+
+        const merged = mergeQuestionSets(local, pod)
+        expect(merged.alwaysNeededItems[0].category).toBe('Baby')
+    })
+})

--- a/src/edit-questions/item-sections.test.ts
+++ b/src/edit-questions/item-sections.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import {
+    ALWAYS_NEEDED_CATEGORY,
+    defaultCategoryFor,
+    groupItemsIntoSections,
+    assignItemsToSection,
+    renameSection,
+    removeSection,
+    sectionNamesIn,
+} from './item-sections'
+import type { Item, Question, Option } from './types'
+
+const now = '2024-06-01T00:00:00.000Z'
+const before = '2024-01-01T00:00:00.000Z'
+
+function item(overrides: Partial<Item> & { id: string; text: string }): Item {
+    return { personSelections: [], lastModified: before, ...overrides }
+}
+
+const option: Option = { id: 'opt-yes', text: 'Yes', order: 0, items: [] }
+
+describe('defaultCategoryFor', () => {
+    const question = (questionType?: Question['questionType']): Question => ({
+        id: 'q1', type: 'saved', text: 'Staying overnight?', order: 0, questionType, options: [option],
+    })
+
+    it('uses the option text for multiple-choice questions', () => {
+        expect(defaultCategoryFor(question('multiple-choice'), option)).toBe('Yes')
+    })
+
+    it('uses the question text for single-choice questions', () => {
+        expect(defaultCategoryFor(question('single-choice'), option)).toBe('Staying overnight?')
+    })
+
+    it('treats a question with no explicit type as single-choice', () => {
+        expect(defaultCategoryFor(question(undefined), option)).toBe('Staying overnight?')
+    })
+})
+
+describe('groupItemsIntoSections', () => {
+    it('puts unstamped items under the default label', () => {
+        const items = [item({ id: 'i1', text: 'Snacks', order: 0 })]
+        const groups = groupItemsIntoSections(items, ALWAYS_NEEDED_CATEGORY)
+        expect(groups).toEqual([{ label: 'Essentials', items }])
+    })
+
+    it('splits stamped items into their own sections, ordered by earliest item', () => {
+        const items = [
+            item({ id: 'i1', text: 'Snacks', order: 0 }),
+            item({ id: 'i2', text: 'Nappies', order: 1, category: 'Baby' }),
+            item({ id: 'i3', text: 'Wipes', order: 2, category: 'Baby' }),
+            item({ id: 'i4', text: 'Plasters', order: 3, category: 'First aid' }),
+        ]
+        const groups = groupItemsIntoSections(items, ALWAYS_NEEDED_CATEGORY)
+        expect(groups.map(g => g.label)).toEqual(['Essentials', 'Baby', 'First aid'])
+        expect(groups[1].items.map(i => i.text)).toEqual(['Nappies', 'Wipes'])
+    })
+
+    it('keeps a section contiguous even when its items are interleaved by order', () => {
+        // A merge or an old-client write can leave order and category disagreeing.
+        // Grouping by label (never a positional walk) means the section still
+        // renders once, rather than the header appearing twice.
+        const items = [
+            item({ id: 'i1', text: 'Nappies', order: 0, category: 'Baby' }),
+            item({ id: 'i2', text: 'Plasters', order: 1, category: 'First aid' }),
+            item({ id: 'i3', text: 'Wipes', order: 2, category: 'Baby' }),
+        ]
+        const groups = groupItemsIntoSections(items, ALWAYS_NEEDED_CATEGORY)
+        expect(groups.map(g => g.label)).toEqual(['Baby', 'First aid'])
+        expect(groups[0].items.map(i => i.text)).toEqual(['Nappies', 'Wipes'])
+    })
+})
+
+describe('sectionNamesIn', () => {
+    it('lists distinct category names across every item-bearing location', () => {
+        const qs = {
+            _id: '1',
+            people: [],
+            alwaysNeededItems: [item({ id: 'i1', text: 'Nappies', category: 'Baby' })],
+            questions: [{
+                id: 'q1', type: 'saved' as const, text: 'Overnight?', order: 0,
+                options: [{
+                    id: 'o1', text: 'Yes', order: 0,
+                    items: [
+                        item({ id: 'i2', text: 'Toothbrush', category: 'Toiletries' }),
+                        item({ id: 'i3', text: 'Toothpaste', category: 'Toiletries' }),
+                    ],
+                }],
+            }],
+        }
+        expect(sectionNamesIn(qs).sort()).toEqual(['Baby', 'Toiletries'])
+    })
+})
+
+describe('assignItemsToSection', () => {
+    const items = [
+        item({ id: 'i1', text: 'Nappies', order: 0 }),
+        item({ id: 'i2', text: 'Snacks', order: 1 }),
+    ]
+
+    it('stamps the category and a fresh lastModified on the moved item only', () => {
+        const result = assignItemsToSection(items, ['i1'], 'Baby', now)
+        expect(result[0].category).toBe('Baby')
+        expect(result[0].lastModified).toBe(now)
+        expect(result[1].category).toBeUndefined()
+        expect(result[1].lastModified).toBe(before)
+    })
+
+    it('clears the category when moving an item back to the default section', () => {
+        const stamped = [item({ id: 'i1', text: 'Nappies', order: 0, category: 'Baby' })]
+        const result = assignItemsToSection(stamped, ['i1'], undefined, now)
+        expect(result[0].category).toBeUndefined()
+        expect(result[0].lastModified).toBe(now)
+    })
+
+    it('leaves items untouched when the category is already correct', () => {
+        const stamped = [item({ id: 'i1', text: 'Nappies', order: 0, category: 'Baby' })]
+        expect(assignItemsToSection(stamped, ['i1'], 'Baby', now)[0]).toBe(stamped[0])
+    })
+})
+
+describe('renameSection', () => {
+    it('restamps every item in the section, including soft-deleted ones', () => {
+        const items = [
+            item({ id: 'i1', text: 'Nappies', category: 'Baby' }),
+            item({ id: 'i2', text: 'Wipes', category: 'Baby', deletedAt: before }),
+            item({ id: 'i3', text: 'Plasters', category: 'First aid' }),
+        ]
+        const result = renameSection(items, 'Baby', 'Baby & toddler', now)
+        expect(result.map(i => i.category)).toEqual(['Baby & toddler', 'Baby & toddler', 'First aid'])
+        // A restored item must come back into the renamed section, so deleted
+        // items are renamed too rather than being left pointing at a dead name.
+        expect(result[1].category).toBe('Baby & toddler')
+        expect(result[2].lastModified).toBe(before)
+    })
+})
+
+describe('removeSection', () => {
+    it('clears the category on its items rather than deleting them', () => {
+        const items = [
+            item({ id: 'i1', text: 'Nappies', category: 'Baby' }),
+            item({ id: 'i2', text: 'Plasters', category: 'First aid' }),
+        ]
+        const result = removeSection(items, 'Baby', now)
+        expect(result).toHaveLength(2)
+        expect(result[0].category).toBeUndefined()
+        expect(result[0].text).toBe('Nappies')
+        expect(result[1].category).toBe('First aid')
+    })
+})

--- a/src/edit-questions/item-sections.test.ts
+++ b/src/edit-questions/item-sections.test.ts
@@ -7,6 +7,9 @@ import {
     renameSection,
     removeSection,
     sectionNamesIn,
+    buildSectionSequence,
+    applySectionLayout,
+    type SectionSequenceEntry,
 } from './item-sections'
 import type { Item, Question, Option } from './types'
 
@@ -132,6 +135,107 @@ describe('renameSection', () => {
         // items are renamed too rather than being left pointing at a dead name.
         expect(result[1].category).toBe('Baby & toddler')
         expect(result[2].lastModified).toBe(before)
+    })
+})
+
+describe('buildSectionSequence', () => {
+    it('interleaves a header before each section, default section first', () => {
+        const items = [
+            item({ id: 'i1', text: 'Snacks', order: 0 }),
+            item({ id: 'i2', text: 'Nappies', order: 1, category: 'Baby' }),
+        ]
+        const sequence = buildSectionSequence(items, 'Essentials', [])
+        expect(sequence.map(e => e.kind === 'header' ? `#${e.label}` : e.item.text))
+            .toEqual(['#Essentials', 'Snacks', '#Baby', 'Nappies'])
+    })
+
+    it('includes draft sections that have no items yet', () => {
+        const items = [item({ id: 'i1', text: 'Snacks', order: 0 })]
+        const sequence = buildSectionSequence(items, 'Essentials', ['First aid'])
+        expect(sequence.map(e => e.kind === 'header' ? `#${e.label}` : e.item.text))
+            .toEqual(['#Essentials', 'Snacks', '#First aid'])
+    })
+
+    it('does not duplicate a draft section that has since gained items', () => {
+        const items = [item({ id: 'i1', text: 'Plasters', order: 0, category: 'First aid' })]
+        const sequence = buildSectionSequence(items, 'Essentials', ['First aid'])
+        expect(sequence.filter(e => e.kind === 'header')).toHaveLength(1)
+    })
+
+    it('follows array position, not the stale order field', () => {
+        // Mid-edit the array is the truth: `order` is left stale on purpose so
+        // renumberItemOrder can tell at save which items actually moved.
+        const items = [
+            item({ id: 'i1', text: 'Wipes', order: 5 }),
+            item({ id: 'i2', text: 'Snacks', order: 1 }),
+        ]
+        const sequence = buildSectionSequence(items, 'Essentials', [])
+        expect(sequence.filter(e => e.kind === 'item').map(e => e.kind === 'item' && e.item.text))
+            .toEqual(['Wipes', 'Snacks'])
+    })
+
+    it('omits the default header when every item is in a named section', () => {
+        const items = [item({ id: 'i1', text: 'Plasters', category: 'First aid' })]
+        const sequence = buildSectionSequence(items, 'Essentials', [])
+        expect(sequence.map(e => e.kind === 'header' ? `#${e.label}` : e.item.text))
+            .toEqual(['#First aid', 'Plasters'])
+    })
+})
+
+describe('applySectionLayout', () => {
+    const snacks = item({ id: 'i1', text: 'Snacks' })
+    const nappies = item({ id: 'i2', text: 'Nappies' })
+
+    function sequence(...entries: Array<string | Item>): SectionSequenceEntry[] {
+        return entries.map(e =>
+            typeof e === 'string' ? { kind: 'header' as const, label: e } : { kind: 'item' as const, item: e }
+        )
+    }
+
+    it('stamps each item with the nearest header above it', () => {
+        const result = applySectionLayout(
+            sequence('Essentials', snacks, 'Baby', nappies), 'Essentials', now
+        )
+        expect(result.map(i => [i.text, i.category])).toEqual([
+            ['Snacks', undefined],
+            ['Nappies', 'Baby'],
+        ])
+    })
+
+    it('returns items in displayed order so a cross-section drag also moves them', () => {
+        const result = applySectionLayout(
+            sequence('Baby', nappies, 'Essentials', snacks), 'Essentials', now
+        )
+        expect(result.map(i => i.text)).toEqual(['Nappies', 'Snacks'])
+        expect(result.map(i => i.category)).toEqual(['Baby', undefined])
+    })
+
+    it('clears the category for items dragged back under the default header', () => {
+        const stamped = item({ id: 'i2', text: 'Nappies', category: 'Baby' })
+        const result = applySectionLayout(sequence('Essentials', stamped), 'Essentials', now)
+        expect(result[0].category).toBeUndefined()
+        expect(result[0].lastModified).toBe(now)
+    })
+
+    it('treats items dragged above the first header as the default section', () => {
+        const stamped = item({ id: 'i2', text: 'Nappies', category: 'Baby' })
+        const result = applySectionLayout(sequence(stamped, 'Baby'), 'Essentials', now)
+        expect(result[0].category).toBeUndefined()
+    })
+
+    it('only bumps lastModified on items whose section actually changed', () => {
+        const stamped = item({ id: 'i2', text: 'Nappies', category: 'Baby' })
+        const result = applySectionLayout(sequence('Essentials', snacks, 'Baby', stamped), 'Essentials', now)
+        expect(result[0].lastModified).toBe(before)
+        expect(result[1].lastModified).toBe(before)
+    })
+
+    it('drops empty sections — a header with no items below it stamps nothing', () => {
+        const result = applySectionLayout(
+            sequence('Essentials', snacks, 'First aid'), 'Essentials', now
+        )
+        expect(result).toHaveLength(1)
+        expect(result[0].category).toBeUndefined()
     })
 })
 

--- a/src/edit-questions/item-sections.ts
+++ b/src/edit-questions/item-sections.ts
@@ -1,0 +1,101 @@
+/**
+ * Sections within a single item list (the always-needed list, or one option's
+ * items). A section is just a `category` stamped on each of its items — see the
+ * note on `ItemSchema.category`. There is no section entity and no boundary
+ * marker, which is what keeps the feature safe across per-item LWW merges and
+ * old clients.
+ *
+ * Items with no category of their own belong to the list's default section,
+ * named by `defaultCategoryFor` / `ALWAYS_NEEDED_CATEGORY` — the same values
+ * `generatePackingListItems` falls back to, so the editor shows exactly the
+ * grouping the generated packing list will have.
+ */
+import { groupItemsByCategory, type CategoryAccessors, type CategoryGroup } from '../utils/groupByCategory'
+import type { Item, Option, PackingListQuestionSet, Question } from './types'
+
+/** Default section name for items in the always-needed list. */
+export const ALWAYS_NEEDED_CATEGORY = 'Essentials'
+
+/**
+ * The section an item falls into when it carries no category of its own:
+ * the option text for multiple-choice questions (each option is already its
+ * own group), the question text otherwise.
+ */
+export function defaultCategoryFor(question: Question, option: Option): string {
+    return question.questionType === 'multiple-choice' ? option.text : question.text
+}
+
+const ITEM_ACCESSORS: CategoryAccessors<Item> = {
+    category: item => item.category,
+    order: item => item.order,
+    text: item => item.text,
+}
+
+/**
+ * Group an item list into its sections, ordered by each section's earliest
+ * item. Grouping is by label rather than by walking positions, so a section
+ * stays contiguous — and appears exactly once — even if a merge leaves an
+ * item's order and category disagreeing.
+ */
+export function groupItemsIntoSections(items: Item[], defaultLabel: string): CategoryGroup<Item>[] {
+    return groupItemsByCategory(items, ITEM_ACCESSORS, { uncategorisedLabel: defaultLabel })
+}
+
+/** Every distinct section name in use, for offering existing names as suggestions. */
+export function sectionNamesIn(qs: PackingListQuestionSet): string[] {
+    const names = new Set<string>()
+    for (const item of qs.alwaysNeededItems ?? []) {
+        if (item.category) names.add(item.category)
+    }
+    for (const question of qs.questions ?? []) {
+        for (const option of question.options) {
+            for (const item of option.items) {
+                if (item.category) names.add(item.category)
+            }
+        }
+    }
+    return [...names]
+}
+
+/**
+ * Move items into a section (or back to the default section with `undefined`).
+ * Only items whose category actually changes get a fresh `lastModified`, so a
+ * no-op drag doesn't churn sync or win unrelated merges.
+ */
+export function assignItemsToSection(
+    items: Item[],
+    itemIds: string[],
+    category: string | undefined,
+    now: string,
+): Item[] {
+    const ids = new Set(itemIds)
+    return items.map(item => {
+        if (!item.id || !ids.has(item.id) || item.category === category) return item
+        const { category: _dropped, ...rest } = item
+        return { ...rest, ...(category !== undefined ? { category } : {}), lastModified: now }
+    })
+}
+
+/**
+ * Rename a section by restamping every item in it. Soft-deleted items are
+ * renamed too, so an item restored later rejoins the renamed section instead of
+ * reappearing under a name that no longer exists.
+ */
+export function renameSection(items: Item[], from: string, to: string, now: string): Item[] {
+    if (from === to) return items
+    return items.map(item =>
+        item.category === from ? { ...item, category: to, lastModified: now } : item
+    )
+}
+
+/**
+ * Remove a section, keeping its items — they fall back to the list's default
+ * section. Removing a grouping should never destroy what was grouped.
+ */
+export function removeSection(items: Item[], label: string, now: string): Item[] {
+    return items.map(item => {
+        if (item.category !== label) return item
+        const { category: _dropped, ...rest } = item
+        return { ...rest, lastModified: now }
+    })
+}

--- a/src/edit-questions/item-sections.ts
+++ b/src/edit-questions/item-sections.ts
@@ -41,6 +41,89 @@ export function groupItemsIntoSections(items: Item[], defaultLabel: string): Cat
     return groupItemsByCategory(items, ITEM_ACCESSORS, { uncategorisedLabel: defaultLabel })
 }
 
+/**
+ * A section list flattened for display: a header before each section, then its
+ * items. This is the only place position carries meaning — it's what the editor
+ * drags against, and `applySectionLayout` turns it straight back into stamped
+ * categories. Nothing positional is ever stored.
+ */
+export type SectionSequenceEntry =
+    | { kind: 'header'; label: string }
+    | { kind: 'item'; item: Item }
+
+/**
+ * Build the display sequence for the editor. `draftSections` are sections the
+ * user has created but not yet dragged anything into; they exist only in editor
+ * state, since a section with no items has nothing to stamp and so cannot be
+ * stored.
+ *
+ * Unlike `groupItemsIntoSections` — which the packing list uses, and which sorts
+ * by the stamped `order` — this groups by *array position*. Inside the editor
+ * the array is the source of truth: `order` is deliberately left stale until
+ * `renumberItemOrder` runs at save, because that staleness is exactly how a
+ * reorder earns its `lastModified` bump. Both paths share the same bucketing by
+ * label, so the sections themselves can't drift; only the basis for ordering
+ * within them differs, and saving makes the two agree.
+ */
+export function buildSectionSequence(
+    items: Item[],
+    defaultLabel: string,
+    draftSections: string[],
+): SectionSequenceEntry[] {
+    const buckets = new Map<string, Item[]>()
+    // The default section always leads, so the "main pile" stays the top of the
+    // list even if a categorised item happens to sit first in the array.
+    buckets.set(defaultLabel, [])
+    for (const item of items) {
+        const label = item.category ?? defaultLabel
+        if (!buckets.has(label)) buckets.set(label, [])
+        buckets.get(label)!.push(item)
+    }
+    for (const draft of draftSections) {
+        if (!buckets.has(draft)) buckets.set(draft, [])
+    }
+    return [...buckets.entries()]
+        // An empty default section has no header to show; drafts do, since their
+        // header is the drop target that brings them into existence.
+        .filter(([label, bucket]) => bucket.length > 0 || label !== defaultLabel)
+        .flatMap(([label, bucket]) => [
+            { kind: 'header' as const, label },
+            ...bucket.map(item => ({ kind: 'item' as const, item })),
+        ])
+}
+
+/**
+ * Turn a dragged sequence back into a flat item list, stamping each item with
+ * the nearest header above it. Items under the default header (or above the
+ * first header) carry no category at all, so "back to the main pile" stores
+ * nothing rather than storing the default name.
+ *
+ * Only items whose section actually changed get a fresh `lastModified` —
+ * position changes are stamped separately by `renumberItemOrder` at save.
+ */
+export function applySectionLayout(
+    sequence: SectionSequenceEntry[],
+    defaultLabel: string,
+    now: string,
+): Item[] {
+    let current: string | undefined
+    const result: Item[] = []
+    for (const entry of sequence) {
+        if (entry.kind === 'header') {
+            current = entry.label === defaultLabel ? undefined : entry.label
+            continue
+        }
+        const item = entry.item
+        if (item.category === current) {
+            result.push(item)
+            continue
+        }
+        const { category: _dropped, ...rest } = item
+        result.push({ ...rest, ...(current !== undefined ? { category: current } : {}), lastModified: now })
+    }
+    return result
+}
+
 /** Every distinct section name in use, for offering existing names as suggestions. */
 export function sectionNamesIn(qs: PackingListQuestionSet): string[] {
     const names = new Set<string>()

--- a/src/edit-questions/types.test.ts
+++ b/src/edit-questions/types.test.ts
@@ -59,6 +59,18 @@ describe('ItemSchema - order (backward compatible)', () => {
   })
 })
 
+describe('ItemSchema - category (backward compatible)', () => {
+  it('accepts an item with a category', () => {
+    const parsed = ItemSchema.parse({ text: 'Toothbrush', personSelections: [], category: 'Toiletries' })
+    expect(parsed.category).toBe('Toiletries')
+  })
+
+  it('accepts a legacy item without a category', () => {
+    const parsed = ItemSchema.parse({ text: 'Towel', personSelections: [] })
+    expect(parsed.category).toBeUndefined()
+  })
+})
+
 describe('renumberItemOrder', () => {
   const now = '2024-06-01T00:00:00.000Z'
 

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -67,6 +67,12 @@ export const PersonSelectionSchema = z.object({
 // are never touched by those suggestions.
 // `order` is optional and additive: items without it sort after ordered ones
 // in their original position, so legacy data keeps its array order.
+// `category` is optional and additive: it names the section this item belongs
+// to on the generated packing list, letting one long item list (always-needed,
+// or a single option's items) split into several groups. Stamped on every item
+// in a section rather than marking a boundary, so it survives per-item LWW
+// merges and old clients intact — see the note in generatePackingListItems.
+// Absent means "fall back to the option/question text" exactly as before.
 // Quantity-suggestion fields, all optional and additive: the item's rate is
 // "pack `perNight` per `perNights` nights" (perNights defaults to 1, so
 // perNight alone means a per-night amount, e.g. socks 1/night; perNights: 4
@@ -80,6 +86,7 @@ export const ItemSchema = z.object({
   communal: z.boolean().optional(),
   ageRanges: z.array(AgeRangeSchema).optional(),
   order: z.number().optional(),
+  category: z.string().optional(),
   perNight: z.number().optional(),
   perNights: z.number().optional(),
   maxQuantity: z.number().optional(),

--- a/src/pages/questions-page.option-section.test.tsx
+++ b/src/pages/questions-page.option-section.test.tsx
@@ -14,9 +14,15 @@ function makeOption(overrides: Partial<Option> = {}): Option {
     return { id: 'o1', order: 0, text: 'Yes', items: [], ...overrides }
 }
 
-function renderOption(option: Option) {
+function renderOption(option: Option, sectionDefaultLabel = 'Yes') {
     return render(
-        <OptionSection option={option} people={people} onEdit={vi.fn()} onDelete={vi.fn()} />
+        <OptionSection
+            option={option}
+            people={people}
+            sectionDefaultLabel={sectionDefaultLabel}
+            onEdit={vi.fn()}
+            onDelete={vi.fn()}
+        />
     )
 }
 
@@ -55,5 +61,37 @@ describe('OptionSection with items', () => {
         fireEvent.click(toggle)
         expect(screen.getByText('Toothbrush')).toBeTruthy()
         expect(screen.getByText('Towel')).toBeTruthy()
+    })
+
+    it('shows no section headings when the items are all in the default section', () => {
+        renderOption(withItems())
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        // 'Yes' appears as the option's own heading; it must not also appear as
+        // a section heading when the list isn't actually split.
+        expect(screen.queryByTestId('item-section-heading')).toBeNull()
+    })
+})
+
+describe('OptionSection with sectioned items', () => {
+    const sectioned = () => makeOption({
+        items: [
+            { text: 'Toothbrush', personSelections: [], category: 'Toiletries' },
+            { text: 'Pyjamas', personSelections: [], category: 'Sleep' },
+            { text: 'Socks', personSelections: [] },
+        ],
+    })
+
+    it('groups the items under their section headings', () => {
+        renderOption(sectioned())
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        const headings = screen.getAllByTestId('item-section-heading').map(h => h.textContent)
+        // The default section leads, named as the generated list will name it.
+        expect(headings).toEqual(['Yes', 'Toiletries', 'Sleep'])
+    })
+
+    it('names the default section after the question for single-choice questions', () => {
+        renderOption(sectioned(), 'Staying overnight?')
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        expect(screen.getAllByTestId('item-section-heading')[0].textContent).toBe('Staying overnight?')
     })
 })

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -1,24 +1,8 @@
 import { useState, useEffect, useCallback, useRef, useMemo, memo } from 'react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import {
-    DndContext,
-    closestCenter,
-    KeyboardSensor,
-    MouseSensor,
-    TouchSensor,
-    useSensor,
-    useSensors,
-    type DragEndEvent,
-    type Modifier,
-} from '@dnd-kit/core'
-import {
-    SortableContext,
-    sortableKeyboardCoordinates,
-    verticalListSortingStrategy,
-    useSortable,
-} from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
 import { useDatabase } from '../components/DatabaseContext'
+import { SectionedItemReorder } from '../components/SectionedItemReorder'
+import { ALWAYS_NEEDED_CATEGORY, buildSectionSequence, defaultCategoryFor, sectionNamesIn } from '../edit-questions/item-sections'
 import { DatabaseMigration } from '../services/migration'
 import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, newDraftQuestion, renumberItemOrder, AGE_RANGE_OPTIONS } from '../edit-questions/types'
 import { Link } from 'react-router-dom'
@@ -631,7 +615,11 @@ function useItemListState(initialItems: Item[], people: Person[]) {
             personSelections: people.map(p => ({ personId: p.id, selected: true })),
         }]), [people])
 
-    return { items, scrollRef, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, moveItem, reorderItem, addItem }
+    // Whole-list replacement, used when a sectioned drag re-stamps categories
+    // and reorders in one go (see applySectionLayout).
+    const replaceItems = useCallback((next: Item[]) => setItems(next), [])
+
+    return { items, scrollRef, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, moveItem, reorderItem, addItem, replaceItems }
 }
 
 // "2 per night" / "1 per 4 nights" — the human phrasing of an item's rate
@@ -833,83 +821,14 @@ const ItemEditorRow = memo(function ItemEditorRow({ item, itemIdx, people, allIt
     )
 })
 
-// Lock the drag to the vertical axis — the list is one column, so any
-// horizontal drift just reads as jitter. (Inlined rather than pulling in
-// @dnd-kit/modifiers for a one-line transform.)
-const restrictToVerticalAxis: Modifier = ({ transform }) => ({ ...transform, x: 0 })
-
-// A single row in reorder mode: a drag handle (dnd-kit sortable) plus the
-// up/down buttons, which stay as the discrete, always-available fallback.
-function SortableItemRow({ id, item, index, isLast, moveItem }: {
-    id: string
-    item: Item
-    index: number
-    isLast: boolean
-    moveItem: (idx: number, direction: 'up' | 'down') => void
-}) {
-    const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id })
-    const style: React.CSSProperties = {
-        transform: CSS.Transform.toString(transform),
-        transition,
-    }
-    return (
-        <div
-            ref={setNodeRef}
-            style={style}
-            data-reorder-row
-            className={`flex items-center gap-1 rounded-lg border bg-white p-2 ${isDragging ? 'relative z-10 border-primary-400 shadow-md opacity-95' : 'border-gray-200'}`}
-        >
-            <button
-                type="button"
-                ref={setActivatorNodeRef}
-                {...attributes}
-                {...listeners}
-                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-50 cursor-grab active:cursor-grabbing touch-none"
-                title="Drag to reorder"
-                aria-label={`Drag ${item.text || 'item'} to reorder`}
-            >
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                    <path d="M7 4a1 1 0 100 2 1 1 0 000-2zM7 9a1 1 0 100 2 1 1 0 000-2zM7 14a1 1 0 100 2 1 1 0 000-2zM13 4a1 1 0 100 2 1 1 0 000-2zM13 9a1 1 0 100 2 1 1 0 000-2zM13 14a1 1 0 100 2 1 1 0 000-2z" />
-                </svg>
-            </button>
-            <span className="flex-1 min-w-0 truncate text-sm text-gray-800 px-1">
-                {item.text || <span className="text-gray-400 italic">Unnamed item</span>}
-            </span>
-            <div className="flex gap-1 shrink-0">
-                <button
-                    type="button"
-                    onClick={() => moveItem(index, 'up')}
-                    disabled={index === 0}
-                    className={`inline-flex items-center justify-center w-11 h-11 rounded-lg border transition-colors ${index === 0 ? 'text-gray-200 border-gray-100 cursor-not-allowed' : 'text-gray-600 border-gray-200 hover:bg-gray-50 active:bg-gray-100'}`}
-                    title="Move item up"
-                    aria-label={`Move ${item.text || 'item'} up`}
-                >
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
-                    </svg>
-                </button>
-                <button
-                    type="button"
-                    onClick={() => moveItem(index, 'down')}
-                    disabled={isLast}
-                    className={`inline-flex items-center justify-center w-11 h-11 rounded-lg border transition-colors ${isLast ? 'text-gray-200 border-gray-100 cursor-not-allowed' : 'text-gray-600 border-gray-200 hover:bg-gray-50 active:bg-gray-100'}`}
-                    title="Move item down"
-                    aria-label={`Move ${item.text || 'item'} down`}
-                >
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                    </svg>
-                </button>
-            </div>
-        </div>
-    )
-}
-
-function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, moveItem, reorderItem, addItem }: {
+function ItemListEditor({ items, people, allItemNames, scrollRef, sectionDefaultLabel, suggestedSectionNames, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, addItem, replaceItems }: {
     items: Item[]
     people: Person[]
     allItemNames: string[]
     scrollRef: React.RefObject<HTMLDivElement | null>
+    /** What the packing list will call items that carry no category of their own. */
+    sectionDefaultLabel: string
+    suggestedSectionNames: string[]
     updateItemText: (idx: number, text: string) => void
     togglePerson: (itemIdx: number, personIdx: number) => void
     toggleCommunal: (itemIdx: number) => void
@@ -917,9 +836,8 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
     updatePerNights: (itemIdx: number, perNights: number | undefined) => void
     updateMaxQuantity: (itemIdx: number, maxQuantity: number | undefined) => void
     removeItem: (idx: number) => void
-    moveItem: (idx: number, direction: 'up' | 'down') => void
-    reorderItem: (from: number, to: number) => void
     addItem: () => void
+    replaceItems: (items: Item[]) => void
 }) {
     const [openQuantityIdx, setOpenQuantityIdx] = useState<number | null>(null)
     const [reorderMode, setReorderMode] = useState(false)
@@ -931,42 +849,21 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
     const canReorder = items.length > 1
     const inReorder = reorderMode && canReorder
 
-    // dnd-kit needs a stable id per row that survives reorders. Items may lack
-    // an `id` (e.g. defaults not yet saved), so map each item object to a
-    // client-only drag id. Reordering splices the same object references, so
-    // ids stay put across a drag; edits create new objects (fine — not mid-drag).
-    const dragIdMap = useRef(new WeakMap<Item, string>())
-    const dragIdSeq = useRef(0)
-    const dragIdFor = (item: Item): string => {
-        let id = dragIdMap.current.get(item)
-        if (!id) {
-            id = `item-${dragIdSeq.current++}`
-            dragIdMap.current.set(item, id)
-        }
-        return id
-    }
-    const itemIds = items.map(dragIdFor)
+    // Normal editing mode shows the same section headings as the reorder view,
+    // read-only, so the editor always previews how the packing list will group
+    // these items. Each entry keeps its flat array index, which is what every
+    // per-item handler addresses.
+    const editorSequence = useMemo(() => {
+        const indexOf = new Map(items.map((item, i) => [item, i]))
+        return buildSectionSequence(items, sectionDefaultLabel, [])
+            .map(entry => entry.kind === 'header'
+                ? { kind: 'header' as const, label: entry.label }
+                : { kind: 'item' as const, item: entry.item, index: indexOf.get(entry.item)! })
+    }, [items, sectionDefaultLabel])
 
-    // Split mouse/touch sensors so each platform gets the right activation:
-    //  - Mouse: a small distance threshold, so desktop drags start instantly
-    //    while taps on the sibling buttons still register as clicks.
-    //  - Touch: a press-and-hold delay, so an ordinary swipe scrolls the list
-    //    (and doesn't jump the page / toggle the mobile URL bar); only a
-    //    deliberate hold begins a drag. This is dnd-kit's recommended mobile
-    //    setup and is what fixes the touch jankiness.
-    //  - Keyboard: makes the drag operable without a pointer.
-    const sensors = useSensors(
-        useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
-        useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
-        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-    )
-    const handleDragEnd = (e: DragEndEvent) => {
-        const { active, over } = e
-        if (!over || active.id === over.id) return
-        const from = itemIds.indexOf(String(active.id))
-        const to = itemIds.indexOf(String(over.id))
-        if (from !== -1 && to !== -1) reorderItem(from, to)
-    }
+    // Only worth showing headings once the list is actually split.
+    const hasSections = editorSequence.filter(e => e.kind === 'header').length > 1
+
     return (
         <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
             {items.length > 0 && (
@@ -982,55 +879,39 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, updateItemText
                             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
                             </svg>
-                            {reorderMode ? 'Finish reordering' : 'Reorder items'}
+                            {reorderMode ? 'Finish organising' : 'Organise items'}
                         </button>
                     )}
                 </div>
             )}
-            {inReorder && (
-                <div className="text-[11px] text-gray-400 mb-2 px-0.5">
-                    Drag the handle (press and hold on touch), or use the arrows, then tap Finish reordering.
-                </div>
-            )}
             <div className="space-y-2">
                 {inReorder && (
-                    <DndContext
-                        sensors={sensors}
-                        collisionDetection={closestCenter}
-                        modifiers={[restrictToVerticalAxis]}
-                        // Only ever auto-scroll the modal's own scroll area. The
-                        // modal doesn't lock body scroll, so without this dnd-kit
-                        // scrolls the whole window when a drag nears the screen
-                        // edge — which jumps the page and toggles the mobile URL
-                        // bar mid-drag.
-                        autoScroll={{ canScroll: (el) => el === scrollRef.current }}
-                        onDragEnd={handleDragEnd}
-                    >
-                        <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-                            <div className="space-y-2">
-                                {items.map((item, itemIdx) => (
-                                    <SortableItemRow
-                                        key={itemIds[itemIdx]}
-                                        id={itemIds[itemIdx]}
-                                        item={item}
-                                        index={itemIdx}
-                                        isLast={itemIdx === items.length - 1}
-                                        moveItem={moveItem}
-                                    />
-                                ))}
-                            </div>
-                        </SortableContext>
-                    </DndContext>
+                    <SectionedItemReorder
+                        items={items}
+                        defaultLabel={sectionDefaultLabel}
+                        suggestedSectionNames={suggestedSectionNames}
+                        scrollRef={scrollRef}
+                        onChange={replaceItems}
+                    />
                 )}
-                {!inReorder && items.map((item, itemIdx) => (
+                {!inReorder && editorSequence.map(entry => entry.kind === 'header' ? (
+                    hasSections && (
+                        <div key={`header-${entry.label}`} className="flex items-center gap-2 pt-3 pb-1">
+                            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide truncate">
+                                {entry.label}
+                            </span>
+                            <span className="flex-1 h-px bg-gray-200" />
+                        </div>
+                    )
+                ) : (
                     <ItemEditorRow
-                        key={itemIdx}
-                        item={item}
-                        itemIdx={itemIdx}
+                        key={`item-${entry.index}`}
+                        item={entry.item}
+                        itemIdx={entry.index}
                         people={people}
                         allItemNames={allItemNames}
                         isDesktop={isDesktop}
-                        quantityOpen={openQuantityIdx === itemIdx}
+                        quantityOpen={openQuantityIdx === entry.index}
                         onToggleQuantity={toggleQuantity}
                         updateItemText={updateItemText}
                         togglePerson={togglePerson}
@@ -1078,16 +959,24 @@ function useBodyScrollLock() {
     }, [])
 }
 
-function OptionEditModal({ option, people, allItemNames, onSave, onClose }: {
+function OptionEditModal({ option, question, people, allItemNames, suggestedSectionNames, onSave, onClose }: {
     option: Option | null
+    question: Question | undefined
     people: Person[]
     allItemNames: string[]
+    suggestedSectionNames: string[]
     onSave: (updated: Option) => void
     onClose: () => void
 }) {
     useBodyScrollLock()
     const [text, setText] = useState(option?.text ?? '')
-    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, moveItem, reorderItem, addItem } = useItemListState(option?.items ?? [], people)
+    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, addItem, replaceItems } = useItemListState(option?.items ?? [], people)
+
+    // Tracks the option text as it's typed, so the default section heading shows
+    // the name the generated list will actually use.
+    const sectionDefaultLabel = question
+        ? defaultCategoryFor(question, { id: option?.id ?? '', text, order: option?.order ?? 0, items: [] })
+        : text
 
     const handleSave = () => onSave({
         id: option?.id ?? crypto.randomUUID(),
@@ -1135,9 +1024,10 @@ function OptionEditModal({ option, people, allItemNames, onSave, onClose }: {
                 <ItemListEditor
                     items={items} people={people} allItemNames={allItemNames}
                     scrollRef={scrollRef} updateItemText={updateItemText}
+                    sectionDefaultLabel={sectionDefaultLabel} suggestedSectionNames={suggestedSectionNames}
                     togglePerson={togglePerson} toggleCommunal={toggleCommunal}
                     updatePerNight={updatePerNight} updatePerNights={updatePerNights} updateMaxQuantity={updateMaxQuantity}
-                    removeItem={removeItem} moveItem={moveItem} reorderItem={reorderItem} addItem={addItem}
+                    removeItem={removeItem} addItem={addItem} replaceItems={replaceItems}
                 />
                 <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex gap-2 justify-end">
                     <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
@@ -1152,15 +1042,16 @@ function OptionEditModal({ option, people, allItemNames, onSave, onClose }: {
     )
 }
 
-function AlwaysNeededModal({ initialItems, people, allItemNames, onSave, onClose }: {
+function AlwaysNeededModal({ initialItems, people, allItemNames, suggestedSectionNames, onSave, onClose }: {
     initialItems: Item[]
     people: Person[]
     allItemNames: string[]
+    suggestedSectionNames: string[]
     onSave: (items: Item[]) => void
     onClose: () => void
 }) {
     useBodyScrollLock()
-    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, moveItem, reorderItem, addItem } = useItemListState(initialItems, people)
+    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, addItem, replaceItems } = useItemListState(initialItems, people)
 
     return (
         <div
@@ -1190,9 +1081,10 @@ function AlwaysNeededModal({ initialItems, people, allItemNames, onSave, onClose
                 <ItemListEditor
                     items={items} people={people} allItemNames={allItemNames}
                     scrollRef={scrollRef} updateItemText={updateItemText}
+                    sectionDefaultLabel={ALWAYS_NEEDED_CATEGORY} suggestedSectionNames={suggestedSectionNames}
                     togglePerson={togglePerson} toggleCommunal={toggleCommunal}
                     updatePerNight={updatePerNight} updatePerNights={updatePerNights} updateMaxQuantity={updateMaxQuantity}
-                    removeItem={removeItem} moveItem={moveItem} reorderItem={reorderItem} addItem={addItem}
+                    removeItem={removeItem} addItem={addItem} replaceItems={replaceItems}
                 />
                 <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex gap-2 justify-end">
                     <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
@@ -1619,6 +1511,11 @@ export function QuestionsPage() {
         return [...new Set(names)]
     }, [data])
 
+    // Section names already in use anywhere in the question set, offered as
+    // suggestions so the same section spelled two ways doesn't split into two
+    // groups on the packing list.
+    const suggestedSectionNames = useMemo(() => data ? sectionNamesIn(data) : [], [data])
+
     // Memoized so their identity is stable across re-renders that don't change
     // the data (modal opens, sync ticks) — they feed the memoized sections.
     const people = useMemo(() => (data?.people ?? []).filter(p => !p.deletedAt), [data])
@@ -1686,8 +1583,10 @@ export function QuestionsPage() {
             {optionModal !== null && (
                 <OptionEditModal
                     option={optionModal.option}
+                    question={data?.questions.find(q => q.id === optionModal.questionId)}
                     people={people}
                     allItemNames={allItemNames}
+                    suggestedSectionNames={suggestedSectionNames}
                     onSave={handleOptionModalSave}
                     onClose={() => setOptionModal(null)}
                 />
@@ -1697,6 +1596,7 @@ export function QuestionsPage() {
                     initialItems={activeAlwaysNeededItems}
                     people={people}
                     allItemNames={allItemNames}
+                    suggestedSectionNames={suggestedSectionNames}
                     onSave={handleAlwaysSave}
                     onClose={() => setAlwaysModal(false)}
                 />

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -112,6 +112,43 @@ const ItemRow = memo(function ItemRow({ item, people }: { item: Item; people: Pe
     )
 })
 
+/**
+ * Read-only item list, split by section the same way the editor and the
+ * generated packing list are — so this page shows the grouping a list will
+ * actually have without opening a modal. Headings only appear once a list is
+ * genuinely split; an unsectioned list renders exactly as it did before.
+ */
+const SectionedItemRows = memo(function SectionedItemRows({ items, people, defaultLabel }: {
+    items: Item[]
+    people: Person[]
+    defaultLabel: string
+}) {
+    const sequence = useMemo(
+        () => buildSectionSequence(items, defaultLabel, []),
+        [items, defaultLabel],
+    )
+    const hasSections = sequence.filter(e => e.kind === 'header').length > 1
+    return (
+        <>
+            {sequence.map((entry, i) => entry.kind === 'header' ? (
+                hasSections && (
+                    <div key={`header-${entry.label}`} className="flex items-center gap-2 pt-2 pb-0.5 px-2">
+                        <span
+                            data-testid="item-section-heading"
+                            className="text-[11px] font-semibold text-gray-400 uppercase tracking-wide truncate"
+                        >
+                            {entry.label}
+                        </span>
+                        <span className="flex-1 h-px bg-gray-100" />
+                    </div>
+                )
+            ) : (
+                <ItemRow key={`item-${i}`} item={entry.item} people={people} />
+            ))}
+        </>
+    )
+})
+
 function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete: () => void }) {
     return (
         <DropdownMenu.Root>
@@ -152,9 +189,11 @@ function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete:
     )
 }
 
-export function OptionSection({ option, people, onEdit, onDelete }: {
+export function OptionSection({ option, people, sectionDefaultLabel, onEdit, onDelete }: {
     option: Option
     people: Person[]
+    /** What the packing list will call items here that carry no category. */
+    sectionDefaultLabel: string
     onEdit: () => void
     onDelete: () => void
 }) {
@@ -243,9 +282,7 @@ export function OptionSection({ option, people, onEdit, onDelete }: {
             </div>
             {hasExpandedRef.current && (
                 <div className={`space-y-0.5${isExpanded ? '' : ' hidden'}`}>
-                    {option.items.map((item, i) => (
-                        <ItemRow key={i} item={item} people={people} />
-                    ))}
+                    <SectionedItemRows items={option.items} people={people} defaultLabel={sectionDefaultLabel} />
                 </div>
             )}
             {showDeleteModal && (
@@ -467,6 +504,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                             key={option.id}
                             option={option}
                             people={people}
+                            sectionDefaultLabel={defaultCategoryFor(question, option)}
                             onEdit={() => onEditOption(question.id, option)}
                             onDelete={() => onDeleteOption(question.id, option.id)}
                         />
@@ -527,9 +565,7 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, onEdit }: { i
             </div>
             {hasExpandedRef.current && (
                 <div className={`mt-3 space-y-1${isExpanded ? '' : ' hidden'}`}>
-                    {items.map((item, i) => (
-                        <ItemRow key={i} item={item} people={people} />
-                    ))}
+                    <SectionedItemRows items={items} people={people} defaultLabel={ALWAYS_NEEDED_CATEGORY} />
                 </div>
             )}
         </div>

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -25,6 +25,7 @@ import { MILESTONE_MESSAGES, resolveMilestone } from './packing-milestones'
 import { formatTripDates } from '../create-packing-list/tripDetails'
 import { tapFeedback } from '../utils/haptics'
 import { prefersReducedMotion } from '../utils/prefersReducedMotion'
+import { groupItemsByCategory, sortByOrder, type CategoryAccessors } from '../utils/groupByCategory'
 
 type FormData = {
     items: Record<string, boolean>
@@ -74,34 +75,22 @@ interface ListSection {
 // Generated items carry an `order` stamped from the question set; sort by it so
 // the list mirrors how the user arranged their questions. Items without one
 // (legacy lists, custom additions) fall back to alphabetical at the end.
+const PACKING_ITEM_ACCESSORS: CategoryAccessors<PackingListItem> = {
+    category: item => item.category,
+    order: item => item.order,
+    text: item => item.itemText,
+}
+
 function sortByItemOrder(items: PackingListItem[]): PackingListItem[] {
-    return items.sort((a, b) =>
-        ((a.order ?? Infinity) - (b.order ?? Infinity)) || a.itemText.localeCompare(b.itemText)
-    )
+    return sortByOrder(items, PACKING_ITEM_ACCESSORS)
 }
 
 export function groupByCategory(items: PackingListItem[]) {
-    const map = new Map<string, PackingListItem[]>()
-    for (const item of items) {
-        const cat = item.category ?? 'Other'
-        if (!map.has(cat)) map.set(cat, [])
-        map.get(cat)!.push(item)
-    }
-    // Categories follow their earliest item; ties (all-legacy) stay alphabetical
-    const minOrder = (catItems: PackingListItem[]) =>
-        Math.min(...catItems.map(i => i.order ?? Infinity))
-    return [...map.entries()]
-        .sort(([a, aItems], [b, bItems]) => {
-            if (a === 'Essentials') return -1
-            if (b === 'Essentials') return 1
-            if (a === 'Other') return 1
-            if (b === 'Other') return -1
-            return (minOrder(aItems) - minOrder(bItems)) || a.localeCompare(b)
-        })
-        .map(([category, catItems]) => ({
-            label: category,
-            items: sortByItemOrder(catItems),
-        }))
+    return groupItemsByCategory(items, PACKING_ITEM_ACCESSORS, {
+        uncategorisedLabel: 'Other',
+        pinFirst: 'Essentials',
+        pinLast: 'Other',
+    })
 }
 
 export function groupByPerson(items: PackingListItem[]) {

--- a/src/services/rdfSerialization.test.ts
+++ b/src/services/rdfSerialization.test.ts
@@ -382,6 +382,33 @@ describe('questionSetToDataset / datasetToQuestionSet', () => {
         expect(result.alwaysNeededItems[1].perNights).toBeUndefined()
     })
 
+    it('round-trips category on alwaysNeededItems and omits it when not set', () => {
+        const qs = makeQuestionSet({
+            alwaysNeededItems: [
+                { text: 'Nappies', category: 'Baby', personSelections: [{ personId: 'p1', selected: true }] },
+                { text: 'Snacks', personSelections: [{ personId: 'p1', selected: true }] },
+            ],
+        })
+        const result = roundTripQs(qs)
+        expect(result.alwaysNeededItems[0].category).toBe('Baby')
+        expect(result.alwaysNeededItems[1].category).toBeUndefined()
+    })
+
+    it('round-trips category on option items', () => {
+        const qs = makeQuestionSet({
+            questions: [makeQuestion({
+                options: [{
+                    id: 'opt-yes',
+                    text: 'Yes',
+                    order: 0,
+                    items: [{ text: 'Toothbrush', category: 'Toiletries', personSelections: [{ personId: 'p1', selected: true }] }],
+                }],
+            })],
+        })
+        const result = roundTripQs(qs)
+        expect(result.questions[0].options[0].items[0].category).toBe('Toiletries')
+    })
+
     it('round-trips a saved question with option and items', () => {
         const option = makeOption({
             items: [{ text: 'Nappies', personSelections: [{ personId: 'p1', selected: true }] }],

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -455,6 +455,9 @@ function questionItemToThings(
 
     if (item.id) itemBuilder = itemBuilder.addStringNoLocale(PMU.questionItemId, item.id)
     if (item.order !== undefined) itemBuilder = itemBuilder.addInteger(PMU.order, item.order)
+    // Same predicate as PackingListItem.category — it's the same relation, and
+    // the item's category flows straight through to the generated list item.
+    if (item.category !== undefined) itemBuilder = itemBuilder.addStringNoLocale(PMU.category, item.category)
     if (item.communal !== undefined) itemBuilder = itemBuilder.addBoolean(PMU.communal, item.communal)
     // perNight is stored as a decimal to allow rates like 0.5 per night
     if (item.perNight !== undefined) itemBuilder = itemBuilder.addDecimal(PMU.perNight, item.perNight)
@@ -627,6 +630,7 @@ function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
     const id = getStringNoLocale(thing, PMU.questionItemId) ?? undefined
     const communal = getBoolean(thing, PMU.communal)
     const order = getInteger(thing, PMU.order)
+    const category = getStringNoLocale(thing, PMU.category) ?? undefined
     const perNight = getDecimal(thing, PMU.perNight)
     const perNights = getInteger(thing, PMU.perNights)
     const maxQuantity = getInteger(thing, PMU.maxQuantity)
@@ -664,6 +668,7 @@ function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
         ...(maxQuantity !== null ? { maxQuantity } : {}),
         ...(ageRanges.length > 0 ? { ageRanges } : {}),
         ...(order !== null ? { order } : {}),
+        ...(category !== undefined ? { category } : {}),
         ...(lastModified !== undefined ? { lastModified } : {}),
         ...(deletedAt !== undefined ? { deletedAt } : {}),
     }

--- a/src/utils/groupByCategory.ts
+++ b/src/utils/groupByCategory.ts
@@ -1,0 +1,80 @@
+/**
+ * Grouping items into categories (the "sections" a packing list is split into).
+ *
+ * Shared by the packing list view and the question-set editor so the two can't
+ * drift: what you arrange in the editor is what you get on the list. Both sides
+ * store the category by stamping it onto each item, so grouping is just a
+ * bucket-by-label — there is no positional boundary state to reconstruct.
+ *
+ * Categories are ordered by their earliest item so they follow the order the
+ * user arranged their items in, with optional pinned labels for the list view's
+ * "Essentials first, Other last" convention.
+ */
+
+export interface CategoryAccessors<T> {
+    category: (item: T) => string | undefined
+    order: (item: T) => number | undefined
+    /** Used only as a tie-break when two items have no order. */
+    text: (item: T) => string
+}
+
+export interface CategoryGroupingOptions {
+    /** Label for items carrying no category of their own. */
+    uncategorisedLabel: string
+    /** Label always sorted to the front, whatever its items' order. */
+    pinFirst?: string
+    /** Label always sorted to the back, whatever its items' order. */
+    pinLast?: string
+}
+
+export interface CategoryGroup<T> {
+    label: string
+    items: T[]
+}
+
+/**
+ * Items carry an `order` stamped from the question set; sort by it so lists
+ * mirror how the user arranged their items. Items without one (legacy data,
+ * custom additions) fall back to alphabetical at the end.
+ */
+export function sortByOrder<T>(items: T[], accessors: CategoryAccessors<T>): T[] {
+    return items.sort((a, b) =>
+        ((accessors.order(a) ?? Infinity) - (accessors.order(b) ?? Infinity))
+        || accessors.text(a).localeCompare(accessors.text(b))
+    )
+}
+
+export function groupItemsByCategory<T>(
+    items: T[],
+    accessors: CategoryAccessors<T>,
+    options: CategoryGroupingOptions,
+): CategoryGroup<T>[] {
+    const { uncategorisedLabel, pinFirst, pinLast } = options
+
+    const map = new Map<string, T[]>()
+    for (const item of items) {
+        const label = accessors.category(item) ?? uncategorisedLabel
+        if (!map.has(label)) map.set(label, [])
+        map.get(label)!.push(item)
+    }
+
+    const minOrder = (groupItems: T[]) =>
+        Math.min(...groupItems.map(i => accessors.order(i) ?? Infinity))
+
+    return [...map.entries()]
+        .sort(([a, aItems], [b, bItems]) => {
+            if (pinFirst !== undefined) {
+                if (a === pinFirst) return -1
+                if (b === pinFirst) return 1
+            }
+            if (pinLast !== undefined) {
+                if (a === pinLast) return 1
+                if (b === pinLast) return -1
+            }
+            return (minOrder(aItems) - minOrder(bItems)) || a.localeCompare(b)
+        })
+        .map(([label, groupItems]) => ({
+            label,
+            items: sortByOrder(groupItems, accessors),
+        }))
+}


### PR DESCRIPTION
## The problem

A category on the packing list is derived one-to-one from a question or option, so a long item list always produced exactly one group. The default template alone ships **40 always-needed items** (all `Essentials`) and **25 under overnight → "Yes"** (all under the question text). The only way to organise those was to split questions that didn't otherwise want splitting — which is what users have been doing.

## What this adds

An optional `category` on question-set items. An item's own category wins over the one derived from its question/option, so a list can be split into sections without adding a question. Absent means the previous behaviour exactly.

In the editor, "Reorder items" becomes **"Organise items"**: drag an item under a heading (or step it past one with the arrows) to put it in that section, and add, rename or remove headings alongside. Normal editing mode shows the same headings read-only, so the editor previews how the generated list will group.

Removing a section clears its items' category rather than deleting them — they fall back to the main pile.

## Why the category is stamped per item

Sections are stored by stamping a category on each item, not by marking a boundary. Position is only ever the interaction: every drop runs the sequence back through `applySectionLayout`, which stamps each item with the nearest heading above it.

That choice is what makes it safe to ship to a population that includes installed mobile builds which may never update:

- **Merge.** `resolveItem` is per-item, whole-object LWW. A boundary marker is state spanning several items, so a merge could leave the marker carried by an item sitting mid-way through another section, with no way to detect or repair it. A stamp is local to one item, so the worst merge outcome is one item in the wrong group.
- **Old clients.** The RDF reader is allowlist-based, so an old client ignores the new predicate and sees precisely the question set it saw before. Writes are full dataset rebuilds, so an old client drops the category on items it rewrites — losing one item's section rather than a whole section's boundary.

`PMU.category` already existed for `PackingListItem`, so no new vocab was needed, and the packing list's own format is unchanged — shared lists are schema-identical whether or not sections are used.

## Backwards compatibility

`src/edit-questions/item-category-compat.test.ts` pins both properties:

- Categories are purely additive on the wire — a sectioned question set round-trips to something byte-identical to the unsectioned one once `category` is stripped, with the same item count, order and texts, and no extra `QuestionItem` things in the dataset. (Written so it can't pass vacuously.)
- When an old client drops the category on an item it rewrote, the blast radius is that item alone — its section-mates keep theirs.

## Notes for review

- Grouping now goes through one shared helper (`src/utils/groupByCategory.ts`) used by both the list and the editor, so the two can't drift. Grouping is by label rather than a positional walk, so a section stays contiguous — and appears once — even if a merge leaves an item's order and category disagreeing.
- The editor sequences by array position rather than the stamped `order`: mid-edit the array is the truth, and leaving `order` stale is exactly how `renumberItemOrder` tells at save which items actually moved.
- A section with no items has nothing to stamp and so can't be stored. Newly added ones live in editor state until something lands in them, and are forgotten if nothing does.

## Testing

- 874 unit tests pass; `tsc -b` and `npm run lint` clean (9 pre-existing warnings, 0 errors).
- Driven in the running app end to end: added a section, moved items in with the arrows, renamed it, saved, generated a list and confirmed `First aid (3)` and `Essentials (5)` group separately; then removed the section and confirmed all 8 items survived back in the default pile.
- Driving the UI caught one real bug, fixed in e5c15b6: an item's "move down" was disabled once it was the last *item*, making a freshly added section unreachable without a drag.

## Deliberately not in this PR

Pre-sectioning the default template. That's the change that makes this useful on day one for people who configure nothing, but shipping both at once means the first sectioned data in the wild meets a population that's ~100% old clients. Worth landing this first and pre-sectioning the template in a follow-up, once clients understand sections. It'll also need `template-updates.ts` to treat "existing item moved under a new heading" as a change rather than a new item to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017Vui2dWrrAth2nWHRp7sAS)_