### PR TITLE
Make item sections legible on the questions page

### DIFF
--- a/src/components/SectionedItemReorder.tsx
+++ b/src/components/SectionedItemReorder.tsx
@@ -34,10 +34,19 @@ import {
     sectionLabelsIn,
     type SectionSequenceEntry,
 } from '../edit-questions/item-sections'
+import { sectionAccent } from '../edit-questions/section-accent'
 
 // Drags only ever move rows up and down the list.
 const restrictToVerticalAxis: Modifier = ({ transform }) => ({ ...transform, x: 0 })
 
+/**
+ * A section's banner, and the drop target that puts an item into it.
+ *
+ * Drawn as a filled bar in the section's own colour rather than a caption with
+ * a rule beside it: this is the line you drag an item across, so it has to be
+ * obvious where one section stops and the next starts, and the colour is the
+ * same one the section wears on the questions page behind the modal.
+ */
 function SectionHeaderRow({ id, label, isDefault, onRename, onRemove }: {
     id: string
     label: string
@@ -50,6 +59,7 @@ function SectionHeaderRow({ id, label, isDefault, onRename, onRemove }: {
     const { setNodeRef, transform, transition } = useSortable({ id, disabled: true })
     const [editing, setEditing] = useState(false)
     const [draft, setDraft] = useState(label)
+    const accent = sectionAccent(label, isDefault)
 
     const commit = () => {
         const trimmed = draft.trim()
@@ -62,7 +72,7 @@ function SectionHeaderRow({ id, label, isDefault, onRename, onRemove }: {
         <div
             ref={setNodeRef}
             style={{ transform: CSS.Transform.toString(transform), transition }}
-            className="flex items-center gap-2 pt-3 pb-1"
+            className="pt-1"
         >
             {editing ? (
                 <input
@@ -75,21 +85,21 @@ function SectionHeaderRow({ id, label, isDefault, onRename, onRemove }: {
                         if (e.key === 'Escape') { setDraft(label); setEditing(false) }
                     }}
                     aria-label={`Rename section ${label}`}
-                    className="flex-1 min-w-0 border border-primary-300 rounded-lg px-2 py-1 text-xs font-semibold uppercase tracking-wide focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    className="w-full border border-primary-300 rounded-lg px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-primary-500"
                 />
             ) : (
-                <>
-                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide truncate">
+                <div className={`flex items-center gap-2 rounded-lg border ${accent.border} ${accent.header} px-3 py-2`}>
+                    <span className={`w-1.5 h-4 rounded-full shrink-0 ${accent.rail}`} aria-hidden="true" />
+                    <span className={`text-sm font-semibold truncate ${accent.text}`}>
                         {label}
                     </span>
-                    <span className="flex-1 h-px bg-gray-200" />
                     {!isDefault && (
                         <>
                             <button
                                 type="button"
                                 onClick={() => { setDraft(label); setEditing(true) }}
                                 aria-label={`Rename section ${label}`}
-                                className="text-[11px] text-gray-400 hover:text-primary-600 px-1"
+                                className={`ml-auto text-[11px] px-1 ${accent.muted} hover:text-primary-700`}
                             >
                                 Rename
                             </button>
@@ -97,13 +107,13 @@ function SectionHeaderRow({ id, label, isDefault, onRename, onRemove }: {
                                 type="button"
                                 onClick={onRemove}
                                 aria-label={`Remove section ${label}`}
-                                className="text-[11px] text-gray-400 hover:text-red-600 px-1"
+                                className={`text-[11px] px-1 ${accent.muted} hover:text-red-600`}
                             >
                                 Remove
                             </button>
                         </>
                     )}
-                </>
+                </div>
             )}
         </div>
     )

--- a/src/edit-questions/item-sections.test.ts
+++ b/src/edit-questions/item-sections.test.ts
@@ -10,6 +10,7 @@ import {
     removeSection,
     sectionNamesIn,
     buildSectionSequence,
+    buildSectionGroups,
     applySectionLayout,
     sectionLabelAt,
     sectionLabelsIn,
@@ -186,6 +187,41 @@ describe('buildSectionSequence', () => {
         const sequence = buildSectionSequence(items, 'Essentials', [])
         expect(sequence.map(e => e.kind === 'header' ? `#${e.label}` : e.item.text))
             .toEqual(['#First aid', 'Plasters'])
+    })
+})
+
+describe('buildSectionGroups', () => {
+    it('gathers each section and its items', () => {
+        const items = [
+            item({ id: 'i1', text: 'Snacks' }),
+            item({ id: 'i2', text: 'Nappies', category: 'Baby' }),
+            item({ id: 'i3', text: 'Wipes', category: 'Baby' }),
+        ]
+        expect(buildSectionGroups(items, 'Essentials').map(g => [g.label, g.entries.map(e => e.item.text)]))
+            .toEqual([['Essentials', ['Snacks']], ['Baby', ['Nappies', 'Wipes']]])
+    })
+
+    it('keeps each item pointing at its place in the flat array', () => {
+        // Sections group by category, so the last row on screen need not be the
+        // last item in the array. Addressing an edit by what the eye sees would
+        // change the wrong item.
+        const items = [
+            item({ id: 'i1', text: 'Nappies', category: 'Baby' }),
+            item({ id: 'i2', text: 'Snacks' }),
+            item({ id: 'i3', text: 'Wipes', category: 'Baby' }),
+        ]
+        expect(buildSectionGroups(items, 'Essentials').map(g => g.entries.map(e => e.index)))
+            .toEqual([[1], [0, 2]])
+    })
+
+    it('returns a single group for a list nobody has split up', () => {
+        const groups = buildSectionGroups([item({ id: 'i1', text: 'Snacks' })], 'Essentials')
+        expect(groups).toHaveLength(1)
+        expect(groups[0].label).toBe('Essentials')
+    })
+
+    it('has no groups at all for an empty list', () => {
+        expect(buildSectionGroups([], 'Essentials')).toEqual([])
     })
 })
 

--- a/src/edit-questions/item-sections.ts
+++ b/src/edit-questions/item-sections.ts
@@ -149,6 +149,40 @@ export function buildSectionSequence(
         ])
 }
 
+/** An item together with its position in the flat list every edit addresses. */
+export interface PositionedItem {
+    item: Item
+    index: number
+}
+
+/** One section and its items, in display order. */
+export interface SectionGroup {
+    label: string
+    entries: PositionedItem[]
+}
+
+/**
+ * The display sequence gathered back up into sections, for views that draw a
+ * section as a container rather than as a heading followed by loose rows.
+ *
+ * Each item keeps its index in `items`, because sections group by category
+ * while every per-item handler addresses the flat array — the two orders differ,
+ * so the index has to be carried rather than recomputed from the position on
+ * screen. Drafts aren't accepted: an empty section only exists inside the
+ * reorder view, which works against the sequence directly.
+ */
+export function buildSectionGroups(items: Item[], defaultLabel: string): SectionGroup[] {
+    const indexOf = new Map(items.map((item, i) => [item, i]))
+    const groups: SectionGroup[] = []
+    for (const entry of buildSectionSequence(items, defaultLabel, [])) {
+        if (entry.kind === 'header') groups.push({ label: entry.label, entries: [] })
+        // The sequence always opens with a header, so there is a group to put
+        // this in — but a stray item is dropped rather than crashing a page.
+        else groups[groups.length - 1]?.entries.push({ item: entry.item, index: indexOf.get(entry.item)! })
+    }
+    return groups
+}
+
 /**
  * Turn a dragged sequence back into a flat item list, stamping each item with
  * the nearest header above it. Items under the default header (or above the

--- a/src/edit-questions/section-accent.test.ts
+++ b/src/edit-questions/section-accent.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { SECTION_ACCENTS, DEFAULT_SECTION_ACCENT, sectionAccent } from './section-accent'
+
+describe('sectionAccent', () => {
+    it('gives the same section the same colour everywhere', () => {
+        // The whole point: "Toiletries" under one option must look like
+        // "Toiletries" under another, so the eye can follow it down the page.
+        expect(sectionAccent('Toiletries', false)).toBe(sectionAccent('Toiletries', false))
+    })
+
+    it('gives the default section a neutral accent, whatever it is called', () => {
+        // Colour means "a section someone named". The default section is just
+        // the main pile, so it must not compete for attention.
+        expect(sectionAccent('Yes', true)).toBe(DEFAULT_SECTION_ACCENT)
+        expect(sectionAccent('Toiletries', true)).toBe(DEFAULT_SECTION_ACCENT)
+    })
+
+    it('never hands a named section the neutral accent', () => {
+        for (const label of ['Toiletries', 'Clothes', 'Kit & Gear', '', 'ẞ']) {
+            expect(sectionAccent(label, false)).not.toBe(DEFAULT_SECTION_ACCENT)
+        }
+    })
+
+    it('spreads the built-in section names across the palette', () => {
+        // Sections that sit next to each other should mostly differ. Collisions
+        // are unavoidable with a fixed palette; a heavily bunched hash is not.
+        const labels = ['Documents & Money', 'Medicines & First Aid', 'Tech & Chargers',
+            'Toiletries', 'Clothes', 'Sleep & Comfort', 'Toys & Games', 'Food & Kitchen']
+        const distinct = new Set(labels.map(l => sectionAccent(l, false)))
+        expect(distinct.size).toBeGreaterThanOrEqual(SECTION_ACCENTS.length - 2)
+    })
+
+    it('keeps every palette entry a complete set of classes', () => {
+        // Tailwind only emits classes it can see spelled out, so these are
+        // literals rather than something built from a colour name.
+        for (const accent of [...SECTION_ACCENTS, DEFAULT_SECTION_ACCENT]) {
+            expect(accent.border).toMatch(/^border-/)
+            expect(accent.header).toMatch(/^bg-/)
+            expect(accent.text).toMatch(/^text-/)
+            expect(accent.muted).toMatch(/^text-/)
+            expect(accent.rail).toMatch(/^bg-/)
+        }
+    })
+})

--- a/src/edit-questions/section-accent.ts
+++ b/src/edit-questions/section-accent.ts
@@ -1,0 +1,74 @@
+/**
+ * Colours for the section headings in the questions editor.
+ *
+ * Sections used to be a line of 11px grey capitals with a hairline beside it,
+ * which is roughly how you'd style a caption you wanted people to skip. A
+ * section is the thing that decides how the packing list is grouped, so it gets
+ * a card of its own with a coloured heading strip instead.
+ *
+ * The colour is derived from the section *name*, not its position, so
+ * "Toiletries" is the same colour under every option and in every list. That's
+ * what makes the grouping legible at a glance across a long page — you learn a
+ * section by its colour and can then follow it without reading. A fixed palette
+ * means two names can collide; that costs nothing, because colour here is a
+ * grouping cue on top of a heading that already says the name.
+ *
+ * Every class is written out in full: Tailwind scans source text, so a class
+ * assembled from a colour variable would simply not exist at runtime.
+ */
+
+export interface SectionAccent {
+    /** Card outline. */
+    border: string
+    /** Heading strip fill. */
+    header: string
+    /** Heading text on that fill. */
+    text: string
+    /** Secondary text on that fill — the item count. */
+    muted: string
+    /** Solid marker, used where a heading stands alone rather than atop a card. */
+    rail: string
+}
+
+/**
+ * Deliberately avoids blue and emerald: those already mean "shared" and "per
+ * night" on the item badges inside these very lists, and a section heading in
+ * the same colour would suggest a link that isn't there.
+ */
+export const SECTION_ACCENTS: readonly SectionAccent[] = [
+    { border: 'border-violet-200', header: 'bg-violet-50', text: 'text-violet-900', muted: 'text-violet-500', rail: 'bg-violet-400' },
+    { border: 'border-amber-200', header: 'bg-amber-50', text: 'text-amber-900', muted: 'text-amber-600', rail: 'bg-amber-400' },
+    { border: 'border-rose-200', header: 'bg-rose-50', text: 'text-rose-900', muted: 'text-rose-500', rail: 'bg-rose-400' },
+    { border: 'border-cyan-200', header: 'bg-cyan-50', text: 'text-cyan-900', muted: 'text-cyan-600', rail: 'bg-cyan-400' },
+    { border: 'border-lime-200', header: 'bg-lime-50', text: 'text-lime-900', muted: 'text-lime-600', rail: 'bg-lime-500' },
+    { border: 'border-fuchsia-200', header: 'bg-fuchsia-50', text: 'text-fuchsia-900', muted: 'text-fuchsia-500', rail: 'bg-fuchsia-400' },
+    { border: 'border-indigo-200', header: 'bg-indigo-50', text: 'text-indigo-900', muted: 'text-indigo-500', rail: 'bg-indigo-400' },
+    { border: 'border-orange-200', header: 'bg-orange-50', text: 'text-orange-900', muted: 'text-orange-600', rail: 'bg-orange-400' },
+]
+
+/**
+ * The default section — the option's or question's own name — is the main pile
+ * rather than something the user chose to separate out, so it stays neutral.
+ * That way colour on this page always means "someone named this group".
+ */
+export const DEFAULT_SECTION_ACCENT: SectionAccent = {
+    border: 'border-gray-200',
+    header: 'bg-gray-100',
+    text: 'text-gray-700',
+    muted: 'text-gray-400',
+    rail: 'bg-gray-300',
+}
+
+/** Plain string hash — stable across reloads, machines and stored data. */
+function hashLabel(label: string): number {
+    let hash = 0
+    for (let i = 0; i < label.length; i++) {
+        hash = (hash * 31 + label.charCodeAt(i)) | 0
+    }
+    return Math.abs(hash)
+}
+
+export function sectionAccent(label: string, isDefault: boolean): SectionAccent {
+    if (isDefault) return DEFAULT_SECTION_ACCENT
+    return SECTION_ACCENTS[hashLabel(label) % SECTION_ACCENTS.length]
+}

--- a/src/pages/questions-page.option-section.test.tsx
+++ b/src/pages/questions-page.option-section.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, within } from '@testing-library/react'
 import React from 'react'
 import { OptionSection } from './questions-page'
+import { DEFAULT_SECTION_ACCENT, sectionAccent } from '../edit-questions/section-accent'
 import type { Item, Option, Person } from '../edit-questions/types'
 
 vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
@@ -95,6 +96,14 @@ describe('OptionSection with items', () => {
         // a section heading when the list isn't actually split.
         expect(screen.queryByTestId('item-section-heading')).toBeNull()
     })
+
+    it('wraps nothing in a section card when the list is not split', () => {
+        // A single-section list has no grouping to show, so the cards would be
+        // decoration around the whole thing.
+        renderOption(withItems())
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        expect(screen.queryByTestId('item-section')).toBeNull()
+    })
 })
 
 describe('OptionSection with sectioned items', () => {
@@ -118,6 +127,43 @@ describe('OptionSection with sectioned items', () => {
         renderOption(sectioned(), 'Staying overnight?')
         fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
         expect(screen.getAllByTestId('item-section-heading')[0].textContent).toBe('Staying overnight?')
+    })
+
+    it('puts each section in its own card, with its items inside it', () => {
+        // A heading with a hairline beside it left every item looking like it
+        // belonged to the same undifferentiated list; the card is what makes
+        // "these three items are the Toiletries" visible without reading.
+        renderOption(sectioned())
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        const cards = screen.getAllByTestId('item-section')
+        expect(cards).toHaveLength(3)
+        expect(within(cards[1]).getByTestId('item-section-heading').textContent).toBe('Toiletries')
+        expect(within(cards[1]).getByText('Toothbrush')).toBeTruthy()
+        expect(within(cards[1]).queryByText('Socks')).toBeNull()
+    })
+
+    it('counts the items in each section', () => {
+        renderOption(makeOption({
+            items: [
+                { text: 'Socks', personSelections: [] },
+                { text: 'Toothbrush', personSelections: [], category: 'Toiletries' },
+                { text: 'Toothpaste', personSelections: [], category: 'Toiletries' },
+            ],
+        }))
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        const counts = screen.getAllByTestId('item-section-count').map(c => c.textContent)
+        expect(counts).toEqual(['1 item', '2 items'])
+    })
+
+    it('colours named sections and leaves the default one neutral', () => {
+        // Colour is the cue that carries across options: the same section name
+        // looks the same wherever it appears, and the main pile stays quiet.
+        renderOption(sectioned())
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        const cards = screen.getAllByTestId('item-section')
+        expect(cards[0].className).toContain(DEFAULT_SECTION_ACCENT.border)
+        expect(cards[1].className).toContain(sectionAccent('Toiletries', false).border)
+        expect(cards[2].className).toContain(sectionAccent('Sleep', false).border)
     })
 })
 

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useCallback, useRef, useMemo, memo, Fragment } fro
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useDatabase } from '../components/DatabaseContext'
 import { SectionedItemReorder } from '../components/SectionedItemReorder'
-import { ALWAYS_NEEDED_CATEGORY, buildSectionSequence, defaultCategoryFor, sectionNamesIn } from '../edit-questions/item-sections'
+import { ALWAYS_NEEDED_CATEGORY, buildSectionGroups, defaultCategoryFor, sectionNamesIn, type PositionedItem } from '../edit-questions/item-sections'
+import { sectionAccent } from '../edit-questions/section-accent'
 import { DatabaseMigration } from '../services/migration'
 import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, newDraftQuestion, renumberItemOrder, AGE_RANGE_OPTIONS } from '../edit-questions/types'
 import { Link } from 'react-router-dom'
@@ -158,8 +159,12 @@ const ItemRow = memo(function ItemRow({ item, people, index, isOpen, onOpen }: {
 /**
  * Read-only item list, split by section the same way the editor and the
  * generated packing list are — so this page shows the grouping a list will
- * actually have without opening a modal. Headings only appear once a list is
- * genuinely split; an unsectioned list renders exactly as it did before.
+ * actually have without opening a modal.
+ *
+ * Each section is a card with a coloured heading strip (see `section-accent`):
+ * a run of items under a line of grey capitals read as one undivided list, and
+ * the grouping is the whole point of the page. Cards only appear once a list is
+ * genuinely split; an unsectioned list renders as plain rows, as it did before.
  */
 const SectionedItemRows = memo(function SectionedItemRows({ items, people, defaultLabel, allItemNames = NO_NAMES, sectionNames = NO_NAMES, onItemChange }: {
     items: Item[]
@@ -175,18 +180,8 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
     // costs more than one mounted editor.
     const [openIndex, setOpenIndex] = useState<number | null>(null)
 
-    // Each entry keeps its flat array index, which is what `applyItemEdit`
-    // addresses. Sections group by category, not by array position, so the two
-    // orders differ and the index has to be carried rather than recomputed.
-    const sequence = useMemo(() => {
-        const indexOf = new Map(items.map((item, i) => [item, i]))
-        return buildSectionSequence(items, defaultLabel, [])
-            .map(entry => entry.kind === 'header'
-                ? { kind: 'header' as const, label: entry.label }
-                : { kind: 'item' as const, item: entry.item, index: indexOf.get(entry.item)! })
-    }, [items, defaultLabel])
-
-    const hasSections = sequence.filter(e => e.kind === 'header').length > 1
+    const groups = useMemo(() => buildSectionGroups(items, defaultLabel), [items, defaultLabel])
+    const hasSections = groups.length > 1
     // A sync or a delete can shrink the list under an open row; treat an index
     // that no longer exists as closed rather than rendering against undefined.
     const openAt = openIndex !== null && openIndex < items.length ? openIndex : null
@@ -209,43 +204,62 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
         if ((edited.category ?? null) !== (before.category ?? null)) setOpenIndex(null)
     }, [openAt, items, onItemChange])
 
+    const renderRow = (entry: PositionedItem) => (
+        <Fragment key={`item-${entry.index}`}>
+            <ItemRow
+                item={entry.item}
+                people={people}
+                index={entry.index}
+                isOpen={openAt === entry.index}
+                onOpen={onItemChange ? handleOpen : undefined}
+            />
+            {openAt === entry.index && (
+                <ItemInlineEditor
+                    item={entry.item}
+                    people={people}
+                    allItemNames={allItemNames}
+                    sectionNames={sectionNames}
+                    sectionDefaultLabel={defaultLabel}
+                    onChange={handleChange}
+                    onClose={handleClose}
+                />
+            )}
+        </Fragment>
+    )
+
+    if (!hasSections) {
+        return <div className="space-y-0.5">{groups.flatMap(group => group.entries).map(renderRow)}</div>
+    }
+
     return (
-        <>
-            {sequence.map(entry => entry.kind === 'header' ? (
-                hasSections && (
-                    <div key={`header-${entry.label}`} className="flex items-center gap-2 pt-2 pb-0.5 px-2">
-                        <span
-                            data-testid="item-section-heading"
-                            className="text-[11px] font-semibold text-gray-400 uppercase tracking-wide truncate"
-                        >
-                            {entry.label}
-                        </span>
-                        <span className="flex-1 h-px bg-gray-100" />
+        <div className="space-y-2">
+            {groups.map(group => {
+                const accent = sectionAccent(group.label, group.label === defaultLabel)
+                return (
+                    <div
+                        key={`section-${group.label}`}
+                        data-testid="item-section"
+                        className={`rounded-lg border ${accent.border} bg-white overflow-hidden`}
+                    >
+                        <div className={`flex items-center gap-2 px-2.5 py-1.5 ${accent.header}`}>
+                            <span
+                                data-testid="item-section-heading"
+                                className={`text-sm font-semibold ${accent.text} truncate`}
+                            >
+                                {group.label}
+                            </span>
+                            <span
+                                data-testid="item-section-count"
+                                className={`ml-auto shrink-0 text-[11px] font-medium ${accent.muted}`}
+                            >
+                                {group.entries.length} item{group.entries.length === 1 ? '' : 's'}
+                            </span>
+                        </div>
+                        <div className="p-1 space-y-0.5">{group.entries.map(renderRow)}</div>
                     </div>
                 )
-            ) : (
-                <Fragment key={`item-${entry.index}`}>
-                    <ItemRow
-                        item={entry.item}
-                        people={people}
-                        index={entry.index}
-                        isOpen={openAt === entry.index}
-                        onOpen={onItemChange ? handleOpen : undefined}
-                    />
-                    {openAt === entry.index && (
-                        <ItemInlineEditor
-                            item={entry.item}
-                            people={people}
-                            allItemNames={allItemNames}
-                            sectionNames={sectionNames}
-                            sectionDefaultLabel={defaultLabel}
-                            onChange={handleChange}
-                            onClose={handleClose}
-                        />
-                    )}
-                </Fragment>
-            ))}
-        </>
+            })}
+        </div>
     )
 })
 
@@ -394,7 +408,7 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
                 </div>
             </div>
             {hasExpandedRef.current && (
-                <div className={`space-y-0.5${isExpanded ? '' : ' hidden'}`}>
+                <div className={isExpanded ? undefined : 'hidden'}>
                     <SectionedItemRows
                         items={option.items}
                         people={people}
@@ -698,7 +712,7 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, allItemNames,
                 </button>
             </div>
             {hasExpandedRef.current && (
-                <div className={`mt-3 space-y-1${isExpanded ? '' : ' hidden'}`}>
+                <div className={`mt-3${isExpanded ? '' : ' hidden'}`}>
                     <SectionedItemRows
                         items={items}
                         people={people}
@@ -935,20 +949,33 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, sectionDefault
     const canReorder = items.length > 1
     const inReorder = reorderMode && canReorder
 
-    // Normal editing mode shows the same section headings as the reorder view,
-    // read-only, so the editor always previews how the packing list will group
-    // these items. Each entry keeps its flat array index, which is what every
-    // per-item handler addresses.
-    const editorSequence = useMemo(() => {
-        const indexOf = new Map(items.map((item, i) => [item, i]))
-        return buildSectionSequence(items, sectionDefaultLabel, [])
-            .map(entry => entry.kind === 'header'
-                ? { kind: 'header' as const, label: entry.label }
-                : { kind: 'item' as const, item: entry.item, index: indexOf.get(entry.item)! })
-    }, [items, sectionDefaultLabel])
+    // Normal editing mode shows the same section cards as the read-only list on
+    // the page behind, so the editor always previews how the packing list will
+    // group these items — and the same section is the same colour in both.
+    const groups = useMemo(() => buildSectionGroups(items, sectionDefaultLabel), [items, sectionDefaultLabel])
 
-    // Only worth showing headings once the list is actually split.
-    const hasSections = editorSequence.filter(e => e.kind === 'header').length > 1
+    // Only worth drawing the cards once the list is actually split.
+    const hasSections = groups.length > 1
+
+    const renderRow = (entry: PositionedItem) => (
+        <ItemEditorRow
+            key={`item-${entry.index}`}
+            item={entry.item}
+            itemIdx={entry.index}
+            people={people}
+            allItemNames={allItemNames}
+            isDesktop={isDesktop}
+            quantityOpen={openQuantityIdx === entry.index}
+            onToggleQuantity={toggleQuantity}
+            updateItemText={updateItemText}
+            togglePerson={togglePerson}
+            toggleCommunal={toggleCommunal}
+            updatePerNight={updatePerNight}
+            updatePerNights={updatePerNights}
+            updateMaxQuantity={updateMaxQuantity}
+            removeItem={removeItem}
+        />
+    )
 
     return (
         <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
@@ -970,8 +997,8 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, sectionDefault
                     )}
                 </div>
             )}
-            <div className="space-y-2">
-                {inReorder && (
+            {inReorder && (
+                <div className="space-y-2">
                     <SectionedItemReorder
                         items={items}
                         defaultLabel={sectionDefaultLabel}
@@ -979,36 +1006,37 @@ function ItemListEditor({ items, people, allItemNames, scrollRef, sectionDefault
                         scrollRef={scrollRef}
                         onChange={replaceItems}
                     />
-                )}
-                {!inReorder && editorSequence.map(entry => entry.kind === 'header' ? (
-                    hasSections && (
-                        <div key={`header-${entry.label}`} className="flex items-center gap-2 pt-3 pb-1">
-                            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide truncate">
-                                {entry.label}
-                            </span>
-                            <span className="flex-1 h-px bg-gray-200" />
-                        </div>
-                    )
-                ) : (
-                    <ItemEditorRow
-                        key={`item-${entry.index}`}
-                        item={entry.item}
-                        itemIdx={entry.index}
-                        people={people}
-                        allItemNames={allItemNames}
-                        isDesktop={isDesktop}
-                        quantityOpen={openQuantityIdx === entry.index}
-                        onToggleQuantity={toggleQuantity}
-                        updateItemText={updateItemText}
-                        togglePerson={togglePerson}
-                        toggleCommunal={toggleCommunal}
-                        updatePerNight={updatePerNight}
-                        updatePerNights={updatePerNights}
-                        updateMaxQuantity={updateMaxQuantity}
-                        removeItem={removeItem}
-                    />
-                ))}
-            </div>
+                </div>
+            )}
+            {!inReorder && !hasSections && (
+                <div className="space-y-2">
+                    {groups.flatMap(group => group.entries).map(renderRow)}
+                </div>
+            )}
+            {!inReorder && hasSections && (
+                <div className="space-y-3">
+                    {groups.map(group => {
+                        const accent = sectionAccent(group.label, group.label === sectionDefaultLabel)
+                        return (
+                            <div
+                                key={`section-${group.label}`}
+                                data-testid="editor-item-section"
+                                className={`rounded-lg border ${accent.border} overflow-hidden`}
+                            >
+                                <div className={`flex items-center gap-2 px-3 py-2 ${accent.header}`}>
+                                    <span className={`text-sm font-semibold ${accent.text} truncate`}>
+                                        {group.label}
+                                    </span>
+                                    <span className={`ml-auto shrink-0 text-[11px] font-medium ${accent.muted}`}>
+                                        {group.entries.length} item{group.entries.length === 1 ? '' : 's'}
+                                    </span>
+                                </div>
+                                <div className="p-2 space-y-2">{group.entries.map(renderRow)}</div>
+                            </div>
+                        )
+                    })}
+                </div>
+            )}
             {!inReorder && (
                 <button
                     type="button"


### PR DESCRIPTION
Sections were a line of 11px grey capitals with a hairline beside it, so
the items under one heading ran into the items under the next and the
grouping — the thing that decides how a packing list is laid out — was
invisible unless you stopped to read.

Each section is now a card with a coloured heading strip, sized like a
heading rather than a caption, with its item count on the right. The
colour comes from the section's *name*, so "Toiletries" is the same
colour under every option, in the editor modal and in the reorder view:
you learn a section by its colour and can then follow it down a long page
without reading. The default section (the option's or question's own
name) stays neutral grey, so colour always means "someone named this
group". Lists nobody has split still render as plain rows.

The reorder view keeps its flat sortable list — wrapping items in cards
would break dragging across headings — and instead draws each heading as
a filled bar in the section's colour, which is also the drop target.

Both views were building the same section-and-index structure inline;
that is now `buildSectionGroups` alongside the sequence it is built from.