### PR TITLE
Pre-populate the wizard with the family you already set up

### DIFF
--- a/e2e/tests/a-onboarding.spec.ts
+++ b/e2e/tests/a-onboarding.spec.ts
@@ -84,4 +84,32 @@ test.describe('A – Onboarding & Wizard', () => {
     await expect(page.getByRole('button', { name: 'Yes, Override' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
   })
+
+  test('A5: re-running the wizard pre-populates the group from the saved question set', async ({ freshPage: page }) => {
+    // First run: a person and a pet, so both row types get re-populated
+    await page.goto('/#/wizard')
+    const nameInputs = page.locator('input[type="text"]')
+    await nameInputs.first().fill('Alice')
+    await page.selectOption('[name="people.0.ageRange"]', 'Adult')
+    await page.selectOption('[name="people.0.gender"]', 'female')
+    await page.getByRole('button', { name: /Add a Pet/i }).click()
+    await nameInputs.nth(1).fill('Rex')
+    await page.selectOption('[name="people.1.species"]', 'dog')
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await waitForWizardSuccess(page)
+    await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
+    await page.getByRole('button', { name: 'Maybe Later' }).click()
+    await page.waitForURL(/#\/manage-questions/, { timeout: 8_000 })
+    await page.waitForLoadState('networkidle')
+
+    // Second run: the wizard starts from the family set up the first time
+    await page.goto('/#/wizard')
+    await expect(page.getByText(/filled in the people from your current setup/i)).toBeVisible({ timeout: 10_000 })
+    await expect(nameInputs.first()).toHaveValue('Alice')
+    await expect(nameInputs.nth(1)).toHaveValue('Rex')
+    await expect(page.locator('[name="people.0.ageRange"]')).toHaveValue('Adult')
+    await expect(page.locator('[name="people.0.gender"]')).toHaveValue('female')
+    await expect(page.locator('[name="people.1.species"]')).toHaveValue('dog')
+    await expect(page.getByText('2 in your group')).toBeVisible()
+  })
 })

--- a/src/pages/wizard-prefill.test.ts
+++ b/src/pages/wizard-prefill.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { peopleToWizardEntries } from './wizard-prefill'
+import { Person } from '../edit-questions/types'
+
+describe('peopleToWizardEntries', () => {
+    it('maps a person to a person entry, keeping age range, gender and birthday', () => {
+        const people: Person[] = [
+            { id: '1', name: 'Sam', ageRange: 'Adult', gender: 'female', dateOfBirth: '1990-04-02' },
+        ]
+
+        expect(peopleToWizardEntries(people)).toEqual([
+            { kind: 'person', name: 'Sam', ageRange: 'Adult', gender: 'female', dateOfBirth: '1990-04-02' },
+        ])
+    })
+
+    it('maps a pet to a pet entry with its species', () => {
+        const people: Person[] = [
+            { id: '1', name: 'Rex', species: 'dog' },
+        ]
+
+        expect(peopleToWizardEntries(people)).toEqual([
+            { kind: 'pet', name: 'Rex', species: 'dog' },
+        ])
+    })
+
+    it('leaves unset age range, gender and birthday as the empty select value', () => {
+        const people: Person[] = [{ id: '1', name: 'Alex' }]
+
+        expect(peopleToWizardEntries(people)).toEqual([
+            { kind: 'person', name: 'Alex', ageRange: '', gender: undefined, dateOfBirth: '' },
+        ])
+    })
+
+    it('skips soft-deleted people and pets', () => {
+        const people: Person[] = [
+            { id: '1', name: 'Sam', ageRange: 'Adult' },
+            { id: '2', name: 'Gone', ageRange: 'Child', deletedAt: '2025-01-01T00:00:00.000Z' },
+            { id: '3', name: 'Rex', species: 'dog', deletedAt: '2025-01-01T00:00:00.000Z' },
+        ]
+
+        expect(peopleToWizardEntries(people).map(e => e.name)).toEqual(['Sam'])
+    })
+
+    it('preserves the order of the existing group', () => {
+        const people: Person[] = [
+            { id: '1', name: 'Sam', ageRange: 'Adult' },
+            { id: '2', name: 'Rex', species: 'dog' },
+            { id: '3', name: 'Ellie', ageRange: 'Baby' },
+        ]
+
+        expect(peopleToWizardEntries(people).map(e => e.name)).toEqual(['Sam', 'Rex', 'Ellie'])
+    })
+
+    it('returns an empty array when there is nobody left to prefill', () => {
+        expect(peopleToWizardEntries([])).toEqual([])
+        expect(peopleToWizardEntries([
+            { id: '1', name: 'Gone', deletedAt: '2025-01-01T00:00:00.000Z' },
+        ])).toEqual([])
+    })
+})

--- a/src/pages/wizard-prefill.ts
+++ b/src/pages/wizard-prefill.ts
@@ -1,0 +1,31 @@
+import { Person } from '../edit-questions/types'
+import { WizardEntry } from './wizard-types'
+
+/**
+ * Turns the people already stored in a question set back into wizard form rows,
+ * so someone re-running the wizard starts from the family they set up before
+ * rather than from a blank 'Me'.
+ *
+ * Soft-deleted people are skipped — they're removed everywhere else in the app,
+ * so they shouldn't reappear here. Unset values become '' (the untouched select
+ * / empty date input) rather than undefined, which keeps the inputs controlled.
+ *
+ * Cast through unknown: `gender` is undefined for people who never picked one,
+ * which the strict discriminated union doesn't model — the same compromise the
+ * wizard makes when it seeds a new row.
+ */
+export function peopleToWizardEntries(people: Person[]): WizardEntry[] {
+    return people
+        .filter(person => !person.deletedAt)
+        .map(person =>
+            person.species
+                ? { kind: 'pet', name: person.name, species: person.species }
+                : {
+                    kind: 'person',
+                    name: person.name,
+                    ageRange: person.ageRange ?? '',
+                    gender: person.gender,
+                    dateOfBirth: person.dateOfBirth ?? '',
+                }
+        ) as unknown as WizardEntry[]
+}

--- a/src/pages/wizard-types.test.ts
+++ b/src/pages/wizard-types.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { wizardSchema } from './wizard-types'
+
+const person = (name: string) => ({ kind: 'person' as const, name, ageRange: 'Adult' as const, gender: 'female' as const })
+
+describe('wizardSchema', () => {
+    it('requires at least one person or pet', () => {
+        const result = wizardSchema.safeParse({ people: [] })
+        expect(result.success).toBe(false)
+    })
+
+    it('accepts a large group — big families are not capped', () => {
+        const people = Array.from({ length: 25 }, (_, i) => person(`Person ${i + 1}`))
+        expect(wizardSchema.safeParse({ people }).success).toBe(true)
+    })
+
+    it('still requires an age range or birthday for each person', () => {
+        const result = wizardSchema.safeParse({
+            people: [{ kind: 'person', name: 'Sam', gender: 'female' }],
+        })
+        expect(result.success).toBe(false)
+    })
+})

--- a/src/pages/wizard-types.ts
+++ b/src/pages/wizard-types.ts
@@ -23,10 +23,13 @@ export const wizardPetSchema = z.object({
 
 export const wizardEntrySchema = z.discriminatedUnion('kind', [wizardPersonSchema, wizardPetSchema])
 
+// No upper bound on the group: 'Edit People' has never capped it, so a cap
+// here only blocked large families from (re-)running the wizard. The cost of
+// more people is linear — the question and item counts don't change, only the
+// per-person selections on each item.
 export const wizardSchema = z.object({
     people: z.array(wizardEntrySchema)
-        .min(1, 'At least 1 person or pet required')
-        .max(10, 'Maximum of 10 reached'),
+        .min(1, 'At least 1 person or pet required'),
 }).superRefine((data, ctx) => {
     data.people.forEach((entry, index) => {
         if (entry.kind === 'person' && !entry.ageRange && !entry.dateOfBirth) {

--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -151,6 +151,20 @@ describe('Wizard', () => {
             expect(await screen.findByText(/filled in the people from your current setup/i)).toBeTruthy()
         })
 
+        it('keeps letting a large family add more people', async () => {
+            const people = Array.from({ length: 12 }, (_, i) => ({
+                id: String(i),
+                name: `Person ${i + 1}`,
+                ageRange: 'Adult',
+            }))
+            renderWithExisting({ ...existingSet, people })
+
+            await waitFor(() => expect(screen.getAllByLabelText(/^name$/i)).toHaveLength(12))
+            expect(screen.getByRole('button', { name: /add another person/i })).toBeTruthy()
+            expect(screen.getByRole('button', { name: /add a pet/i })).toBeTruthy()
+            expect(screen.queryByText(/maximum of 10/i)).toBeNull()
+        })
+
         it('keeps the default single row when the existing set has nobody left', async () => {
             renderWithExisting({ ...existingSet, people: [] })
 

--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -98,6 +98,70 @@ describe('Wizard', () => {
         expect(screen.queryByText(/you already have packing list questions set up/i)).toBeNull()
     })
 
+    describe('re-running the wizard', () => {
+        const existingSet = {
+            people: [
+                { id: '1', name: 'Sam', ageRange: 'Adult', gender: 'female', dateOfBirth: '1990-04-02' },
+                { id: '2', name: 'Ellie', ageRange: 'Baby' },
+                { id: '3', name: 'Rex', species: 'dog' },
+                { id: '4', name: 'Gone', ageRange: 'Child', deletedAt: '2025-01-01T00:00:00.000Z' },
+            ],
+            alwaysNeededItems: [],
+            questions: [],
+        }
+
+        function renderWithExisting(questionSet: unknown) {
+            const db = makeDb({ getQuestionSet: vi.fn().mockResolvedValue(questionSet) })
+            mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+            return render(
+                <MemoryRouter>
+                    <Wizard />
+                </MemoryRouter>
+            )
+        }
+
+        it('prefills the group with the people and pets already saved, skipping deleted ones', async () => {
+            renderWithExisting(existingSet)
+
+            await waitFor(() => {
+                const nameInputs = screen.getAllByLabelText(/^name$/i) as HTMLInputElement[]
+                expect(nameInputs.map(input => input.value)).toEqual(['Sam', 'Ellie', 'Rex'])
+            })
+            expect(screen.getByText('3 in your group')).toBeTruthy()
+        })
+
+        it('prefills age range, gender, birthday and species', async () => {
+            const { container } = renderWithExisting(existingSet)
+
+            await waitFor(() => expect(screen.getAllByLabelText(/^name$/i)).toHaveLength(3))
+
+            const selects = screen.getAllByRole('combobox') as HTMLSelectElement[]
+            // Sam: age + gender, Ellie: age + gender, Rex: species
+            expect(selects.map(select => select.value)).toEqual(['Adult', 'female', 'Baby', '', 'dog'])
+
+            const birthdays = Array.from(
+                container.querySelectorAll('input[type="date"]')
+            ) as HTMLInputElement[]
+            expect(birthdays.map(input => input.value)).toEqual(['1990-04-02', ''])
+        })
+
+        it('tells the user their existing group has been filled in', async () => {
+            renderWithExisting(existingSet)
+
+            expect(await screen.findByText(/filled in the people from your current setup/i)).toBeTruthy()
+        })
+
+        it('keeps the default single row when the existing set has nobody left', async () => {
+            renderWithExisting({ ...existingSet, people: [] })
+
+            await waitFor(() => {
+                const nameInputs = screen.getAllByLabelText(/^name$/i) as HTMLInputElement[]
+                expect(nameInputs.map(input => input.value)).toEqual(['Me'])
+            })
+            expect(screen.queryByText(/filled in the people from your current setup/i)).toBeNull()
+        })
+    })
+
     it('shows success modal but not pod prompt immediately after generation succeeds', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -13,6 +13,7 @@ import { useWizardGeneration } from './useWizardGeneration'
 import { AGE_RANGE_OPTIONS, GENDER_OPTIONS, PET_SPECIES_OPTIONS } from '../edit-questions/types'
 import { deriveAgeRange } from '../edit-questions/age-derivation'
 import { buildRevealSteps, buildGenerationSummary, REVEAL_STEP_MS } from './wizard-reveal'
+import { peopleToWizardEntries } from './wizard-prefill'
 import { prefersReducedMotion } from '../utils/prefersReducedMotion'
 
 const SOLID_POD_UPSELL_SHOWN_KEY = 'solid-pod-upsell-shown'
@@ -24,6 +25,7 @@ export const Wizard = () => {
     const [showSuccessModal, setShowSuccessModal] = useState(false)
     const [pendingNavRoute, setPendingNavRoute] = useState<string | null>(null)
     const [hasExistingData, setHasExistingData] = useState(false)
+    const [isPrefilled, setIsPrefilled] = useState(false)
     const [revealedCount, setRevealedCount] = useState(0)
     const [isRevealComplete, setIsRevealComplete] = useState(false)
     const { isLoggedIn } = useSolidPod()
@@ -39,7 +41,7 @@ export const Wizard = () => {
         [generatedSet]
     )
 
-    const { register, control, handleSubmit, watch, setValue, formState: { errors } } = useForm<WizardFormData>({
+    const { register, control, handleSubmit, watch, setValue, reset, formState: { errors } } = useForm<WizardFormData>({
         resolver: zodResolver(wizardSchema),
         defaultValues: {
             people: [{ kind: 'person', name: 'Me', ageRange: undefined, gender: undefined }],
@@ -51,12 +53,18 @@ export const Wizard = () => {
         name: 'people'
     })
 
-    // Check for existing data on mount
+    // Check for existing data on mount, and start someone re-running the wizard
+    // from the group they already set up rather than from a blank 'Me' row.
     useEffect(() => {
         const checkExistingData = async () => {
             try {
-                await db.getQuestionSet()
+                const existingSet = await db.getQuestionSet()
                 setHasExistingData(true)
+                const existingEntries = peopleToWizardEntries(existingSet.people ?? [])
+                if (existingEntries.length > 0) {
+                    reset({ people: existingEntries })
+                    setIsPrefilled(true)
+                }
             } catch (err: unknown) {
                 const hasName = typeof err === 'object' && err !== null && 'name' in err
                 if (!hasName || (err as { name: string }).name !== 'not_found') {
@@ -66,7 +74,7 @@ export const Wizard = () => {
             }
         }
         checkExistingData()
-    }, [db])
+    }, [db, reset])
 
     // Open success modal when generation completes, starting the reveal at the
     // first person. Users who prefer reduced motion get the whole thing at once.
@@ -187,6 +195,12 @@ export const Wizard = () => {
                             {fields.length} in your group
                         </span>
                     </div>
+
+                    {isPrefilled && (
+                        <p className="mb-4 text-sm text-gray-600">
+                            We've filled in the people from your current setup — add, remove or change anyone before generating.
+                        </p>
+                    )}
 
                     <div className="space-y-4">
                         {fields.map((field, index) => {

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -318,34 +318,26 @@ export const Wizard = () => {
                         })}
                     </div>
 
-                    {fields.length < 10 && (
-                        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
-                            <button
-                                type="button"
-                                onClick={handleAddPerson}
-                                className="w-full py-3 px-4 border-2 border-dashed border-primary-300 rounded-xl text-primary-700 font-semibold hover:border-primary-500 hover:bg-primary-50 transition-all duration-200 flex items-center justify-center gap-2"
-                            >
-                                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                    <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
-                                </svg>
-                                Add Another Person
-                            </button>
-                            <button
-                                type="button"
-                                onClick={handleAddPet}
-                                className="w-full py-3 px-4 border-2 border-dashed border-primary-300 rounded-xl text-primary-700 font-semibold hover:border-primary-500 hover:bg-primary-50 transition-all duration-200 flex items-center justify-center gap-2"
-                            >
-                                <span className="text-lg leading-none">🐾</span>
-                                Add a Pet
-                            </button>
-                        </div>
-                    )}
-
-                    {fields.length >= 10 && (
-                        <p className="mt-4 text-sm text-gray-600 text-center">
-                            Maximum of 10 reached
-                        </p>
-                    )}
+                    <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        <button
+                            type="button"
+                            onClick={handleAddPerson}
+                            className="w-full py-3 px-4 border-2 border-dashed border-primary-300 rounded-xl text-primary-700 font-semibold hover:border-primary-500 hover:bg-primary-50 transition-all duration-200 flex items-center justify-center gap-2"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
+                            </svg>
+                            Add Another Person
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleAddPet}
+                            className="w-full py-3 px-4 border-2 border-dashed border-primary-300 rounded-xl text-primary-700 font-semibold hover:border-primary-500 hover:bg-primary-50 transition-all duration-200 flex items-center justify-center gap-2"
+                        >
+                            <span className="text-lg leading-none">🐾</span>
+                            Add a Pet
+                        </button>
+                    </div>
 
                     {errors.people && typeof errors.people.message === 'string' && (
                         <p className="text-danger-500 text-sm mt-2">{errors.people.message}</p>


### PR DESCRIPTION
Re-running the setup wizard reset you to a single blank `Me` row, so anyone regenerating their questions had to retype their whole group. Now it starts from the family already saved.

## Changes

**`src/pages/wizard-prefill.ts` (new)** — `peopleToWizardEntries(people)` maps the `Person[]` on a saved question set back into wizard form rows:

- people keep name, age range, gender and birthday; pets keep name and species
- soft-deleted entries are skipped, saved order is preserved
- unset values become `''` (the untouched select / empty date input) so the inputs stay controlled

**`src/pages/wizard.tsx`** — the mount effect already fetched the existing question set to decide whether to show the override warning, so it now also `reset()`s the form with those entries when there is anyone to prefill. A line under "Who's Packing?" explains the rows came from the current setup and can be changed before generating. With no existing set — or none left after deletions — the default single `Me` row is unchanged.

**`src/pages/wizard-types.ts`** — dropped the 10-person cap. "Edit People" has never capped the group, so the wizard's max only ever blocked large families; with prefill in place it would have stopped anyone who had added an 11th person from re-running the wizard at all. The cost of more people is linear and small — question and item counts don't change, only the per-person selections on each item (~6.5 KB per person, so a 20-person group is ~150 KB). The "Maximum of 10 reached" message and the gate on the add buttons are gone with it.

## Testing

Written test-first (red → green).

- `wizard-prefill.test.ts` — 6 unit tests for the mapping (person, pet, unset fields, soft-deleted, order, empty).
- `wizard-types.test.ts` — schema still requires at least one person and an age range or birthday, and now accepts a 25-person group.
- `wizard.test.tsx` — prefilled names with deleted people skipped; age/gender/birthday/species values; the explanatory note; a 12-person group can still add more; default row preserved when nobody is left.
- `e2e/tests/a-onboarding.spec.ts` — new A5 generates with a person and a dog, revisits `/#/wizard`, and asserts both rows come back with their values.

`npm test` passes (1023 tests, type check included), the 5 `a-onboarding` e2e tests pass, `npm run lint` reports no new problems, and `npm run build` succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKc154pT21Gt6fA9jzfmrs)_