### PR TITLE
Add items where they belong, in one step

### DIFF
--- a/src/components/AddItemComposer.test.tsx
+++ b/src/components/AddItemComposer.test.tsx
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { AddItemComposer } from './AddItemComposer'
+import { buildSuggestionIndex } from '../utils/itemSuggestions'
+import type { PackingListItem } from '../create-packing-list/types'
+
+const mk = (over: Partial<PackingListItem>): PackingListItem => ({
+    id: Math.random().toString(36).slice(2),
+    itemText: 'Item',
+    personId: 'p1',
+    personName: 'Alice',
+    questionId: '',
+    optionId: '',
+    packed: false,
+    ...over,
+})
+
+const emptyIndex = buildSuggestionIndex([])
+
+function renderComposer(props: Partial<React.ComponentProps<typeof AddItemComposer>> = {}) {
+    const onAdd = vi.fn()
+    render(
+        <AddItemComposer
+            personName="Alice"
+            personId="p1"
+            suggestions={emptyIndex}
+            targetLabel="Alice"
+            onAdd={onAdd}
+            {...props}
+        />
+    )
+    return { onAdd, input: screen.getByPlaceholderText('Add new item...') as HTMLInputElement }
+}
+
+describe('AddItemComposer', () => {
+    it('adds the typed item to its target on Enter', () => {
+        const { onAdd, input } = renderComposer({ category: 'Toiletries' })
+        fireEvent.change(input, { target: { value: 'Sun cream' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith(
+            { personName: 'Alice', personId: 'p1', communal: undefined, category: 'Toiletries' },
+            'Sun cream',
+            undefined,
+        )
+    })
+
+    it('adds on the Add button too', () => {
+        const { onAdd, input } = renderComposer()
+        fireEvent.change(input, { target: { value: 'Sun cream' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+        expect(onAdd).toHaveBeenCalled()
+    })
+
+    it('clears the field afterwards so the next item can be typed straight away', () => {
+        const { input } = renderComposer()
+        fireEvent.change(input, { target: { value: 'Sun cream' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(input.value).toBe('')
+    })
+
+    it('ignores an empty or blank name', () => {
+        const { onAdd, input } = renderComposer()
+        fireEvent.change(input, { target: { value: '   ' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).not.toHaveBeenCalled()
+    })
+
+    it('passes a quantity when one is given', () => {
+        const { onAdd, input } = renderComposer()
+        fireEvent.change(input, { target: { value: 'Socks' } })
+        fireEvent.change(screen.getByLabelText('Quantity'), { target: { value: '3' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith(expect.anything(), 'Socks', 3)
+    })
+
+    it('marks communal items as shared', () => {
+        const { onAdd, input } = renderComposer({ personName: '', personId: '', communal: true })
+        fireEvent.change(input, { target: { value: 'Tent' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith(
+            expect.objectContaining({ communal: true, personName: '' }),
+            'Tent',
+            undefined,
+        )
+    })
+})
+
+describe('AddItemComposer: choosing a section', () => {
+    const categoryOptions = ['Toiletries', 'Clothes', 'Other']
+
+    it('has no section picker when the section is already decided', () => {
+        const { input } = renderComposer({ category: 'Clothes' })
+        fireEvent.change(input, { target: { value: 'Sun cream' } })
+        expect(screen.queryByLabelText('Section')).toBeNull()
+    })
+
+    it('keeps out of the way until there is an item to file', () => {
+        const { input } = renderComposer({ categoryOptions })
+        expect(screen.queryByLabelText('Section')).toBeNull()
+        expect(screen.queryByLabelText('Quantity')).toBeNull()
+        fireEvent.change(input, { target: { value: 'S' } })
+        expect(screen.getByLabelText('Section')).toBeTruthy()
+        expect(screen.getByLabelText('Quantity')).toBeTruthy()
+    })
+
+    it('files the item under the chosen section', () => {
+        const { onAdd, input } = renderComposer({ categoryOptions })
+        fireEvent.change(input, { target: { value: 'Sun cream' } })
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Toiletries' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith(
+            expect.objectContaining({ category: 'Toiletries' }),
+            'Sun cream',
+            undefined,
+        )
+    })
+
+    it('treats the catch-all section as no section at all', () => {
+        const { onAdd, input } = renderComposer({ categoryOptions, category: 'Clothes' })
+        fireEvent.change(input, { target: { value: 'Odds and ends' } })
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Other' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith(
+            expect.objectContaining({ category: undefined }),
+            'Odds and ends',
+            undefined,
+        )
+    })
+
+    it('keeps the chosen section for the next item', () => {
+        const { onAdd, input } = renderComposer({ categoryOptions })
+        fireEvent.change(input, { target: { value: 'Sun cream' } })
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Toiletries' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        fireEvent.change(input, { target: { value: 'Shampoo' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenLastCalledWith(
+            expect.objectContaining({ category: 'Toiletries' }),
+            'Shampoo',
+            undefined,
+        )
+    })
+})
+
+describe('AddItemComposer: choosing who it is for', () => {
+    const peopleOptions = [{ name: 'Alice', id: 'p1' }, { name: 'Bob', id: 'p2' }]
+
+    it('has no person picker when there is only one place it can go', () => {
+        const { input } = renderComposer()
+        fireEvent.change(input, { target: { value: 'Sun cream' } })
+        expect(screen.queryByLabelText('Who for')).toBeNull()
+    })
+
+    it('adds the item for the chosen person', () => {
+        const { onAdd, input } = renderComposer({ peopleOptions })
+        fireEvent.change(input, { target: { value: 'Sun cream' } })
+        fireEvent.change(screen.getByLabelText('Who for'), { target: { value: 'Bob' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith(
+            expect.objectContaining({ personName: 'Bob', personId: 'p2' }),
+            'Sun cream',
+            undefined,
+        )
+    })
+})
+
+describe('AddItemComposer: suggestions', () => {
+    const suggestions = buildSuggestionIndex([
+        mk({ itemText: 'Sun cream', personName: 'Bob', category: 'Toiletries' }),
+        mk({ itemText: 'Sunhat', personName: 'Bob', category: 'Clothes' }),
+    ])
+
+    it('offers matching names once something is typed', () => {
+        const { input } = renderComposer({ suggestions })
+        expect(screen.queryByRole('listbox')).toBeNull()
+        fireEvent.change(input, { target: { value: 'sun' } })
+        expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual([
+            'Sun creamToiletries',
+            'SunhatClothes',
+        ])
+    })
+
+    it('fills in the name and its section when one is picked', () => {
+        const { onAdd, input } = renderComposer({
+            suggestions,
+            categoryOptions: ['Toiletries', 'Clothes', 'Other'],
+        })
+        fireEvent.change(input, { target: { value: 'sunh' } })
+        fireEvent.click(screen.getByRole('option', { name: /Sunhat/ }))
+        expect(input.value).toBe('Sunhat')
+        expect((screen.getByLabelText('Section') as HTMLSelectElement).value).toBe('Clothes')
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith(
+            expect.objectContaining({ category: 'Clothes' }),
+            'Sunhat',
+            undefined,
+        )
+    })
+
+    it('adds a highlighted suggestion on Enter rather than the raw text', () => {
+        const { onAdd, input } = renderComposer({ suggestions })
+        fireEvent.change(input, { target: { value: 'sunh' } })
+        fireEvent.keyDown(input, { key: 'ArrowDown' })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(input.value).toBe('Sunhat')
+        expect(onAdd).not.toHaveBeenCalled()
+    })
+
+    it('closes the suggestions on Escape without closing the composer', () => {
+        const onClose = vi.fn()
+        const { input } = renderComposer({ suggestions, onClose })
+        fireEvent.change(input, { target: { value: 'sun' } })
+        fireEvent.keyDown(input, { key: 'Escape' })
+        expect(screen.queryByRole('listbox')).toBeNull()
+        expect(onClose).not.toHaveBeenCalled()
+    })
+})
+
+describe('AddItemComposer: opened in place', () => {
+    it('closes on Escape when there is nothing to dismiss first', () => {
+        const onClose = vi.fn()
+        const { input } = renderComposer({ onClose })
+        fireEvent.keyDown(input, { key: 'Escape' })
+        expect(onClose).toHaveBeenCalled()
+    })
+
+    it('closes when focus leaves an empty composer', () => {
+        const onClose = vi.fn()
+        renderComposer({ onClose })
+        fireEvent.blur(screen.getByTestId('add-item-composer'))
+        expect(onClose).toHaveBeenCalled()
+    })
+
+    it('stays open when focus leaves a half-typed item', () => {
+        const onClose = vi.fn()
+        const { input } = renderComposer({ onClose })
+        fireEvent.change(input, { target: { value: 'Sun cr' } })
+        fireEvent.blur(screen.getByTestId('add-item-composer'))
+        expect(onClose).not.toHaveBeenCalled()
+    })
+})

--- a/src/components/AddItemComposer.tsx
+++ b/src/components/AddItemComposer.tsx
@@ -1,0 +1,293 @@
+/**
+ * The one way items get added to a packing list.
+ *
+ * Three things made adding an item harder than it should be, and this component
+ * exists to fix all three:
+ *
+ *  - *Where it lands.* A typed item used to fall into "Other" whatever card you
+ *    typed it into, so adding to a particular section was impossible. Here the
+ *    section is either fixed by where the composer was opened (a section's own
+ *    ＋ button) or picked from a dropdown, and it is stamped onto the item.
+ *  - *How much typing.* The list is its own dictionary — see `itemSuggestions` —
+ *    so a match carries its section across and the quantity is set here rather
+ *    than in a second trip through the item editor.
+ *  - *What it costs to type.* The draft lives in this component. The page used
+ *    to hold every add-input's text in one page-level object, so a keystroke in
+ *    any of them re-rendered every card and every row of the list. Memoised and
+ *    self-contained, a keystroke now re-renders one composer.
+ *
+ * Adding keeps the composer open, focused and cleared, with the section and
+ * person still selected, because people add items in runs rather than one at a
+ * time.
+ */
+import { memo, useMemo, useRef, useState } from 'react'
+import { ownerKeyFor, suggestFor, type ItemSuggestion, type SuggestionIndex } from '../utils/itemSuggestions'
+
+/** What the packing list calls the section for items with no category. */
+export const UNCATEGORISED_LABEL = 'Other'
+
+export interface AddItemTarget {
+    personName: string
+    personId: string
+    communal?: boolean
+    /** undefined = the catch-all section */
+    category?: string
+}
+
+export interface PersonOption {
+    name: string
+    id: string
+}
+
+interface AddItemComposerProps {
+    /** Who the item is for, unless `peopleOptions` offers a choice. */
+    personName: string
+    personId: string
+    communal?: boolean
+    /** Section the item lands in, and the initial value of the section picker. */
+    category?: string
+    /** Providing these turns on the section picker. */
+    categoryOptions?: readonly string[]
+    /** Providing these turns on the person picker. */
+    peopleOptions?: readonly PersonOption[]
+    suggestions: SuggestionIndex
+    /** Names the composer for screen readers, e.g. "Alice" or "Toiletries for Alice". */
+    targetLabel: string
+    onAdd: (target: AddItemTarget, text: string, quantity?: number) => void
+    /** Set on composers opened in place, which dismiss on Escape or empty blur. */
+    onClose?: () => void
+    autoFocus?: boolean
+    placeholder?: string
+}
+
+const FIELD = 'px-3 py-2 border border-gray-300 rounded-md bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500'
+
+export const AddItemComposer = memo(function AddItemComposer({
+    personName,
+    personId,
+    communal,
+    category,
+    categoryOptions,
+    peopleOptions,
+    suggestions,
+    targetLabel,
+    onAdd,
+    onClose,
+    autoFocus,
+    placeholder = 'Add new item...',
+}: AddItemComposerProps) {
+    const [text, setText] = useState('')
+    const [quantity, setQuantity] = useState('')
+    const [chosenCategory, setChosenCategory] = useState(category ?? UNCATEGORISED_LABEL)
+    // Held by name, not id: custom items carry no person id, so a name is the
+    // only thing that identifies a person on every list.
+    const [chosenPersonName, setChosenPersonName] = useState(personName)
+    const [highlighted, setHighlighted] = useState(-1)
+    const [suggestionsOpen, setSuggestionsOpen] = useState(true)
+    const inputRef = useRef<HTMLInputElement>(null)
+
+    const person: PersonOption = peopleOptions?.find(p => p.name === chosenPersonName)
+        ?? peopleOptions?.[0]
+        ?? { name: personName, id: personId }
+
+    const target: AddItemTarget = {
+        personName: communal ? '' : person.name,
+        personId: communal ? '' : person.id,
+        communal,
+        category: categoryOptions
+            ? (chosenCategory === UNCATEGORISED_LABEL ? undefined : chosenCategory)
+            : category,
+    }
+
+    const ownerKey = ownerKeyFor(target)
+    const matches = useMemo(
+        () => suggestionsOpen ? suggestFor(suggestions, ownerKey, text) : [],
+        [suggestions, ownerKey, text, suggestionsOpen],
+    )
+
+    const setDraft = (value: string) => {
+        setText(value)
+        setHighlighted(-1)
+        setSuggestionsOpen(true)
+    }
+
+    const applySuggestion = (suggestion: ItemSuggestion) => {
+        setText(suggestion.text)
+        setSuggestionsOpen(false)
+        setHighlighted(-1)
+        // A suggestion knows where it belongs; taking its section is the whole
+        // point of offering it. Only meaningful when a section can be chosen —
+        // an in-place composer already has one.
+        if (categoryOptions && suggestion.category && categoryOptions.includes(suggestion.category)) {
+            setChosenCategory(suggestion.category)
+        }
+        inputRef.current?.focus()
+    }
+
+    const submit = () => {
+        const trimmed = text.trim()
+        if (!trimmed) return
+        const parsed = parseInt(quantity, 10)
+        onAdd(target, trimmed, Number.isFinite(parsed) && parsed > 1 ? parsed : undefined)
+        setText('')
+        setQuantity('')
+        setHighlighted(-1)
+        setSuggestionsOpen(true)
+        inputRef.current?.focus()
+    }
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'ArrowDown' && matches.length > 0) {
+            e.preventDefault()
+            setHighlighted(prev => (prev + 1) % matches.length)
+            return
+        }
+        if (e.key === 'ArrowUp' && matches.length > 0) {
+            e.preventDefault()
+            setHighlighted(prev => (prev <= 0 ? matches.length : prev) - 1)
+            return
+        }
+        if (e.key === 'Enter') {
+            e.preventDefault()
+            const picked = matches[highlighted]
+            if (picked) applySuggestion(picked)
+            else submit()
+            return
+        }
+        if (e.key === 'Escape') {
+            e.preventDefault()
+            // Escape backs out one layer at a time: the suggestions first, then
+            // the composer — so dismissing a dropdown never loses what was typed.
+            if (matches.length > 0) {
+                setSuggestionsOpen(false)
+                setHighlighted(-1)
+                return
+            }
+            onClose?.()
+        }
+    }
+
+    // An in-place composer that has been left empty has served its purpose; one
+    // with half an item in it has not, and must not take the draft with it.
+    const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+        if (e.currentTarget.contains(e.relatedTarget)) return
+        setSuggestionsOpen(false)
+        if (!text.trim()) onClose?.()
+    }
+
+    const listboxId = `add-item-suggestions-${personId || 'shared'}-${category ?? 'any'}`
+
+    // At rest a composer is a single field, exactly as light as the plain input
+    // it replaces — there is one on every card, and a card is mostly items. The
+    // quantity and the pickers earn their space only once there is an item to
+    // apply them to, which is also the first moment they can be answered.
+    const expanded = text.trim().length > 0
+
+    return (
+        <div
+            data-testid="add-item-composer"
+            onBlur={handleBlur}
+            className="flex flex-wrap items-center gap-2"
+        >
+            {/* At rest the name shares its line with Add, so a card carries no
+                more furniture than the plain input it replaces. Once the
+                quantity and pickers are in play the name takes the line to
+                itself and they wrap underneath — three fields abreast is
+                unusable on a phone, and it is where the suggestions drop. */}
+            <div className={`relative min-w-[8rem] ${expanded ? 'basis-full' : 'flex-1 basis-40'}`}>
+                <input
+                    ref={inputRef}
+                    type="text"
+                    role="combobox"
+                    aria-expanded={matches.length > 0}
+                    aria-controls={listboxId}
+                    aria-autocomplete="list"
+                    aria-label={`Add an item to ${targetLabel}`}
+                    autoComplete="off"
+                    enterKeyHint="done"
+                    value={text}
+                    autoFocus={autoFocus}
+                    onChange={e => setDraft(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder={placeholder}
+                    className={`w-full ${FIELD}`}
+                />
+                {matches.length > 0 && (
+                    <ul
+                        id={listboxId}
+                        role="listbox"
+                        className="absolute left-0 right-0 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+                    >
+                        {matches.map((suggestion, i) => (
+                            <li key={suggestion.text}>
+                                <button
+                                    type="button"
+                                    role="option"
+                                    aria-selected={i === highlighted}
+                                    // Blur would close the list before the click landed.
+                                    onMouseDown={e => e.preventDefault()}
+                                    onClick={() => applySuggestion(suggestion)}
+                                    className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm ${i === highlighted ? 'bg-blue-50 text-blue-900' : 'text-gray-700 hover:bg-gray-50'}`}
+                                >
+                                    <span className="truncate">{suggestion.text}</span>
+                                    {suggestion.category && (
+                                        <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[11px] text-gray-500">
+                                            {suggestion.category}
+                                        </span>
+                                    )}
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+
+            {expanded && <input
+                type="number"
+                min={1}
+                inputMode="numeric"
+                aria-label="Quantity"
+                title="How many to pack (leave blank for one)"
+                value={quantity}
+                onChange={e => setQuantity(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); submit() } }}
+                placeholder="Qty"
+                className={`w-16 shrink-0 ${FIELD}`}
+            />}
+
+            {expanded && categoryOptions && (
+                <select
+                    aria-label="Section"
+                    value={chosenCategory}
+                    onChange={e => setChosenCategory(e.target.value)}
+                    className={`min-w-0 flex-1 sm:flex-none sm:max-w-[11rem] ${FIELD}`}
+                >
+                    {categoryOptions.map(option => (
+                        <option key={option} value={option}>{option}</option>
+                    ))}
+                </select>
+            )}
+
+            {expanded && peopleOptions && peopleOptions.length > 0 && (
+                <select
+                    aria-label="Who for"
+                    value={person.name}
+                    onChange={e => setChosenPersonName(e.target.value)}
+                    className={`min-w-0 flex-1 sm:flex-none sm:max-w-[9rem] ${FIELD}`}
+                >
+                    {peopleOptions.map(option => (
+                        <option key={option.name} value={option.name}>{option.name}</option>
+                    ))}
+                </select>
+            )}
+
+            <button
+                type="button"
+                onClick={submit}
+                className="shrink-0 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
+            >
+                Add
+            </button>
+        </div>
+    )
+})

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { ViewPackingList, groupByCategory, groupByPerson } from './view-packing-list'
@@ -2123,5 +2123,154 @@ describe('ViewPackingList check-off feedback', () => {
         expect(saveWithSyncPrevention).not.toHaveBeenCalled()
         expect(mockTapFeedback).toHaveBeenCalledTimes(1)
         expect(screen.getByTestId('item-tick-a1')).toBeTruthy()
+    })
+})
+
+// ─── Adding items ───────────────────────────────────────────────────────────
+
+describe('ViewPackingList adding items', () => {
+    let db: ReturnType<typeof makeDbMultiCategory>
+
+    beforeEach(() => {
+        db = makeDbMultiCategory()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    async function savedItem(text: string): Promise<PackingListItem> {
+        let found: PackingListItem | undefined
+        await waitFor(() => {
+            const calls = db.savePackingList.mock.calls
+            // Last match, not first: an item added for one person may share its
+            // name with one somebody else already has.
+            found = calls.at(-1)?.[0].items.findLast((i: PackingListItem) => i.itemText === text)
+            expect(found).toBeTruthy()
+        })
+        return found!
+    }
+
+    function composerFor(label: string) {
+        const input = screen.getByLabelText(`Add an item to ${label}`) as HTMLInputElement
+        return { input, fields: within(input.closest('[data-testid="add-item-composer"]') as HTMLElement) }
+    }
+
+    function typeAndAdd(input: HTMLInputElement, text: string) {
+        fireEvent.change(input, { target: { value: text } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+    }
+
+    it('files a new item under the section chosen on the person card', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+        const { input, fields } = composerFor("Alice's items")
+        fireEvent.change(input, { target: { value: 'Trail map' } })
+        fireEvent.change(fields.getByLabelText('Section'), { target: { value: 'Hiking' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+
+        const added = await savedItem('Trail map')
+        expect(added.category).toBe('Hiking')
+        expect(added.personName).toBe('Alice')
+    })
+
+    it('still files into the catch-all section when no section is chosen', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+        typeAndAdd(composerFor("Alice's items").input, 'Odds and ends')
+
+        expect((await savedItem('Odds and ends')).category).toBeUndefined()
+    })
+
+    it('saves a quantity typed alongside the item', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+        const { input, fields } = composerFor("Alice's items")
+        fireEvent.change(input, { target: { value: 'Socks' } })
+        fireEvent.change(fields.getByLabelText('Quantity'), { target: { value: '5' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+
+        expect((await savedItem('Socks')).quantity).toBe(5)
+    })
+
+    it('adds straight into a section from that section’s own + Add button', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add item to Hiking for Alice' }))
+        typeAndAdd(composerFor('Hiking for Alice').input, 'Compass')
+
+        const added = await savedItem('Compass')
+        expect(added.category).toBe('Hiking')
+        expect(added.personName).toBe('Alice')
+    })
+
+    it('opens only one in-place composer at a time', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add item to Hiking for Alice' }))
+        expect(screen.getByLabelText('Add an item to Hiking for Alice')).toBeTruthy()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add item to Other for Alice' }))
+        expect(screen.queryByLabelText('Add an item to Hiking for Alice')).toBeNull()
+        expect(screen.getByLabelText('Add an item to Other for Alice')).toBeTruthy()
+    })
+
+    it('adds for someone with nothing in a section yet, from question view', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: 'Question View' }))
+
+        const { input, fields } = composerFor('Hiking')
+        fireEvent.change(input, { target: { value: 'Walking poles' } })
+        fireEvent.change(fields.getByLabelText('Who for'), { target: { value: 'Bob' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+
+        const added = await savedItem('Walking poles')
+        expect(added.category).toBe('Hiking')
+        expect(added.personName).toBe('Bob')
+        expect(added.personId).toBe('p2')
+    })
+
+    it('suggests an item someone else has, and files it in the same section', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+
+        const { input } = composerFor("Bob's items")
+        fireEvent.change(input, { target: { value: 'ten' } })
+        fireEvent.click(screen.getByRole('option', { name: /Tent/ }))
+        fireEvent.keyDown(input, { key: 'Enter' })
+
+        const added = await savedItem('Tent')
+        expect(added.category).toBe('Hiking')
+        expect(added.personName).toBe('Bob')
+    })
+
+    it('does not suggest what this person already has', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+
+        fireEvent.change(composerFor("Alice's items").input, { target: { value: 'ten' } })
+        expect(screen.queryByRole('option', { name: /Tent/ })).toBeNull()
     })
 })

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from 'react'
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useDebouncedCallback } from 'use-debounce'
 import { PackingList, PackingListItem } from '../create-packing-list/types'
@@ -27,6 +27,9 @@ import { tapFeedback } from '../utils/haptics'
 import { prefersReducedMotion } from '../utils/prefersReducedMotion'
 import { groupItemsByCategory, sortByOrder, type CategoryAccessors } from '../utils/groupByCategory'
 import { CATEGORY_ORDER } from '../edit-questions/item-sections'
+import { AddItemComposer, UNCATEGORISED_LABEL, type AddItemTarget, type PersonOption } from '../components/AddItemComposer'
+import { buildSuggestionIndex } from '../utils/itemSuggestions'
+import { useIsDesktop } from '../hooks/useIsDesktop'
 
 type FormData = {
     items: Record<string, boolean>
@@ -88,10 +91,15 @@ function sortByItemOrder(items: PackingListItem[]): PackingListItem[] {
 
 export function groupByCategory(items: PackingListItem[]) {
     return groupItemsByCategory(items, PACKING_ITEM_ACCESSORS, {
-        uncategorisedLabel: 'Other',
+        uncategorisedLabel: UNCATEGORISED_LABEL,
         order: CATEGORY_ORDER,
-        pinLast: 'Other',
+        pinLast: UNCATEGORISED_LABEL,
     })
+}
+
+/** The catch-all section is the absence of a category, not a category named "Other". */
+function categoryFromLabel(label: string): string | undefined {
+    return label === UNCATEGORISED_LABEL ? undefined : label
 }
 
 export function groupByPerson(items: PackingListItem[]) {
@@ -136,7 +144,10 @@ export function ViewPackingList() {
     const [showPacked, setShowPacked] = useState(false)
     const [viewMode, setViewMode] = useState<'person' | 'question'>('person')
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
-    const [newItemInputs, setNewItemInputs] = useState<Record<string, string>>({})
+    // Which section has an add-item composer open inside it. Only one is mounted
+    // at a time: a composer per group would put an input in front of every
+    // heading on the page, which is what the list already pays for in item rows.
+    const [openComposerKey, setOpenComposerKey] = useState<string | null>(null)
     const [itemToDelete, setItemToDelete] = useState<string | null>(null)
     const [editingItemId, setEditingItemId] = useState<string | null>(null)
     const [editingItemText, setEditingItemText] = useState<string>('')
@@ -204,6 +215,7 @@ export function ViewPackingList() {
 
     const handleCheckAll = (items: PackingListItem[]) =>
         items.forEach(item => setValue(`items.${item.id}`, true))
+    const isDesktop = useIsDesktop()
     const { isLoggedIn, session } = useSolidPod()
     const { showToast } = useToast()
     const { db } = useDatabase()
@@ -262,8 +274,40 @@ export function ViewPackingList() {
 
     useEffect(() => {
         if (!recentlyAddedItemId) return
-        itemRowRefs.current.get(recentlyAddedItemId)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        // 'nearest' rather than 'center': items are usually added in runs, and
+        // centring a row that is already on screen drags the composer being
+        // typed into out from under the cursor.
+        itemRowRefs.current.get(recentlyAddedItemId)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
     }, [recentlyAddedItemId])
+
+    // Everything the add-item composers need, derived once per list rather than
+    // per composer: there is one on every card, and they re-render whenever an
+    // item is ticked.
+    const suggestionIndex = useMemo(
+        () => buildSuggestionIndex(packingList?.items ?? [], packingList?.deletedItems ?? []),
+        [packingList?.items, packingList?.deletedItems],
+    )
+
+    // The sections a new item can be filed into: the ones this list already
+    // shows, in the order it shows them, plus the catch-all. Offering sections
+    // the list doesn't use would invent cards no one asked for — new sections
+    // belong to the question set, where they can be arranged.
+    const categoryOptions = useMemo(() => {
+        const labels = groupByCategory(packingList?.items ?? []).map(group => group.label)
+        return labels.includes(UNCATEGORISED_LABEL) ? labels : [...labels, UNCATEGORISED_LABEL]
+    }, [packingList?.items])
+
+    const peopleOptions = useMemo<PersonOption[]>(() => {
+        const byName = new Map<string, string>()
+        for (const guest of packingList?.guests ?? []) byName.set(guest.name, guest.id)
+        for (const item of packingList?.items ?? []) {
+            if (item.communal || !item.personName) continue
+            if (!byName.has(item.personName)) byName.set(item.personName, item.personId)
+        }
+        return [...byName.entries()]
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([name, id]) => ({ name, id }))
+    }, [packingList?.items, packingList?.guests])
 
 
     const { register, setValue, getValues, control, reset } = useForm<FormData>({
@@ -665,43 +709,51 @@ export function ViewPackingList() {
         }
     }
 
-    const handleAddItem = async (inputKey: string, personName: string, guestId?: string, communal?: boolean) => {
+    const handleAddItem = async (target: AddItemTarget, itemText: string, quantity?: number) => {
         if (!packingList) return
 
-        const newItemText = newItemInputs[inputKey]?.trim()
+        const newItemText = itemText.trim()
         if (!newItemText) return
 
         try {
             setAutoSaveStatus('saving')
 
             const maxOrder = Math.max(-1, ...packingList.items.map(i => i.order ?? -1))
-            const newItem = {
+            const newItem: PackingListItem = {
                 id: `item-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
                 itemText: newItemText,
-                personName: communal ? '' : personName,
-                personId: guestId ?? '',
+                personName: target.communal ? '' : target.personName,
+                personId: target.communal ? '' : target.personId,
                 questionId: '',
                 optionId: '',
                 packed: false,
-                ...(communal ? { communal: true } : {}),
+                ...(target.communal ? { communal: true } : {}),
+                ...(target.category ? { category: target.category } : {}),
+                // A quantity of one is what an absent quantity already means.
+                ...(quantity && quantity > 1 ? { quantity } : {}),
                 order: maxOrder + 1,
                 lastModified: new Date().toISOString(),
             }
 
-            // Add to form values and clear the input before saving
             setValue(`items.${newItem.id}`, false)
-            setNewItemInputs({ ...newItemInputs, [inputKey]: '' })
 
-            // Make sure the category the new item lands in is expanded so it's
-            // visible. New items have no category, so they land under "Other" —
-            // keyed `${sectionKey}::Other` in person view and
-            // `Other::${personName}` in question view.
+            // Make sure the group the item lands in is expanded, so an item
+            // filed into a collapsed section isn't added into thin air. The two
+            // views key the same group the opposite way round.
+            const sectionKey = target.communal ? SHARED_SECTION_KEY : target.personName
+            const categoryLabel = target.category ?? UNCATEGORISED_LABEL
             setCollapsedCategories(prev => {
-                const sectionKey = inputKey.split('::add::')[0]
-                const keysToExpand = [`${sectionKey}::Other`, `Other::${personName}`]
+                const keysToExpand = [`${sectionKey}::${categoryLabel}`, `${categoryLabel}::${target.personName}`]
                 if (!keysToExpand.some(k => prev.has(k))) return prev
                 const next = new Set(prev)
                 for (const k of keysToExpand) next.delete(k)
+                return next
+            })
+            setCollapsedPersons(prev => {
+                if (!prev.has(sectionKey) && !prev.has(categoryLabel)) return prev
+                const next = new Set(prev)
+                next.delete(sectionKey)
+                next.delete(categoryLabel)
                 return next
             })
 
@@ -717,6 +769,17 @@ export function ViewPackingList() {
             setAutoSaveStatus('error')
         }
     }
+
+    // The composers are memoised, so their onAdd has to keep the same identity
+    // across renders or every tick of a checkbox would re-render every one of
+    // them. The ref carries the current list to a callback that never changes.
+    const addItemRef = useRef(handleAddItem)
+    useEffect(() => { addItemRef.current = handleAddItem })
+    const handleComposerAdd = useCallback(
+        (target: AddItemTarget, itemText: string, quantity?: number) => {
+            addItemRef.current(target, itemText, quantity)
+        }, [])
+    const closeComposer = useCallback(() => setOpenComposerKey(null), [])
 
     const handleAddGuest = async () => {
         if (!packingList || !newGuestName.trim()) return
@@ -824,7 +887,9 @@ export function ViewPackingList() {
     }, {} as Record<string, { packed: number; total: number }>)
 
     const guestNames = new Set((packingList.guests ?? []).map(g => g.name))
-    const guestIdByName = new Map((packingList.guests ?? []).map(g => [g.name, g.id]))
+    const personIdByName = new Map(peopleOptions.map(person => [person.name, person.id]))
+    // Only worth offering a section picker once the list has sections to pick.
+    const sectionChoices = categoryOptions.length > 1 ? categoryOptions : undefined
 
     // A section is worth celebrating once every item in it is packed
     const isSectionComplete = (stats?: { packed: number; total: number }) =>
@@ -1217,33 +1282,23 @@ export function ViewPackingList() {
                                     </div>
                                 </div>
                                 {!collapsedPersons.has(sectionKey) && <div>
-                                    {/* Add new item input — only shown when this section maps to a single person/guest */}
-                                    {!isCategorySection && (
-                                        <div className="mb-4 pb-4 border-b border-gray-200">
-                                            <div className="flex gap-2">
-                                                <input
-                                                    type="text"
-                                                    value={newItemInputs[sectionKey] || ''}
-                                                    onChange={(e) => setNewItemInputs({ ...newItemInputs, [sectionKey]: e.target.value })}
-                                                    onKeyPress={(e) => {
-                                                        if (e.key === 'Enter') {
-                                                            e.preventDefault()
-                                                            handleAddItem(sectionKey, section.name, section.guestId, section.communal)
-                                                        }
-                                                    }}
-                                                    placeholder="Add new item..."
-                                                    className="flex-1 min-w-0 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
-                                                />
-                                                <button
-                                                    type="button"
-                                                    onClick={() => handleAddItem(sectionKey, section.name, section.guestId, section.communal)}
-                                                    className="shrink-0 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
-                                                >
-                                                    Add
-                                                </button>
-                                            </div>
-                                        </div>
-                                    )}
+                                    {/* Every card can be typed into directly. What varies is which
+                                        part of the target the card already knows: a person's card
+                                        knows who, and asks which section; a section's card knows
+                                        which section, and asks who. */}
+                                    <div className="mb-4 pb-4 border-b border-gray-200">
+                                        <AddItemComposer
+                                            personName={isCategorySection ? '' : section.name}
+                                            personId={isCategorySection ? '' : (guestId ?? personIdByName.get(section.name) ?? '')}
+                                            communal={section.communal}
+                                            category={isCategorySection ? categoryFromLabel(title) : undefined}
+                                            categoryOptions={isCategorySection ? undefined : sectionChoices}
+                                            peopleOptions={isCategorySection && peopleOptions.length > 0 ? peopleOptions : undefined}
+                                            suggestions={suggestionIndex}
+                                            targetLabel={isShared ? 'shared items' : isCategorySection ? title : `${section.name}'s items`}
+                                            onAdd={handleComposerAdd}
+                                        />
+                                    </div>
                                     {isComplete && items.length === 0 && (
                                         <p className="text-sm font-medium text-emerald-700">
                                             Nothing left to pack 🎒
@@ -1252,53 +1307,78 @@ export function ViewPackingList() {
                                     {innerGroups.map(({ label, items: catItems }) => {
                                         const categoryKey = `${sectionKey}::${label}`
                                         const isCollapsed = collapsedCategories.has(categoryKey)
-                                        const innerInputKey = `${sectionKey}::add::${label}`
+                                        // Both views end up describing the same place; only which
+                                        // half the card supplies changes.
+                                        const groupLabel = isCategorySection
+                                            ? `${title} for ${label}`
+                                            : `${label} for ${isShared ? 'shared items' : section.name}`
+                                        const groupTarget = isCategorySection
+                                            ? {
+                                                personName: label,
+                                                personId: personIdByName.get(label) ?? '',
+                                                category: categoryFromLabel(title),
+                                            }
+                                            : {
+                                                personName: section.name,
+                                                personId: guestId ?? personIdByName.get(section.name) ?? '',
+                                                communal: section.communal,
+                                                category: categoryFromLabel(label),
+                                            }
+                                        const composerOpen = openComposerKey === categoryKey
                                         return (
                                             <div key={categoryKey} className="mb-3">
-                                                <div className="flex items-center justify-between py-1 mb-1">
+                                                <div className="flex items-center justify-between gap-2 py-1 mb-1">
                                                     <button
                                                         type="button"
                                                         aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${label}`}
                                                         onClick={() => toggleCategory(categoryKey)}
-                                                        className="flex items-center gap-1 text-sm font-semibold text-gray-600 hover:text-gray-900"
+                                                        className="flex items-center gap-1 text-left text-sm font-semibold text-gray-600 hover:text-gray-900"
                                                     >
                                                         <span>{isCollapsed ? '▶' : '▼'}</span>
                                                         <span>{label}</span>
                                                         <span className="text-xs font-normal text-gray-400 ml-1">({catItems.length})</span>
                                                     </button>
                                                     {!isCollapsed && (
-                                                        <button
-                                                            type="button"
-                                                            aria-label="Check all"
-                                                            onClick={() => handleCheckAll(catItems)}
-                                                            className="text-xs text-blue-600 hover:text-blue-800"
-                                                        >
-                                                            Check all
-                                                        </button>
+                                                        <div className="flex shrink-0 items-center gap-2">
+                                                            {/* Adding straight into a group is the whole point: the
+                                                                item lands where it was typed instead of falling
+                                                                into the catch-all section. */}
+                                                            <button
+                                                                type="button"
+                                                                aria-label={`Add item to ${groupLabel}`}
+                                                                aria-expanded={composerOpen}
+                                                                onClick={() => setOpenComposerKey(composerOpen ? null : categoryKey)}
+                                                                className={`rounded-full border px-2.5 py-1 text-xs font-semibold transition-colors ${composerOpen ? 'border-blue-300 bg-blue-100 text-blue-800' : 'border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100'}`}
+                                                            >
+                                                                {/* A section name is what the heading is for; on a
+                                                                    phone the word "Add" is what pushes it off. */}
+                                                                {isDesktop ? '+ Add' : '+'}
+                                                            </button>
+                                                            <button
+                                                                type="button"
+                                                                aria-label="Check all"
+                                                                onClick={() => handleCheckAll(catItems)}
+                                                                className="text-xs text-blue-600 hover:text-blue-800"
+                                                            >
+                                                                Check all
+                                                            </button>
+                                                        </div>
                                                     )}
                                                 </div>
-                                                {!isCollapsed && isCategorySection && (
-                                                    <div className="flex gap-2 mb-2">
-                                                        <input
-                                                            type="text"
-                                                            value={newItemInputs[innerInputKey] || ''}
-                                                            onChange={(e) => setNewItemInputs({ ...newItemInputs, [innerInputKey]: e.target.value })}
-                                                            onKeyPress={(e) => {
-                                                                if (e.key === 'Enter') {
-                                                                    e.preventDefault()
-                                                                    handleAddItem(innerInputKey, label, guestIdByName.get(label))
-                                                                }
-                                                            }}
-                                                            placeholder={`Add item for ${label}...`}
-                                                            className="flex-1 min-w-0 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                                                {!isCollapsed && composerOpen && (
+                                                    <div className="mb-2">
+                                                        <AddItemComposer
+                                                            personName={groupTarget.personName}
+                                                            personId={groupTarget.personId}
+                                                            communal={groupTarget.communal}
+                                                            category={groupTarget.category}
+                                                            suggestions={suggestionIndex}
+                                                            targetLabel={groupLabel}
+                                                            placeholder={`Add to ${label}...`}
+                                                            onAdd={handleComposerAdd}
+                                                            onClose={closeComposer}
+                                                            autoFocus
                                                         />
-                                                        <button
-                                                            type="button"
-                                                            onClick={() => handleAddItem(innerInputKey, label, guestIdByName.get(label))}
-                                                            className="shrink-0 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
-                                                        >
-                                                            Add
-                                                        </button>
                                                     </div>
                                                 )}
                                                 {!isCollapsed && (

--- a/src/utils/itemSuggestions.test.ts
+++ b/src/utils/itemSuggestions.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { buildSuggestionIndex, suggestFor, SHARED_OWNER_KEY, ownerKeyFor } from './itemSuggestions'
+import type { PackingListItem } from '../create-packing-list/types'
+
+const mk = (over: Partial<PackingListItem>): PackingListItem => ({
+    id: Math.random().toString(36).slice(2),
+    itemText: 'Item',
+    personId: 'p1',
+    personName: 'Alice',
+    questionId: '',
+    optionId: '',
+    packed: false,
+    ...over,
+})
+
+describe('buildSuggestionIndex', () => {
+    it('collects one suggestion per distinct item name', () => {
+        const index = buildSuggestionIndex([
+            mk({ itemText: 'Sunhat', personName: 'Alice' }),
+            mk({ itemText: 'Sunhat', personName: 'Bob' }),
+            mk({ itemText: 'Passport', personName: 'Alice' }),
+        ])
+        expect(index.all.map(s => s.text)).toEqual(['Passport', 'Sunhat'])
+    })
+
+    it('carries the category the name is usually filed under', () => {
+        const index = buildSuggestionIndex([
+            mk({ itemText: 'Sunhat', category: 'Clothes' }),
+        ])
+        expect(index.all[0].category).toBe('Clothes')
+    })
+
+    it('prefers the most common category when a name is filed two ways', () => {
+        const index = buildSuggestionIndex([
+            mk({ itemText: 'Sunhat', personName: 'Alice', category: 'Clothes' }),
+            mk({ itemText: 'Sunhat', personName: 'Bob', category: 'Clothes' }),
+            mk({ itemText: 'Sunhat', personName: 'Cara' }),
+        ])
+        expect(index.all[0].category).toBe('Clothes')
+    })
+
+    it('includes items that were removed earlier, so they are easy to put back', () => {
+        const index = buildSuggestionIndex(
+            [mk({ itemText: 'Passport' })],
+            [mk({ itemText: 'Travel pillow', category: 'Sleep & Comfort' })],
+        )
+        expect(index.all.map(s => s.text)).toContain('Travel pillow')
+    })
+
+    it('records what each person already has', () => {
+        const index = buildSuggestionIndex([
+            mk({ itemText: 'Sunhat', personName: 'Alice' }),
+            mk({ itemText: 'Tent', communal: true, personName: '' }),
+        ])
+        expect(index.ownedBy.get('Alice')?.has('sunhat')).toBe(true)
+        expect(index.ownedBy.get(SHARED_OWNER_KEY)?.has('tent')).toBe(true)
+    })
+})
+
+describe('ownerKeyFor', () => {
+    it('keys communal items separately from anyone with a name', () => {
+        expect(ownerKeyFor({ personName: '', personId: '', communal: true })).toBe(SHARED_OWNER_KEY)
+        expect(ownerKeyFor({ personName: 'Alice', personId: 'p1' })).toBe('Alice')
+    })
+})
+
+describe('suggestFor', () => {
+    const index = buildSuggestionIndex([
+        mk({ itemText: 'Sun cream', personName: 'Alice', category: 'Toiletries' }),
+        mk({ itemText: 'Sunhat', personName: 'Alice', category: 'Clothes' }),
+        mk({ itemText: 'Sunglasses', personName: 'Bob' }),
+        mk({ itemText: 'Passport', personName: 'Bob', category: 'Documents & Money' }),
+        mk({ itemText: 'Beach towel', personName: 'Bob' }),
+    ])
+
+    it('matches on any part of the name, case-insensitively', () => {
+        expect(suggestFor(index, 'Cara', 'TOWEL').map(s => s.text)).toEqual(['Beach towel'])
+    })
+
+    it('ranks names that start with what was typed first', () => {
+        expect(suggestFor(index, 'Cara', 'sun').map(s => s.text))
+            .toEqual(['Sun cream', 'Sunglasses', 'Sunhat'])
+    })
+
+    it('leaves out what this person already has', () => {
+        expect(suggestFor(index, 'Alice', 'sun').map(s => s.text)).toEqual(['Sunglasses'])
+    })
+
+    it('leaves out an exact match, since typing it is already enough', () => {
+        expect(suggestFor(index, 'Cara', 'Passport')).toEqual([])
+    })
+
+    it('suggests nothing until something has been typed', () => {
+        expect(suggestFor(index, 'Cara', '  ')).toEqual([])
+    })
+
+    it('caps how many are offered', () => {
+        expect(suggestFor(index, 'Cara', 's', 2)).toHaveLength(2)
+    })
+})

--- a/src/utils/itemSuggestions.ts
+++ b/src/utils/itemSuggestions.ts
@@ -1,0 +1,120 @@
+/**
+ * Suggestions for the "add an item" composer.
+ *
+ * A packing list is its own best dictionary: by the time someone is adding
+ * things by hand, the list already knows how "Sun cream" is spelled and which
+ * section it belongs in — usually because somebody else on the trip has one.
+ * So the catalogue is built from the list itself (including items deleted
+ * earlier, which are exactly the things people put back), and picking a
+ * suggestion carries its category across. That is what turns "add to a
+ * particular section" from a chore into a single tap.
+ *
+ * The index is built once per list and filtered per keystroke, so the work that
+ * happens while someone is typing is a scan of distinct names, not of items.
+ */
+import type { PackingListItem } from '../create-packing-list/types'
+
+/** Owner key for communal items, which belong to no one in particular. */
+export const SHARED_OWNER_KEY = '__shared__'
+
+const DEFAULT_LIMIT = 6
+
+export interface ItemSuggestion {
+    text: string
+    /** Section the name is usually filed under; absent = uncategorised. */
+    category?: string
+}
+
+export interface SuggestionIndex {
+    /** Every distinct name on the list, alphabetically. */
+    all: ItemSuggestion[]
+    /** Lowercased names each owner already has, so we don't offer duplicates. */
+    ownedBy: Map<string, Set<string>>
+}
+
+export interface SuggestionOwner {
+    personName: string
+    personId: string
+    communal?: boolean
+}
+
+export function ownerKeyFor(owner: SuggestionOwner): string {
+    return owner.communal ? SHARED_OWNER_KEY : owner.personName
+}
+
+/** Case-insensitive but deterministic — locale collation orders "Sun cream"
+ *  against "Sunglasses" differently between engines, and the suggestion order
+ *  is asserted in tests. */
+const byName = (a: string, b: string) => {
+    const x = a.toLowerCase()
+    const y = b.toLowerCase()
+    return x < y ? -1 : x > y ? 1 : 0
+}
+
+export function buildSuggestionIndex(
+    items: readonly PackingListItem[],
+    deletedItems: readonly PackingListItem[] = [],
+): SuggestionIndex {
+    // name (lowercased) -> the name as first seen, and how often each category
+    // has been used for it. A name filed two ways takes the majority verdict so
+    // one stray uncategorised copy doesn't lose the section.
+    const names = new Map<string, { text: string; categories: Map<string | undefined, number> }>()
+    const ownedBy = new Map<string, Set<string>>()
+
+    const record = (item: PackingListItem, owned: boolean) => {
+        const text = item.itemText.trim()
+        if (!text) return
+        const key = text.toLowerCase()
+        const entry = names.get(key) ?? { text, categories: new Map() }
+        entry.categories.set(item.category, (entry.categories.get(item.category) ?? 0) + 1)
+        names.set(key, entry)
+        if (!owned) return
+        const owner = ownerKeyFor(item)
+        const set = ownedBy.get(owner) ?? new Set<string>()
+        set.add(key)
+        ownedBy.set(owner, set)
+    }
+
+    for (const item of items) record(item, true)
+    // Deleted items stock the catalogue but are not "owned" — the whole point is
+    // that they can be added back.
+    for (const item of deletedItems) record(item, false)
+
+    const all = [...names.values()]
+        .map(({ text, categories }) => {
+            const [category] = [...categories.entries()]
+                .sort(([, a], [, b]) => b - a)[0]
+            return category === undefined ? { text } : { text, category }
+        })
+        .sort((a, b) => byName(a.text, b.text))
+
+    return { all, ownedBy }
+}
+
+/**
+ * Names worth offering for `query`, best first: names starting with what was
+ * typed lead, then names containing it. Anything the owner already has is left
+ * out, as is an exact match — by then the typing is done.
+ */
+export function suggestFor(
+    index: SuggestionIndex,
+    ownerKey: string,
+    query: string,
+    limit = DEFAULT_LIMIT,
+): ItemSuggestion[] {
+    const needle = query.trim().toLowerCase()
+    if (!needle) return []
+    const owned = index.ownedBy.get(ownerKey)
+
+    const starts: ItemSuggestion[] = []
+    const contains: ItemSuggestion[] = []
+    for (const suggestion of index.all) {
+        const name = suggestion.text.toLowerCase()
+        if (name === needle) continue
+        if (owned?.has(name)) continue
+        if (name.startsWith(needle)) starts.push(suggestion)
+        else if (name.includes(needle)) contains.push(suggestion)
+        if (starts.length >= limit) break
+    }
+    return [...starts, ...contains].slice(0, limit)
+}


### PR DESCRIPTION
## The friction

Adding an item to a packing list — especially to a particular section — was harder than it should have been:

- **You couldn't choose a section.** In person view, anything typed into a card fell into "Other", whatever heading it was typed next to. There was no way at all to add to Toiletries.
- **Question view was worse.** Its per-person inputs only existed for people who *already* had items in that section, so you couldn't add for anyone else — and what you did add carried no category, so it left the section you typed it into on the very next render.
- **Quantity meant a second pass** through the item editor.
- **Every keystroke re-rendered the whole list.** All the add-inputs shared one page-level `newItemInputs` object, so typing in any of them re-rendered every card and every item row.

## The design

One composer, used everywhere, that always knows where the item is going.

**Card level** — the input each card already had, upgraded. A person's card knows *who* and asks *which section*; a section's card (question view) knows *which section* and asks *who*. At rest it is still just a field and an Add button; the quantity and pickers appear once there is an item to apply them to, so cards are no heavier than before.

**Section level** — every group heading gains a **＋** that opens the same composer *inside* that group, with both the person and the section already decided. One tap, item lands exactly where you pressed. Only one is mounted at a time.

**Suggestions** — a packing list is its own dictionary. Type three letters and it offers names already on the list (including ones deleted earlier), each showing the section it is usually filed under. Picking one fills the name *and* sets the section, so "Bob needs a sunhat too" is one tap and it lands in Clothes. Names the person already has are left out.

Adding keeps the composer open, cleared and focused, with the section and person still selected — items get added in runs, not one at a time.

## Performance

Strictly better than before, not worse:

- The draft lives in the composer, which is memoised behind a stable `onAdd`. A keystroke re-renders one composer instead of the entire list; ticking a checkbox re-renders no composers at all.
- Question view goes from one input per (section × person) to one per section, plus a button per group.
- The suggestion catalogue is built once per list and filtered per keystroke — a scan of distinct names, not of items.
- New items now scroll in with `block: 'nearest'` rather than `'center'`, so adding a run of items doesn't drag the composer out from under you.

## Mobile and desktop

Verified in a real browser at 390×844 and 1280×900:

- Phone: name takes its own line once you start typing, with `[Qty] [Section] [Add]` wrapping underneath — three fields abreast is unusable at that width. Native `<select>`s so section and person are one tap.
- The group ＋ drops its "Add" label below `sm`, which is what was pushing section names off their headings.

## Tests

`npm test` green (1110). New coverage: the suggestion index (12), the composer (20 — sections, people, quantity, suggestions, keyboard, dismissal), and the page (8 — section stamping from both views, in-place adds, quantity, suggestion-driven filing).

No e2e test added: this environment's Chromium build doesn't match the pinned Playwright version, so I couldn't run the suite to verify one. The existing `f-sync` spec's `getByPlaceholder('Add new item...')` still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFqW5TxRDenbitQWzFJ7Fw

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFqW5TxRDenbitQWzFJ7Fw)_