### PR TITLE
Add items to the questions page where they belong

### DIFF
--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -305,4 +305,81 @@ test.describe('B – Editing Questions', () => {
     await expect(page.getByText('InlineRenameTest')).toBeVisible({ timeout: 5_000 })
     await expect(page.getByText(originalName, { exact: true })).not.toBeVisible()
   })
+
+  test('B10: add an item straight into a named section', async ({ freshPage: page }) => {
+    // Contrast with B4, which is the old way in: open the modal, append a blank
+    // row, fight react-select, save the whole option — and the row still landed
+    // in whichever section came last.
+    await setupWizardAndGoToQuestions(page)
+    await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
+
+    const toiletries = page.getByTestId('item-section').filter({ hasText: 'Toiletries' }).first()
+    await expect(toiletries).toBeVisible({ timeout: 5_000 })
+    await toiletries.getByTestId('add-to-section').click()
+
+    const field = page.getByLabel('New item in Toiletries')
+    await expect(field).toBeVisible({ timeout: 3_000 })
+    await field.fill('SectionAddTest')
+    await field.press('Enter')
+
+    // It lands under the heading it was typed into, not at the end of the list.
+    await expect(toiletries.getByText('SectionAddTest')).toBeVisible({ timeout: 5_000 })
+    // And the composer stays, cleared, because items go in in runs.
+    await expect(field).toHaveValue('')
+
+    // Adding saves as it goes — no confirmation step to reach for.
+    await page.waitForTimeout(800)
+    await page.reload()
+    await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
+    const afterReload = page.getByTestId('item-section').filter({ hasText: 'Toiletries' }).first()
+    await expect(afterReload.getByText('SectionAddTest')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('B11: a suggested name brings its section with it', async ({ freshPage: page }) => {
+    await setupWizardAndGoToQuestions(page)
+    await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
+
+    // The composer at the foot of the list is the one that asks where the item
+    // goes, so it is the one a suggestion can answer for.
+    await page.getByRole('button', { name: '+ Add item' }).first().click()
+    const field = page.getByLabel(/^New item in /)
+    await expect(field).toBeVisible({ timeout: 3_000 })
+
+    // "Sunscreen" lives under Toiletries in a question elsewhere in the set;
+    // taking the suggestion is what files it there without a second trip.
+    await field.fill('sunscr')
+    const suggestion = page.getByRole('option', { name: /Sunscreen/ }).first()
+    await expect(suggestion).toBeVisible({ timeout: 3_000 })
+    await suggestion.click()
+    await expect(page.getByLabel('Section')).toHaveValue('Toiletries')
+
+    await field.press('Enter')
+    const toiletries = page.getByTestId('item-section').filter({ hasText: 'Toiletries' }).first()
+    await expect(toiletries.getByText('Sunscreen')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('B12: an answer with no items can take its first one', async ({ freshPage: page }) => {
+    // Before, an empty answer had no expander and no input at all: its only way
+    // in was the option modal.
+    await setupWizardAndGoToQuestions(page)
+    // Pinned by position, not by its "No items" hint: adding the item removes
+    // that hint, and a locator built on it would stop matching the thing it is
+    // meant to be checking.
+    const options = page.getByTestId('option-section')
+    await expect(options.first()).toBeVisible({ timeout: 5_000 })
+    let emptyIndex = -1
+    for (let i = 0; i < await options.count(); i++) {
+      if (await options.nth(i).getByText('No items').count()) { emptyIndex = i; break }
+    }
+    expect(emptyIndex).toBeGreaterThanOrEqual(0)
+    const emptyOption = options.nth(emptyIndex)
+    await emptyOption.getByTestId('option-expand-chevron').click()
+
+    await emptyOption.getByRole('button', { name: '+ Add item' }).click()
+    const field = emptyOption.locator('input[role="combobox"]')
+    await field.fill('FirstItemTest')
+    await field.press('Enter')
+    await expect(emptyOption.getByText('FirstItemTest')).toBeVisible({ timeout: 5_000 })
+    await expect(emptyOption.getByText('No items')).not.toBeVisible()
+  })
 })

--- a/src/components/AddItemComposer.tsx
+++ b/src/components/AddItemComposer.tsx
@@ -20,8 +20,9 @@
  * person still selected, because people add items in runs rather than one at a
  * time.
  */
-import { memo, useMemo, useRef, useState } from 'react'
-import { ownerKeyFor, suggestFor, type ItemSuggestion, type SuggestionIndex } from '../utils/itemSuggestions'
+import { memo, useRef, useState } from 'react'
+import { ItemNameField, FIELD } from './ItemNameField'
+import { ownerKeyFor, type ItemSuggestion, type SuggestionIndex } from '../utils/itemSuggestions'
 
 /** What the packing list calls the section for items with no category. */
 export const UNCATEGORISED_LABEL = 'Other'
@@ -60,8 +61,6 @@ interface AddItemComposerProps {
     placeholder?: string
 }
 
-const FIELD = 'px-3 py-2 border border-gray-300 rounded-md bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500'
-
 export const AddItemComposer = memo(function AddItemComposer({
     personName,
     personId,
@@ -82,8 +81,6 @@ export const AddItemComposer = memo(function AddItemComposer({
     // Held by name, not id: custom items carry no person id, so a name is the
     // only thing that identifies a person on every list.
     const [chosenPersonName, setChosenPersonName] = useState(personName)
-    const [highlighted, setHighlighted] = useState(-1)
-    const [suggestionsOpen, setSuggestionsOpen] = useState(true)
     const inputRef = useRef<HTMLInputElement>(null)
 
     const person: PersonOption = peopleOptions?.find(p => p.name === chosenPersonName)
@@ -100,28 +97,14 @@ export const AddItemComposer = memo(function AddItemComposer({
     }
 
     const ownerKey = ownerKeyFor(target)
-    const matches = useMemo(
-        () => suggestionsOpen ? suggestFor(suggestions, ownerKey, text) : [],
-        [suggestions, ownerKey, text, suggestionsOpen],
-    )
-
-    const setDraft = (value: string) => {
-        setText(value)
-        setHighlighted(-1)
-        setSuggestionsOpen(true)
-    }
 
     const applySuggestion = (suggestion: ItemSuggestion) => {
-        setText(suggestion.text)
-        setSuggestionsOpen(false)
-        setHighlighted(-1)
         // A suggestion knows where it belongs; taking its section is the whole
         // point of offering it. Only meaningful when a section can be chosen —
         // an in-place composer already has one.
         if (categoryOptions && suggestion.category && categoryOptions.includes(suggestion.category)) {
             setChosenCategory(suggestion.category)
         }
-        inputRef.current?.focus()
     }
 
     const submit = () => {
@@ -131,47 +114,13 @@ export const AddItemComposer = memo(function AddItemComposer({
         onAdd(target, trimmed, Number.isFinite(parsed) && parsed > 1 ? parsed : undefined)
         setText('')
         setQuantity('')
-        setHighlighted(-1)
-        setSuggestionsOpen(true)
         inputRef.current?.focus()
-    }
-
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'ArrowDown' && matches.length > 0) {
-            e.preventDefault()
-            setHighlighted(prev => (prev + 1) % matches.length)
-            return
-        }
-        if (e.key === 'ArrowUp' && matches.length > 0) {
-            e.preventDefault()
-            setHighlighted(prev => (prev <= 0 ? matches.length : prev) - 1)
-            return
-        }
-        if (e.key === 'Enter') {
-            e.preventDefault()
-            const picked = matches[highlighted]
-            if (picked) applySuggestion(picked)
-            else submit()
-            return
-        }
-        if (e.key === 'Escape') {
-            e.preventDefault()
-            // Escape backs out one layer at a time: the suggestions first, then
-            // the composer — so dismissing a dropdown never loses what was typed.
-            if (matches.length > 0) {
-                setSuggestionsOpen(false)
-                setHighlighted(-1)
-                return
-            }
-            onClose?.()
-        }
     }
 
     // An in-place composer that has been left empty has served its purpose; one
     // with half an item in it has not, and must not take the draft with it.
     const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
         if (e.currentTarget.contains(e.relatedTarget)) return
-        setSuggestionsOpen(false)
         if (!text.trim()) onClose?.()
     }
 
@@ -194,52 +143,21 @@ export const AddItemComposer = memo(function AddItemComposer({
                 quantity and pickers are in play the name takes the line to
                 itself and they wrap underneath — three fields abreast is
                 unusable on a phone, and it is where the suggestions drop. */}
-            <div className={`relative min-w-[8rem] ${expanded ? 'basis-full' : 'flex-1 basis-40'}`}>
-                <input
-                    ref={inputRef}
-                    type="text"
-                    role="combobox"
-                    aria-expanded={matches.length > 0}
-                    aria-controls={listboxId}
-                    aria-autocomplete="list"
-                    aria-label={`Add an item to ${targetLabel}`}
-                    autoComplete="off"
-                    enterKeyHint="done"
+            <div className={`min-w-[8rem] ${expanded ? 'basis-full' : 'flex-1 basis-40'}`}>
+                <ItemNameField
                     value={text}
+                    onChange={setText}
+                    suggestions={suggestions}
+                    ownerKey={ownerKey}
+                    onPick={applySuggestion}
+                    onSubmit={submit}
+                    onClose={onClose}
+                    label={`Add an item to ${targetLabel}`}
+                    listboxId={listboxId}
+                    inputRef={inputRef}
                     autoFocus={autoFocus}
-                    onChange={e => setDraft(e.target.value)}
-                    onKeyDown={handleKeyDown}
                     placeholder={placeholder}
-                    className={`w-full ${FIELD}`}
                 />
-                {matches.length > 0 && (
-                    <ul
-                        id={listboxId}
-                        role="listbox"
-                        className="absolute left-0 right-0 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
-                    >
-                        {matches.map((suggestion, i) => (
-                            <li key={suggestion.text}>
-                                <button
-                                    type="button"
-                                    role="option"
-                                    aria-selected={i === highlighted}
-                                    // Blur would close the list before the click landed.
-                                    onMouseDown={e => e.preventDefault()}
-                                    onClick={() => applySuggestion(suggestion)}
-                                    className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm ${i === highlighted ? 'bg-blue-50 text-blue-900' : 'text-gray-700 hover:bg-gray-50'}`}
-                                >
-                                    <span className="truncate">{suggestion.text}</span>
-                                    {suggestion.category && (
-                                        <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[11px] text-gray-500">
-                                            {suggestion.category}
-                                        </span>
-                                    )}
-                                </button>
-                            </li>
-                        ))}
-                    </ul>
-                )}
             </div>
 
             {expanded && <input

--- a/src/components/AddQuestionItem.test.tsx
+++ b/src/components/AddQuestionItem.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { AddQuestionItem } from './AddQuestionItem'
+import { buildIndexOf } from '../utils/itemSuggestions'
+
+const emptyIndex = buildIndexOf([])
+
+function renderComposer(props: Partial<React.ComponentProps<typeof AddQuestionItem>> = {}) {
+    const onAdd = vi.fn()
+    render(
+        <AddQuestionItem
+            defaultLabel="Yes"
+            suggestions={emptyIndex}
+            ownerKey="q1:o1"
+            targetLabel="Yes"
+            onAdd={onAdd}
+            {...props}
+        />
+    )
+    return { onAdd, input: screen.getByRole('combobox') as HTMLInputElement }
+}
+
+describe('AddQuestionItem', () => {
+    it('adds the typed item to the section it was opened in', () => {
+        const { onAdd, input } = renderComposer({ category: 'Toiletries' })
+        fireEvent.change(input, { target: { value: 'Razor' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith('Razor', 'Toiletries')
+    })
+
+    it('adds on the Add button too', () => {
+        const { onAdd, input } = renderComposer()
+        fireEvent.change(input, { target: { value: 'Razor' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+        expect(onAdd).toHaveBeenCalledWith('Razor', undefined)
+    })
+
+    it('clears the field so the next item can be typed straight away', () => {
+        const { input } = renderComposer()
+        fireEvent.change(input, { target: { value: 'Razor' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(input.value).toBe('')
+    })
+
+    it('ignores a blank name', () => {
+        const { onAdd, input } = renderComposer()
+        fireEvent.change(input, { target: { value: '   ' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).not.toHaveBeenCalled()
+    })
+
+    it('trims what was typed', () => {
+        const { onAdd, input } = renderComposer()
+        fireEvent.change(input, { target: { value: '  Razor ' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith('Razor', undefined)
+    })
+})
+
+describe('AddQuestionItem: choosing a section', () => {
+    const sectionOptions = ['Toiletries', 'Clothes']
+
+    it('has no section picker when the section is already decided', () => {
+        const { input } = renderComposer({ category: 'Clothes' })
+        fireEvent.change(input, { target: { value: 'Sun hat' } })
+        expect(screen.queryByLabelText('Section')).toBeNull()
+    })
+
+    it('keeps out of the way until there is an item to file', () => {
+        const { input } = renderComposer({ sectionOptions })
+        expect(screen.queryByLabelText('Section')).toBeNull()
+        fireEvent.change(input, { target: { value: 'S' } })
+        expect(screen.getByLabelText('Section')).toBeTruthy()
+    })
+
+    it('offers the list’s own default section by name', () => {
+        const { input } = renderComposer({ sectionOptions })
+        fireEvent.change(input, { target: { value: 'S' } })
+        const options = [...(screen.getByLabelText('Section') as HTMLSelectElement).options].map(o => o.value)
+        expect(options).toEqual(['Yes', 'Toiletries', 'Clothes'])
+    })
+
+    it('files the item under the chosen section', () => {
+        const { onAdd, input } = renderComposer({ sectionOptions })
+        fireEvent.change(input, { target: { value: 'Razor' } })
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Toiletries' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith('Razor', 'Toiletries')
+    })
+
+    it('stores no section for the default one', () => {
+        const { onAdd, input } = renderComposer({ sectionOptions, category: 'Toiletries' })
+        fireEvent.change(input, { target: { value: 'Odds and ends' } })
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Yes' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith('Odds and ends', undefined)
+    })
+
+    it('keeps the chosen section for the next item', () => {
+        const { onAdd, input } = renderComposer({ sectionOptions })
+        fireEvent.change(input, { target: { value: 'Razor' } })
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Toiletries' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        fireEvent.change(input, { target: { value: 'Shampoo' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenLastCalledWith('Shampoo', 'Toiletries')
+    })
+})
+
+describe('AddQuestionItem: suggestions', () => {
+    const suggestions = buildIndexOf([
+        { text: 'Sun cream', category: 'Toiletries', owner: 'q1:o2' },
+        { text: 'Sunhat', category: 'Clothes', owner: 'q1:o2' },
+        { text: 'Sun lounger', owner: 'q1:o1' },
+    ])
+
+    it('offers names from elsewhere in the question set', () => {
+        const { input } = renderComposer({ suggestions })
+        expect(screen.queryByRole('listbox')).toBeNull()
+        fireEvent.change(input, { target: { value: 'sun' } })
+        expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual([
+            'Sun creamToiletries',
+            'SunhatClothes',
+        ])
+    })
+
+    it('leaves out names this list already has', () => {
+        // "Sun lounger" is owned by q1:o1 — the list being added to.
+        const { input } = renderComposer({ suggestions })
+        fireEvent.change(input, { target: { value: 'sun l' } })
+        expect(screen.queryByRole('listbox')).toBeNull()
+    })
+
+    it('takes the name and its section when one is picked', () => {
+        const { onAdd, input } = renderComposer({ suggestions, sectionOptions: ['Toiletries', 'Clothes'] })
+        fireEvent.change(input, { target: { value: 'sunh' } })
+        fireEvent.click(screen.getByRole('option', { name: /Sunhat/ }))
+        expect(input.value).toBe('Sunhat')
+        expect((screen.getByLabelText('Section') as HTMLSelectElement).value).toBe('Clothes')
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith('Sunhat', 'Clothes')
+    })
+
+    it('brings a section this list does not have yet with it', () => {
+        // The suggestion is the one thing that knows "Sun cream goes in
+        // Toiletries". Dropping the section because this answer has no
+        // Toiletries yet would lose exactly the knowledge being offered.
+        const { onAdd, input } = renderComposer({ suggestions, sectionOptions: ['Clothes'] })
+        fireEvent.change(input, { target: { value: 'sun c' } })
+        fireEvent.click(screen.getByRole('option', { name: /Sun cream/ }))
+        expect((screen.getByLabelText('Section') as HTMLSelectElement).value).toBe('Toiletries')
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith('Sun cream', 'Toiletries')
+    })
+
+    it('leaves a fixed section alone when a suggestion disagrees', () => {
+        // Opened from the Clothes heading: the user has already said where this
+        // is going, and there is no picker to show them it moved.
+        const { onAdd, input } = renderComposer({ suggestions, category: 'Clothes' })
+        fireEvent.change(input, { target: { value: 'sun c' } })
+        fireEvent.click(screen.getByRole('option', { name: /Sun cream/ }))
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith('Sun cream', 'Clothes')
+    })
+})
+
+describe('AddQuestionItem: dismissing', () => {
+    it('closes on Escape', () => {
+        const onClose = vi.fn()
+        const { input } = renderComposer({ onClose })
+        fireEvent.keyDown(input, { key: 'Escape' })
+        expect(onClose).toHaveBeenCalled()
+    })
+
+    it('closes the suggestions first, keeping what was typed', () => {
+        const onClose = vi.fn()
+        const suggestions = buildIndexOf([{ text: 'Sun cream', owner: 'q1:o2' }])
+        const { input } = renderComposer({ onClose, suggestions })
+        fireEvent.change(input, { target: { value: 'sun' } })
+        fireEvent.keyDown(input, { key: 'Escape' })
+        expect(screen.queryByRole('listbox')).toBeNull()
+        expect(onClose).not.toHaveBeenCalled()
+        expect(input.value).toBe('sun')
+    })
+
+    it('closes when focus leaves an empty composer', () => {
+        const onClose = vi.fn()
+        renderComposer({ onClose })
+        fireEvent.blur(screen.getByTestId('add-question-item'))
+        expect(onClose).toHaveBeenCalled()
+    })
+
+    it('stays open when focus leaves a half-typed item', () => {
+        const onClose = vi.fn()
+        const { input } = renderComposer({ onClose })
+        fireEvent.change(input, { target: { value: 'Raz' } })
+        fireEvent.blur(screen.getByTestId('add-question-item'))
+        expect(onClose).not.toHaveBeenCalled()
+    })
+})

--- a/src/components/AddQuestionItem.tsx
+++ b/src/components/AddQuestionItem.tsx
@@ -1,0 +1,176 @@
+/**
+ * The one way items get added to a question set from the questions page.
+ *
+ * Adding an item here used to mean opening the option's editor modal, scrolling
+ * to the bottom of its list, tapping "+ Add Item" for a blank row, typing into
+ * it, and saving the whole option — and the row landed in whichever section the
+ * list happened to end with, so putting an item in a *particular* section then
+ * needed a second trip through the row editor or the drag view. This is that
+ * job in one line, in place, with the section already decided by where the
+ * composer was opened.
+ *
+ * Its two jobs, in order of how much typing they save:
+ *
+ *  - *Where it lands.* Either fixed (opened from a section's own ＋) or picked
+ *    here, and stamped on the item — see `appendItemToSection`.
+ *  - *How much typing.* The question set is its own dictionary, so a matched
+ *    name arrives with the section it is filed under everywhere else, and one
+ *    tap files it there — even into a section this list has not used yet.
+ *
+ * What the item is *for* is deliberately not here: a new item goes to everyone,
+ * as it always has, and who-it's-for and how-many live one tap away in the row
+ * the item just landed in. Adding them would put four controls in front of
+ * someone whose next move, nine times in ten, is to type the next item.
+ *
+ * The draft lives in this component and at most one is mounted at a time, so a
+ * keystroke re-renders one composer rather than every question on the page.
+ */
+import { memo, useEffect, useRef, useState } from 'react'
+import { FIELD_BASE, ItemNameField } from './ItemNameField'
+import type { ItemSuggestion, SuggestionIndex } from '../utils/itemSuggestions'
+
+const FIELD = `${FIELD_BASE} focus:ring-primary-500`
+
+/** Room to leave under the field for its suggestion list and a phone keyboard. */
+const ROOM_BELOW = 260
+
+interface AddQuestionItemProps {
+    /** Section the item lands in; undefined = the list's default section. */
+    category?: string
+    /** Providing these turns on the section picker. */
+    sectionOptions?: readonly string[]
+    /** What this list calls items carrying no section of their own. */
+    defaultLabel: string
+    suggestions: SuggestionIndex
+    /** Which list this is, so its own names aren't offered back to it. */
+    ownerKey: string
+    /** Names the composer for screen readers, e.g. "Toiletries". */
+    targetLabel: string
+    onAdd: (text: string, category: string | undefined) => void
+    onClose?: () => void
+    autoFocus?: boolean
+    placeholder?: string
+}
+
+export const AddQuestionItem = memo(function AddQuestionItem({
+    category,
+    sectionOptions,
+    defaultLabel,
+    suggestions,
+    ownerKey,
+    targetLabel,
+    onAdd,
+    onClose,
+    autoFocus,
+    placeholder,
+}: AddQuestionItemProps) {
+    const [text, setText] = useState('')
+    const [chosenLabel, setChosenLabel] = useState(category ?? defaultLabel)
+    const inputRef = useRef<HTMLInputElement>(null)
+    const rootRef = useRef<HTMLDivElement>(null)
+
+    // A composer opens at the bottom of its section, which for a long section on
+    // a phone is at or below the fold — and the browser's own focus scroll only
+    // brings it just barely into view, where the keyboard then covers it. Pull it
+    // up far enough that the field, its suggestions and the keyboard all fit;
+    // leave it alone when there is already room, so opening one near the top of
+    // the screen doesn't jump the page for no reason.
+    useEffect(() => {
+        const el = rootRef.current
+        if (!autoFocus || !el?.scrollIntoView) return
+        const { top, bottom } = el.getBoundingClientRect()
+        if (top < 0 || bottom + ROOM_BELOW > window.innerHeight) {
+            el.scrollIntoView({ block: 'center', behavior: 'smooth' })
+        }
+    }, [autoFocus])
+
+    const picking = sectionOptions !== undefined
+    // The default section is offered by name, so "the main pile" is a choice
+    // rather than the absence of one. A section a suggestion brought with it is
+    // offered too, even if this list has never used it — that is how a name
+    // filed under Toiletries elsewhere lands in Toiletries here.
+    const labels = picking
+        ? [...new Set([defaultLabel, ...sectionOptions, chosenLabel])]
+        : []
+    const targetCategory = picking
+        ? (chosenLabel === defaultLabel ? undefined : chosenLabel)
+        : category
+
+    const applySuggestion = (suggestion: ItemSuggestion) => {
+        // A suggestion knows where it belongs, and carrying that across is the
+        // whole point of offering it. Only when there is a picker to show it in:
+        // silently moving an item out of the section its ＋ was tapped in would
+        // be a change nobody could see.
+        if (picking && suggestion.category) setChosenLabel(suggestion.category)
+    }
+
+    const submit = () => {
+        const trimmed = text.trim()
+        if (!trimmed) return
+        onAdd(trimmed, targetCategory)
+        setText('')
+        inputRef.current?.focus()
+    }
+
+    // A composer left empty has served its purpose; one with half an item in it
+    // has not, and must not take the draft with it.
+    const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+        if (e.currentTarget.contains(e.relatedTarget)) return
+        if (!text.trim()) onClose?.()
+    }
+
+    // At rest this is one field and an Add button, so it fits a phone's width
+    // without wrapping. The section picker earns its space only once there is an
+    // item to file, which is also the first moment it can be answered.
+    const expanded = text.trim().length > 0
+
+    return (
+        <div
+            ref={rootRef}
+            data-testid="add-question-item"
+            onBlur={handleBlur}
+            className="flex flex-wrap items-center gap-2"
+        >
+            <div className={`min-w-[8rem] ${expanded && picking ? 'basis-full' : 'flex-1 basis-40'}`}>
+                <ItemNameField
+                    value={text}
+                    onChange={setText}
+                    suggestions={suggestions}
+                    ownerKey={ownerKey}
+                    onPick={applySuggestion}
+                    onSubmit={submit}
+                    onClose={onClose}
+                    // Named as a field, not as the action: the ＋ that opened it
+                    // is the button called "add an item to Toiletries".
+                    label={`New item in ${targetLabel}`}
+                    listboxId={`add-question-item-${ownerKey}-${category ?? 'any'}`}
+                    inputRef={inputRef}
+                    autoFocus={autoFocus}
+                    placeholder={placeholder ?? 'Add an item...'}
+                    inputClassName={FIELD}
+                />
+            </div>
+
+            {expanded && picking && (
+                <select
+                    aria-label="Section"
+                    value={chosenLabel}
+                    onChange={e => setChosenLabel(e.target.value)}
+                    className={`min-w-0 flex-1 sm:flex-none sm:max-w-[13rem] ${FIELD}`}
+                >
+                    {labels.map(label => (
+                        <option key={label} value={label}>{label}</option>
+                    ))}
+                </select>
+            )}
+
+            <button
+                type="button"
+                onClick={submit}
+                className="shrink-0 px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 transition-colors text-sm font-medium"
+            >
+                Add
+            </button>
+        </div>
+    )
+})

--- a/src/components/ItemNameField.tsx
+++ b/src/components/ItemNameField.tsx
@@ -1,0 +1,173 @@
+/**
+ * The "type an item name" field, with the collection's own names offered back
+ * as you type.
+ *
+ * Shared by both add-an-item composers — the packing list's and the question
+ * set's — because typing an item name is the same job on both pages and the
+ * keyboard contract is the fiddly part: arrows move through the matches, Enter
+ * takes a highlighted match or else submits what was typed, and Escape backs
+ * out one layer at a time so dismissing the dropdown never loses the draft.
+ *
+ * The field owns the dropdown (which match is highlighted, whether it is
+ * showing at all) and nothing else. The text belongs to the composer around it,
+ * which is what has to clear it after an add and read it to decide whether
+ * there is an item to file yet.
+ */
+import { useMemo, useState } from 'react'
+import { suggestFor, type ItemSuggestion, type SuggestionIndex } from '../utils/itemSuggestions'
+
+/** A composer field, bar the focus ring — each page brings its own accent. */
+export const FIELD_BASE = 'px-3 py-2 border border-gray-300 rounded-md bg-white text-sm text-gray-700 focus:outline-none focus:ring-2'
+export const FIELD = `${FIELD_BASE} focus:ring-blue-500`
+
+interface ItemNameFieldProps {
+    value: string
+    onChange: (text: string) => void
+    suggestions: SuggestionIndex
+    /** Whose existing names to leave out of the offers — see `buildIndexOf`. */
+    ownerKey: string
+    /** A suggestion was taken; its name is already in `value`. */
+    onPick?: (suggestion: ItemSuggestion) => void
+    onSubmit: () => void
+    /** Escape with nothing left to dismiss — set by composers opened in place. */
+    onClose?: () => void
+    /**
+     * The field's accessible name. Set by the composer rather than built here,
+     * because a page with a ＋ per section heading has to keep the two apart:
+     * a field and a button that both announce "add an item to Toiletries" are
+     * indistinguishable to anyone listening.
+     */
+    label: string
+    /** Distinct per mounted field: ties the input to its own listbox. */
+    listboxId: string
+    inputRef?: React.RefObject<HTMLInputElement | null>
+    autoFocus?: boolean
+    placeholder?: string
+    /** Defaults to the packing list's accent; see `FIELD_BASE`. */
+    inputClassName?: string
+}
+
+export function ItemNameField({
+    value,
+    onChange,
+    suggestions,
+    ownerKey,
+    onPick,
+    onSubmit,
+    onClose,
+    label,
+    listboxId,
+    inputRef,
+    autoFocus,
+    placeholder = 'Add new item...',
+    inputClassName = FIELD,
+}: ItemNameFieldProps) {
+    const [highlighted, setHighlighted] = useState(-1)
+    const [open, setOpen] = useState(true)
+
+    const matches = useMemo(
+        () => open ? suggestFor(suggestions, ownerKey, value) : [],
+        [suggestions, ownerKey, value, open],
+    )
+
+    const applySuggestion = (suggestion: ItemSuggestion) => {
+        onChange(suggestion.text)
+        setOpen(false)
+        setHighlighted(-1)
+        onPick?.(suggestion)
+        inputRef?.current?.focus()
+    }
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'ArrowDown' && matches.length > 0) {
+            e.preventDefault()
+            setHighlighted(prev => (prev + 1) % matches.length)
+            return
+        }
+        if (e.key === 'ArrowUp' && matches.length > 0) {
+            e.preventDefault()
+            setHighlighted(prev => (prev <= 0 ? matches.length : prev) - 1)
+            return
+        }
+        if (e.key === 'Enter') {
+            e.preventDefault()
+            const picked = matches[highlighted]
+            if (picked) applySuggestion(picked)
+            else onSubmit()
+            return
+        }
+        if (e.key === 'Escape') {
+            e.preventDefault()
+            // Escape backs out one layer at a time: the suggestions first, then
+            // the composer — so dismissing a dropdown never loses what was typed.
+            if (matches.length > 0) {
+                setOpen(false)
+                setHighlighted(-1)
+                return
+            }
+            onClose?.()
+        }
+    }
+
+    // Leaving the field for anywhere else — including the composer's own
+    // quantity box — puts the dropdown away. It hangs over whatever is below it,
+    // so it has no business outliving the field it belongs to.
+    const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+        if (e.currentTarget.contains(e.relatedTarget)) return
+        setOpen(false)
+    }
+
+    return (
+        <div className="relative w-full" onBlur={handleBlur}>
+            <input
+                ref={inputRef}
+                type="text"
+                role="combobox"
+                aria-expanded={matches.length > 0}
+                aria-controls={listboxId}
+                aria-autocomplete="list"
+                aria-label={label}
+                autoComplete="off"
+                enterKeyHint="done"
+                value={value}
+                autoFocus={autoFocus}
+                onChange={e => {
+                    onChange(e.target.value)
+                    setHighlighted(-1)
+                    setOpen(true)
+                }}
+                onKeyDown={handleKeyDown}
+                placeholder={placeholder}
+                className={`w-full ${inputClassName}`}
+            />
+            {matches.length > 0 && (
+                <ul
+                    id={listboxId}
+                    role="listbox"
+                    className="absolute left-0 right-0 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+                >
+                    {matches.map((suggestion, i) => (
+                        <li key={suggestion.text}>
+                            <button
+                                type="button"
+                                role="option"
+                                aria-selected={i === highlighted}
+                                // Blur would close the list before the click landed.
+                                onMouseDown={e => e.preventDefault()}
+                                onClick={() => applySuggestion(suggestion)}
+                                className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm ${i === highlighted ? 'bg-blue-50 text-blue-900' : 'text-gray-700 hover:bg-gray-50'}`}
+                            >
+                                <span className="truncate">{suggestion.text}</span>
+                                {suggestion.category && (
+                                    <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[11px] text-gray-500">
+                                        {suggestion.category}
+                                    </span>
+                                )}
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    )
+}

--- a/src/edit-questions/item-edits.test.ts
+++ b/src/edit-questions/item-edits.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { applyItemEdit, withQuestionOptions } from './item-edits'
+import { appendItemToSection, applyItemEdit, withQuestionOptions } from './item-edits'
 import type { Item, Option, Question } from './types'
 
 const NOW = '2024-06-01T12:00:00.000Z'
@@ -164,5 +164,85 @@ describe('applyItemEdit across sections', () => {
         const edited = { ...list[0], text: 'Wool socks', category: 'Toiletries' }
         const result = applyItemEdit(list, 0, edited, 'Yes', NOW)
         expect(result.map(i => i.text)).toEqual(['Toothbrush', 'Shampoo', 'Wool socks'])
+    })
+})
+
+// ── appendItemToSection ──────────────────────────────────────────────────────
+
+describe('appendItemToSection', () => {
+    const sectioned = () => [
+        makeItem('Socks', { order: 0 }),
+        makeItem('Toothbrush', { category: 'Toiletries', order: 1 }),
+        makeItem('Shampoo', { category: 'Toiletries', order: 2 }),
+    ]
+
+    it('lands the item at the bottom of the named section', () => {
+        const result = appendItemToSection(sectioned(), makeItem('Razor'), 'Toiletries', 'Yes', NOW)
+        expect(result.map(i => i.text)).toEqual(['Socks', 'Toothbrush', 'Shampoo', 'Razor'])
+    })
+
+    it('stamps the section on the new item', () => {
+        const result = appendItemToSection(sectioned(), makeItem('Razor'), 'Toiletries', 'Yes', NOW)
+        expect(result.find(i => i.text === 'Razor')?.category).toBe('Toiletries')
+    })
+
+    it('lands it under the section it was typed into, not at the end of the list', () => {
+        // The whole point of a ＋ on a heading: an item typed under Toiletries
+        // sits in Toiletries, not in whichever section happens to be last.
+        const list = [
+            makeItem('Toothbrush', { category: 'Toiletries', order: 0 }),
+            makeItem('Tent', { category: 'Kit & Gear', order: 1 }),
+        ]
+        const result = appendItemToSection(list, makeItem('Razor'), 'Toiletries', 'Yes', NOW)
+        expect(result.map(i => i.text)).toEqual(['Toothbrush', 'Razor', 'Tent'])
+    })
+
+    it('renumbers order so the generated packing list picks the position up', () => {
+        // The generated list sorts by `order`, not array position: without this
+        // the new item would sort into its section at whatever position the item
+        // it displaced already had.
+        const list = [
+            makeItem('Toothbrush', { category: 'Toiletries', order: 0 }),
+            makeItem('Tent', { category: 'Kit & Gear', order: 1 }),
+        ]
+        const result = appendItemToSection(list, makeItem('Razor'), 'Toiletries', 'Yes', NOW)
+        expect(result.map(i => i.order)).toEqual([0, 1, 2])
+    })
+
+    it('stores no category for the list’s default section', () => {
+        // "The main pile" stores nothing rather than the default section's name —
+        // see the note on applySectionLayout.
+        const result = appendItemToSection(sectioned(), makeItem('Hat'), undefined, 'Yes', NOW)
+        expect('category' in result.find(i => i.text === 'Hat')!).toBe(false)
+    })
+
+    it('puts a default-section item after the last one, wherever those sit', () => {
+        const result = appendItemToSection(sectioned(), makeItem('Hat'), undefined, 'Yes', NOW)
+        expect(result.map(i => i.text)).toEqual(['Socks', 'Hat', 'Toothbrush', 'Shampoo'])
+    })
+
+    it('creates a section that has no items yet', () => {
+        const result = appendItemToSection(sectioned(), makeItem('Snorkel'), 'Beach kit', 'Yes', NOW)
+        expect(result.filter(i => i.category === 'Beach kit').map(i => i.text)).toEqual(['Snorkel'])
+        expect(result[result.length - 1].text).toBe('Snorkel')
+    })
+
+    it('appends to an empty list', () => {
+        const result = appendItemToSection([], makeItem('Socks'), undefined, 'Yes', NOW)
+        expect(result.map(i => i.text)).toEqual(['Socks'])
+        expect(result[0].order).toBe(0)
+    })
+
+    it('stamps lastModified on the new item so it survives a sync merge', () => {
+        const result = appendItemToSection(sectioned(), makeItem('Razor'), 'Toiletries', 'Yes', NOW)
+        expect(result.find(i => i.text === 'Razor')?.lastModified).toBe(NOW)
+    })
+
+    it('leaves untouched items alone, identity included', () => {
+        const list = sectioned()
+        const result = appendItemToSection(list, makeItem('Razor'), 'Toiletries', 'Yes', NOW)
+        expect(result[0]).toBe(list[0])
+        expect(result[1]).toBe(list[1])
+        expect(result[2]).toBe(list[2])
     })
 })

--- a/src/edit-questions/item-edits.ts
+++ b/src/edit-questions/item-edits.ts
@@ -41,6 +41,51 @@ export function withQuestionOptions(
 }
 
 /**
+ * Add a new item to the bottom of one section.
+ *
+ * `category` names the section — `undefined` for the list's default one, which
+ * is stored as no category at all rather than as the default's name (see the
+ * note on `applySectionLayout`).
+ *
+ * The item is inserted after the last item already in that section rather than
+ * pushed onto the end, because the array position is what the section views
+ * bucket by: appending would put an item typed under Toiletries below whichever
+ * section happens to come last. Renumbering afterwards is what makes the
+ * generated packing list agree, since it sorts by the stamped `order` and would
+ * otherwise sort the new item into its section at a stale position. Items whose
+ * position is unchanged keep their identity and their old timestamp.
+ */
+export function appendItemToSection(
+    items: Item[],
+    newItem: Item,
+    category: string | undefined,
+    defaultLabel: string,
+    now: string,
+): Item[] {
+    const placed: Item = {
+        ...newItem,
+        ...(category !== undefined ? { category } : {}),
+        lastModified: now,
+    }
+    const targetLabel = category ?? defaultLabel
+
+    // A section with nothing in it yet — one just named, or the very first item
+    // of the list — has no run to join, so it starts one at the end.
+    let insertAt = items.length
+    for (let i = items.length - 1; i >= 0; i--) {
+        if ((items[i].category ?? defaultLabel) === targetLabel) {
+            insertAt = i + 1
+            break
+        }
+    }
+
+    return renumberItemOrder(
+        [...items.slice(0, insertAt), placed, ...items.slice(insertAt)],
+        now,
+    )
+}
+
+/**
  * Apply an edit to the item at `index`.
  *
  * When the edit leaves the item in the same section this is a straight

--- a/src/edit-questions/item-suggestions.test.ts
+++ b/src/edit-questions/item-suggestions.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { ALWAYS_LIST_KEY, listKeyFor, buildQuestionSetSuggestions } from './item-suggestions'
+import { suggestFor } from '../utils/itemSuggestions'
+import type { Item, PackingListQuestionSet, Question } from './types'
+
+function makeItem(text: string, overrides: Partial<Item> = {}): Item {
+    return { text, personSelections: [], ...overrides }
+}
+
+function makeQuestion(id: string, options: { id: string; items: Item[] }[]): Question {
+    return {
+        id,
+        type: 'saved',
+        text: `Question ${id}`,
+        order: 0,
+        options: options.map((o, i) => ({ id: o.id, text: `Option ${o.id}`, order: i, items: o.items })),
+    }
+}
+
+function makeSet(overrides: Partial<PackingListQuestionSet> = {}): PackingListQuestionSet {
+    return { people: [], alwaysNeededItems: [], questions: [], ...overrides }
+}
+
+describe('buildQuestionSetSuggestions', () => {
+    it('collects every distinct name in the set, wherever it lives', () => {
+        const index = buildQuestionSetSuggestions(makeSet({
+            alwaysNeededItems: [makeItem('Passport')],
+            questions: [makeQuestion('q1', [{ id: 'o1', items: [makeItem('Sunhat')] }])],
+        }))
+        expect(index.all.map(s => s.text)).toEqual(['Passport', 'Sunhat'])
+    })
+
+    it('carries the section a name is usually filed under', () => {
+        const index = buildQuestionSetSuggestions(makeSet({
+            alwaysNeededItems: [makeItem('Toothbrush', { category: 'Toiletries' })],
+        }))
+        expect(index.all[0].category).toBe('Toiletries')
+    })
+
+    it('leaves a name uncategorised when it carries no section of its own', () => {
+        // The section an uncategorised item shows under is the list's own default
+        // heading — the option or question text. That name means nothing in
+        // another list, so picking the suggestion must not stamp it.
+        const index = buildQuestionSetSuggestions(makeSet({
+            alwaysNeededItems: [makeItem('Toothbrush')],
+        }))
+        expect(index.all[0].category).toBeUndefined()
+    })
+
+    it('takes the majority verdict when a name is filed two ways', () => {
+        const index = buildQuestionSetSuggestions(makeSet({
+            alwaysNeededItems: [makeItem('Towel')],
+            questions: [makeQuestion('q1', [
+                { id: 'o1', items: [makeItem('Towel', { category: 'Toiletries' })] },
+                { id: 'o2', items: [makeItem('Towel', { category: 'Toiletries' })] },
+            ])],
+        }))
+        expect(index.all[0].category).toBe('Toiletries')
+    })
+
+    it('keeps offering a name the list deleted — those are what people put back', () => {
+        const index = buildQuestionSetSuggestions(makeSet({
+            alwaysNeededItems: [makeItem('Sun cream', { deletedAt: '2024-01-01T00:00:00.000Z' })],
+        }))
+        expect(suggestFor(index, ALWAYS_LIST_KEY, 'sun').map(s => s.text)).toEqual(['Sun cream'])
+    })
+
+    it('skips deleted questions and options entirely', () => {
+        const deleted = makeQuestion('q1', [{ id: 'o1', items: [makeItem('Wetsuit')] }])
+        const index = buildQuestionSetSuggestions(makeSet({
+            questions: [{ ...deleted, deletedAt: '2024-01-01T00:00:00.000Z' }],
+        }))
+        expect(index.all).toEqual([])
+    })
+})
+
+describe('buildQuestionSetSuggestions: what each list already has', () => {
+    const set = makeSet({
+        alwaysNeededItems: [makeItem('Passport')],
+        questions: [makeQuestion('q1', [{ id: 'o1', items: [makeItem('Sunhat')] }])],
+    })
+    const index = buildQuestionSetSuggestions(set)
+
+    it('does not offer a list a name it already holds', () => {
+        expect(suggestFor(index, ALWAYS_LIST_KEY, 'pass')).toEqual([])
+    })
+
+    it('does offer that name to a list that does not have it', () => {
+        expect(suggestFor(index, listKeyFor('q1', 'o1'), 'pass').map(s => s.text)).toEqual(['Passport'])
+    })
+
+    it('keys options separately, so two answers do not share a dictionary', () => {
+        expect(suggestFor(index, listKeyFor('q1', 'o2'), 'sunh').map(s => s.text)).toEqual(['Sunhat'])
+        expect(suggestFor(index, listKeyFor('q1', 'o1'), 'sunh')).toEqual([])
+    })
+})

--- a/src/edit-questions/item-suggestions.ts
+++ b/src/edit-questions/item-suggestions.ts
@@ -1,0 +1,55 @@
+/**
+ * The question set as a dictionary of its own item names.
+ *
+ * Someone adding "Toothbrush" to a new answer has almost certainly typed it
+ * before, somewhere else in the same set, and filed it under Toiletries when
+ * they did. Offering it back — with its section attached — is what lets an item
+ * land in the right section from one tap, instead of being typed, saved, and
+ * then moved.
+ *
+ * An "owner" here is one item list: the always-needed list, or one option's
+ * items. That is the unit a name can be a duplicate within, so it is the unit
+ * suggestions are withheld from.
+ */
+import { buildIndexOf, type SuggestionIndex, type SuggestionSource } from '../utils/itemSuggestions'
+import type { Item, PackingListQuestionSet } from './types'
+
+/** Owner key for the always-needed list, which belongs to no question. */
+export const ALWAYS_LIST_KEY = '__always__'
+
+export function listKeyFor(questionId: string, optionId: string): string {
+    return `${questionId}:${optionId}`
+}
+
+/**
+ * Every distinct name in the set, with the section it is usually filed under.
+ *
+ * Items carrying no category of their own contribute an uncategorised entry on
+ * purpose: the heading such an item shows under is its own list's default label
+ * — an option or question text — which means nothing in the list being added
+ * to, so picking the suggestion must leave the section alone rather than stamp
+ * a name from somewhere else.
+ */
+export function buildQuestionSetSuggestions(qs: PackingListQuestionSet): SuggestionIndex {
+    const sources: SuggestionSource[] = []
+    const record = (items: Item[], owner: string) => {
+        for (const item of items) {
+            sources.push({
+                text: item.text,
+                category: item.category,
+                // A deleted name stays in the catalogue but is not held by the
+                // list, so the list can be offered it back.
+                ...(item.deletedAt ? {} : { owner }),
+            })
+        }
+    }
+
+    record(qs.alwaysNeededItems ?? [], ALWAYS_LIST_KEY)
+    for (const question of qs.questions ?? []) {
+        if (question.deletedAt) continue
+        for (const option of question.options) {
+            record(option.items, listKeyFor(question.id, option.id))
+        }
+    }
+    return buildIndexOf(sources)
+}

--- a/src/pages/questions-page.option-section.test.tsx
+++ b/src/pages/questions-page.option-section.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { OptionSection } from './questions-page'
 import { DEFAULT_SECTION_ACCENT, sectionAccent } from '../edit-questions/section-accent'
 import type { Item, Option, Person } from '../edit-questions/types'
+import { buildIndexOf } from '../utils/itemSuggestions'
 
 vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
 vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn() }))
@@ -282,5 +283,227 @@ describe('OptionSection inline item editing', () => {
         fireEvent.click(screen.getByTitle('Edit Socks'))
         fireEvent.click(within(screen.getByTestId('item-inline-editor')).getByTitle('Bob'))
         expect(screen.getByTestId('item-inline-editor')).toBeTruthy()
+    })
+})
+
+describe('OptionSection adding items', () => {
+    const suggestions = buildIndexOf([
+        { text: 'Toothpaste', category: 'Toiletries', owner: 'q1:o2' },
+        { text: 'Socks', owner: 'q1:o1' },
+    ])
+
+    /** The same section with adding switched on, expanded. */
+    function renderAddable(option: Option, sectionNames: string[] = []) {
+        const onItemAdd = vi.fn()
+        render(
+            <OptionSection
+                option={option}
+                people={twoPeople}
+                sectionDefaultLabel="Yes"
+                allItemNames={[]}
+                sectionNames={sectionNames}
+                questionId="q1"
+                suggestions={suggestions}
+                onEdit={vi.fn()}
+                onDelete={vi.fn()}
+                onItemChange={vi.fn()}
+                onItemAdd={onItemAdd}
+            />
+        )
+        const toggle = screen.queryByRole('button', { name: /Yes/ })
+        if (toggle) fireEvent.click(toggle)
+        return { onItemAdd }
+    }
+
+    const sectioned = () => makeOption({
+        items: [
+            makeItem('Socks'),
+            makeItem('Toothbrush', { category: 'Toiletries' }),
+            makeItem('Pyjamas', { category: 'Sleep' }),
+        ],
+    })
+
+    it('puts an add button on every section heading', () => {
+        renderAddable(sectioned())
+        expect(screen.getAllByTestId('add-to-section')).toHaveLength(3)
+        expect(screen.getByLabelText('Add an item to Toiletries')).toBeTruthy()
+    })
+
+    it('offers no add buttons on a read-only list', () => {
+        renderOption(sectioned())
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        expect(screen.queryByTestId('add-to-section')).toBeNull()
+        expect(screen.queryByRole('button', { name: '+ Add item' })).toBeNull()
+    })
+
+    it('files an item under the section whose button was tapped', () => {
+        // The whole point: the item lands where it was typed, with no second
+        // trip through the row editor to move it there.
+        const { onItemAdd } = renderAddable(sectioned())
+        fireEvent.click(screen.getByLabelText('Add an item to Toiletries'))
+        const input = screen.getByRole('combobox')
+        fireEvent.change(input, { target: { value: 'Razor' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onItemAdd).toHaveBeenCalledWith('q1', 'o1', 'Razor', 'Toiletries')
+    })
+
+    it('stores no section for an item added to the default one', () => {
+        const { onItemAdd } = renderAddable(sectioned())
+        fireEvent.click(screen.getByLabelText('Add an item to Yes'))
+        const input = screen.getByRole('combobox')
+        fireEvent.change(input, { target: { value: 'Hat' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onItemAdd).toHaveBeenCalledWith('q1', 'o1', 'Hat', undefined)
+    })
+
+    it('opens the composer inside the section it belongs to', () => {
+        renderAddable(sectioned())
+        fireEvent.click(screen.getByLabelText('Add an item to Toiletries'))
+        const cards = screen.getAllByTestId('item-section')
+        expect(within(cards[1]).getByTestId('add-question-item')).toBeTruthy()
+        expect(within(cards[0]).queryByTestId('add-question-item')).toBeNull()
+    })
+
+    it('keeps only one composer open at a time', () => {
+        // One per heading would put an input in front of every section — the
+        // cost the read-only rows exist to avoid.
+        renderAddable(sectioned())
+        fireEvent.click(screen.getByLabelText('Add an item to Toiletries'))
+        fireEvent.click(screen.getByLabelText('Add an item to Sleep'))
+        expect(screen.getAllByTestId('add-question-item')).toHaveLength(1)
+    })
+
+    it('closes when the same heading is tapped again', () => {
+        renderAddable(sectioned())
+        fireEvent.click(screen.getByLabelText('Add an item to Toiletries'))
+        fireEvent.click(screen.getByLabelText('Add an item to Toiletries'))
+        expect(screen.queryByTestId('add-question-item')).toBeNull()
+    })
+
+    it('stays open after an add, so items go in in runs', () => {
+        const { onItemAdd } = renderAddable(sectioned())
+        fireEvent.click(screen.getByLabelText('Add an item to Toiletries'))
+        const input = screen.getByRole('combobox')
+        fireEvent.change(input, { target: { value: 'Razor' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        fireEvent.change(input, { target: { value: 'Shampoo' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onItemAdd).toHaveBeenLastCalledWith('q1', 'o1', 'Shampoo', 'Toiletries')
+    })
+
+    it('has no section picker on a composer opened from a heading', () => {
+        // The heading already answered that question.
+        renderAddable(sectioned())
+        fireEvent.click(screen.getByLabelText('Add an item to Toiletries'))
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Razor' } })
+        expect(screen.queryByLabelText('Section')).toBeNull()
+    })
+})
+
+describe('OptionSection adding from the foot of the list', () => {
+    const suggestions = buildIndexOf([{ text: 'Toothpaste', category: 'Toiletries', owner: 'q1:o2' }])
+
+    function renderAddable(option: Option, sectionNames: string[] = []) {
+        const onItemAdd = vi.fn()
+        render(
+            <OptionSection
+                option={option}
+                people={twoPeople}
+                sectionDefaultLabel="Yes"
+                sectionNames={sectionNames}
+                questionId="q1"
+                suggestions={suggestions}
+                onEdit={vi.fn()}
+                onDelete={vi.fn()}
+                onItemAdd={onItemAdd}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        return { onItemAdd }
+    }
+
+    it('offers an add row under an unsectioned list, which has no headings', () => {
+        const { onItemAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }))
+        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
+        const input = screen.getByRole('combobox')
+        fireEvent.change(input, { target: { value: 'Hat' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onItemAdd).toHaveBeenCalledWith('q1', 'o1', 'Hat', undefined)
+    })
+
+    it('asks which section, offering the list’s own and the set’s others', () => {
+        renderAddable(
+            makeOption({ items: [makeItem('Toothbrush', { category: 'Toiletries' })] }),
+            ['Clothes'],
+        )
+        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'H' } })
+        const options = [...(screen.getByLabelText('Section') as HTMLSelectElement).options].map(o => o.value)
+        expect(options).toEqual(['Yes', 'Toiletries', 'Clothes'])
+    })
+
+    it('files an item into a section this answer has never used', () => {
+        // A section is only ever a name stamped on an item, so an answer can be
+        // given its first Toiletries item without anything being created first.
+        const { onItemAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }), ['Toiletries'])
+        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
+        const input = screen.getByRole('combobox')
+        fireEvent.change(input, { target: { value: 'Razor' } })
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Toiletries' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onItemAdd).toHaveBeenCalledWith('q1', 'o1', 'Razor', 'Toiletries')
+    })
+
+    it('replaces the add row with the composer rather than showing both', () => {
+        renderAddable(makeOption({ items: [makeItem('Socks')] }))
+        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
+        expect(screen.queryByRole('button', { name: '+ Add item' })).toBeNull()
+    })
+
+    it('offers a name used elsewhere in the set, with the section it is filed under', () => {
+        renderAddable(makeOption({ items: [makeItem('Socks')] }))
+        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'tooth' } })
+        fireEvent.click(screen.getByRole('option', { name: /Toothpaste/ }))
+        expect((screen.getByLabelText('Section') as HTMLSelectElement).value).toBe('Toiletries')
+    })
+})
+
+describe('OptionSection with no items, once items can be added', () => {
+    function renderEmpty() {
+        const onItemAdd = vi.fn()
+        render(
+            <OptionSection
+                option={makeOption()}
+                people={people}
+                sectionDefaultLabel="Yes"
+                questionId="q1"
+                suggestions={buildIndexOf([])}
+                onEdit={vi.fn()}
+                onDelete={vi.fn()}
+                onItemAdd={onItemAdd}
+            />
+        )
+        return { onItemAdd }
+    }
+
+    it('becomes expandable, since it no longer opens onto nothing', () => {
+        renderEmpty()
+        expect(screen.getByTestId('option-expand-chevron')).toBeTruthy()
+    })
+
+    it('still says it has no items', () => {
+        renderEmpty()
+        expect(screen.getByText('No items')).toBeTruthy()
+    })
+
+    it('takes the first item, which it had no way to accept before', () => {
+        const { onItemAdd } = renderEmpty()
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
+        const input = screen.getByRole('combobox')
+        fireEvent.change(input, { target: { value: 'Socks' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onItemAdd).toHaveBeenCalledWith('q1', 'o1', 'Socks', undefined)
     })
 })

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -20,8 +20,11 @@ import { TemplateUpdatesCard } from '../components/TemplateUpdatesCard'
 import { LoadingState } from '../components/LoadingState'
 import { AgeTransition } from '../edit-questions/age-derivation'
 import { useIsDesktop } from '../hooks/useIsDesktop'
-import { applyItemEdit, withQuestionOptions } from '../edit-questions/item-edits'
+import { appendItemToSection, applyItemEdit, withQuestionOptions } from '../edit-questions/item-edits'
 import { ItemInlineEditor } from '../components/ItemInlineEditor'
+import { AddQuestionItem } from '../components/AddQuestionItem'
+import { ALWAYS_LIST_KEY, buildQuestionSetSuggestions, listKeyFor } from '../edit-questions/item-suggestions'
+import { buildIndexOf, type SuggestionIndex } from '../utils/itemSuggestions'
 import {
     AVATAR_ON,
     AVATAR_OFF,
@@ -156,6 +159,22 @@ const ItemRow = memo(function ItemRow({ item, people, index, isOpen, onOpen }: {
     )
 })
 
+/** Composer key for the one at the foot of a list, which picks its own section. */
+const LIST_COMPOSER = '__list__'
+
+/**
+ * Everything one item list needs to add to itself. Passed as a single object so
+ * a list that can't be added to (a foreign pod's, say) is `undefined` rather
+ * than three separate omitted props — and so one `useMemo` keeps the whole lot
+ * stable for the memoized rows below.
+ */
+export interface ItemAdding {
+    suggestions: SuggestionIndex
+    /** Which list this is, so its own names aren't offered back to it. */
+    ownerKey: string
+    onAdd: (text: string, category: string | undefined) => void
+}
+
 /**
  * Read-only item list, split by section the same way the editor and the
  * generated packing list are — so this page shows the grouping a list will
@@ -165,13 +184,23 @@ const ItemRow = memo(function ItemRow({ item, people, index, isOpen, onOpen }: {
  * a run of items under a line of grey capitals read as one undivided list, and
  * the grouping is the whole point of the page. Cards only appear once a list is
  * genuinely split; an unsectioned list renders as plain rows, as it did before.
+ *
+ * Every heading carries a ＋ that adds to *that* section, which is the shortest
+ * way to say where an item goes: you tap it where you want the item, and it
+ * lands there. The list also ends with one that picks its own section, for a
+ * list with no sections yet and for sections that don't exist yet. Only one
+ * composer is mounted at a time — one per heading would put an input in front
+ * of every section on the page, which is the cost the read-only rows exist to
+ * avoid.
  */
-const SectionedItemRows = memo(function SectionedItemRows({ items, people, defaultLabel, allItemNames = NO_NAMES, sectionNames = NO_NAMES, onItemChange }: {
+const SectionedItemRows = memo(function SectionedItemRows({ items, people, defaultLabel, allItemNames = NO_NAMES, sectionNames = NO_NAMES, adding, onItemChange }: {
     items: Item[]
     people: Person[]
     defaultLabel: string
     allItemNames?: string[]
     sectionNames?: string[]
+    /** Omit to leave the list read-only — no ＋ buttons, no composer. */
+    adding?: ItemAdding
     /** Omit to keep the list purely read-only — rows then aren't clickable. */
     onItemChange?: (index: number, edited: Item) => void
 }) {
@@ -179,9 +208,38 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
     // every edit is addressed by. At most one is open, so a long list never
     // costs more than one mounted editor.
     const [openIndex, setOpenIndex] = useState<number | null>(null)
+    // Which composer is open, by section label (or LIST_COMPOSER for the one at
+    // the foot). Same one-at-a-time rule, for the same reason.
+    const [openComposer, setOpenComposer] = useState<string | null>(null)
+    const closeComposer = useCallback(() => setOpenComposer(null), [])
 
     const groups = useMemo(() => buildSectionGroups(items, defaultLabel), [items, defaultLabel])
     const hasSections = groups.length > 1
+
+    // Sections the foot composer can file into: the ones this list already has,
+    // plus every name used elsewhere in the set — so filing an item under
+    // Toiletries doesn't depend on this particular answer having used it yet.
+    const sectionOptions = useMemo(
+        () => [...new Set([...groups.map(group => group.label), ...sectionNames])]
+            .filter(label => label !== defaultLabel),
+        [groups, sectionNames, defaultLabel])
+
+    const renderComposer = (label: string, forSection: boolean) => adding && (
+        <AddQuestionItem
+            category={forSection && label !== defaultLabel ? label : undefined}
+            sectionOptions={forSection ? undefined : sectionOptions}
+            defaultLabel={defaultLabel}
+            suggestions={adding.suggestions}
+            ownerKey={adding.ownerKey}
+            targetLabel={label}
+            // Where it is going, restated where the typing happens: the heading
+            // it opened under scrolls off a phone as soon as the keyboard is up.
+            placeholder={forSection ? `Add to ${label}...` : 'Add an item...'}
+            onAdd={adding.onAdd}
+            onClose={closeComposer}
+            autoFocus
+        />
+    )
     // A sync or a delete can shrink the list under an open row; treat an index
     // that no longer exists as closed rather than rendering against undefined.
     const openAt = openIndex !== null && openIndex < items.length ? openIndex : null
@@ -227,38 +285,86 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
         </Fragment>
     )
 
+    // The foot of every list: one tap to a composer that asks where the item
+    // goes. It replaces itself with the composer rather than sitting above it,
+    // so the list never grows two add affordances at once.
+    const listFooter = adding && (
+        openComposer === LIST_COMPOSER
+            ? <div className="mt-2">{renderComposer(defaultLabel, false)}</div>
+            : (
+                <button
+                    type="button"
+                    onClick={() => setOpenComposer(LIST_COMPOSER)}
+                    className="mt-2 w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
+                >
+                    + Add item
+                </button>
+            )
+    )
+
     if (!hasSections) {
-        return <div className="space-y-0.5">{groups.flatMap(group => group.entries).map(renderRow)}</div>
+        return (
+            <div>
+                <div className="space-y-0.5">{groups.flatMap(group => group.entries).map(renderRow)}</div>
+                {listFooter}
+            </div>
+        )
     }
 
     return (
-        <div className="space-y-2">
-            {groups.map(group => {
-                const accent = sectionAccent(group.label, group.label === defaultLabel)
-                return (
-                    <div
-                        key={`section-${group.label}`}
-                        data-testid="item-section"
-                        className={`rounded-lg border ${accent.border} bg-white overflow-hidden`}
-                    >
-                        <div className={`flex items-center gap-2 px-2.5 py-1.5 ${accent.header}`}>
-                            <span
-                                data-testid="item-section-heading"
-                                className={`text-sm font-semibold ${accent.text} truncate`}
-                            >
-                                {group.label}
-                            </span>
-                            <span
-                                data-testid="item-section-count"
-                                className={`ml-auto shrink-0 text-[11px] font-medium ${accent.muted}`}
-                            >
-                                {group.entries.length} item{group.entries.length === 1 ? '' : 's'}
-                            </span>
+        <div>
+            <div className="space-y-2">
+                {groups.map(group => {
+                    const accent = sectionAccent(group.label, group.label === defaultLabel)
+                    return (
+                        <div
+                            key={`section-${group.label}`}
+                            data-testid="item-section"
+                            // Deliberately not `overflow-hidden`: the composer's
+                            // suggestion list hangs below the card and was being
+                            // clipped away to nothing. The heading rounds its own
+                            // top corners instead of relying on the card to crop
+                            // them.
+                            className={`rounded-lg border ${accent.border} bg-white`}
+                        >
+                            <div className={`flex items-center gap-2 rounded-t-lg px-2.5 py-1.5 ${accent.header}`}>
+                                <span
+                                    data-testid="item-section-heading"
+                                    className={`text-sm font-semibold ${accent.text} truncate`}
+                                >
+                                    {group.label}
+                                </span>
+                                <span
+                                    data-testid="item-section-count"
+                                    className={`ml-auto shrink-0 text-[11px] font-medium ${accent.muted}`}
+                                >
+                                    {group.entries.length} item{group.entries.length === 1 ? '' : 's'}
+                                </span>
+                                {adding && (
+                                    <button
+                                        type="button"
+                                        data-testid="add-to-section"
+                                        onClick={() => setOpenComposer(prev => prev === group.label ? null : group.label)}
+                                        aria-expanded={openComposer === group.label}
+                                        aria-label={`Add an item to ${group.label}`}
+                                        title={`Add an item to ${group.label}`}
+                                        className={`shrink-0 -my-1 rounded p-1.5 ${accent.text} hover:bg-white/70 transition-colors`}
+                                    >
+                                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v14M5 12h14" />
+                                        </svg>
+                                    </button>
+                                )}
+                            </div>
+                            <div className="p-1 space-y-0.5">{group.entries.map(renderRow)}</div>
+                            {openComposer === group.label && (
+                                <div className="px-1.5 pb-1.5 pt-0.5">{renderComposer(group.label, true)}</div>
+                            )}
                         </div>
-                        <div className="p-1 space-y-0.5">{group.entries.map(renderRow)}</div>
-                    </div>
-                )
-            })}
+                    )
+                })}
+            </div>
+            {listFooter}
         </div>
     )
 })
@@ -303,7 +409,7 @@ function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete:
     )
 }
 
-export function OptionSection({ option, people, sectionDefaultLabel, allItemNames, sectionNames, questionId, onEdit, onDelete, onItemChange }: {
+export function OptionSection({ option, people, sectionDefaultLabel, allItemNames, sectionNames, questionId, suggestions, onEdit, onDelete, onItemChange, onItemAdd }: {
     option: Option
     people: Person[]
     /** What the packing list will call items here that carry no category. */
@@ -311,10 +417,13 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
     allItemNames?: string[]
     sectionNames?: string[]
     questionId?: string
+    suggestions?: SuggestionIndex
     onEdit: () => void
     onDelete: () => void
     /** Omit to leave the item rows read-only. */
     onItemChange?: (questionId: string, optionId: string, index: number, edited: Item) => void
+    /** Omit to leave the list unaddable — no ＋ buttons appear. */
+    onItemAdd?: (questionId: string, optionId: string, text: string, category: string | undefined) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(false)
     // Bound to this option's ids once, so the memoized row list isn't handed a
@@ -325,6 +434,15 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
             ? (index: number, edited: Item) => onItemChange(questionId, optionId, index, edited)
             : undefined,
         [onItemChange, questionId, optionId])
+    const adding = useMemo<ItemAdding | undefined>(
+        () => onItemAdd && questionId && suggestions
+            ? {
+                suggestions,
+                ownerKey: listKeyFor(questionId, optionId),
+                onAdd: (text, category) => onItemAdd(questionId, optionId, text, category),
+            }
+            : undefined,
+        [onItemAdd, questionId, optionId, suggestions])
     const [showDeleteModal, setShowDeleteModal] = useState(false)
     // Items aren't mounted until first expand (cheap initial render for large
     // sets), but stay mounted afterwards so re-expanding is instant.
@@ -332,11 +450,14 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
     if (isExpanded) hasExpandedRef.current = true
     // Nothing to reveal when an answer has no items, so drop the chevron and the
     // toggle entirely and say so inline — an expander that opens onto nothing
-    // just reads as broken.
+    // just reads as broken. Once items can be added it no longer opens onto
+    // nothing, and an answer with no items is exactly the one most in need of
+    // somewhere to put the first.
     const isEmpty = option.items.length === 0
+    const canExpand = !isEmpty || adding !== undefined
     const heading = (
         <>
-            {isEmpty ? (
+            {!canExpand ? (
                 // Spacer keeps the text aligned with the chevroned siblings.
                 <span className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
             ) : (
@@ -359,9 +480,9 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
         </>
     )
     return (
-        <div className="bg-gray-50 rounded-lg p-3">
+        <div data-testid="option-section" className="bg-gray-50 rounded-lg p-3">
             <div className={`flex items-center${isExpanded ? ' mb-2' : ''}`}>
-                {isEmpty ? (
+                {!canExpand ? (
                     <div className="flex items-center gap-2 flex-1 text-left min-w-0">
                         {heading}
                     </div>
@@ -415,6 +536,7 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
                         defaultLabel={sectionDefaultLabel}
                         allItemNames={allItemNames}
                         sectionNames={sectionNames}
+                        adding={adding}
                         onItemChange={handleItemChange}
                     />
                 </div>
@@ -534,13 +656,14 @@ function QuestionContextMenu({ onMoveUp, onMoveDown, onEdit, onDelete }: {
 
 // Memoized with id-based handlers whose identity survives page re-renders, so
 // opening a modal (or a background sync tick) doesn't re-render every question.
-const QuestionSection = memo(function QuestionSection({ question, people, canMoveUp, canMoveDown, allItemNames, sectionNames, onEdit, onDelete, onAddOption, onEditOption, onDeleteOption, onMove, onItemChange }: {
+const QuestionSection = memo(function QuestionSection({ question, people, canMoveUp, canMoveDown, allItemNames, sectionNames, suggestions, onEdit, onDelete, onAddOption, onEditOption, onDeleteOption, onMove, onItemChange, onItemAdd }: {
     question: Question
     people: Person[]
     canMoveUp: boolean
     canMoveDown: boolean
     allItemNames: string[]
     sectionNames: string[]
+    suggestions: SuggestionIndex
     onEdit: (question: Question) => void
     onDelete: (id: string) => void
     onAddOption: (questionId: string) => void
@@ -548,6 +671,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
     onDeleteOption: (questionId: string, optionId: string) => void
     onMove: (id: string, direction: 'up' | 'down') => void
     onItemChange: (questionId: string, optionId: string, index: number, edited: Item) => void
+    onItemAdd: (questionId: string, optionId: string, text: string, category: string | undefined) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(true)
     const [showDeleteModal, setShowDeleteModal] = useState(false)
@@ -645,9 +769,11 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                             allItemNames={allItemNames}
                             sectionNames={sectionNames}
                             questionId={question.id}
+                            suggestions={suggestions}
                             onEdit={() => onEditOption(question.id, option)}
                             onDelete={() => onDeleteOption(question.id, option.id)}
                             onItemChange={onItemChange}
+                            onItemAdd={onItemAdd}
                         />
                     ))}
                     <button
@@ -669,15 +795,20 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
     )
 })
 
-const AlwaysSection = memo(function AlwaysSection({ items, people, allItemNames, sectionNames, onEdit, onItemChange }: {
+const AlwaysSection = memo(function AlwaysSection({ items, people, allItemNames, sectionNames, suggestions, onEdit, onItemChange, onItemAdd }: {
     items: Item[]
     people: Person[]
     allItemNames: string[]
     sectionNames: string[]
+    suggestions: SuggestionIndex
     onEdit: () => void
     onItemChange: (index: number, edited: Item) => void
+    onItemAdd: (text: string, category: string | undefined) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(false)
+    const adding = useMemo<ItemAdding>(
+        () => ({ suggestions, ownerKey: ALWAYS_LIST_KEY, onAdd: onItemAdd }),
+        [suggestions, onItemAdd])
     // Same lazy-mount-then-keep pattern as the sections above.
     const hasExpandedRef = useRef(isExpanded)
     if (isExpanded) hasExpandedRef.current = true
@@ -719,6 +850,7 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, allItemNames,
                         defaultLabel={ALWAYS_NEEDED_CATEGORY}
                         allItemNames={allItemNames}
                         sectionNames={sectionNames}
+                        adding={adding}
                         onItemChange={onItemChange}
                     />
                 </div>
@@ -1560,6 +1692,45 @@ export function QuestionsPage() {
         })
     }, [saveData])
 
+    // A new item goes to everyone on the list, which is what the editor modal's
+    // "+ Add Item" has always done. Who it's for and how many are a tap away in
+    // the row it just landed in, so the composer doesn't have to ask.
+    const newItem = useCallback((text: string): Item => ({
+        id: crypto.randomUUID(),
+        text,
+        personSelections: (dataRef.current?.people ?? [])
+            .filter(person => !person.deletedAt)
+            .map(person => ({ personId: person.id, selected: true })),
+    }), [])
+
+    const handleOptionItemAdd = useCallback(async (questionId: string, optionId: string, text: string, category: string | undefined) => {
+        const data = dataRef.current
+        if (!data) return
+        const question = data.questions.find(q => q.id === questionId)
+        const option = question?.options.find(o => o.id === optionId)
+        if (!question || !option) return
+        const now = new Date().toISOString()
+        const items = appendItemToSection(option.items, newItem(text), category, defaultCategoryFor(question, option), now)
+        await saveData({
+            ...data,
+            questions: withQuestionOptions(data.questions, questionId, options =>
+                options.map(o => o.id === optionId ? { ...o, items } : o), now),
+        })
+    }, [saveData, newItem])
+
+    const handleAlwaysItemAdd = useCallback(async (text: string, category: string | undefined) => {
+        const data = dataRef.current
+        if (!data) return
+        const stored = data.alwaysNeededItems ?? []
+        // Same split as handleAlwaysItemChange: the rows show the active items, so
+        // that is the list being added to, and the tombstones ride along untouched.
+        const active = stored.filter(i => !i.deletedAt)
+        const deleted = stored.filter(i => i.deletedAt)
+        const now = new Date().toISOString()
+        const items = appendItemToSection(active, newItem(text), category, ALWAYS_NEEDED_CATEGORY, now)
+        await saveData({ ...data, alwaysNeededItems: [...items, ...deleted] })
+    }, [saveData, newItem])
+
     const handleAlwaysItemChange = useCallback(async (index: number, edited: Item) => {
         const data = dataRef.current
         if (!data) return
@@ -1642,14 +1813,13 @@ export function QuestionsPage() {
     const openPeopleModal = useCallback(() => setPeopleModal(true), [])
     const openAlwaysModal = useCallback(() => setAlwaysModal(true), [])
 
-    const allItemNames = useMemo(() => {
-        if (!data) return []
-        const names = [
-            ...(data.alwaysNeededItems ?? []).filter(i => !i.deletedAt).map(i => i.text),
-            ...data.questions.filter(q => !q.deletedAt).flatMap(q => q.options.flatMap(o => o.items.filter(i => !i.deletedAt).map(i => i.text))),
-        ].filter(Boolean)
-        return [...new Set(names)]
-    }, [data])
+    // The set as a dictionary of its own item names: what the add composers
+    // offer as you type, and what the name fields offer as existing options.
+    // One scan serves both, and the names arrive deduped and alphabetical.
+    const suggestions = useMemo(
+        () => data ? buildQuestionSetSuggestions(data) : buildIndexOf([]),
+        [data])
+    const allItemNames = useMemo(() => suggestions.all.map(s => s.text), [suggestions])
 
     // Section names already in use anywhere in the question set, offered as
     // suggestions so the same section spelled two ways doesn't split into two
@@ -1694,8 +1864,10 @@ export function QuestionsPage() {
                     people={people}
                     allItemNames={allItemNames}
                     sectionNames={suggestedSectionNames}
+                    suggestions={suggestions}
                     onEdit={openAlwaysModal}
                     onItemChange={handleAlwaysItemChange}
+                    onItemAdd={handleAlwaysItemAdd}
                 />
                 {activeQuestions.map((q, qi) => (
                     <QuestionSection
@@ -1706,6 +1878,7 @@ export function QuestionsPage() {
                         canMoveDown={qi < activeQuestions.length - 1}
                         allItemNames={allItemNames}
                         sectionNames={suggestedSectionNames}
+                        suggestions={suggestions}
                         onEdit={openEditQuestion}
                         onDelete={handleDeleteQuestion}
                         onAddOption={openAddOption}
@@ -1713,6 +1886,7 @@ export function QuestionsPage() {
                         onDeleteOption={handleDeleteOption}
                         onMove={handleMoveQuestion}
                         onItemChange={handleOptionItemChange}
+                        onItemAdd={handleOptionItemAdd}
                     />
                 ))}
                 <button

--- a/src/utils/itemSuggestions.ts
+++ b/src/utils/itemSuggestions.ts
@@ -1,16 +1,22 @@
 /**
- * Suggestions for the "add an item" composer.
+ * Suggestions for the "add an item" composers.
  *
- * A packing list is its own best dictionary: by the time someone is adding
- * things by hand, the list already knows how "Sun cream" is spelled and which
- * section it belongs in — usually because somebody else on the trip has one.
- * So the catalogue is built from the list itself (including items deleted
- * earlier, which are exactly the things people put back), and picking a
- * suggestion carries its category across. That is what turns "add to a
- * particular section" from a chore into a single tap.
+ * A collection of items is its own best dictionary: by the time someone is
+ * adding things by hand, their packing list — or their question set — already
+ * knows how "Sun cream" is spelled and which section it belongs in, usually
+ * because somebody else on the trip has one. So the catalogue is built from
+ * what is already there (including items deleted earlier, which are exactly the
+ * things people put back), and picking a suggestion carries its category
+ * across. That is what turns "add to a particular section" from a chore into a
+ * single tap.
  *
- * The index is built once per list and filtered per keystroke, so the work that
- * happens while someone is typing is a scan of distinct names, not of items.
+ * The index is built once per collection and filtered per keystroke, so the
+ * work that happens while someone is typing is a scan of distinct names, not of
+ * items.
+ *
+ * `buildIndexOf` is the shape-agnostic core: an owner is whatever "already has
+ * this one" means for the page — a person on a packing list, one option's item
+ * list in a question set — and the two pages differ only in how they name it.
  */
 import type { PackingListItem } from '../create-packing-list/types'
 
@@ -51,34 +57,37 @@ const byName = (a: string, b: string) => {
     return x < y ? -1 : x > y ? 1 : 0
 }
 
-export function buildSuggestionIndex(
-    items: readonly PackingListItem[],
-    deletedItems: readonly PackingListItem[] = [],
-): SuggestionIndex {
+/** One name going into the catalogue, reduced to what the index cares about. */
+export interface SuggestionSource {
+    text: string
+    category?: string
+    /**
+     * The list that already holds this name, so it isn't offered back to it.
+     * Omit for names that only stock the catalogue — deleted items, which are
+     * exactly the things people add back.
+     */
+    owner?: string
+}
+
+export function buildIndexOf(sources: Iterable<SuggestionSource>): SuggestionIndex {
     // name (lowercased) -> the name as first seen, and how often each category
     // has been used for it. A name filed two ways takes the majority verdict so
     // one stray uncategorised copy doesn't lose the section.
     const names = new Map<string, { text: string; categories: Map<string | undefined, number> }>()
     const ownedBy = new Map<string, Set<string>>()
 
-    const record = (item: PackingListItem, owned: boolean) => {
-        const text = item.itemText.trim()
-        if (!text) return
+    for (const source of sources) {
+        const text = source.text.trim()
+        if (!text) continue
         const key = text.toLowerCase()
         const entry = names.get(key) ?? { text, categories: new Map() }
-        entry.categories.set(item.category, (entry.categories.get(item.category) ?? 0) + 1)
+        entry.categories.set(source.category, (entry.categories.get(source.category) ?? 0) + 1)
         names.set(key, entry)
-        if (!owned) return
-        const owner = ownerKeyFor(item)
-        const set = ownedBy.get(owner) ?? new Set<string>()
+        if (source.owner === undefined) continue
+        const set = ownedBy.get(source.owner) ?? new Set<string>()
         set.add(key)
-        ownedBy.set(owner, set)
+        ownedBy.set(source.owner, set)
     }
-
-    for (const item of items) record(item, true)
-    // Deleted items stock the catalogue but are not "owned" — the whole point is
-    // that they can be added back.
-    for (const item of deletedItems) record(item, false)
 
     const all = [...names.values()]
         .map(({ text, categories }) => {
@@ -89,6 +98,24 @@ export function buildSuggestionIndex(
         .sort((a, b) => byName(a.text, b.text))
 
     return { all, ownedBy }
+}
+
+/** The catalogue a packing list makes of itself, owned per person. */
+export function buildSuggestionIndex(
+    items: readonly PackingListItem[],
+    deletedItems: readonly PackingListItem[] = [],
+): SuggestionIndex {
+    const source = (item: PackingListItem, owned: boolean): SuggestionSource => ({
+        text: item.itemText,
+        category: item.category,
+        ...(owned ? { owner: ownerKeyFor(item) } : {}),
+    })
+    return buildIndexOf([
+        ...items.map(item => source(item, true)),
+        // Deleted items stock the catalogue but are not "owned" — the whole
+        // point is that they can be added back.
+        ...deletedItems.map(item => source(item, false)),
+    ])
 }
 
 /**


### PR DESCRIPTION
## The friction

Adding one item to a particular section of an answer took six interactions and a modal round-trip:

1. Tap the option's pencil (or ⋯ → Edit on mobile) — a full-screen modal opens
2. Scroll past its whole item list
3. Tap **+ Add Item** — a blank row appears at the end, inheriting only the *last* item's section
4. Type into a react-select
5. The section is wrong unless you happened to want the last one, so: drag it in "Organise items", or close, tap the row, and change Section in the row editor
6. Tap **Save changes** — rewrites the whole option

Then start again at step 1 for the next item. And an answer with **no** items had no expander and no input at all — the modal was its only way in.

Meanwhile item *editing* was already fixed (tap a row → inline editor, #268), and the packing list already got a section-aware composer (#270). The questions page was the odd one out.

## The design

**A ＋ on every section heading.** It opens a composer inside that section card, section already decided, and the item lands there. Tapping it where you want the item is the shortest way to say where the item goes.

**A ＋ Add item at the foot of every list**, which asks where the item goes. Covers a list with no sections yet, and sections that don't exist yet — including a section this answer has never used, since a section is only ever a name stamped on an item, so nothing has to be created first.

**Empty answers become expandable**, revealing that add row. An expander that opens onto an add row is no longer opening onto nothing, and an answer with no items is the one most in need of somewhere to put the first.

**The set is its own dictionary.** A matched name arrives with the section it's filed under everywhere else, and one tap files it there — "Sunscreen goes in Toiletries" is a fact the app already knows rather than one to re-answer. The same scan now feeds the name fields, which used to walk the set separately.

**What the item is *for* is deliberately not asked.** It goes to everyone, exactly as `+ Add Item` always did; who-it's-for and how-many are one tap away in the row it just landed in. Four controls in front of someone whose next move is to type the next item is the friction, not the fix.

Adding saves as it goes and the composer stays open, cleared and focused, because people add items in runs.

## Performance

The read-only rows exist so a large question set isn't dozens of mounted editors, and that property is kept:

- Nothing new is mounted at rest — a heading gains one 16px ＋, no inputs.
- One composer exists at a time, page-wide per list. A composer per heading would put an input in front of every section.
- The draft lives in the composer, so a keystroke re-renders one composer, not every question.
- `ItemAdding` is one memoized object per list, so the memoized sections still skip renders. `allItemNames` is now derived from the suggestion index instead of a second scan of the set — one pass where there were two.

## What the running UI showed and the tests couldn't

Driven at 390×844 and 1280×900 against a real build; all three found by looking, not by a failing test:

- **The suggestion dropdown was clipped away to nothing** by the section card's `overflow-hidden`. The heading rounds its own top corners now instead of the card cropping them.
- **A composer at the bottom of a nine-item section opens below a phone's fold**, where the keyboard covers it — the browser's own focus scroll only brings it just barely into view. It pulls itself into view when there isn't room, and stays put when there is.
- **The shared field brought the packing list's blue focus ring onto a teal page.** The ring is now the caller's.

## Structure

`AddItemComposer`'s combobox — input, suggestion listbox, and the fiddly keyboard contract — is extracted to `ItemNameField` and shared, rather than duplicated for a second page. `buildSuggestionIndex` gains a shape-agnostic core (`buildIndexOf`) so the question set can build one too, keyed per item list rather than per person. Both refactors are behaviour-preserving: the packing list's 20 composer tests and 116 page tests pass untouched.

`appendItemToSection` inserts after the last item already in the target section rather than appending, because array position is what the section views bucket by, then renumbers `order` so the generated packing list agrees. Items whose position is unchanged keep their identity and their old timestamp.

## Testing

- 1179 unit tests pass (`npm test`, typecheck included); 57 new across the suggestion index, `appendItemToSection`, the composer, and the page wiring
- B suite 13/13, including three new e2e tests — add into a named section (and survive a reload), a suggestion bringing its section, and an empty answer taking its first item
- C/A/D suites 16/16, covering the refactored packing-list composer
- Lint unchanged at 13 pre-existing warnings

---
_Generated by [Claude Code](https://claude.ai/code/session_011Pk9TtpAxVn3zz1YGYR23Y)_