### PR TITLE
Replace the organise arrows with a move menu

### DIFF
--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -130,7 +130,7 @@ test.describe('B – Editing Questions', () => {
     await expect(page.getByText('WaterBottleTest')).toBeVisible({ timeout: 5_000 })
   })
 
-  test('B6: reorder always-needed items via reorder mode', async ({ freshPage: page }) => {
+  test('B6: reorder always-needed items via the move menu', async ({ freshPage: page }) => {
     await setupWizardAndGoToQuestions(page)
     await openAlwaysNeededModal(page)
 
@@ -141,12 +141,14 @@ test.describe('B – Editing Questions', () => {
     const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
     expect(first).not.toEqual(second)
 
-    // Enter organise mode — rows collapse to name + large move buttons
+    // Enter organise mode — rows collapse to name + drag handle + move menu
     await page.getByRole('button', { name: 'Organise items' }).click()
     await expect(page.locator('.cursor-text')).toHaveCount(0)
 
-    // Move the first item down one position, leave organise mode, save
-    await page.locator('button[title="Move item down"]').first().click()
+    // Send the second item to the top of the section, swapping the two.
+    // The menu is portaled to document.body.
+    await page.locator('[data-reorder-row]').nth(1).getByTitle('Move item').click()
+    await page.getByRole('menuitem', { name: 'Move to top of section' }).click()
     await page.getByRole('button', { name: 'Finish organising' }).click()
     await expect(itemTexts.first()).toContainText(second)
     await expect(itemTexts.nth(1)).toContainText(first)
@@ -200,6 +202,44 @@ test.describe('B – Editing Questions', () => {
     await expect(itemTexts.nth(1)).toContainText(first)
 
     // Persist and reopen — the dragged order must survive a save round-trip
+    await page.getByRole('button', { name: 'Save changes' }).click()
+    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
+    await openAlwaysNeededModal(page)
+    await expect(itemTexts.first()).toContainText(second)
+    await expect(itemTexts.nth(1)).toContainText(first)
+  })
+
+  test('B8: reorder always-needed items from the keyboard', async ({ freshPage: page }) => {
+    await setupWizardAndGoToQuestions(page)
+    await openAlwaysNeededModal(page)
+
+    const itemTexts = page.locator('.cursor-text')
+    const first = (await itemTexts.first().innerText()).split('\n')[0].trim()
+    const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
+    expect(first).not.toEqual(second)
+
+    await page.getByRole('button', { name: 'Organise items' }).click()
+    const rows = page.locator('[data-reorder-row]')
+    await expect(rows.first()).toBeVisible()
+
+    // Space picks the item up, the arrow keys move it, space drops it — no
+    // pointer and no per-direction buttons involved. Each step waits for the
+    // drag to catch up: a real user cannot press the next key within the same
+    // frame, and dnd-kit ignores keys it receives before it has measured.
+    const announcements = page.locator('[role="status"][aria-live="assertive"]')
+    await page.locator('button[title^="Drag to reorder"]').first().focus()
+    await page.keyboard.press('Space')
+    await expect(announcements).toContainText(`Picked up ${first}`)
+    await page.keyboard.press('ArrowDown')
+    await expect(announcements).toContainText('position 2')
+    await page.keyboard.press('Space')
+    await expect(announcements).toContainText('Dropped')
+
+    await expect(rows.first()).toContainText(second)
+    await expect(rows.nth(1)).toContainText(first)
+
+    // Persist and reopen — the keyboard move must survive a save round-trip
+    await page.getByRole('button', { name: 'Finish organising' }).click()
     await page.getByRole('button', { name: 'Save changes' }).click()
     await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
     await openAlwaysNeededModal(page)

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -30,7 +30,7 @@ test.describe('C – Packing Lists', () => {
   test('C7: reordered question-set items flow through to the view list page', async ({ freshPage: page }) => {
     await runWizard(page)
 
-    // Reorder the always-needed items: move the first item down one position
+    // Reorder the always-needed items: send the second one to the top
     await page.goto('/#/manage-questions')
     await page.locator('button[title="Edit always needed items"]').click()
     await expect(page.getByRole('heading', { name: 'Always Needed Items' })).toBeVisible({ timeout: 3_000 })
@@ -39,7 +39,9 @@ test.describe('C – Packing Lists', () => {
     const first = (await itemTexts.first().innerText()).split('\n')[0].trim()
     const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
     await page.getByRole('button', { name: 'Organise items' }).click()
-    await page.locator('button[title="Move item down"]').first().click()
+    // The move menu is portaled to document.body
+    await page.locator('[data-reorder-row]').nth(1).getByTitle('Move item').click()
+    await page.getByRole('menuitem', { name: 'Move to top of section' }).click()
     await page.getByRole('button', { name: 'Finish organising' }).click()
     await page.getByRole('button', { name: 'Save changes' }).click()
     await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })

--- a/src/components/SectionedItemReorder.test.tsx
+++ b/src/components/SectionedItemReorder.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest'
+import React, { createRef } from 'react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { SectionedItemReorder } from './SectionedItemReorder'
+import type { Item } from '../edit-questions/types'
+
+function item(text: string, category?: string): Item {
+    return { id: text, text, personSelections: [], ...(category ? { category } : {}) }
+}
+
+function renderReorder(items: Item[]) {
+    const onChange = vi.fn<(items: Item[]) => void>()
+    render(
+        <SectionedItemReorder
+            items={items}
+            defaultLabel="Essentials"
+            suggestedSectionNames={[]}
+            scrollRef={createRef<HTMLDivElement>()}
+            onChange={onChange}
+        />
+    )
+    return onChange
+}
+
+/** Radix opens its menu on pointerdown, which fireEvent.click does not send. */
+function openMenuFor(itemText: string) {
+    fireEvent.pointerDown(screen.getByRole('button', { name: `Move ${itemText}` }), { button: 0 })
+    return screen.getByRole('menu')
+}
+
+const layout = (items: Item[]) => items.map(i => [i.text, i.category])
+
+describe('SectionedItemReorder rows', () => {
+    const items = () => [item('Snacks'), item('Crisps'), item('Water')]
+
+    it('keeps a drag handle on every row', () => {
+        renderReorder(items())
+        expect(screen.getAllByRole('button', { name: /^Drag /})).toHaveLength(3)
+    })
+
+    it('no longer offers the up and down step buttons', () => {
+        renderReorder(items())
+        expect(screen.queryByRole('button', { name: /^Move .* up$/ })).toBeNull()
+        expect(screen.queryByRole('button', { name: /^Move .* down$/ })).toBeNull()
+    })
+})
+
+describe('SectionedItemReorder move menu', () => {
+    const unsectioned = () => [item('Snacks'), item('Crisps'), item('Water')]
+    const sectioned = () => [
+        item('Snacks'), item('Crisps'),
+        item('Nappies', 'Baby'), item('Wipes', 'Baby'),
+    ]
+
+    it('moves an item to the top of its section', () => {
+        const onChange = renderReorder(unsectioned())
+        fireEvent.click(within(openMenuFor('Water')).getByText('Move to top of section'))
+        expect(onChange.mock.calls[0][0].map(i => i.text)).toEqual(['Water', 'Snacks', 'Crisps'])
+    })
+
+    it('moves an item to the bottom of its section', () => {
+        const onChange = renderReorder(unsectioned())
+        fireEvent.click(within(openMenuFor('Snacks')).getByText('Move to bottom of section'))
+        expect(onChange.mock.calls[0][0].map(i => i.text)).toEqual(['Crisps', 'Water', 'Snacks'])
+    })
+
+    it('moves within the item\'s own section only, leaving other sections alone', () => {
+        const onChange = renderReorder(sectioned())
+        fireEvent.click(within(openMenuFor('Wipes')).getByText('Move to top of section'))
+        expect(layout(onChange.mock.calls[0][0])).toEqual([
+            ['Snacks', undefined], ['Crisps', undefined],
+            ['Wipes', 'Baby'], ['Nappies', 'Baby'],
+        ])
+    })
+
+    it('hides the top and bottom entries when the item is already there', () => {
+        renderReorder(unsectioned())
+        const first = openMenuFor('Snacks')
+        expect(within(first).queryByText('Move to top of section')).toBeNull()
+        expect(within(first).getByText('Move to bottom of section')).toBeTruthy()
+    })
+
+    it('offers the other sections by name, but not the item\'s own', () => {
+        renderReorder(sectioned())
+        const menu = openMenuFor('Snacks')
+        expect(within(menu).getByText('Move to Baby')).toBeTruthy()
+        expect(within(menu).queryByText('Move to Essentials')).toBeNull()
+    })
+
+    it('moves an item into another section, at the bottom of it', () => {
+        const onChange = renderReorder(sectioned())
+        fireEvent.click(within(openMenuFor('Snacks')).getByText('Move to Baby'))
+        expect(layout(onChange.mock.calls[0][0])).toEqual([
+            ['Crisps', undefined],
+            ['Nappies', 'Baby'], ['Wipes', 'Baby'], ['Snacks', 'Baby'],
+        ])
+    })
+
+    it('moves an item back to the default section', () => {
+        const onChange = renderReorder(sectioned())
+        fireEvent.click(within(openMenuFor('Nappies')).getByText('Move to Essentials'))
+        expect(layout(onChange.mock.calls[0][0])).toEqual([
+            ['Snacks', undefined], ['Crisps', undefined], ['Nappies', undefined],
+            ['Wipes', 'Baby'],
+        ])
+    })
+
+    it('still offers the default section when every item is categorised', () => {
+        const onChange = renderReorder([item('Nappies', 'Baby'), item('Wipes', 'Baby')])
+        fireEvent.click(within(openMenuFor('Wipes')).getByText('Move to Essentials'))
+        expect(layout(onChange.mock.calls[0][0])).toEqual([
+            ['Wipes', undefined], ['Nappies', 'Baby'],
+        ])
+    })
+
+    it('shows no section entries at all when there is only one section', () => {
+        renderReorder(unsectioned())
+        expect(within(openMenuFor('Crisps')).queryByText(/^Move to (?!top|bottom)/)).toBeNull()
+    })
+
+    it('offers a section the user just added but has not filled yet', () => {
+        const onChange = renderReorder(unsectioned())
+        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
+        fireEvent.change(screen.getByLabelText('New section name'), { target: { value: 'First aid' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+        fireEvent.click(within(openMenuFor('Crisps')).getByText('Move to First aid'))
+        expect(layout(onChange.mock.calls[0][0])).toEqual([
+            ['Snacks', undefined], ['Water', undefined], ['Crisps', 'First aid'],
+        ])
+    })
+})

--- a/src/components/SectionedItemReorder.tsx
+++ b/src/components/SectionedItemReorder.tsx
@@ -20,12 +20,18 @@ import {
 } from '@dnd-kit/core'
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import type { Item } from '../edit-questions/types'
 import {
     applySectionLayout,
     buildSectionSequence,
+    isAtSectionEdge,
+    moveItemToSection,
+    moveItemWithinSection,
     removeSection,
     renameSection,
+    sectionLabelAt,
+    sectionLabelsIn,
     type SectionSequenceEntry,
 } from '../edit-questions/item-sections'
 
@@ -103,12 +109,86 @@ function SectionHeaderRow({ id, label, isDefault, onRename, onRemove }: {
     )
 }
 
-function SortableSectionItem({ id, item, canMoveUp, canMoveDown, onMove }: {
+/**
+ * Every move the drag handle can make, offered as menu commands. Dragging is
+ * the quick way; this is the way that works from the keyboard, with a screen
+ * reader, or when the destination is off-screen — so it names its destinations
+ * rather than relying on aim.
+ */
+function MoveMenu({ label, canMoveToTop, canMoveToBottom, otherSections, onMoveWithinSection, onMoveToSection }: {
+    label: string
+    canMoveToTop: boolean
+    canMoveToBottom: boolean
+    otherSections: string[]
+    onMoveWithinSection: (position: 'top' | 'bottom') => void
+    onMoveToSection: (label: string) => void
+}) {
+    const hasMoves = canMoveToTop || canMoveToBottom || otherSections.length > 0
+    return (
+        <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
+                <button
+                    type="button"
+                    disabled={!hasMoves}
+                    title="Move item"
+                    aria-label={`Move ${label}`}
+                    className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 active:bg-gray-100 disabled:text-gray-200 disabled:border-gray-100 disabled:hover:bg-transparent transition-colors"
+                >
+                    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                        <circle cx="12" cy="5" r="1.5" />
+                        <circle cx="12" cy="12" r="1.5" />
+                        <circle cx="12" cy="19" r="1.5" />
+                    </svg>
+                </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                    align="end"
+                    sideOffset={4}
+                    className="min-w-52 max-w-72 bg-white rounded-lg shadow-lg border border-gray-100 py-1 z-50"
+                >
+                    {canMoveToTop && (
+                        <DropdownMenu.Item
+                            onSelect={() => onMoveWithinSection('top')}
+                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 cursor-default outline-none"
+                        >
+                            Move to top of section
+                        </DropdownMenu.Item>
+                    )}
+                    {canMoveToBottom && (
+                        <DropdownMenu.Item
+                            onSelect={() => onMoveWithinSection('bottom')}
+                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 cursor-default outline-none"
+                        >
+                            Move to bottom of section
+                        </DropdownMenu.Item>
+                    )}
+                    {otherSections.length > 0 && (canMoveToTop || canMoveToBottom) && (
+                        <DropdownMenu.Separator className="my-1 h-px bg-gray-100" />
+                    )}
+                    {otherSections.map(section => (
+                        <DropdownMenu.Item
+                            key={section}
+                            onSelect={() => onMoveToSection(section)}
+                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 cursor-default outline-none truncate"
+                        >
+                            Move to {section}
+                        </DropdownMenu.Item>
+                    ))}
+                </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+    )
+}
+
+function SortableSectionItem({ id, item, canMoveToTop, canMoveToBottom, otherSections, onMoveWithinSection, onMoveToSection }: {
     id: string
     item: Item
-    canMoveUp: boolean
-    canMoveDown: boolean
-    onMove: (direction: 'up' | 'down') => void
+    canMoveToTop: boolean
+    canMoveToBottom: boolean
+    otherSections: string[]
+    onMoveWithinSection: (position: 'top' | 'bottom') => void
+    onMoveToSection: (label: string) => void
 }) {
     const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id })
     return (
@@ -134,32 +214,14 @@ function SortableSectionItem({ id, item, canMoveUp, canMoveDown, onMove }: {
             <span className="flex-1 min-w-0 truncate text-sm text-gray-800 px-1">
                 {item.text || <span className="text-gray-400 italic">Unnamed item</span>}
             </span>
-            <div className="flex gap-1 shrink-0">
-                <button
-                    type="button"
-                    onClick={() => onMove('up')}
-                    disabled={!canMoveUp}
-                    className={`inline-flex items-center justify-center w-11 h-11 rounded-lg border transition-colors ${!canMoveUp ? 'text-gray-200 border-gray-100 cursor-not-allowed' : 'text-gray-600 border-gray-200 hover:bg-gray-50 active:bg-gray-100'}`}
-                    title="Move item up"
-                    aria-label={`Move ${item.text || 'item'} up`}
-                >
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
-                    </svg>
-                </button>
-                <button
-                    type="button"
-                    onClick={() => onMove('down')}
-                    disabled={!canMoveDown}
-                    className={`inline-flex items-center justify-center w-11 h-11 rounded-lg border transition-colors ${!canMoveDown ? 'text-gray-200 border-gray-100 cursor-not-allowed' : 'text-gray-600 border-gray-200 hover:bg-gray-50 active:bg-gray-100'}`}
-                    title="Move item down"
-                    aria-label={`Move ${item.text || 'item'} down`}
-                >
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                    </svg>
-                </button>
-            </div>
+            <MoveMenu
+                label={item.text || 'item'}
+                canMoveToTop={canMoveToTop}
+                canMoveToBottom={canMoveToBottom}
+                otherSections={otherSections}
+                onMoveWithinSection={onMoveWithinSection}
+                onMoveToSection={onMoveToSection}
+            />
         </div>
     )
 }
@@ -224,15 +286,27 @@ export function SectionedItemReorder({ items, defaultLabel, suggestedSectionName
         applySequence(next)
     }
 
-    // The arrows are the keyboard//no-pointer equivalent of dragging: stepping
-    // an item past a header moves it into the neighbouring section, exactly as
-    // dragging across that header would.
-    const moveEntry = (seqIndex: number, direction: 'up' | 'down') => {
-        const target = direction === 'up' ? seqIndex - 1 : seqIndex + 1
-        if (target < 0 || target >= sequence.length) return
+    const sectionLabels = sectionLabelsIn(sequence, defaultLabel)
+
+    // Screen-reader narration for a keyboard drag. dnd-kit's defaults would read
+    // out the internal drag ids, and they know nothing about sections — so both
+    // the item and where it has landed are named here instead.
+    const describe = (id: string | number) => {
+        const entry = sequence[entryIds.indexOf(String(id))]
+        return entry?.kind === 'item' ? (entry.item.text || 'unnamed item') : 'item'
+    }
+    const describeDrop = (activeId: string | number, overId: string | number) => {
+        const from = entryIds.indexOf(String(activeId))
+        const to = entryIds.indexOf(String(overId))
+        if (from === -1 || to === -1) return describe(activeId)
         const next = [...sequence]
-        ;[next[seqIndex], next[target]] = [next[target], next[seqIndex]]
-        applySequence(next)
+        const [moved] = next.splice(from, 1)
+        next.splice(to, 0, moved)
+        const landed = next.indexOf(moved)
+        const label = sectionLabelAt(next, landed, defaultLabel)
+        const position = next.slice(0, landed).filter((e, i) =>
+            e.kind === 'item' && sectionLabelAt(next, i, defaultLabel) === label).length + 1
+        return `${describe(activeId)}, position ${position} in ${label}`
     }
 
     const addSection = () => {
@@ -255,17 +329,12 @@ export function SectionedItemReorder({ items, defaultLabel, suggestedSectionName
         onChange(removeSection(items, label, new Date().toISOString()))
     }
 
-    // An item can step down onto any following entry — including a trailing
-    // section heading, which is how a newly added (still empty) section gets its
-    // first item without a drag. Stepping up above the very first heading is the
-    // only no-op, since that heading is already the default section.
-    const firstItemIndex = sequence.findIndex(e => e.kind === 'item')
-
     return (
         <>
             <div className="text-[11px] text-gray-400 mb-2 px-0.5">
-                Drag the handle (press and hold on touch), or use the arrows, to reorder.
-                Move an item under a section heading to put it in that section.
+                Drag the handle (press and hold on touch) to reorder, or focus it and press
+                space, then the arrow keys. Each item's move menu jumps it to the top or
+                bottom of its section, or into another section.
             </div>
             <DndContext
                 sensors={sensors}
@@ -274,6 +343,26 @@ export function SectionedItemReorder({ items, defaultLabel, suggestedSectionName
                 // Only ever auto-scroll the modal's own scroll area — see the
                 // note on the unsectioned editor for why.
                 autoScroll={{ canScroll: (el) => el === scrollRef.current }}
+                accessibility={{
+                    screenReaderInstructions: {
+                        draggable: 'Press space to pick up the item, the arrow keys to move it '
+                            + 'up or down the list and across section headings, space again to '
+                            + 'drop it, and escape to cancel. The move menu on each row can also '
+                            + 'send it straight to the top or bottom of a section.',
+                    },
+                    announcements: {
+                        onDragStart: ({ active }) => `Picked up ${describe(active.id)}.`,
+                        // dnd-kit reports the item as over itself the moment it
+                        // is picked up; announcing that would talk over the
+                        // "picked up" message before it has been read.
+                        onDragOver: ({ active, over }) =>
+                            over && over.id !== active.id ? `${describeDrop(active.id, over.id)}.` : undefined,
+                        onDragEnd: ({ active, over }) => over
+                            ? `Dropped ${describeDrop(active.id, over.id)}.`
+                            : `Dropped ${describe(active.id)} back where it started.`,
+                        onDragCancel: ({ active }) => `Cancelled moving ${describe(active.id)}.`,
+                    },
+                }}
                 onDragEnd={handleDragEnd}
             >
                 <SortableContext items={entryIds} strategy={verticalListSortingStrategy}>
@@ -292,9 +381,11 @@ export function SectionedItemReorder({ items, defaultLabel, suggestedSectionName
                                 key={entryIds[i]}
                                 id={entryIds[i]}
                                 item={entry.item}
-                                canMoveUp={i > firstItemIndex}
-                                canMoveDown={i < sequence.length - 1}
-                                onMove={direction => moveEntry(i, direction)}
+                                canMoveToTop={!isAtSectionEdge(sequence, i, 'top')}
+                                canMoveToBottom={!isAtSectionEdge(sequence, i, 'bottom')}
+                                otherSections={sectionLabels.filter(l => l !== sectionLabelAt(sequence, i, defaultLabel))}
+                                onMoveWithinSection={position => applySequence(moveItemWithinSection(sequence, i, position))}
+                                onMoveToSection={label => applySequence(moveItemToSection(sequence, i, label, defaultLabel))}
                             />
                         ))}
                     </div>

--- a/src/edit-questions/item-sections.test.ts
+++ b/src/edit-questions/item-sections.test.ts
@@ -9,6 +9,11 @@ import {
     sectionNamesIn,
     buildSectionSequence,
     applySectionLayout,
+    sectionLabelAt,
+    sectionLabelsIn,
+    moveItemWithinSection,
+    moveItemToSection,
+    isAtSectionEdge,
     type SectionSequenceEntry,
 } from './item-sections'
 import type { Item, Question, Option } from './types'
@@ -250,5 +255,133 @@ describe('removeSection', () => {
         expect(result[0].category).toBeUndefined()
         expect(result[0].text).toBe('Nappies')
         expect(result[1].category).toBe('First aid')
+    })
+})
+
+describe('sequence moves', () => {
+    const snacks = item({ id: 'i1', text: 'Snacks' })
+    const crisps = item({ id: 'i2', text: 'Crisps' })
+    const water = item({ id: 'i3', text: 'Water' })
+    const nappies = item({ id: 'i4', text: 'Nappies', category: 'Baby' })
+    const wipes = item({ id: 'i5', text: 'Wipes', category: 'Baby' })
+
+    function sequence(...entries: Array<string | Item>): SectionSequenceEntry[] {
+        return entries.map(e =>
+            typeof e === 'string' ? { kind: 'header' as const, label: e } : { kind: 'item' as const, item: e }
+        )
+    }
+
+    const labels = (seq: SectionSequenceEntry[]) =>
+        seq.map(e => e.kind === 'header' ? `#${e.label}` : e.item.text)
+
+    // Essentials: Snacks, Crisps, Water | Baby: Nappies, Wipes
+    const twoSections = () =>
+        sequence('Essentials', snacks, crisps, water, 'Baby', nappies, wipes)
+
+    describe('sectionLabelAt', () => {
+        it('reports the nearest heading above the entry', () => {
+            expect(sectionLabelAt(twoSections(), 2, 'Essentials')).toBe('Essentials')
+            expect(sectionLabelAt(twoSections(), 6, 'Essentials')).toBe('Baby')
+        })
+
+        it('falls back to the default label above the first heading', () => {
+            expect(sectionLabelAt(sequence(snacks, 'Baby', nappies), 0, 'Essentials')).toBe('Essentials')
+        })
+    })
+
+    describe('sectionLabelsIn', () => {
+        it('lists the sections in display order', () => {
+            expect(sectionLabelsIn(twoSections(), 'Essentials')).toEqual(['Essentials', 'Baby'])
+        })
+
+        it('still offers the default section when it is empty and so has no heading', () => {
+            // Every item is categorised, so buildSectionSequence omits the
+            // default heading — but "back to the main pile" must stay reachable.
+            expect(sectionLabelsIn(sequence('Baby', nappies), 'Essentials')).toEqual(['Essentials', 'Baby'])
+        })
+    })
+
+    describe('moveItemWithinSection', () => {
+        it('moves an item to the top of its own section', () => {
+            expect(labels(moveItemWithinSection(twoSections(), 3, 'top')))
+                .toEqual(['#Essentials', 'Water', 'Snacks', 'Crisps', '#Baby', 'Nappies', 'Wipes'])
+        })
+
+        it('moves an item to the bottom of its own section, above the next heading', () => {
+            expect(labels(moveItemWithinSection(twoSections(), 1, 'bottom')))
+                .toEqual(['#Essentials', 'Crisps', 'Water', 'Snacks', '#Baby', 'Nappies', 'Wipes'])
+        })
+
+        it('keeps a later section intact when its own items move', () => {
+            expect(labels(moveItemWithinSection(twoSections(), 6, 'top')))
+                .toEqual(['#Essentials', 'Snacks', 'Crisps', 'Water', '#Baby', 'Wipes', 'Nappies'])
+        })
+
+        it('leaves the sequence alone when the item is already there', () => {
+            const seq = twoSections()
+            expect(moveItemWithinSection(seq, 1, 'top')).toEqual(seq)
+            expect(moveItemWithinSection(seq, 3, 'bottom')).toEqual(seq)
+        })
+
+        it('handles a section with no heading above it', () => {
+            expect(labels(moveItemWithinSection(sequence(snacks, crisps, 'Baby', nappies), 1, 'top')))
+                .toEqual(['Crisps', 'Snacks', '#Baby', 'Nappies'])
+        })
+    })
+
+    describe('isAtSectionEdge', () => {
+        it('recognises the first and last item of a section', () => {
+            const seq = twoSections()
+            expect(isAtSectionEdge(seq, 1, 'top')).toBe(true)
+            expect(isAtSectionEdge(seq, 2, 'top')).toBe(false)
+            expect(isAtSectionEdge(seq, 3, 'bottom')).toBe(true)
+            expect(isAtSectionEdge(seq, 5, 'bottom')).toBe(false)
+            expect(isAtSectionEdge(seq, 6, 'bottom')).toBe(true)
+        })
+    })
+
+    describe('moveItemToSection', () => {
+        it('appends the item to the end of the target section', () => {
+            expect(labels(moveItemToSection(twoSections(), 1, 'Baby', 'Essentials')))
+                .toEqual(['#Essentials', 'Crisps', 'Water', '#Baby', 'Nappies', 'Wipes', 'Snacks'])
+        })
+
+        it('moves an item back into the default section', () => {
+            expect(labels(moveItemToSection(twoSections(), 5, 'Essentials', 'Essentials')))
+                .toEqual(['#Essentials', 'Snacks', 'Crisps', 'Water', 'Nappies', '#Baby', 'Wipes'])
+        })
+
+        it('moves an item into a section that is still empty', () => {
+            const seq = sequence('Essentials', snacks, 'First aid')
+            expect(labels(moveItemToSection(seq, 1, 'First aid', 'Essentials')))
+                .toEqual(['#Essentials', '#First aid', 'Snacks'])
+        })
+
+        it('moves an item to the default section even when it has no heading', () => {
+            // Sits above the first heading, which applySectionLayout reads as
+            // the default section.
+            const seq = sequence('Baby', nappies, wipes)
+            expect(labels(moveItemToSection(seq, 1, 'Essentials', 'Essentials')))
+                .toEqual(['Nappies', '#Baby', 'Wipes'])
+        })
+
+        it('leaves the sequence alone for an unknown section', () => {
+            const seq = twoSections()
+            expect(moveItemToSection(seq, 1, 'Nowhere', 'Essentials')).toEqual(seq)
+        })
+    })
+
+    describe('round trip through applySectionLayout', () => {
+        it('restamps a menu move into the target section', () => {
+            const moved = moveItemToSection(twoSections(), 1, 'Baby', 'Essentials')
+            const result = applySectionLayout(moved, 'Essentials', now)
+            expect(result.map(i => [i.text, i.category])).toEqual([
+                ['Crisps', undefined],
+                ['Water', undefined],
+                ['Nappies', 'Baby'],
+                ['Wipes', 'Baby'],
+                ['Snacks', 'Baby'],
+            ])
+        })
     })
 })

--- a/src/edit-questions/item-sections.ts
+++ b/src/edit-questions/item-sections.ts
@@ -124,6 +124,103 @@ export function applySectionLayout(
     return result
 }
 
+/**
+ * The section an entry belongs to: the nearest header above it, or the default
+ * section for entries sitting above the first header (which is how
+ * `applySectionLayout` reads them).
+ */
+export function sectionLabelAt(
+    sequence: SectionSequenceEntry[],
+    index: number,
+    defaultLabel: string,
+): string {
+    for (let i = index; i >= 0; i--) {
+        const entry = sequence[i]
+        if (entry.kind === 'header') return entry.label
+    }
+    return defaultLabel
+}
+
+/**
+ * Every section the sequence can move an item into, in display order. The
+ * default section is always offered even when it currently has no header:
+ * emptying it must not strand items in the sections they were put in.
+ */
+export function sectionLabelsIn(sequence: SectionSequenceEntry[], defaultLabel: string): string[] {
+    const labels = sequence.flatMap(e => e.kind === 'header' ? [e.label] : [])
+    return labels.includes(defaultLabel) ? labels : [defaultLabel, ...labels]
+}
+
+/** Where the section containing `index` starts and ends (both inclusive, items only). */
+function sectionBounds(sequence: SectionSequenceEntry[], index: number): { first: number; last: number } {
+    let first = 0
+    for (let i = index; i >= 0; i--) {
+        if (sequence[i].kind === 'header') { first = i + 1; break }
+    }
+    let last = sequence.length - 1
+    for (let i = index + 1; i < sequence.length; i++) {
+        if (sequence[i].kind === 'header') { last = i - 1; break }
+    }
+    return { first, last }
+}
+
+/** Whether the item at `index` already sits at the top or bottom of its section. */
+export function isAtSectionEdge(
+    sequence: SectionSequenceEntry[],
+    index: number,
+    position: 'top' | 'bottom',
+): boolean {
+    const { first, last } = sectionBounds(sequence, index)
+    return index === (position === 'top' ? first : last)
+}
+
+/**
+ * Move an item to the top or bottom of the section it is already in, leaving
+ * every other section untouched.
+ */
+export function moveItemWithinSection(
+    sequence: SectionSequenceEntry[],
+    index: number,
+    position: 'top' | 'bottom',
+): SectionSequenceEntry[] {
+    if (isAtSectionEdge(sequence, index, position)) return sequence
+    const { first, last } = sectionBounds(sequence, index)
+    const next = [...sequence]
+    const [moved] = next.splice(index, 1)
+    // Removing the item shifts everything below it up one, so the bottom slot
+    // is `last` rather than `last + 1`.
+    next.splice(position === 'top' ? first : last, 0, moved)
+    return next
+}
+
+/**
+ * Move an item to the bottom of another section — the keyboard equivalent of
+ * dragging it under that section's heading. Moving into the default section
+ * when that section has no header puts the item above the first header, which
+ * `applySectionLayout` reads as "no category".
+ */
+export function moveItemToSection(
+    sequence: SectionSequenceEntry[],
+    index: number,
+    targetLabel: string,
+    defaultLabel: string,
+): SectionSequenceEntry[] {
+    const next = [...sequence]
+    const [moved] = next.splice(index, 1)
+    const header = next.findIndex(e => e.kind === 'header' && e.label === targetLabel)
+    if (header === -1) {
+        if (targetLabel !== defaultLabel) return sequence
+        next.unshift(moved)
+        return next
+    }
+    let insertAt = next.length
+    for (let i = header + 1; i < next.length; i++) {
+        if (next[i].kind === 'header') { insertAt = i; break }
+    }
+    next.splice(insertAt, 0, moved)
+    return next
+}
+
 /** Every distinct section name in use, for offering existing names as suggestions. */
 export function sectionNamesIn(qs: PackingListQuestionSet): string[] {
     const names = new Set<string>()


### PR DESCRIPTION
## What

In organise mode, each item row lost its up/down arrow buttons and gained a move menu. The drag handle stays exactly as it was.

The menu offers:
- **Move to top of section**
- **Move to bottom of section**
- **Move to _&lt;section&gt;_** — one entry per other section, named

Entries that would do nothing are omitted (no "move to top" on the first item of a section, no entry for the item's own section), and the trigger is disabled when there is nothing to move to at all.

## Why

The arrows only stepped one row at a time, so moving an item across a long list — or into another section — meant repeated clicking, and the only way to reach a still-empty section was to step all the way down onto its heading. The menu names its destinations instead of relying on aim or repetition, which also makes it the affordance that works off-screen and from the keyboard.

## Keyboard reordering

dnd-kit's keyboard sensor was already wired up but effectively undiscoverable. It is now a first-class path:

- Focus the drag handle, press <kbd>space</kbd> to pick the item up, the arrow keys to move it up and down the list and across section headings, <kbd>space</kbd> to drop, <kbd>esc</kbd> to cancel.
- Custom `screenReaderInstructions` describe exactly that, so a screen reader gets the instructions on focusing a handle.
- Custom `announcements` replace dnd-kit's defaults, which would have read out internal drag ids and know nothing about sections. A move now announces e.g. _"Snacks, position 2 in Toiletries"_ — the item by name, and where it landed.
- The move menu itself is keyboard-navigable (Radix), matching the existing option context menu on this page.
- The hint line above the list now describes both routes.

## Implementation

The moves are pure functions over the display sequence in `item-sections.ts` (`moveItemWithinSection`, `moveItemToSection`, plus `sectionLabelAt` / `sectionLabelsIn` / `isAtSectionEdge`), so they go back through the same `applySectionLayout` path a drag does — categories are restamped from the nearest heading above, and nothing positional is stored.

One case the arrows handled implicitly is kept explicit: the default section is always offered as a destination, even when it currently holds no items and so has no heading. Moving there puts the item above the first heading, which `applySectionLayout` already reads as "no category".

## Testing

- 27 new unit tests: the sequence-move helpers in `item-sections.test.ts` (including a round trip through `applySectionLayout`), and a new `SectionedItemReorder.test.tsx` covering the menu's contents and every move it can make.
- E2E `B6` rewritten to reorder via the menu; new E2E `B8` reorders with the keyboard only and checks the move survives a save round-trip.
- `npm test` (951 passed), `npx tsc -b`, `npm run lint` and the full `b-questions` Playwright suite all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_014AxX2syk5XuqwH8Vp23DXn)_