### PR TITLE
Stop guessing the Pod URL from the WebID host

### DIFF
--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -19,6 +19,8 @@ import {
     getCollaborators,
     getPodOwnerName,
     friendlyPodName,
+    getPrimaryPodUrl,
+    derivePodUrlFromWebId,
 } from './solidPod'
 import { AuthenticationError } from './solidPod'
 import { PackingAppDatabase } from './database'
@@ -61,8 +63,9 @@ vi.mock('@inrupt/solid-client', async (importOriginal) => {
     }
 })
 
-import { getFile, getSolidDataset, getContainedResourceUrlAll, overwriteFile, createSolidDataset, createContainerAt, universalAccess, getResourceInfoWithAcl, hasResourceAcl, hasFallbackAcl, hasAccessibleAcl, getResourceAcl, createAclFromFallbackAcl, saveAclFor, setAgentResourceAccess, setAgentDefaultAccess, deleteFile } from '@inrupt/solid-client'
+import { getFile, getSolidDataset, getContainedResourceUrlAll, getPodUrlAll, overwriteFile, createSolidDataset, createContainerAt, universalAccess, getResourceInfoWithAcl, hasResourceAcl, hasFallbackAcl, hasAccessibleAcl, getResourceAcl, createAclFromFallbackAcl, saveAclFor, setAgentResourceAccess, setAgentDefaultAccess, deleteFile } from '@inrupt/solid-client'
 
+const mockGetPodUrlAll = vi.mocked(getPodUrlAll)
 const mockGetFile = vi.mocked(getFile)
 const mockGetSolidDataset = vi.mocked(getSolidDataset)
 const mockGetContainedResourceUrlAll = vi.mocked(getContainedResourceUrlAll)
@@ -1114,5 +1117,106 @@ describe('friendlyPodName', () => {
 
     it('returns the input unchanged when the URL is invalid', () => {
         expect(friendlyPodName('not-a-url')).toBe('not-a-url')
+    })
+})
+
+// ─── getPrimaryPodUrl ────────────────────────────────────────────────────────
+
+describe('getPrimaryPodUrl', () => {
+    const CSS_WEB_ID = 'http://localhost:4000/testuser/profile/card#me'
+    const ESS_WEB_ID = 'https://id.inrupt.com/hannahwprior'
+    const ESS_POD_URL = 'https://storage.inrupt.com/d8c8c02b-b47c-48e9-b737-619f2958689f/'
+
+    const sessionFor = (webId: string) => ({
+        info: { isLoggedIn: true, webId },
+        fetch: vi.fn(),
+    } as unknown as Session)
+
+    beforeEach(() => {
+        localStorage.clear()
+        vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('returns null when there is no session', async () => {
+        expect(await getPrimaryPodUrl(null)).toBeNull()
+    })
+
+    it('returns null when the session is not logged in', async () => {
+        const session = { info: { isLoggedIn: false, webId: ESS_WEB_ID }, fetch: vi.fn() } as unknown as Session
+
+        expect(await getPrimaryPodUrl(session)).toBeNull()
+        expect(mockGetPodUrlAll).not.toHaveBeenCalled()
+    })
+
+    it('uses the storage location advertised in the profile (pim:storage)', async () => {
+        mockGetPodUrlAll.mockResolvedValueOnce([ESS_POD_URL])
+        const session = sessionFor(ESS_WEB_ID)
+
+        expect(await getPrimaryPodUrl(session)).toBe(ESS_POD_URL)
+        expect(mockGetPodUrlAll).toHaveBeenCalledWith(ESS_WEB_ID, expect.objectContaining({ fetch: session.fetch }))
+    })
+
+    it('derives the Pod root from a CSS-style WebID when the profile has no pim:storage', async () => {
+        mockGetPodUrlAll.mockResolvedValueOnce([])
+
+        expect(await getPrimaryPodUrl(sessionFor(CSS_WEB_ID))).toBe('http://localhost:4000/testuser/')
+    })
+
+    it('returns null rather than guessing when an identity-provider WebID has no pim:storage', async () => {
+        mockGetPodUrlAll.mockResolvedValueOnce([])
+
+        // https://id.inrupt.com/ hosts identities, not storage — writing there 404s
+        expect(await getPrimaryPodUrl(sessionFor(ESS_WEB_ID))).toBeNull()
+    })
+
+    it('returns null rather than guessing when the profile cannot be fetched', async () => {
+        mockGetPodUrlAll.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+        expect(await getPrimaryPodUrl(sessionFor(ESS_WEB_ID))).toBeNull()
+    })
+
+    it('falls back to the last known Pod URL when the profile cannot be fetched', async () => {
+        mockGetPodUrlAll.mockResolvedValueOnce([ESS_POD_URL])
+        const session = sessionFor(ESS_WEB_ID)
+        expect(await getPrimaryPodUrl(session)).toBe(ESS_POD_URL)
+
+        mockGetPodUrlAll.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+        expect(await getPrimaryPodUrl(session)).toBe(ESS_POD_URL)
+    })
+
+    it('does not reuse another user\'s cached Pod URL', async () => {
+        mockGetPodUrlAll.mockResolvedValueOnce([ESS_POD_URL])
+        expect(await getPrimaryPodUrl(sessionFor(ESS_WEB_ID))).toBe(ESS_POD_URL)
+
+        mockGetPodUrlAll.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+        expect(await getPrimaryPodUrl(sessionFor('https://id.inrupt.com/someoneelse'))).toBeNull()
+    })
+})
+
+// ─── derivePodUrlFromWebId ───────────────────────────────────────────────────
+
+describe('derivePodUrlFromWebId', () => {
+    it('strips the profile document path from a WebID stored inside its Pod', () => {
+        expect(derivePodUrlFromWebId('http://localhost:4000/testuser/profile/card#me'))
+            .toBe('http://localhost:4000/testuser/')
+    })
+
+    it('handles a WebID at the root of a per-user host', () => {
+        expect(derivePodUrlFromWebId('https://alice.solidcommunity.net/profile/card#me'))
+            .toBe('https://alice.solidcommunity.net/')
+    })
+
+    it('returns null for an identity-provider WebID that says nothing about storage', () => {
+        expect(derivePodUrlFromWebId('https://id.inrupt.com/hannahwprior')).toBeNull()
+    })
+
+    it('returns null for an invalid URL', () => {
+        expect(derivePodUrlFromWebId('not-a-url')).toBeNull()
     })
 })

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -186,6 +186,16 @@ export async function getPodOwnerName(session: Session, podUrl: string, explicit
     }
 }
 
+/**
+ * Derives the Pod root from a WebID that lives inside the Pod it describes —
+ * the `.../profile/card#me` convention used by CSS and NSS.
+ *
+ * Returns null for every other WebID shape. A WebID minted by an identity
+ * provider (e.g. https://id.inrupt.com/alice) says nothing about where that
+ * user's storage lives — it is on a different host entirely
+ * (https://storage.inrupt.com/<uuid>/). Guessing a Pod root from it sends every
+ * read and write to the identity provider, which 404s.
+ */
 export function derivePodUrlFromWebId(webId: string): string | null {
     try {
         const url = new URL(webId)
@@ -193,11 +203,6 @@ export function derivePodUrlFromWebId(webId: string): string | null {
         const path = url.pathname
         if (path.endsWith('/profile/card')) {
             url.pathname = path.slice(0, -'profile/card'.length)
-            return url.toString()
-        }
-        const firstSegment = path.split('/').find(s => s.length > 0)
-        if (firstSegment) {
-            url.pathname = '/' + firstSegment + '/'
             return url.toString()
         }
     } catch { /* ignore URL parse errors */ }
@@ -449,44 +454,70 @@ function getStatusCode(err: unknown): number | undefined {
     return typeof code === 'number' ? code : undefined
 }
 
+const POD_URL_CACHE_PREFIX = 'pod-url:'
+
 /**
- * Validates session and retrieves the user's primary Pod URL
- * @returns Pod URL if valid, null otherwise
+ * The last Pod URL we successfully resolved for a WebID. Used only when the
+ * profile document can't be read, so a momentary network blip doesn't leave the
+ * app with no idea where the Pod is (which would also switch the local database
+ * namespace, making the user's lists look like they had vanished).
+ */
+function readCachedPodUrl(webId: string): string | null {
+    try {
+        return localStorage.getItem(`${POD_URL_CACHE_PREFIX}${webId}`)
+    } catch {
+        return null
+    }
+}
+
+function cachePodUrl(webId: string, podUrl: string): void {
+    try {
+        localStorage.setItem(`${POD_URL_CACHE_PREFIX}${webId}`, podUrl)
+    } catch { /* storage unavailable (private browsing, quota) — caching is best-effort */ }
+}
+
+/**
+ * Validates session and retrieves the user's primary Pod URL.
+ *
+ * The `pim:storage` triple in the WebID profile is the only authoritative source
+ * for where a Pod lives, so an unreadable profile means "unknown", never "guess
+ * from the WebID host".
+ *
+ * @returns Pod URL if it can be determined, null otherwise
  */
 export async function getPrimaryPodUrl(session: Session | null): Promise<string | null> {
     if (!session || !session.info.isLoggedIn || !session.info.webId) {
         return null
     }
 
+    const webId = session.info.webId
+
+    let podUrls: string[]
     try {
-        const podUrls = await getPodUrlAll(session.info.webId, { fetch: session.fetch })
-        if (podUrls && podUrls.length > 0) {
-            return podUrls[0]
-        }
-    } catch {
-        // getPodUrlAll failed (e.g. CSS v7 doesn't expose pim:storage) — fall through to derivation
+        podUrls = await getPodUrlAll(webId, { fetch: session.fetch })
+    } catch (err) {
+        // The profile document itself couldn't be fetched (transient network
+        // error, DPoP nonce race, expired token). We know nothing about the
+        // Pod's location, so reuse the last known one and otherwise give up —
+        // callers report "no pod" and retry on the next sync.
+        console.warn('getPrimaryPodUrl: could not read the WebID profile', err)
+        return readCachedPodUrl(webId)
     }
 
-    // Fallback: derive Pod URL from WebID using CSS convention.
-    // WebID = http://host/podName/profile/card#me → Pod = http://host/podName/
-    // This covers CSS v7 installations that don't include pim:storage in the profile.
-    try {
-        const url = new URL(session.info.webId)
-        url.hash = ''
-        const path = url.pathname
-        if (path.endsWith('/profile/card')) {
-            url.pathname = path.slice(0, -'profile/card'.length)
-            return url.toString()
-        }
-        // Generic fallback: use the first path segment as Pod root
-        const firstSegment = path.split('/').find(s => s.length > 0)
-        if (firstSegment) {
-            url.pathname = '/' + firstSegment + '/'
-            return url.toString()
-        }
-    } catch { /* ignore URL parse errors */ }
+    if (podUrls && podUrls.length > 0) {
+        cachePodUrl(webId, podUrls[0])
+        return podUrls[0]
+    }
 
-    return null
+    // Profile was readable but declares no pim:storage — the case for CSS v7,
+    // where the WebID sits inside the Pod it belongs to.
+    const derivedPodUrl = derivePodUrlFromWebId(webId)
+    if (derivedPodUrl) {
+        cachePodUrl(webId, derivedPodUrl)
+        return derivedPodUrl
+    }
+
+    return readCachedPodUrl(webId)
 }
 
 /**

--- a/src/test-utils/fullyPopulatedFixtures.ts
+++ b/src/test-utils/fullyPopulatedFixtures.ts
@@ -109,7 +109,6 @@ const fullyPopulatedQuestionSetItem: Required<Item> = {
     ageRanges: ['Adult'],
     category: 'Toiletries',
     order: 1,
-    category: 'Toiletries',
     perNight: 2,
     perNights: 3,
     maxQuantity: 7,


### PR DESCRIPTION
## The error

Sentry, production, `javascript-react`:

```
Error: Creating the empty Container at [https://id.inrupt.com/hannahwprior/pack-me-up/packing-lists/] failed:
[404] [] {"status":404,"title":"Not Found","detail":"HTTP 404 Not Found","instance":"/hannahwprior/pack-me-up/packing-lists/"}
```

## Root cause

`id.inrupt.com` is Inrupt's **identity provider**. It hosts WebIDs, not storage — that user's Pod lives on `storage.inrupt.com/<uuid>/`. Every read and write for this user was being aimed at the IdP, and the first write to create the container is where it surfaced.

`getPrimaryPodUrl` (`src/services/solidPod.ts`) asked the WebID profile for `pim:storage` — the only authoritative answer — but wrapped that lookup in a bare `catch {}` and fell through to deriving a Pod root from the WebID string, ending in a generic *"the first path segment is the Pod"* guess:

```ts
} catch {
    // getPodUrlAll failed (e.g. CSS v7 doesn't expose pim:storage) — fall through to derivation
}
...
const firstSegment = path.split('/').find(s => s.length > 0)
if (firstSegment) {
    url.pathname = '/' + firstSegment + '/'   // https://id.inrupt.com/hannahwprior/
    return url.toString()
}
```

The comment conflates two different situations. A profile that is *readable but has no `pim:storage`* is the CSS v7 case, where derivation is correct. A profile that *can't be fetched at all* — a network blip, the DPoP nonce race already noted in `DatabaseContext`, an expired token — tells us nothing, and the guess turns it into a confidently wrong URL on the wrong host.

There's a second, quieter symptom: `DatabaseContext` uses the resolved Pod URL as the local PouchDB namespace, so a transient lookup failure silently switched namespaces and the user's lists appeared to vanish.

## The fix

- An unreadable profile now means *unknown*, never *guess*: reuse the last Pod URL resolved for that WebID (cached in `localStorage`, keyed by WebID), otherwise return `null` so callers report "no pod" and retry on the next sync/poll.
- `pim:storage` stays authoritative when present, and is what gets cached.
- Derivation is kept only for the `.../profile/card#me` convention, where the WebID genuinely lives inside the Pod it describes (CSS/NSS). The generic path-segment guess is removed from both `getPrimaryPodUrl` and `derivePodUrlFromWebId`.
- The cache keeps the database namespace stable across a transient failure.

## Tests

New `getPrimaryPodUrl` and `derivePodUrlFromWebId` suites in `src/services/solidPod.test.ts`, written red-first — the four covering the bug (IdP WebID with no `pim:storage`, unfetchable profile, cache reuse, no cross-user cache bleed) failed against the old implementation. Full suite: 1009 passing, typecheck and lint clean.

## Unrelated fix, included to unblock

`src/test-utils/fullyPopulatedFixtures.ts` had a duplicate `category` key, so `npm run typecheck` — and therefore `npm test` — was failing on `main`. Removed the duplicate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4eEnHCA4AyrPaRMGrEk2i)_