### PR TITLE
Make a deleted always-needed item stay deleted

### DIFF
--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -21,10 +21,19 @@ async function openPeopleModal(page: import('@playwright/test').Page) {
   await expect(page.getByRole('heading', { name: 'Edit People' })).toBeVisible({ timeout: 3_000 })
 }
 
-/** Open the Always Needed Items editing modal via the pencil icon in the section header. */
-async function openAlwaysNeededModal(page: import('@playwright/test').Page) {
-  await page.locator('button[title="Edit always needed items"]').click()
-  await expect(page.getByRole('heading', { name: 'Always Needed Items' })).toBeVisible({ timeout: 3_000 })
+/**
+ * Expand the Always Needed Items list. There is no modal behind it any more —
+ * the list on the page is the editor, and every change saves as it is made.
+ */
+async function openAlwaysNeeded(page: import('@playwright/test').Page) {
+  await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
+  await expect(page.getByTestId('item-row').first()).toBeVisible({ timeout: 5_000 })
+}
+
+/** The item names as the read-only list shows them, top to bottom. */
+async function itemNames(page: import('@playwright/test').Page): Promise<string[]> {
+  const rows = await page.getByTestId('item-row').allInnerTexts()
+  return rows.map(t => t.split('\n')[0].trim())
 }
 
 test.describe('B – Editing Questions', () => {
@@ -36,8 +45,8 @@ test.describe('B – Editing Questions', () => {
     await expect(page.locator('button[title="Edit people"]')).toBeVisible()
     // Always Needed Items section is visible
     await expect(page.getByText(/Always Needed Items/i).first()).toBeVisible()
-    // Always Needed Items pencil button is visible
-    await expect(page.locator('button[title="Edit always needed items"]')).toBeVisible()
+    // Its items are edited in place, so there is no pencil into a modal.
+    await expect(page.locator('button[title="Edit always needed items"]')).toHaveCount(0)
   })
 
   test('B2: add a person to the question set', async ({ freshPage: page }) => {
@@ -103,71 +112,56 @@ test.describe('B – Editing Questions', () => {
 
   test('B4: add an always-needed item', async ({ freshPage: page }) => {
     await setupWizardAndGoToQuestions(page)
-    // Open Always Needed Items modal
-    await openAlwaysNeededModal(page)
-    // Click "+ Add Item" to append a new empty item row
-    await page.getByRole('button', { name: '+ Add Item' }).click()
-    // The new item uses CustomCreatableSelect in inactive mode (.cursor-text).
-    // Clicking it transitions to the full react-select (ActiveSelect with autoFocus).
-    await page.locator('.cursor-text').last().click()
-    // Wait for the react-select control to mount (ActiveSelect renders after activation).
-    const reactSelectControl = page.locator('.react-select__control').last()
-    await expect(reactSelectControl).toBeVisible({ timeout: 3_000 })
-    // Click the control — this is the canonical react-select interaction that reliably
-    // opens the dropdown (fires onControlMouseDown → onMenuOpen → setMenuIsOpen(true)).
-    await reactSelectControl.click()
-    await page.keyboard.type('WaterBottleTest')
-    // Click the first dropdown option — should be 'Create "WaterBottleTest"' since this name
-    // is not in any wizard-generated suggestion. Menu is portaled to document.body.
-    const newItemOption = page.locator('.react-select__option').filter({ hasText: /WaterBottleTest/i }).first()
-    await expect(newItemOption).toBeVisible({ timeout: 5_000 })
-    await newItemOption.click()
-    // Save changes
-    await page.getByRole('button', { name: 'Save changes' }).click()
-    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
-    // Expand the Always Needed Items section to verify the item appears
-    await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
+    await openAlwaysNeeded(page)
+
+    // One field at the foot of the list, rather than a modal, a blank row and a
+    // Save button.
+    await page.getByRole('button', { name: '+ Add item' }).first().click()
+    const field = page.getByLabel(/^New item in /)
+    await expect(field).toBeVisible({ timeout: 3_000 })
+    await field.fill('WaterBottleTest')
+    await field.press('Enter')
+    await expect(page.getByText('WaterBottleTest')).toBeVisible({ timeout: 5_000 })
+
+    // Saved as it was typed — a reload is the only confirmation needed.
+    await page.waitForTimeout(800)
+    await page.reload()
+    await openAlwaysNeeded(page)
     await expect(page.getByText('WaterBottleTest')).toBeVisible({ timeout: 5_000 })
   })
 
   test('B6: reorder always-needed items via the move menu', async ({ freshPage: page }) => {
     await setupWizardAndGoToQuestions(page)
-    await openAlwaysNeededModal(page)
+    await openAlwaysNeeded(page)
 
-    // Item names render in inactive CustomCreatableSelect mode (.cursor-text)
-    const itemTexts = page.locator('.cursor-text')
-    // First line only — the row also renders a "×" clear glyph on its own line
-    const first = (await itemTexts.first().innerText()).split('\n')[0].trim()
-    const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
+    const [first, second] = await itemNames(page)
     expect(first).not.toEqual(second)
 
-    // Enter organise mode — rows collapse to name + drag handle + move menu
+    // Organising is a toggle on the list itself now — no modal to open first.
     await page.getByRole('button', { name: 'Organise items' }).click()
-    await expect(page.locator('.cursor-text')).toHaveCount(0)
+    await expect(page.getByTestId('item-row')).toHaveCount(0)
 
     // Send the second item to the top of the section, swapping the two.
     // The menu is portaled to document.body.
     await page.locator('[data-reorder-row]').nth(1).getByTitle('Move item').click()
     await page.getByRole('menuitem', { name: 'Move to top of section' }).click()
     await page.getByRole('button', { name: 'Finish organising' }).click()
-    await expect(itemTexts.first()).toContainText(second)
-    await expect(itemTexts.nth(1)).toContainText(first)
-    await page.getByRole('button', { name: 'Save changes' }).click()
-    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
+    expect(await itemNames(page)).toEqual([second, first, ...(await itemNames(page)).slice(2)])
 
-    // Reopen the modal — the swapped order must have persisted
-    await openAlwaysNeededModal(page)
-    await expect(itemTexts.first()).toContainText(second)
-    await expect(itemTexts.nth(1)).toContainText(first)
+    // The move saved as it happened, so a reload is the whole verification.
+    await page.waitForTimeout(800)
+    await page.reload()
+    await openAlwaysNeeded(page)
+    const afterReload = await itemNames(page)
+    expect(afterReload[0]).toEqual(second)
+    expect(afterReload[1]).toEqual(first)
   })
 
   test('B7: reorder always-needed items by dragging the handle', async ({ freshPage: page }) => {
     await setupWizardAndGoToQuestions(page)
-    await openAlwaysNeededModal(page)
+    await openAlwaysNeeded(page)
 
-    const itemTexts = page.locator('.cursor-text')
-    const first = (await itemTexts.first().innerText()).split('\n')[0].trim()
-    const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
+    const [first, second] = await itemNames(page)
     expect(first).not.toEqual(second)
 
     await page.getByRole('button', { name: 'Organise items' }).click()
@@ -198,24 +192,21 @@ test.describe('B – Editing Questions', () => {
       await page.getByRole('button', { name: 'Finish organising' }).click()
       await expect(page.getByRole('button', { name: 'Organise items' })).toBeVisible({ timeout: 1_000 })
     }).toPass()
-    await expect(itemTexts.first()).toContainText(second)
-    await expect(itemTexts.nth(1)).toContainText(first)
 
-    // Persist and reopen — the dragged order must survive a save round-trip
-    await page.getByRole('button', { name: 'Save changes' }).click()
-    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
-    await openAlwaysNeededModal(page)
-    await expect(itemTexts.first()).toContainText(second)
-    await expect(itemTexts.nth(1)).toContainText(first)
+    // Persist and reload — the dragged order must survive the round-trip
+    await page.waitForTimeout(800)
+    await page.reload()
+    await openAlwaysNeeded(page)
+    const afterReload = await itemNames(page)
+    expect(afterReload[0]).toEqual(second)
+    expect(afterReload[1]).toEqual(first)
   })
 
   test('B8: reorder always-needed items from the keyboard', async ({ freshPage: page }) => {
     await setupWizardAndGoToQuestions(page)
-    await openAlwaysNeededModal(page)
+    await openAlwaysNeeded(page)
 
-    const itemTexts = page.locator('.cursor-text')
-    const first = (await itemTexts.first().innerText()).split('\n')[0].trim()
-    const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
+    const [first, second] = await itemNames(page)
     expect(first).not.toEqual(second)
 
     await page.getByRole('button', { name: 'Organise items' }).click()
@@ -238,13 +229,14 @@ test.describe('B – Editing Questions', () => {
     await expect(rows.first()).toContainText(second)
     await expect(rows.nth(1)).toContainText(first)
 
-    // Persist and reopen — the keyboard move must survive a save round-trip
+    // Persist and reload — the keyboard move must survive the round-trip
     await page.getByRole('button', { name: 'Finish organising' }).click()
-    await page.getByRole('button', { name: 'Save changes' }).click()
-    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
-    await openAlwaysNeededModal(page)
-    await expect(itemTexts.first()).toContainText(second)
-    await expect(itemTexts.nth(1)).toContainText(first)
+    await page.waitForTimeout(800)
+    await page.reload()
+    await openAlwaysNeeded(page)
+    const afterReload = await itemNames(page)
+    expect(afterReload[0]).toEqual(second)
+    expect(afterReload[1]).toEqual(first)
   })
 
   test('B5: JSON editor mode toggle is not available (editor is always visual)', async ({ freshPage: page }) => {
@@ -356,6 +348,70 @@ test.describe('B – Editing Questions', () => {
     await field.press('Enter')
     const toiletries = page.getByTestId('item-section').filter({ hasText: 'Toiletries' }).first()
     await expect(toiletries.getByText('Sunscreen')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('B13: delete an item from the row you are editing', async ({ freshPage: page }) => {
+    // Deleting used to mean opening the option's modal and finding the row
+    // again; the editor you are already in can do it.
+    await setupWizardAndGoToQuestions(page)
+    await openAlwaysNeeded(page)
+
+    const before = await itemNames(page)
+    const doomed = before[0]
+    await page.getByTestId('item-row').first().click()
+    const editor = page.getByTestId('item-inline-editor')
+    await expect(editor).toBeVisible({ timeout: 3_000 })
+    await editor.getByRole('button', { name: `Delete ${doomed}` }).click()
+    await expect(editor).not.toBeVisible({ timeout: 3_000 })
+
+    // Tombstoned rather than dropped, so it stays gone across a reload.
+    await page.waitForTimeout(800)
+    await page.reload()
+    await openAlwaysNeeded(page)
+    const after = await itemNames(page)
+    expect(after).not.toContain(doomed)
+    expect(after).toHaveLength(before.length - 1)
+  })
+
+  test('B14: create a section, then fill it', async ({ freshPage: page }) => {
+    // The section exists as soon as it is named — before anything is in it, and
+    // across a reload. It used to live only in the reorder view's own state.
+    await setupWizardAndGoToQuestions(page)
+    await openAlwaysNeeded(page)
+
+    await page.getByRole('button', { name: '+ Add section' }).first().click()
+    const nameField = page.getByLabel('New section name')
+    await expect(nameField).toBeVisible({ timeout: 3_000 })
+    await nameField.fill('Paperwork')
+    await nameField.press('Enter')
+
+    const paperwork = page.getByTestId('item-section').filter({ hasText: 'Paperwork' }).first()
+    await expect(paperwork).toBeVisible({ timeout: 5_000 })
+    await expect(paperwork.getByText(/Nothing here yet/)).toBeVisible()
+
+    // Empty, and still there after a reload — the point of storing the name.
+    await page.waitForTimeout(800)
+    await page.reload()
+    await openAlwaysNeeded(page)
+    const afterReload = page.getByTestId('item-section').filter({ hasText: 'Paperwork' }).first()
+    await expect(afterReload).toBeVisible({ timeout: 5_000 })
+
+    // Its own ＋ files the first item straight into it.
+    await afterReload.getByTestId('add-to-section').click()
+    const field = page.getByLabel('New item in Paperwork')
+    await field.fill('BoardingPassTest')
+    await field.press('Enter')
+    await expect(afterReload.getByText('BoardingPassTest')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('B15: editing an option asks for its name and nothing else', async ({ freshPage: page }) => {
+    // The modal used to carry a whole second item editor.
+    await setupWizardAndGoToQuestions(page)
+    await page.getByTitle('Edit option').first().click()
+    await expect(page.getByRole('heading', { name: 'Edit Option' })).toBeVisible({ timeout: 3_000 })
+    await expect(page.getByLabel('Answer text')).toBeVisible()
+    await expect(page.getByRole('button', { name: '+ Add Item' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Organise items' })).toHaveCount(0)
   })
 
   test('B12: an answer with no items can take its first one', async ({ freshPage: page }) => {

--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -137,9 +137,10 @@ test.describe('B – Editing Questions', () => {
     const [first, second] = await itemNames(page)
     expect(first).not.toEqual(second)
 
-    // Organising is a toggle on the list itself now — no modal to open first.
+    // Organising opens onto its own screen: a drag needs a scroll container it
+    // owns, which nested in the page meant a scroll area inside a scroll area.
     await page.getByRole('button', { name: 'Organise items' }).click()
-    await expect(page.getByTestId('item-row')).toHaveCount(0)
+    await expect(page.getByRole('dialog', { name: /^Organise / })).toBeVisible({ timeout: 3_000 })
 
     // Send the second item to the top of the section, swapping the two.
     // The menu is portaled to document.body.

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -34,19 +34,18 @@ test.describe('C – Packing Lists', () => {
 
     // Reorder the always-needed items: send the second one to the top
     await page.goto('/#/manage-questions')
-    await page.locator('button[title="Edit always needed items"]').click()
-    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).toBeVisible({ timeout: 3_000 })
-    const itemTexts = page.locator('.cursor-text')
-    // First line only — the row also renders a "×" clear glyph on its own line
-    const first = (await itemTexts.first().innerText()).split('\n')[0].trim()
-    const second = (await itemTexts.nth(1).innerText()).split('\n')[0].trim()
+    await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
+    const rows = page.getByTestId('item-row')
+    await expect(rows.first()).toBeVisible({ timeout: 5_000 })
+    const names = (await rows.allInnerTexts()).map(t => t.split('\n')[0].trim())
+    const [first, second] = names
     await page.getByRole('button', { name: 'Organise items' }).click()
     // The move menu is portaled to document.body
     await page.locator('[data-reorder-row]').nth(1).getByTitle('Move item').click()
     await page.getByRole('menuitem', { name: 'Move to top of section' }).click()
     await page.getByRole('button', { name: 'Finish organising' }).click()
-    await page.getByRole('button', { name: 'Save changes' }).click()
-    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
+    // The move saved as it happened; give the IndexedDB write time to commit.
+    await page.waitForTimeout(800)
 
     // Create a list and check the view page shows the swapped order
     await page.goto('/#/create-packing-list')
@@ -129,19 +128,14 @@ test.describe('C – Packing Lists', () => {
   async function addAlwaysNeededItem(page: import('@playwright/test').Page, itemName: string) {
     await page.goto('/#/manage-questions')
     await expect(page.getByRole('heading', { name: 'My Questions & Items' })).toBeVisible({ timeout: 8_000 })
-    await page.locator('button[title="Edit always needed items"]').click()
-    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).toBeVisible({ timeout: 3_000 })
-    await page.getByRole('button', { name: '+ Add Item' }).click()
-    await page.locator('.cursor-text').last().click()
-    const control = page.locator('.react-select__control').last()
-    await expect(control).toBeVisible({ timeout: 3_000 })
-    await control.click()
-    await page.keyboard.type(itemName)
-    const option = page.locator('.react-select__option').filter({ hasText: new RegExp(itemName, 'i') }).first()
-    await expect(option).toBeVisible({ timeout: 5_000 })
-    await option.click()
-    await page.getByRole('button', { name: 'Save changes' }).click()
-    await expect(page.getByRole('heading', { name: 'Always Needed Items' })).not.toBeVisible({ timeout: 3_000 })
+    await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
+    await expect(page.getByTestId('item-row').first()).toBeVisible({ timeout: 5_000 })
+    await page.getByRole('button', { name: '+ Add item' }).first().click()
+    const field = page.getByLabel(/^New item in /)
+    await expect(field).toBeVisible({ timeout: 3_000 })
+    await field.fill(itemName)
+    await field.press('Enter')
+    await expect(page.getByText(itemName)).toBeVisible({ timeout: 5_000 })
     // Give the async IndexedDB write time to commit
     await page.waitForTimeout(800)
   }

--- a/src/components/ItemInlineEditor.test.tsx
+++ b/src/components/ItemInlineEditor.test.tsx
@@ -132,32 +132,37 @@ describe('ItemInlineEditor: quantity', () => {
 describe('ItemInlineEditor: section', () => {
     it('shows the default section when the item carries no category', () => {
         renderEditor(makeItem())
-        expect(within(screen.getByTestId('item-section-field')).getByText('Yes')).toBeTruthy()
+        expect((screen.getByLabelText('Section') as HTMLSelectElement).value).toBe('Yes')
     })
 
     it('shows the item’s own section when it has one', () => {
         renderEditor(makeItem({ category: 'Toiletries' }))
-        expect(within(screen.getByTestId('item-section-field')).getByText('Toiletries')).toBeTruthy()
+        expect((screen.getByLabelText('Section') as HTMLSelectElement).value).toBe('Toiletries')
     })
 
     it('moves the item into another section', () => {
         const { onChange } = renderEditor(makeItem())
-        const field = screen.getByTestId('item-section-field')
-        fireEvent.click(within(field).getByText('Yes'))
-        const input = field.querySelector('input') as HTMLInputElement
-        fireEvent.change(input, { target: { value: 'Toiletries' } })
-        fireEvent.blur(input)
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Toiletries' } })
         expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ category: 'Toiletries' }))
     })
 
     it('clears the category when moved back to the default section', () => {
         const { onChange } = renderEditor(makeItem({ category: 'Toiletries' }))
-        const field = screen.getByTestId('item-section-field')
-        fireEvent.click(within(field).getByText('Toiletries'))
-        const input = field.querySelector('input') as HTMLInputElement
-        fireEvent.change(input, { target: { value: 'Yes' } })
-        fireEvent.blur(input)
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Yes' } })
         expect(onChange.mock.calls[0][0].category).toBeUndefined()
+    })
+
+    it('offers only sections that exist — creating one is not a typing gesture', () => {
+        renderEditor(makeItem())
+        const labels = [...screen.getByLabelText('Section').querySelectorAll('option')].map(o => o.textContent)
+        expect(labels).toEqual(['Yes', 'Toiletries', 'Clothes'])
+    })
+
+    it('keeps the item’s own section on offer even when it is not a known name', () => {
+        // Otherwise the select would show — and on the next change commit — some
+        // other section entirely, silently moving the item.
+        renderEditor(makeItem({ category: 'Retired name' }))
+        expect((screen.getByLabelText('Section') as HTMLSelectElement).value).toBe('Retired name')
     })
 })
 

--- a/src/components/ItemInlineEditor.test.tsx
+++ b/src/components/ItemInlineEditor.test.tsx
@@ -174,3 +174,50 @@ describe('ItemInlineEditor: closing', () => {
         expect(onClose).toHaveBeenCalled()
     })
 })
+
+describe('ItemInlineEditor: deleting', () => {
+    function renderDeletable(item: Item) {
+        const onDelete = vi.fn()
+        const onClose = vi.fn()
+        render(
+            <ItemInlineEditor
+                item={item}
+                people={people}
+                allItemNames={['Socks', 'Towel']}
+                sectionNames={['Toiletries']}
+                sectionDefaultLabel="Yes"
+                onChange={vi.fn()}
+                onDelete={onDelete}
+                onClose={onClose}
+            />
+        )
+        return { onDelete, onClose }
+    }
+
+    it('offers no delete when the caller supplies no handler', () => {
+        renderEditor(makeItem())
+        expect(screen.queryByRole('button', { name: /Delete/ })).toBeNull()
+    })
+
+    it('names the item it will delete, so the wrong row is obvious', () => {
+        renderDeletable(makeItem({ text: 'Socks' }))
+        expect(screen.getByRole('button', { name: 'Delete Socks' })).toBeTruthy()
+    })
+
+    it('deletes on click', () => {
+        const { onDelete } = renderDeletable(makeItem())
+        fireEvent.click(screen.getByRole('button', { name: 'Delete Socks' }))
+        expect(onDelete).toHaveBeenCalledTimes(1)
+    })
+
+    it('leaves closing to the caller, whose list has just changed shape', () => {
+        const { onClose } = renderDeletable(makeItem())
+        fireEvent.click(screen.getByRole('button', { name: 'Delete Socks' }))
+        expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('still names the button when the item has no text yet', () => {
+        renderDeletable(makeItem({ text: '' }))
+        expect(screen.getByRole('button', { name: 'Delete item' })).toBeTruthy()
+    })
+})

--- a/src/components/ItemInlineEditor.tsx
+++ b/src/components/ItemInlineEditor.tsx
@@ -62,7 +62,13 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
     // The default section is offered by name, so "back to the main pile" is a
     // choice rather than the absence of one. Storing it clears the category —
     // see the note on applySectionLayout for why the default is never stamped.
-    const sectionOptions = [sectionDefaultLabel, ...sectionNames.filter(name => name !== sectionDefaultLabel)]
+    // The item's own section is included even if it is not among the offered
+    // names, so an unrecognised one is never silently swapped for another.
+    const sectionOptions = [...new Set([
+        sectionDefaultLabel,
+        ...(item.category ? [item.category] : []),
+        ...sectionNames,
+    ])]
     const setSection = useCallback((value: string) => {
         const category = value === '' || value === sectionDefaultLabel ? undefined : value
         onChange({ ...item, category })
@@ -113,13 +119,22 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
 
             <div data-testid="item-section-field">
                 <span className={FIELD_LABEL}>Section</span>
-                <CustomCreatableSelect
+                {/* A choice among sections that exist, never a place to make a
+                    new one. Free text here used to create a section, which is
+                    the same gesture that renames one in the organise view — so
+                    the identical action meant "move this item" in one place and
+                    "rename this whole section" in the other. Creating is its own
+                    button now, at the foot of the list. */}
+                <select
+                    aria-label="Section"
                     value={item.category ?? sectionDefaultLabel}
-                    onChange={setSection}
-                    options={sectionOptions}
-                    placeholder="Section"
-                    menuPortalTarget={document.body}
-                />
+                    onChange={e => setSection(e.target.value)}
+                    className="w-full border border-gray-200 rounded px-3 py-2.5 text-sm text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+                >
+                    {sectionOptions.map(label => (
+                        <option key={label} value={label}>{label}</option>
+                    ))}
+                </select>
             </div>
 
             {/* Delete sits opposite Done, at the far end of the panel: it is the

--- a/src/components/ItemInlineEditor.tsx
+++ b/src/components/ItemInlineEditor.tsx
@@ -20,7 +20,7 @@ import type { Item, Person } from '../edit-questions/types'
 
 const FIELD_LABEL = 'block text-[11px] font-semibold text-gray-400 uppercase tracking-wide mb-1'
 
-export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, allItemNames, sectionNames, sectionDefaultLabel, onChange, onClose }: {
+export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, allItemNames, sectionNames, sectionDefaultLabel, onChange, onDelete, onClose }: {
     item: Item
     people: Person[]
     allItemNames: string[]
@@ -29,6 +29,12 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
     /** What the packing list calls items here that carry no category of their own. */
     sectionDefaultLabel: string
     onChange: (edited: Item) => void
+    /**
+     * Omit to leave the item undeletable. Closing afterwards is the caller's
+     * job, not this panel's: it is the caller that knows the list has just lost
+     * a row and that every index after this one has shifted up.
+     */
+    onDelete?: () => void
     onClose: () => void
 }) {
     const setText = useCallback((text: string) => onChange({ ...item, text }), [item, onChange])
@@ -116,7 +122,20 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
                 />
             </div>
 
-            <div className="flex justify-end">
+            {/* Delete sits opposite Done, at the far end of the panel: it is the
+                one action here that cannot be undone by typing something else,
+                so it stays well away from the button people reach for to leave. */}
+            <div className="flex items-center justify-between">
+                {onDelete ? (
+                    <button
+                        type="button"
+                        onClick={onDelete}
+                        aria-label={item.text ? `Delete ${item.text}` : 'Delete item'}
+                        className="px-2 py-1.5 text-sm font-medium text-gray-400 rounded-lg hover:text-red-600 hover:bg-red-50"
+                    >
+                        Delete
+                    </button>
+                ) : <span />}
                 <button
                     type="button"
                     onClick={onClose}

--- a/src/components/SectionedItemReorder.test.tsx
+++ b/src/components/SectionedItemReorder.test.tsx
@@ -8,13 +8,13 @@ function item(text: string, category?: string): Item {
     return { id: text, text, personSelections: [], ...(category ? { category } : {}) }
 }
 
-function renderReorder(items: Item[]) {
-    const onChange = vi.fn<(items: Item[]) => void>()
+function renderReorder(items: Item[], emptySections?: string[]) {
+    const onChange = vi.fn<(items: Item[], emptySections: string[] | undefined) => void>()
     render(
         <SectionedItemReorder
             items={items}
             defaultLabel="Essentials"
-            suggestedSectionNames={[]}
+            emptySections={emptySections}
             scrollRef={createRef<HTMLDivElement>()}
             onChange={onChange}
         />
@@ -118,15 +118,46 @@ describe('SectionedItemReorder move menu', () => {
         expect(within(openMenuFor('Crisps')).queryByText(/^Move to (?!top|bottom)/)).toBeNull()
     })
 
-    it('offers a section the user just added but has not filled yet', () => {
-        const onChange = renderReorder(unsectioned())
-        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
-        fireEvent.change(screen.getByLabelText('New section name'), { target: { value: 'First aid' } })
-        fireEvent.click(screen.getByRole('button', { name: 'Add' }))
-
+    it('offers a section that has been created but not filled yet', () => {
+        // Created at the foot of the list, and handed here as a prop — the view
+        // no longer keeps sections of its own that vanish when it closes.
+        const onChange = renderReorder(unsectioned(), ['First aid'])
         fireEvent.click(within(openMenuFor('Crisps')).getByText('Move to First aid'))
         expect(layout(onChange.mock.calls[0][0])).toEqual([
             ['Snacks', undefined], ['Water', undefined], ['Crisps', 'First aid'],
         ])
+    })
+
+    it('stops recording a section once something lands in it', () => {
+        const onChange = renderReorder(unsectioned(), ['First aid'])
+        fireEvent.click(within(openMenuFor('Crisps')).getByText('Move to First aid'))
+        expect(onChange.mock.calls[0][1]).toBeUndefined()
+    })
+
+    it('records a section whose last item has just been dragged out', () => {
+        // Dragging a section empty must not destroy it mid-reorganisation.
+        const onChange = renderReorder([item('Snacks'), item('Plasters', 'First aid')])
+        fireEvent.click(within(openMenuFor('Plasters')).getByText('Move to Essentials'))
+        expect(onChange.mock.calls[0][1]).toEqual(['First aid'])
+    })
+
+    it('drops a section that was deliberately removed', () => {
+        const onChange = renderReorder([item('Snacks'), item('Plasters', 'First aid')], ['Spare'])
+        fireEvent.click(screen.getByRole('button', { name: 'Remove section First aid' }))
+        expect(onChange.mock.calls[0][1]).toEqual(['Spare'])
+    })
+
+    it('renames a recorded section along with its items', () => {
+        const onChange = renderReorder([item('Snacks')], ['First aid'])
+        fireEvent.click(screen.getByRole('button', { name: 'Rename section First aid' }))
+        const input = screen.getByLabelText('Rename section First aid')
+        fireEvent.change(input, { target: { value: 'Medical' } })
+        fireEvent.blur(input)
+        expect(onChange.mock.calls[0][1]).toEqual(['Medical'])
+    })
+
+    it('no longer creates sections of its own', () => {
+        renderReorder(unsectioned())
+        expect(screen.queryByRole('button', { name: '+ Add section' })).toBeNull()
     })
 })

--- a/src/components/SectionedItemReorder.tsx
+++ b/src/components/SectionedItemReorder.tsx
@@ -6,7 +6,7 @@
  * back through `applySectionLayout`, which stamps each item with the nearest
  * header above it. See `item-sections.ts` for why the storage is stamped.
  */
-import { useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
     DndContext,
     closestCenter,
@@ -36,6 +36,48 @@ import {
     type SectionSequenceEntry,
 } from '../edit-questions/item-sections'
 import { sectionAccent } from '../edit-questions/section-accent'
+
+/**
+ * Freeze the page while a drag is in progress.
+ *
+ * Not cosmetic. On a phone, scrolling the window is what shows and hides the
+ * browser's URL bar, which resizes the viewport — so every row the drag has
+ * already measured moves, mid-gesture. The item jumps, the drop lands somewhere
+ * else, and the chrome flickers in and out the whole time.
+ *
+ * This used to come free: the reorder view only existed inside a modal, and the
+ * modal locked body scroll for its own reasons. On the page it has to be asked
+ * for, and only for the length of the gesture — locking scroll for as long as
+ * the mode is open would trap a list longer than the screen.
+ */
+function useScrollLockWhileDragging() {
+    const [dragging, setDragging] = useState(false)
+    useEffect(() => {
+        if (!dragging) return
+        const body = document.body
+        const html = document.documentElement
+        const previous = {
+            body: body.style.overflow,
+            html: html.style.overflow,
+            overscroll: body.style.overscrollBehavior,
+        }
+        // Both: the scrolling element is <body> on some browsers and <html> on
+        // others (notably mobile). Chaining is stopped too, so a drag that runs
+        // off the end of the list doesn't hand the scroll to the page.
+        body.style.overflow = 'hidden'
+        html.style.overflow = 'hidden'
+        body.style.overscrollBehavior = 'none'
+        return () => {
+            body.style.overflow = previous.body
+            html.style.overflow = previous.html
+            body.style.overscrollBehavior = previous.overscroll
+        }
+    }, [dragging])
+    return {
+        onDragStart: useCallback(() => setDragging(true), []),
+        onDragStop: useCallback(() => setDragging(false), []),
+    }
+}
 
 // Drags only ever move rows up and down the list.
 const restrictToVerticalAxis: Modifier = ({ transform }) => ({ ...transform, x: 0 })
@@ -283,7 +325,10 @@ export function SectionedItemReorder({ items, defaultLabel, emptySections, scrol
         useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
     )
 
+    const { onDragStart, onDragStop } = useScrollLockWhileDragging()
+
     const handleDragEnd = (e: DragEndEvent) => {
+        onDragStop()
         const { active, over } = e
         if (!over || active.id === over.id) return
         const from = entryIds.indexOf(String(active.id))
@@ -347,7 +392,10 @@ export function SectionedItemReorder({ items, defaultLabel, emptySections, scrol
                 modifiers={[restrictToVerticalAxis]}
                 // Only ever auto-scroll the modal's own scroll area — see the
                 // note on the unsectioned editor for why.
-                autoScroll={scrollRef ? { canScroll: (el) => el === scrollRef.current } : true}
+                // Never `true`: that lets dnd-kit scroll every scrollable
+                // ancestor, the window included, which is what was moving the
+                // page — and the URL bar with it — underneath the drag.
+                autoScroll={{ canScroll: (el) => el === scrollRef?.current }}
                 accessibility={{
                     screenReaderInstructions: {
                         draggable: 'Press space to pick up the item, the arrow keys to move it '
@@ -368,6 +416,8 @@ export function SectionedItemReorder({ items, defaultLabel, emptySections, scrol
                         onDragCancel: ({ active }) => `Cancelled moving ${describe(active.id)}.`,
                     },
                 }}
+                onDragStart={onDragStart}
+                onDragCancel={onDragStop}
                 onDragEnd={handleDragEnd}
             >
                 <SortableContext items={entryIds} strategy={verticalListSortingStrategy}>

--- a/src/components/SectionedItemReorder.tsx
+++ b/src/components/SectionedItemReorder.tsx
@@ -6,7 +6,7 @@
  * back through `applySectionLayout`, which stamps each item with the nearest
  * header above it. See `item-sections.ts` for why the storage is stamped.
  */
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import {
     DndContext,
     closestCenter,
@@ -36,48 +36,6 @@ import {
     type SectionSequenceEntry,
 } from '../edit-questions/item-sections'
 import { sectionAccent } from '../edit-questions/section-accent'
-
-/**
- * Freeze the page while a drag is in progress.
- *
- * Not cosmetic. On a phone, scrolling the window is what shows and hides the
- * browser's URL bar, which resizes the viewport — so every row the drag has
- * already measured moves, mid-gesture. The item jumps, the drop lands somewhere
- * else, and the chrome flickers in and out the whole time.
- *
- * This used to come free: the reorder view only existed inside a modal, and the
- * modal locked body scroll for its own reasons. On the page it has to be asked
- * for, and only for the length of the gesture — locking scroll for as long as
- * the mode is open would trap a list longer than the screen.
- */
-function useScrollLockWhileDragging() {
-    const [dragging, setDragging] = useState(false)
-    useEffect(() => {
-        if (!dragging) return
-        const body = document.body
-        const html = document.documentElement
-        const previous = {
-            body: body.style.overflow,
-            html: html.style.overflow,
-            overscroll: body.style.overscrollBehavior,
-        }
-        // Both: the scrolling element is <body> on some browsers and <html> on
-        // others (notably mobile). Chaining is stopped too, so a drag that runs
-        // off the end of the list doesn't hand the scroll to the page.
-        body.style.overflow = 'hidden'
-        html.style.overflow = 'hidden'
-        body.style.overscrollBehavior = 'none'
-        return () => {
-            body.style.overflow = previous.body
-            html.style.overflow = previous.html
-            body.style.overscrollBehavior = previous.overscroll
-        }
-    }, [dragging])
-    return {
-        onDragStart: useCallback(() => setDragging(true), []),
-        onDragStop: useCallback(() => setDragging(false), []),
-    }
-}
 
 // Drags only ever move rows up and down the list.
 const restrictToVerticalAxis: Modifier = ({ transform }) => ({ ...transform, x: 0 })
@@ -325,10 +283,7 @@ export function SectionedItemReorder({ items, defaultLabel, emptySections, scrol
         useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
     )
 
-    const { onDragStart, onDragStop } = useScrollLockWhileDragging()
-
     const handleDragEnd = (e: DragEndEvent) => {
-        onDragStop()
         const { active, over } = e
         if (!over || active.id === over.id) return
         const from = entryIds.indexOf(String(active.id))
@@ -392,9 +347,10 @@ export function SectionedItemReorder({ items, defaultLabel, emptySections, scrol
                 modifiers={[restrictToVerticalAxis]}
                 // Only ever auto-scroll the modal's own scroll area — see the
                 // note on the unsectioned editor for why.
-                // Never `true`: that lets dnd-kit scroll every scrollable
-                // ancestor, the window included, which is what was moving the
-                // page — and the URL bar with it — underneath the drag.
+                // Only ever the container it was given. `true` would let
+                // dnd-kit scroll every scrollable ancestor, the window
+                // included — which moves the page, and on a phone the URL bar,
+                // underneath a gesture that has already measured it.
                 autoScroll={{ canScroll: (el) => el === scrollRef?.current }}
                 accessibility={{
                     screenReaderInstructions: {
@@ -416,8 +372,6 @@ export function SectionedItemReorder({ items, defaultLabel, emptySections, scrol
                         onDragCancel: ({ active }) => `Cancelled moving ${describe(active.id)}.`,
                     },
                 }}
-                onDragStart={onDragStart}
-                onDragCancel={onDragStop}
                 onDragEnd={handleDragEnd}
             >
                 <SortableContext items={entryIds} strategy={verticalListSortingStrategy}>

--- a/src/components/SectionedItemReorder.tsx
+++ b/src/components/SectionedItemReorder.tsx
@@ -25,6 +25,7 @@ import type { Item } from '../edit-questions/types'
 import {
     applySectionLayout,
     buildSectionSequence,
+    reconcileEmptySections,
     isAtSectionEdge,
     moveItemToSection,
     moveItemWithinSection,
@@ -236,22 +237,22 @@ function SortableSectionItem({ id, item, canMoveToTop, canMoveToBottom, otherSec
     )
 }
 
-export function SectionedItemReorder({ items, defaultLabel, suggestedSectionNames, scrollRef, onChange }: {
+export function SectionedItemReorder({ items, defaultLabel, emptySections, scrollRef, onChange }: {
     items: Item[]
     /** Section name for items carrying no category — what the list will call them. */
     defaultLabel: string
-    suggestedSectionNames: string[]
-    scrollRef: React.RefObject<HTMLDivElement | null>
-    onChange: (items: Item[]) => void
+    /**
+     * Sections of this list with nothing in them yet. They arrive as a prop and
+     * go back through `onChange` rather than living here: an empty section used
+     * to be view state that evaporated when the view closed, which is exactly
+     * what made "create a section, then fill it" impossible to offer anywhere.
+     */
+    emptySections: string[] | undefined
+    /** Confines drag auto-scroll to one element. Omit to let the window scroll. */
+    scrollRef?: React.RefObject<HTMLDivElement | null>
+    onChange: (items: Item[], emptySections: string[] | undefined) => void
 }) {
-    // Sections the user has created but not yet filled. They can't be stored
-    // (a section is only its items' stamps), so they live here until something
-    // lands in them — and are simply forgotten if nothing does.
-    const [draftSections, setDraftSections] = useState<string[]>([])
-    const [addingSection, setAddingSection] = useState(false)
-    const [newSectionName, setNewSectionName] = useState('')
-
-    const sequence = buildSectionSequence(items, defaultLabel, draftSections)
+    const sequence = buildSectionSequence(items, defaultLabel, emptySections ?? [])
 
     // dnd-kit needs a stable id per row across reorders. Items may have no `id`
     // yet (defaults not saved), so map each object to a client-only drag id.
@@ -270,12 +271,10 @@ export function SectionedItemReorder({ items, defaultLabel, suggestedSectionName
 
     const applySequence = (next: SectionSequenceEntry[]) => {
         const updated = applySectionLayout(next, defaultLabel, new Date().toISOString())
-        // A section that still has a header but no items stays a draft, so the
-        // user can keep dragging into it; one that gained items no longer needs
-        // to be remembered here.
-        const filled = new Set(updated.map(i => i.category).filter(Boolean) as string[])
-        setDraftSections(prev => prev.filter(label => !filled.has(label)))
-        onChange(updated)
+        // A section that gained items no longer needs recording; one whose last
+        // item was just dragged out starts being recorded, so dragging a section
+        // empty doesn't destroy it mid-reorganisation.
+        onChange(updated, reconcileEmptySections(items, updated, emptySections))
     }
 
     const sensors = useSensors(
@@ -319,24 +318,20 @@ export function SectionedItemReorder({ items, defaultLabel, suggestedSectionName
         return `${describe(activeId)}, position ${position} in ${label}`
     }
 
-    const addSection = () => {
-        const name = newSectionName.trim()
-        setNewSectionName('')
-        setAddingSection(false)
-        if (!name) return
-        const existing = new Set(sequence.filter(e => e.kind === 'header').map(e => e.kind === 'header' && e.label))
-        if (existing.has(name)) return
-        setDraftSections(prev => [...prev, name])
-    }
-
     const renameSectionAt = (from: string, to: string) => {
-        setDraftSections(prev => prev.map(label => label === from ? to : label))
-        onChange(renameSection(items, from, to, new Date().toISOString()))
+        const renamed = emptySections?.map(label => label === from ? to : label)
+        onChange(renameSection(items, from, to, new Date().toISOString()), renamed)
     }
 
+    // Removing a section is the one deliberate way to lose one, so it drops the
+    // name itself rather than going through `reconcileEmptySections` — which
+    // exists to *keep* a section whose items merely left.
     const removeSectionAt = (label: string) => {
-        setDraftSections(prev => prev.filter(l => l !== label))
-        onChange(removeSection(items, label, new Date().toISOString()))
+        const remaining = emptySections?.filter(l => l !== label)
+        onChange(
+            removeSection(items, label, new Date().toISOString()),
+            remaining?.length ? remaining : undefined,
+        )
     }
 
     return (
@@ -352,7 +347,7 @@ export function SectionedItemReorder({ items, defaultLabel, suggestedSectionName
                 modifiers={[restrictToVerticalAxis]}
                 // Only ever auto-scroll the modal's own scroll area — see the
                 // note on the unsectioned editor for why.
-                autoScroll={{ canScroll: (el) => el === scrollRef.current }}
+                autoScroll={scrollRef ? { canScroll: (el) => el === scrollRef.current } : true}
                 accessibility={{
                     screenReaderInstructions: {
                         draggable: 'Press space to pick up the item, the arrow keys to move it '
@@ -401,43 +396,6 @@ export function SectionedItemReorder({ items, defaultLabel, suggestedSectionName
                     </div>
                 </SortableContext>
             </DndContext>
-            {addingSection ? (
-                <div className="mt-3 flex gap-2">
-                    <input
-                        autoFocus
-                        list="section-name-suggestions"
-                        value={newSectionName}
-                        onChange={e => setNewSectionName(e.target.value)}
-                        onKeyDown={e => {
-                            if (e.key === 'Enter') addSection()
-                            if (e.key === 'Escape') { setNewSectionName(''); setAddingSection(false) }
-                        }}
-                        placeholder="Section name (e.g. Toiletries)"
-                        aria-label="New section name"
-                        className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-                    />
-                    {/* Suggest names already in use so the same section spelled two
-                        ways doesn't split into two groups on the list. */}
-                    <datalist id="section-name-suggestions">
-                        {suggestedSectionNames.map(name => <option key={name} value={name} />)}
-                    </datalist>
-                    <button
-                        type="button"
-                        onClick={addSection}
-                        className="px-3 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700"
-                    >
-                        Add
-                    </button>
-                </div>
-            ) : (
-                <button
-                    type="button"
-                    onClick={() => setAddingSection(true)}
-                    className="mt-3 w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
-                >
-                    + Add section
-                </button>
-            )}
         </>
     )
 }

--- a/src/edit-questions/item-edits.test.ts
+++ b/src/edit-questions/item-edits.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { appendItemToSection, applyItemEdit, withQuestionOptions } from './item-edits'
+import { appendItemToSection, applyItemEdit, tombstoneRemovedItems, withQuestionOptions } from './item-edits'
 import type { Item, Option, Question } from './types'
 
 const NOW = '2024-06-01T12:00:00.000Z'
@@ -244,5 +244,59 @@ describe('appendItemToSection', () => {
         expect(result[0]).toBe(list[0])
         expect(result[1]).toBe(list[1])
         expect(result[2]).toBe(list[2])
+    })
+})
+
+// ── tombstoneRemovedItems ─────────────────────────────────────────────────────
+
+describe('tombstoneRemovedItems', () => {
+    const stored = (): Item[] => [
+        makeItem('Socks', { id: 'i1' }),
+        makeItem('Towel', { id: 'i2' }),
+        makeItem('Old hat', { id: 'i3', deletedAt: '2024-01-01T00:00:00.000Z' }),
+    ]
+
+    it('tombstones an item the editor dropped rather than losing it', () => {
+        const kept = [makeItem('Socks', { id: 'i1' })]
+        const result = tombstoneRemovedItems(stored(), kept, NOW)
+        expect(result.find(i => i.id === 'i2')?.deletedAt).toBe(NOW)
+    })
+
+    it('keeps the dropped item’s payload, so a merge can still identify it', () => {
+        const result = tombstoneRemovedItems(stored(), [makeItem('Socks', { id: 'i1' })], NOW)
+        expect(result.find(i => i.id === 'i2')?.text).toBe('Towel')
+    })
+
+    it('carries existing tombstones through untouched', () => {
+        const result = tombstoneRemovedItems(stored(), [makeItem('Socks', { id: 'i1' })], NOW)
+        const old = result.find(i => i.id === 'i3')
+        expect(old?.deletedAt).toBe('2024-01-01T00:00:00.000Z')
+    })
+
+    it('puts the kept items first, in the order the editor left them', () => {
+        const kept = [makeItem('Towel', { id: 'i2' }), makeItem('Socks', { id: 'i1' })]
+        const result = tombstoneRemovedItems(stored(), kept, NOW)
+        expect(result.slice(0, 2).map(i => i.text)).toEqual(['Towel', 'Socks'])
+    })
+
+    it('adds no tombstone when nothing was removed', () => {
+        const kept = [makeItem('Socks', { id: 'i1' }), makeItem('Towel', { id: 'i2' })]
+        const result = tombstoneRemovedItems(stored(), kept, NOW)
+        expect(result.filter(i => i.deletedAt).map(i => i.id)).toEqual(['i3'])
+    })
+
+    it('lets a brand new item through without matching it to anything', () => {
+        const kept = [makeItem('Socks', { id: 'i1' }), makeItem('Towel', { id: 'i2' }), makeItem('Sun cream', { id: 'i4' })]
+        const result = tombstoneRemovedItems(stored(), kept, NOW)
+        expect(result.filter(i => !i.deletedAt).map(i => i.text)).toEqual(['Socks', 'Towel', 'Sun cream'])
+    })
+
+    it('drops an id-less legacy item outright, as it always did', () => {
+        // mergeItemsById only merges per item when every item on both sides has
+        // an id; without one there is nothing for a tombstone to match on, so a
+        // hard delete is both all we can do and what already happens today.
+        const legacy = [makeItem('Socks'), makeItem('Towel')]
+        const result = tombstoneRemovedItems(legacy, [makeItem('Socks')], NOW)
+        expect(result.map(i => i.text)).toEqual(['Socks'])
     })
 })

--- a/src/edit-questions/item-edits.ts
+++ b/src/edit-questions/item-edits.ts
@@ -86,6 +86,32 @@ export function appendItemToSection(
 }
 
 /**
+ * Fold an editor's finished list back into what was stored, turning the items
+ * it dropped into tombstones instead of letting them vanish.
+ *
+ * A modal that rewrites a whole list on save knows only about the items it was
+ * given, which are the *active* ones — so saving it as-is silently discards
+ * every `deletedAt` the list was carrying, and turns each deletion made in the
+ * modal into a plain absence. `mergeItemsById` resolves an item present on one
+ * side only by keeping it, so both of those come straight back on the next pod
+ * merge: the deletion doesn't stick, and an item deleted on another device
+ * reappears. Marking removals rather than dropping them is what makes a delete
+ * survive the round trip — the same shape `handlePeopleSave` uses for people.
+ *
+ * Items with no `id` are the exception: `mergeItemsById` bows out entirely
+ * unless every item on both sides has one, so there is nothing for a tombstone
+ * to match on and a removal stays a removal.
+ */
+export function tombstoneRemovedItems(stored: Item[], kept: Item[], now: string): Item[] {
+    const keptIds = new Set(kept.map(item => item.id).filter(Boolean))
+    const previouslyDeleted = stored.filter(item => item.deletedAt)
+    const nowDeleted = stored
+        .filter(item => !item.deletedAt && item.id && !keptIds.has(item.id))
+        .map(item => ({ ...item, deletedAt: now }))
+    return [...kept, ...nowDeleted, ...previouslyDeleted]
+}
+
+/**
  * Apply an edit to the item at `index`.
  *
  * When the edit leaves the item in the same section this is a straight

--- a/src/edit-questions/item-sections.test.ts
+++ b/src/edit-questions/item-sections.test.ts
@@ -18,6 +18,7 @@ import {
     moveItemToSection,
     isAtSectionEdge,
     pruneFilledSections,
+    reconcileEmptySections,
     addEmptySection,
     type SectionSequenceEntry,
 } from './item-sections'
@@ -536,5 +537,37 @@ describe('empty sections', () => {
             }
             expect(sectionNamesIn(qs).sort()).toEqual(['Documents', 'Toiletries'])
         })
+    })
+})
+
+describe('reconcileEmptySections', () => {
+    const soap = item({ id: 'i1', text: 'Soap', category: 'Toiletries' })
+    const socks = item({ id: 'i2', text: 'Socks' })
+
+    it('keeps a section whose last item has just gone', () => {
+        // Deleting an item is not a request to delete the section it was in.
+        expect(reconcileEmptySections([soap, socks], [socks], undefined)).toEqual(['Toiletries'])
+    })
+
+    it('forgets a recorded section once it has items', () => {
+        expect(reconcileEmptySections([socks], [socks, soap], ['Toiletries'])).toBeUndefined()
+    })
+
+    it('leaves a section alone while it still has items', () => {
+        const other = item({ id: 'i3', text: 'Shampoo', category: 'Toiletries' })
+        expect(reconcileEmptySections([soap, other], [other], undefined)).toBeUndefined()
+    })
+
+    it('does not invent a section that was already empty and unrecorded', () => {
+        expect(reconcileEmptySections([socks], [socks], undefined)).toBeUndefined()
+    })
+
+    it('keeps recorded sections that are still empty', () => {
+        expect(reconcileEmptySections([socks], [socks], ['Spare'])).toEqual(['Spare'])
+    })
+
+    it('treats a soft-deleted item as gone, keeping its section', () => {
+        const tombstoned = { ...soap, deletedAt: now }
+        expect(reconcileEmptySections([soap, socks], [tombstoned, socks], undefined)).toEqual(['Toiletries'])
     })
 })

--- a/src/edit-questions/item-sections.test.ts
+++ b/src/edit-questions/item-sections.test.ts
@@ -17,6 +17,8 @@ import {
     moveItemWithinSection,
     moveItemToSection,
     isAtSectionEdge,
+    pruneFilledSections,
+    addEmptySection,
     type SectionSequenceEntry,
 } from './item-sections'
 import type { Item, Question, Option } from './types'
@@ -444,5 +446,95 @@ describe('CATEGORY_ORDER', () => {
         expect(at(CATEGORIES.clothes)).toBeLessThan(at(CATEGORIES.kit))
         expect(at(CATEGORIES.kit)).toBe(CATEGORY_ORDER.length - 2)
         expect(at(CATEGORIES.pet)).toBe(CATEGORY_ORDER.length - 1)
+    })
+})
+
+describe('empty sections', () => {
+    describe('buildSectionGroups with recorded empty sections', () => {
+        it('shows a section that has nothing in it yet', () => {
+            const groups = buildSectionGroups([item({ id: 'i1', text: 'Socks' })], 'Yes', ['Toiletries'])
+            expect(groups.map(g => g.label)).toEqual(['Yes', 'Toiletries'])
+            expect(groups[1].entries).toEqual([])
+        })
+
+        it('keeps the flat index of items right when an empty section precedes them', () => {
+            // The index addresses the items array, which knows nothing about a
+            // section that holds none of them.
+            const items = [item({ id: 'i1', text: 'Socks' }), item({ id: 'i2', text: 'Soap', category: 'Toiletries' })]
+            const groups = buildSectionGroups(items, 'Yes', ['Spare'])
+            const soap = groups.flatMap(g => g.entries).find(e => e.item.text === 'Soap')
+            expect(soap?.index).toBe(1)
+        })
+
+        it('does not duplicate a section that has items and is also recorded', () => {
+            const items = [item({ id: 'i1', text: 'Soap', category: 'Toiletries' })]
+            const groups = buildSectionGroups(items, 'Yes', ['Toiletries'])
+            expect(groups.filter(g => g.label === 'Toiletries')).toHaveLength(1)
+        })
+
+        it('behaves as before when none are recorded', () => {
+            const items = [item({ id: 'i1', text: 'Soap', category: 'Toiletries' })]
+            expect(buildSectionGroups(items, 'Yes')).toEqual(buildSectionGroups(items, 'Yes', []))
+        })
+    })
+
+    describe('pruneFilledSections', () => {
+        it('forgets a section once something lands in it', () => {
+            const items = [item({ id: 'i1', text: 'Soap', category: 'Toiletries' })]
+            expect(pruneFilledSections(['Toiletries', 'Spare'], items)).toEqual(['Spare'])
+        })
+
+        it('drops the field entirely once every section has items', () => {
+            const items = [item({ id: 'i1', text: 'Soap', category: 'Toiletries' })]
+            expect(pruneFilledSections(['Toiletries'], items)).toBeUndefined()
+        })
+
+        it('ignores a soft-deleted item, which leaves its section empty again', () => {
+            const items = [item({ id: 'i1', text: 'Soap', category: 'Toiletries', deletedAt: now })]
+            expect(pruneFilledSections(['Toiletries'], items)).toEqual(['Toiletries'])
+        })
+
+        it('passes undefined through', () => {
+            expect(pruneFilledSections(undefined, [])).toBeUndefined()
+        })
+    })
+
+    describe('addEmptySection', () => {
+        it('records a brand new section', () => {
+            expect(addEmptySection(undefined, [], 'Toiletries', 'Yes')).toEqual(['Toiletries'])
+        })
+
+        it('appends to the ones already recorded', () => {
+            expect(addEmptySection(['Spare'], [], 'Toiletries', 'Yes')).toEqual(['Spare', 'Toiletries'])
+        })
+
+        it('refuses a name that already has items — it exists already', () => {
+            const items = [item({ id: 'i1', text: 'Soap', category: 'Toiletries' })]
+            expect(addEmptySection(undefined, items, 'Toiletries', 'Yes')).toBeUndefined()
+        })
+
+        it('refuses a duplicate of one already recorded', () => {
+            expect(addEmptySection(['Toiletries'], [], 'Toiletries', 'Yes')).toEqual(['Toiletries'])
+        })
+
+        it('refuses the default section, which always exists', () => {
+            expect(addEmptySection(undefined, [], 'Yes', 'Yes')).toBeUndefined()
+        })
+    })
+
+    describe('sectionNamesIn', () => {
+        it('offers an empty section by name, so it can be filed into from elsewhere', () => {
+            const qs = {
+                _id: '1',
+                people: [],
+                alwaysNeededItems: [],
+                alwaysNeededEmptySections: ['Documents'],
+                questions: [{
+                    id: 'q1', type: 'saved' as const, text: 'Overnight?', order: 0,
+                    options: [{ id: 'o1', text: 'Yes', order: 0, items: [], emptySections: ['Toiletries'] }],
+                }],
+            }
+            expect(sectionNamesIn(qs).sort()).toEqual(['Documents', 'Toiletries'])
+        })
     })
 })

--- a/src/edit-questions/item-sections.ts
+++ b/src/edit-questions/item-sections.ts
@@ -171,10 +171,14 @@ export interface SectionGroup {
  * screen. Drafts aren't accepted: an empty section only exists inside the
  * reorder view, which works against the sequence directly.
  */
-export function buildSectionGroups(items: Item[], defaultLabel: string): SectionGroup[] {
+export function buildSectionGroups(
+    items: Item[],
+    defaultLabel: string,
+    emptySections: string[] = [],
+): SectionGroup[] {
     const indexOf = new Map(items.map((item, i) => [item, i]))
     const groups: SectionGroup[] = []
-    for (const entry of buildSectionSequence(items, defaultLabel, [])) {
+    for (const entry of buildSectionSequence(items, defaultLabel, emptySections)) {
         if (entry.kind === 'header') groups.push({ label: entry.label, entries: [] })
         // The sequence always opens with a header, so there is a group to put
         // this in — but a stray item is dropped rather than crashing a page.
@@ -318,14 +322,66 @@ export function sectionNamesIn(qs: PackingListQuestionSet): string[] {
     for (const item of qs.alwaysNeededItems ?? []) {
         if (item.category) names.add(item.category)
     }
+    for (const name of qs.alwaysNeededEmptySections ?? []) names.add(name)
     for (const question of qs.questions ?? []) {
         for (const option of question.options) {
             for (const item of option.items) {
                 if (item.category) names.add(item.category)
             }
+            for (const name of option.emptySections ?? []) names.add(name)
         }
     }
     return [...names]
+}
+
+/** The sections an item list describes through its own items. */
+function filledSectionsOf(items: Item[]): Set<string> {
+    const filled = new Set<string>()
+    for (const item of items) {
+        // A soft-deleted item doesn't hold a section open — the section is back
+        // to being empty, and has to stay recorded to survive the next reload.
+        if (item.category && !item.deletedAt) filled.add(item.category)
+    }
+    return filled
+}
+
+/**
+ * Drop the sections that no longer need recording, because their items now
+ * describe them. Run this on every write to an item list: it is what keeps
+ * `emptySections` meaning exactly what it says, so nothing has to remember to
+ * clean up after a drag or an add.
+ *
+ * Returns `undefined` rather than `[]` when nothing is left, so the field
+ * disappears from the document instead of lingering as an empty array.
+ */
+export function pruneFilledSections(
+    emptySections: string[] | undefined,
+    items: Item[],
+): string[] | undefined {
+    if (!emptySections?.length) return undefined
+    const filled = filledSectionsOf(items)
+    const remaining = emptySections.filter(label => !filled.has(label))
+    return remaining.length > 0 ? remaining : undefined
+}
+
+/**
+ * Record a new, empty section — the "+ Add section" action.
+ *
+ * A name that already exists is not an error and not a second section: it is
+ * simply already there, so the list comes back unchanged. The default section
+ * is likewise refused, since every list has one whether or not anything is in it.
+ */
+export function addEmptySection(
+    emptySections: string[] | undefined,
+    items: Item[],
+    label: string,
+    defaultLabel: string,
+): string[] | undefined {
+    const trimmed = label.trim()
+    if (!trimmed || trimmed === defaultLabel) return emptySections?.length ? emptySections : undefined
+    if (emptySections?.includes(trimmed)) return emptySections
+    if (filledSectionsOf(items).has(trimmed)) return emptySections?.length ? emptySections : undefined
+    return [...(emptySections ?? []), trimmed]
 }
 
 /**

--- a/src/edit-questions/item-sections.ts
+++ b/src/edit-questions/item-sections.ts
@@ -365,6 +365,34 @@ export function pruneFilledSections(
 }
 
 /**
+ * Bring the recorded empty sections up to date after an item list changed.
+ *
+ * Two things happen here, and the second is why this exists rather than
+ * `pruneFilledSections` alone: a section whose last item just left stays, now
+ * recorded as empty. Deleting an item — or dragging it elsewhere — is not a
+ * request to delete the section it was in, and letting the section evaporate
+ * underneath the change is exactly the disappearing-section behaviour the
+ * stored names were added to stop.
+ *
+ * Removing a section is a separate, deliberate action, so that path drops the
+ * name itself rather than going through here.
+ */
+export function reconcileEmptySections(
+    previous: Item[],
+    next: Item[],
+    emptySections: string[] | undefined,
+): string[] | undefined {
+    const before = filledSectionsOf(previous)
+    const after = filledSectionsOf(next)
+    const emptied = [...before].filter(label => !after.has(label))
+    const combined = [...(emptySections ?? [])]
+    for (const label of emptied) {
+        if (!combined.includes(label)) combined.push(label)
+    }
+    return pruneFilledSections(combined, next)
+}
+
+/**
  * Record a new, empty section — the "+ Add section" action.
  *
  * A name that already exists is not an error and not a second section: it is

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -96,11 +96,25 @@ export const ItemSchema = z.object({
 
 export const QuestionTypeSchema = z.enum(['single-choice', 'multiple-choice'])
 
+// `emptySections` is optional and additive: the names of sections here that have
+// no items in them yet.
+//
+// A section is otherwise only its items' `category` stamps, so one with nothing
+// in it cannot be described at all — it existed solely as React state inside the
+// reorder view and evaporated the moment you looked away. That made "make a
+// Toiletries section, then fill it" unbuildable, and pushed section creation
+// into the per-item Section field, where typing a new name is indistinguishable
+// from renaming the section the item is already in.
+//
+// So the names are stored, and only while they are empty: whatever fills a
+// section takes its name off this list, because from then on its items describe
+// it. `sectionsOf` is what puts the two halves back together.
 export const OptionSchema = z.object({
   id: z.string(),
   text: z.string(),
   items: z.array(ItemSchema),
-  order: z.number()
+  order: z.number(),
+  emptySections: z.array(z.string()).optional(),
 })
 
 const CommonQuestionSchema = z.object({
@@ -128,6 +142,9 @@ export const PackingListQuestionSetSchema = z.object({
   _rev: z.string().optional(),
   people: z.array(PersonSchema),
   alwaysNeededItems: z.array(ItemSchema),
+  // The always-needed list's own empty sections — same role as an option's
+  // `emptySections`, for the one item list that doesn't belong to an option.
+  alwaysNeededEmptySections: z.array(z.string()).optional(),
   questions: z.array(QuestionSchema),
   lastModified: z.string().optional(), // ISO timestamp for sync conflict resolution
   // Version of the wizard template this set was generated from / last

--- a/src/pages/questions-page.option-section.test.tsx
+++ b/src/pages/questions-page.option-section.test.tsx
@@ -507,3 +507,91 @@ describe('OptionSection with no items, once items can be added', () => {
         expect(onItemAdd).toHaveBeenCalledWith('q1', 'o1', 'Socks', undefined)
     })
 })
+
+describe('OptionSection: deleting an item', () => {
+    const withItems = () => makeOption({ items: [makeItem('Socks'), makeItem('Towel')] })
+
+    /** The section with inline editing *and* deleting switched on. */
+    function renderDeletable(option: Option) {
+        const onItemDelete = vi.fn()
+        render(
+            <OptionSection
+                option={option}
+                people={twoPeople}
+                sectionDefaultLabel="Yes"
+                allItemNames={['Socks', 'Towel']}
+                questionId="q1"
+                onEdit={vi.fn()}
+                onDelete={vi.fn()}
+                onItemChange={vi.fn()}
+                onItemDelete={onItemDelete}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        return { onItemDelete }
+    }
+
+    it('offers no delete when the page supplies no handler', () => {
+        renderEditable(withItems())
+        fireEvent.click(screen.getByTitle('Edit Socks'))
+        // Scoped to the editor: the option's own "Delete option" button is a
+        // different thing entirely and is always there.
+        const editor = screen.getByTestId('item-inline-editor')
+        expect(within(editor).queryByRole('button', { name: /^Delete/ })).toBeNull()
+    })
+
+    it('deletes the row the editor was opened on', () => {
+        const { onItemDelete } = renderDeletable(withItems())
+        fireEvent.click(screen.getByTitle('Edit Towel'))
+        fireEvent.click(screen.getByRole('button', { name: 'Delete Towel' }))
+        expect(onItemDelete).toHaveBeenCalledWith('q1', 'o1', 1)
+    })
+
+    it('closes the editor, whose row has gone and whose index now means another', () => {
+        renderDeletable(withItems())
+        fireEvent.click(screen.getByTitle('Edit Socks'))
+        fireEvent.click(screen.getByRole('button', { name: 'Delete Socks' }))
+        expect(screen.queryByTestId('item-inline-editor')).toBeNull()
+    })
+})
+
+describe('OptionSection: a section with nothing in it yet', () => {
+    function renderWithEmptySection(option: Option) {
+        render(
+            <OptionSection
+                option={option}
+                people={people}
+                sectionDefaultLabel="Yes"
+                questionId="q1"
+                suggestions={buildIndexOf([])}
+                onEdit={vi.fn()}
+                onDelete={vi.fn()}
+                onItemChange={vi.fn()}
+                onItemAdd={vi.fn()}
+            />
+        )
+    }
+
+    it('can be opened even though the option has no items', () => {
+        renderWithEmptySection(makeOption({ items: [], emptySections: ['Toiletries'] }))
+        expect(screen.getByTestId('option-expand-chevron')).toBeTruthy()
+    })
+
+    it('draws the section, so a section you just made is actually there', () => {
+        renderWithEmptySection(makeOption({ items: [], emptySections: ['Toiletries'] }))
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        expect(screen.getByText('Toiletries')).toBeTruthy()
+    })
+
+    it('says it is empty rather than drawing a blank card', () => {
+        renderWithEmptySection(makeOption({ items: [], emptySections: ['Toiletries'] }))
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        expect(screen.getByText(/Nothing here yet/)).toBeTruthy()
+    })
+
+    it('carries its own ＋, so the first item goes straight into it', () => {
+        renderWithEmptySection(makeOption({ items: [], emptySections: ['Toiletries'] }))
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        expect(screen.getByRole('button', { name: 'Add an item to Toiletries' })).toBeTruthy()
+    })
+})

--- a/src/pages/questions-page.option-section.test.tsx
+++ b/src/pages/questions-page.option-section.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import { render, screen, fireEvent, within, act } from '@testing-library/react'
 import React from 'react'
 import { OptionSection } from './questions-page'
 import { DEFAULT_SECTION_ACCENT, sectionAccent } from '../edit-questions/section-accent'
@@ -664,7 +664,7 @@ describe('OptionSection: organising in place', () => {
     const withItems = () => makeOption({ items: [makeItem('Socks'), makeItem('Towel')] })
 
     function renderOrganisable(option: Option, onReorder = vi.fn()) {
-        render(
+        const view = render(
             <OptionSection
                 option={option}
                 people={people}
@@ -679,7 +679,7 @@ describe('OptionSection: organising in place', () => {
             />
         )
         fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
-        return { onReorder }
+        return { onReorder, unmount: view.unmount }
     }
 
     it('offers organising without opening anything', () => {
@@ -714,14 +714,72 @@ describe('OptionSection: organising in place', () => {
         expect(screen.getByRole('button', { name: '+ Add item' })).toBeTruthy()
     })
 
-    it('saves a move as it happens, with no Save to press', () => {
-        const { onReorder } = renderOrganisable(withItems())
-        fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
+    function moveTowelToTop() {
         fireEvent.pointerDown(screen.getByRole('button', { name: 'Move Towel' }), { button: 0 })
         fireEvent.click(within(screen.getByRole('menu')).getByText('Move to top of section'))
+    }
+
+    it('shows the move at once, without waiting for it to be written', () => {
+        const { onReorder } = renderOrganisable(withItems())
+        fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
+        moveTowelToTop()
+        // On screen immediately...
+        const rows = [...document.querySelectorAll('[data-reorder-row]')]
+        expect(rows.map(r => r.textContent)).toEqual([
+            expect.stringContaining('Towel'),
+            expect.stringContaining('Socks'),
+        ])
+        // ...and not yet written, so a run of drags costs one save, not one each.
+        expect(onReorder).not.toHaveBeenCalled()
+    })
+
+    it('writes the move once the dragging stops', async () => {
+        vi.useFakeTimers()
+        try {
+            const { onReorder } = renderOrganisable(withItems())
+            fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
+            moveTowelToTop()
+            await act(async () => { vi.advanceTimersByTime(1000) })
+            expect(onReorder).toHaveBeenCalledWith('q1', 'o1', [
+                expect.objectContaining({ text: 'Towel' }),
+                expect.objectContaining({ text: 'Socks' }),
+            ], undefined)
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('writes what is still in hand when organising finishes', () => {
+        const { onReorder } = renderOrganisable(withItems())
+        fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
+        moveTowelToTop()
+        fireEvent.click(screen.getByRole('button', { name: 'Finish organising' }))
         expect(onReorder).toHaveBeenCalledWith('q1', 'o1', [
             expect.objectContaining({ text: 'Towel' }),
             expect.objectContaining({ text: 'Socks' }),
         ], undefined)
+    })
+
+    it('writes what is still in hand when the list goes away underneath it', () => {
+        const { onReorder, unmount } = renderOrganisable(withItems())
+        fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
+        moveTowelToTop()
+        unmount()
+        expect(onReorder).toHaveBeenCalledTimes(1)
+    })
+
+    it('collapses a run of moves into a single write', async () => {
+        vi.useFakeTimers()
+        try {
+            const { onReorder } = renderOrganisable(withItems())
+            fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
+            moveTowelToTop()
+            fireEvent.pointerDown(screen.getByRole('button', { name: 'Move Socks' }), { button: 0 })
+            fireEvent.click(within(screen.getByRole('menu')).getByText('Move to top of section'))
+            await act(async () => { vi.advanceTimersByTime(1000) })
+            expect(onReorder).toHaveBeenCalledTimes(1)
+        } finally {
+            vi.useRealTimers()
+        }
     })
 })

--- a/src/pages/questions-page.option-section.test.tsx
+++ b/src/pages/questions-page.option-section.test.tsx
@@ -267,11 +267,7 @@ describe('OptionSection inline item editing', () => {
         // the item being edited — and the row has visibly gone somewhere else.
         const { onItemChange } = renderEditable(withItems(), ['Toiletries'])
         fireEvent.click(screen.getByTitle('Edit Socks'))
-        const field = screen.getByTestId('item-section-field')
-        fireEvent.click(within(field).getByText('Yes'))
-        const input = field.querySelector('input') as HTMLInputElement
-        fireEvent.change(input, { target: { value: 'Toiletries' } })
-        fireEvent.blur(input)
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Toiletries' } })
         expect(onItemChange).toHaveBeenCalledWith('q1', 'o1', 0, expect.objectContaining({
             category: 'Toiletries',
         }))
@@ -593,5 +589,73 @@ describe('OptionSection: a section with nothing in it yet', () => {
         renderWithEmptySection(makeOption({ items: [], emptySections: ['Toiletries'] }))
         fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
         expect(screen.getByRole('button', { name: 'Add an item to Toiletries' })).toBeTruthy()
+    })
+})
+
+describe('OptionSection: creating a section', () => {
+    function renderAddable(option: Option, onSectionAdd = vi.fn()) {
+        render(
+            <OptionSection
+                option={option}
+                people={people}
+                sectionDefaultLabel="Yes"
+                sectionNames={['Toiletries']}
+                questionId="q1"
+                suggestions={buildIndexOf([])}
+                onEdit={vi.fn()}
+                onDelete={vi.fn()}
+                onItemChange={vi.fn()}
+                onItemAdd={vi.fn()}
+                onSectionAdd={onSectionAdd}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        return { onSectionAdd }
+    }
+
+    it('offers no "+ Add section" when the page supplies no handler', () => {
+        renderEditable(makeOption({ items: [makeItem('Socks')] }))
+        expect(screen.queryByRole('button', { name: '+ Add section' })).toBeNull()
+    })
+
+    it('names the new section and creates it', () => {
+        const { onSectionAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }))
+        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
+        fireEvent.change(screen.getByLabelText('New section name'), { target: { value: 'Beach kit' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+        expect(onSectionAdd).toHaveBeenCalledWith('q1', 'o1', 'Beach kit')
+    })
+
+    it('creates on Enter, so naming several in a row needs no mouse', () => {
+        const { onSectionAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }))
+        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
+        const input = screen.getByLabelText('New section name')
+        fireEvent.change(input, { target: { value: 'Beach kit' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onSectionAdd).toHaveBeenCalledWith('q1', 'o1', 'Beach kit')
+    })
+
+    it('creates nothing on an empty name', () => {
+        const { onSectionAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }))
+        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+        expect(onSectionAdd).not.toHaveBeenCalled()
+        expect(screen.queryByTestId('add-section')).toBeNull()
+    })
+
+    it('abandons the name on Escape', () => {
+        const { onSectionAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }))
+        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
+        fireEvent.keyDown(screen.getByLabelText('New section name'), { key: 'Escape' })
+        expect(screen.queryByTestId('add-section')).toBeNull()
+        expect(onSectionAdd).not.toHaveBeenCalled()
+    })
+
+    it('suggests names already used elsewhere, so one section is not spelled two ways', () => {
+        renderAddable(makeOption({ items: [makeItem('Socks')] }))
+        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
+        const listId = screen.getByLabelText('New section name').getAttribute('list')
+        const options = [...document.querySelectorAll(`#${CSS.escape(listId!)} option`)].map(o => o.getAttribute('value'))
+        expect(options).toContain('Toiletries')
     })
 })

--- a/src/pages/questions-page.option-section.test.tsx
+++ b/src/pages/questions-page.option-section.test.tsx
@@ -659,3 +659,69 @@ describe('OptionSection: creating a section', () => {
         expect(options).toContain('Toiletries')
     })
 })
+
+describe('OptionSection: organising in place', () => {
+    const withItems = () => makeOption({ items: [makeItem('Socks'), makeItem('Towel')] })
+
+    function renderOrganisable(option: Option, onReorder = vi.fn()) {
+        render(
+            <OptionSection
+                option={option}
+                people={people}
+                sectionDefaultLabel="Yes"
+                questionId="q1"
+                suggestions={buildIndexOf([])}
+                onEdit={vi.fn()}
+                onDelete={vi.fn()}
+                onItemChange={vi.fn()}
+                onItemAdd={vi.fn()}
+                onReorder={onReorder}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        return { onReorder }
+    }
+
+    it('offers organising without opening anything', () => {
+        renderOrganisable(withItems())
+        expect(screen.getByRole('button', { name: 'Organise items' })).toBeTruthy()
+    })
+
+    it('offers nothing to organise with a single item', () => {
+        renderOrganisable(makeOption({ items: [makeItem('Socks')] }))
+        expect(screen.queryByRole('button', { name: 'Organise items' })).toBeNull()
+    })
+
+    it('offers no organising when the page cannot save the result', () => {
+        renderEditable(withItems())
+        expect(screen.queryByRole('button', { name: 'Organise items' })).toBeNull()
+    })
+
+    it('swaps the rows for drag handles and back again', () => {
+        renderOrganisable(withItems())
+        fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
+        expect(screen.getAllByRole('button', { name: /^Drag / })).toHaveLength(2)
+        expect(screen.queryByTestId('item-row')).toBeNull()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Finish organising' }))
+        expect(screen.queryByRole('button', { name: /^Drag / })).toBeNull()
+        expect(screen.getAllByTestId('item-row')).toHaveLength(2)
+    })
+
+    it('keeps the footer, so a section can still be added mid-reorganisation', () => {
+        renderOrganisable(withItems())
+        fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
+        expect(screen.getByRole('button', { name: '+ Add item' })).toBeTruthy()
+    })
+
+    it('saves a move as it happens, with no Save to press', () => {
+        const { onReorder } = renderOrganisable(withItems())
+        fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
+        fireEvent.pointerDown(screen.getByRole('button', { name: 'Move Towel' }), { button: 0 })
+        fireEvent.click(within(screen.getByRole('menu')).getByText('Move to top of section'))
+        expect(onReorder).toHaveBeenCalledWith('q1', 'o1', [
+            expect.objectContaining({ text: 'Towel' }),
+            expect.objectContaining({ text: 'Socks' }),
+        ], undefined)
+    })
+})

--- a/src/pages/questions-page.option-section.test.tsx
+++ b/src/pages/questions-page.option-section.test.tsx
@@ -660,7 +660,7 @@ describe('OptionSection: creating a section', () => {
     })
 })
 
-describe('OptionSection: organising in place', () => {
+describe('OptionSection: organising', () => {
     const withItems = () => makeOption({ items: [makeItem('Socks'), makeItem('Towel')] })
 
     function renderOrganisable(option: Option, onReorder = vi.fn()) {
@@ -697,21 +697,28 @@ describe('OptionSection: organising in place', () => {
         expect(screen.queryByRole('button', { name: 'Organise items' })).toBeNull()
     })
 
-    it('swaps the rows for drag handles and back again', () => {
+    it('opens onto the whole screen, which is what the drag needs', () => {
+        // Tried nested in the page first: a scroll area inside a scroll area,
+        // with neither in charge of the gesture.
         renderOrganisable(withItems())
         fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
-        expect(screen.getAllByRole('button', { name: /^Drag / })).toHaveLength(2)
-        expect(screen.queryByTestId('item-row')).toBeNull()
+        const dialog = screen.getByRole('dialog', { name: 'Organise Yes items' })
+        expect(within(dialog).getAllByRole('button', { name: /^Drag / })).toHaveLength(2)
+    })
 
+    it('closes back to the list', () => {
+        renderOrganisable(withItems())
+        fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
         fireEvent.click(screen.getByRole('button', { name: 'Finish organising' }))
-        expect(screen.queryByRole('button', { name: /^Drag / })).toBeNull()
+        expect(screen.queryByRole('dialog')).toBeNull()
         expect(screen.getAllByTestId('item-row')).toHaveLength(2)
     })
 
-    it('keeps the footer, so a section can still be added mid-reorganisation', () => {
+    it('closes on Escape', () => {
         renderOrganisable(withItems())
         fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
-        expect(screen.getByRole('button', { name: '+ Add item' })).toBeTruthy()
+        fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+        expect(screen.queryByRole('dialog')).toBeNull()
     })
 
     function moveTowelToTop() {
@@ -749,7 +756,7 @@ describe('OptionSection: organising in place', () => {
         }
     })
 
-    it('writes what is still in hand when organising finishes', () => {
+    it('writes what is still in hand when the dialog is closed', () => {
         const { onReorder } = renderOrganisable(withItems())
         fireEvent.click(screen.getByRole('button', { name: 'Organise items' }))
         moveTowelToTop()

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -14,12 +14,10 @@ import { POD_CONTAINERS } from '../services/solidPod'
 import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSerialization'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useForeignPod } from '../components/ForeignPodContext'
-import { CustomCreatableSelect } from '../components/CreatableSelect'
 import { AgePromotionCard } from '../components/AgePromotionCard'
 import { TemplateUpdatesCard } from '../components/TemplateUpdatesCard'
 import { LoadingState } from '../components/LoadingState'
 import { AgeTransition } from '../edit-questions/age-derivation'
-import { useIsDesktop } from '../hooks/useIsDesktop'
 import { appendItemToSection, applyItemEdit, tombstoneRemovedItems, withQuestionOptions } from '../edit-questions/item-edits'
 import { ItemInlineEditor } from '../components/ItemInlineEditor'
 import { AddQuestionItem } from '../components/AddQuestionItem'
@@ -28,9 +26,6 @@ import { buildIndexOf, type SuggestionIndex } from '../utils/itemSuggestions'
 import {
     AVATAR_ON,
     AVATAR_OFF,
-    PersonToggles,
-    QuantityPanel,
-    rateBadge,
     rateLabel,
     quantityTitle,
 } from '../components/ItemEditorControls'
@@ -245,7 +240,7 @@ export interface ItemAdding {
  * of every section on the page, which is the cost the read-only rows exist to
  * avoid.
  */
-const SectionedItemRows = memo(function SectionedItemRows({ items, people, defaultLabel, emptySections = NO_NAMES, allItemNames = NO_NAMES, sectionNames = NO_NAMES, adding, onItemChange, onItemDelete, onSectionAdd }: {
+const SectionedItemRows = memo(function SectionedItemRows({ items, people, defaultLabel, emptySections = NO_NAMES, allItemNames = NO_NAMES, sectionNames = NO_NAMES, adding, onItemChange, onItemDelete, onSectionAdd, onReorder }: {
     items: Item[]
     people: Person[]
     defaultLabel: string
@@ -261,6 +256,8 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
     onItemDelete?: (index: number) => void
     /** Omit to leave the list unable to grow a section. */
     onSectionAdd?: (label: string) => void
+    /** Omit to leave the list unorganisable — no reorder toggle appears. */
+    onReorder?: (items: Item[], emptySections: string[] | undefined) => void
 }) {
     // Which row is expanded, by its position in `items` — the same flat index
     // every edit is addressed by. At most one is open, so a long list never
@@ -271,6 +268,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
     const [openComposer, setOpenComposer] = useState<string | null>(null)
     const closeComposer = useCallback(() => setOpenComposer(null), [])
     const [addingSection, setAddingSection] = useState(false)
+    const [organising, setOrganising] = useState(false)
 
     const groups = useMemo(
         () => buildSectionGroups(items, defaultLabel, emptySections),
@@ -401,9 +399,47 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                 )
     )
 
+    // Reordering needs at least two items to have anything to say, and the
+    // toggle only makes sense where the page can actually save the result.
+    const canOrganise = onReorder !== undefined && items.length > 1
+    const organiseToggle = canOrganise && (
+        <div className="flex justify-end mb-2">
+            <button
+                type="button"
+                onClick={() => setOrganising(o => !o)}
+                aria-pressed={organising}
+                className={`inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 transition-colors ${organising ? 'bg-primary-600 text-white' : 'text-primary-600 hover:bg-primary-50'}`}
+            >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
+                </svg>
+                {organising ? 'Finish organising' : 'Organise items'}
+            </button>
+        </div>
+    )
+
+    // Organising replaces the rows and nothing else: the footer stays, so adding
+    // an item or a section mid-reorganisation doesn't mean leaving the mode you
+    // are reorganising in.
+    if (organising && onReorder) {
+        return (
+            <div>
+                {organiseToggle}
+                <SectionedItemReorder
+                    items={items}
+                    defaultLabel={defaultLabel}
+                    emptySections={emptySections.length > 0 ? emptySections : undefined}
+                    onChange={onReorder}
+                />
+                {listFooter}
+            </div>
+        )
+    }
+
     if (!hasSections) {
         return (
             <div>
+                {organiseToggle}
                 <div className="space-y-0.5">{groups.flatMap(group => group.entries).map(renderRow)}</div>
                 {listFooter}
             </div>
@@ -412,6 +448,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
 
     return (
         <div>
+            {organiseToggle}
             <div className="space-y-2">
                 {groups.map(group => {
                     const accent = sectionAccent(group.label, group.label === defaultLabel)
@@ -529,7 +566,7 @@ function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete:
     )
 }
 
-export function OptionSection({ option, people, sectionDefaultLabel, allItemNames, sectionNames, questionId, suggestions, onEdit, onDelete, onItemChange, onItemAdd, onItemDelete, onSectionAdd }: {
+export function OptionSection({ option, people, sectionDefaultLabel, allItemNames, sectionNames, questionId, suggestions, onEdit, onDelete, onItemChange, onItemAdd, onItemDelete, onSectionAdd, onReorder }: {
     option: Option
     people: Person[]
     /** What the packing list will call items here that carry no category. */
@@ -548,6 +585,8 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
     onItemDelete?: (questionId: string, optionId: string, index: number) => void
     /** Omit to leave the option unable to grow a section. */
     onSectionAdd?: (questionId: string, optionId: string, label: string) => void
+    /** Omit to leave the items unorganisable. */
+    onReorder?: (questionId: string, optionId: string, items: Item[], emptySections: string[] | undefined) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(false)
     // Bound to this option's ids once, so the memoized row list isn't handed a
@@ -568,6 +607,11 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
             ? (label: string) => onSectionAdd(questionId, optionId, label)
             : undefined,
         [onSectionAdd, questionId, optionId])
+    const handleReorder = useMemo(
+        () => onReorder && questionId
+            ? (reordered: Item[], sections: string[] | undefined) => onReorder(questionId, optionId, reordered, sections)
+            : undefined,
+        [onReorder, questionId, optionId])
     const adding = useMemo<ItemAdding | undefined>(
         () => onItemAdd && questionId && suggestions
             ? {
@@ -676,6 +720,7 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
                         onItemChange={handleItemChange}
                         onItemDelete={handleItemDelete}
                         onSectionAdd={handleSectionAdd}
+                        onReorder={handleReorder}
                     />
                 </div>
             )}
@@ -794,7 +839,7 @@ function QuestionContextMenu({ onMoveUp, onMoveDown, onEdit, onDelete }: {
 
 // Memoized with id-based handlers whose identity survives page re-renders, so
 // opening a modal (or a background sync tick) doesn't re-render every question.
-const QuestionSection = memo(function QuestionSection({ question, people, canMoveUp, canMoveDown, allItemNames, sectionNames, suggestions, onEdit, onDelete, onAddOption, onEditOption, onDeleteOption, onMove, onItemChange, onItemAdd, onItemDelete, onSectionAdd }: {
+const QuestionSection = memo(function QuestionSection({ question, people, canMoveUp, canMoveDown, allItemNames, sectionNames, suggestions, onEdit, onDelete, onAddOption, onEditOption, onDeleteOption, onMove, onItemChange, onItemAdd, onItemDelete, onSectionAdd, onReorder }: {
     question: Question
     people: Person[]
     canMoveUp: boolean
@@ -812,6 +857,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
     onItemAdd: (questionId: string, optionId: string, text: string, category: string | undefined) => void
     onItemDelete: (questionId: string, optionId: string, index: number) => void
     onSectionAdd: (questionId: string, optionId: string, label: string) => void
+    onReorder: (questionId: string, optionId: string, items: Item[], emptySections: string[] | undefined) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(true)
     const [showDeleteModal, setShowDeleteModal] = useState(false)
@@ -916,6 +962,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                             onItemAdd={onItemAdd}
                             onItemDelete={onItemDelete}
                             onSectionAdd={onSectionAdd}
+                            onReorder={onReorder}
                         />
                     ))}
                     <button
@@ -937,18 +984,18 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
     )
 })
 
-const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections, allItemNames, sectionNames, suggestions, onEdit, onItemChange, onItemAdd, onItemDelete, onSectionAdd }: {
+const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections, allItemNames, sectionNames, suggestions, onItemChange, onItemAdd, onItemDelete, onSectionAdd, onReorder }: {
     items: Item[]
     people: Person[]
     emptySections?: string[]
     allItemNames: string[]
     sectionNames: string[]
     suggestions: SuggestionIndex
-    onEdit: () => void
     onItemChange: (index: number, edited: Item) => void
     onItemAdd: (text: string, category: string | undefined) => void
     onItemDelete: (index: number) => void
     onSectionAdd: (label: string) => void
+    onReorder: (items: Item[], emptySections: string[] | undefined) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(false)
     const adding = useMemo<ItemAdding>(
@@ -976,16 +1023,6 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections
                         <span className="hidden sm:inline text-sm font-normal text-gray-500">{items.length} items</span>
                     </span>
                 </button>
-                <button
-                    type="button"
-                    onClick={onEdit}
-                    className="p-4 -m-2 text-gray-300 hover:text-gray-600 rounded flex-shrink-0"
-                    title="Edit always needed items"
-                >
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                    </svg>
-                </button>
             </div>
             {hasExpandedRef.current && (
                 <div className={`mt-3${isExpanded ? '' : ' hidden'}`}>
@@ -1000,6 +1037,7 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections
                         onItemChange={onItemChange}
                         onItemDelete={onItemDelete}
                         onSectionAdd={onSectionAdd}
+                        onReorder={onReorder}
                     />
                 </div>
             )}
@@ -1007,377 +1045,39 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections
     )
 })
 
-function useItemListState(initialItems: Item[], people: Person[]) {
-    const [items, setItems] = useState<Item[]>(initialItems)
-    const scrollRef = useRef<HTMLDivElement>(null)
-    const prevCountRef = useRef(initialItems.length)
-
-    useEffect(() => {
-        if (items.length > prevCountRef.current) {
-            requestAnimationFrame(() => {
-                scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
-            })
-        }
-        prevCountRef.current = items.length
-    }, [items.length])
-
-    // All handlers are useCallback'd so the memoized per-item rows only
-    // re-render when their own item changes, not on every keystroke or toggle.
-    const updateItemText = useCallback((idx: number, text: string) =>
-        setItems(prev => prev.map((item, i) => i === idx ? { ...item, text } : item)), [])
-
-    const togglePerson = useCallback((itemIdx: number, personIdx: number) =>
-        setItems(prev => prev.map((item, i) => {
-            if (i !== itemIdx) return item
-            const selections = people.map((p, pi) => ({
-                personId: p.id,
-                selected: item.personSelections?.[pi]?.selected ?? false,
-            }))
-            selections[personIdx] = { ...selections[personIdx], selected: !selections[personIdx].selected }
-            return { ...item, personSelections: selections }
-        })), [people])
-
-    const toggleCommunal = useCallback((itemIdx: number) =>
-        setItems(prev => prev.map((item, i) =>
-            i === itemIdx ? { ...item, communal: item.communal ? undefined : true } : item
-        )), [])
-
-    const updatePerNight = useCallback((itemIdx: number, perNight: number | undefined) =>
-        setItems(prev => prev.map((item, i) =>
-            i === itemIdx ? { ...item, perNight } : item
-        )), [])
-
-    const updatePerNights = useCallback((itemIdx: number, perNights: number | undefined) =>
-        setItems(prev => prev.map((item, i) =>
-            i === itemIdx ? { ...item, perNights } : item
-        )), [])
-
-    const updateMaxQuantity = useCallback((itemIdx: number, maxQuantity: number | undefined) =>
-        setItems(prev => prev.map((item, i) =>
-            i === itemIdx ? { ...item, maxQuantity } : item
-        )), [])
-
-    const removeItem = useCallback((idx: number) =>
-        setItems(prev => prev.filter((_, i) => i !== idx)), [])
-
-    const moveItem = useCallback((idx: number, direction: 'up' | 'down') =>
-        setItems(prev => {
-            const swapIdx = direction === 'up' ? idx - 1 : idx + 1
-            if (swapIdx < 0 || swapIdx >= prev.length) return prev
-            const next = [...prev]
-            ;[next[idx], next[swapIdx]] = [next[swapIdx], next[idx]]
-            return next
-        }), [])
-
-    // Pull the item at `from` out and reinsert it at `to` — used by drag to
-    // reorder; up/down buttons stay as the discrete, keyboard-friendly path.
-    const reorderItem = useCallback((from: number, to: number) =>
-        setItems(prev => {
-            if (from === to || from < 0 || to < 0 || from >= prev.length || to >= prev.length) return prev
-            const next = [...prev]
-            const [moved] = next.splice(from, 1)
-            next.splice(to, 0, moved)
-            return next
-        }), [])
-
-    // The new row inherits the last item's section so it appears at the bottom,
-    // next to the button that made it. Without this an uncategorised item falls
-    // into the default section, which `buildSectionSequence` puts first — so in
-    // a fully sectioned list the row would appear at the very top instead.
-    const addItem = useCallback(() =>
-        setItems(prev => [...prev, {
-            text: '',
-            ...(prev.length > 0 && prev[prev.length - 1].category !== undefined
-                ? { category: prev[prev.length - 1].category }
-                : {}),
-            personSelections: people.map(p => ({ personId: p.id, selected: true })),
-        }]), [people])
-
-    // Whole-list replacement, used when a sectioned drag re-stamps categories
-    // and reorders in one go (see applySectionLayout).
-    const replaceItems = useCallback((next: Item[]) => setItems(next), [])
-
-    return { items, scrollRef, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, moveItem, reorderItem, addItem, replaceItems }
-}
-
-// One editable item row. Memoized (with stable handlers from useItemListState)
-// so toggling a person or typing in one row doesn't re-render every other row —
-// with dozens of items and a large family that re-render is what made the
-// editor modals feel sluggish on phones. Renders only the variant for the
-// current form factor instead of both (CSS-hidden DOM is still DOM).
-const ItemEditorRow = memo(function ItemEditorRow({ item, itemIdx, people, allItemNames, isDesktop, quantityOpen, onToggleQuantity, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem }: {
-    item: Item
-    itemIdx: number
-    people: Person[]
-    allItemNames: string[]
-    isDesktop: boolean
-    quantityOpen: boolean
-    onToggleQuantity: (idx: number) => void
-    updateItemText: (idx: number, text: string) => void
-    togglePerson: (itemIdx: number, personIdx: number) => void
-    toggleCommunal: (itemIdx: number) => void
-    updatePerNight: (itemIdx: number, perNight: number | undefined) => void
-    updatePerNights: (itemIdx: number, perNights: number | undefined) => void
-    updateMaxQuantity: (itemIdx: number, maxQuantity: number | undefined) => void
-    removeItem: (idx: number) => void
-}) {
-    const isCommunal = item.communal === true
-    const hasRate = item.perNight !== undefined
-    return (
-        // content-visibility lets the browser skip layout/paint for rows that
-        // are scrolled out of view — noticeable when a list has dozens of items.
-        <div
-            className="sm:flex sm:flex-wrap sm:items-center sm:gap-2 rounded-lg border border-gray-200 sm:border-transparent p-2 sm:p-0"
-            style={{ contentVisibility: 'auto', containIntrinsicSize: isDesktop ? 'auto 44px' : 'auto 132px' }}
-        >
-            {/* Item name + desktop people + remove */}
-            <div className="flex items-center gap-2 sm:flex-1 sm:min-w-0">
-                <div className="flex-1 min-w-0">
-                    <CustomCreatableSelect
-                        value={item.text}
-                        onChange={val => updateItemText(itemIdx, val)}
-                        options={allItemNames}
-                        placeholder="Item name"
-                        menuPortalTarget={document.body}
-                    />
-                </div>
-                {/* Desktop: shared toggle + inline avatars */}
-                {isDesktop && (
-                    <PersonToggles
-                        item={item}
-                        people={people}
-                        layout="avatars"
-                        onTogglePerson={personIdx => togglePerson(itemIdx, personIdx)}
-                        onToggleCommunal={() => toggleCommunal(itemIdx)}
-                    />
-                )}
-                <button
-                    type="button"
-                    onClick={() => onToggleQuantity(itemIdx)}
-                    title={quantityTitle(item)}
-                    aria-label={`Set suggested quantity for ${item.text || 'item'}`}
-                    aria-expanded={quantityOpen}
-                    className={`inline-flex items-center justify-center h-5 rounded-full px-1.5 text-[10px] font-medium shrink-0 transition-colors ${hasRate ? 'bg-emerald-600 text-white' : AVATAR_OFF}`}
-                >
-                    {hasRate ? rateBadge(item) : '×n'}
-                </button>
-                <button
-                    type="button"
-                    onClick={() => removeItem(itemIdx)}
-                    className="shrink-0 text-gray-300 hover:text-red-400 text-xl leading-none"
-                    title="Remove item"
-                >
-                    ×
-                </button>
-            </div>
-            {/* Mobile: shared toggle + people on their own row as large labelled tiles */}
-            {!isDesktop && (
-                <div className="mt-2">
-                    <PersonToggles
-                        item={item}
-                        people={people}
-                        layout="tiles"
-                        onTogglePerson={personIdx => togglePerson(itemIdx, personIdx)}
-                        onToggleCommunal={() => toggleCommunal(itemIdx)}
-                    />
-                </div>
-            )}
-            {!isDesktop && isCommunal && people.length > 1 && (
-                <div className="mt-1 text-[11px] text-blue-600 px-1">
-                    Packed once for the group — included when a highlighted person is going
-                </div>
-            )}
-            {quantityOpen && (
-                <div className="mt-2 sm:mt-0 w-full">
-                    <QuantityPanel
-                        item={item}
-                        onPerNight={value => updatePerNight(itemIdx, value)}
-                        onPerNights={value => updatePerNights(itemIdx, value)}
-                        onMaxQuantity={value => updateMaxQuantity(itemIdx, value)}
-                    />
-                </div>
-            )}
-        </div>
-    )
-})
-
-function ItemListEditor({ items, people, allItemNames, scrollRef, sectionDefaultLabel, suggestedSectionNames, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, addItem, replaceItems }: {
-    items: Item[]
-    people: Person[]
-    allItemNames: string[]
-    scrollRef: React.RefObject<HTMLDivElement | null>
-    /** What the packing list will call items that carry no category of their own. */
-    sectionDefaultLabel: string
-    suggestedSectionNames: string[]
-    updateItemText: (idx: number, text: string) => void
-    togglePerson: (itemIdx: number, personIdx: number) => void
-    toggleCommunal: (itemIdx: number) => void
-    updatePerNight: (itemIdx: number, perNight: number | undefined) => void
-    updatePerNights: (itemIdx: number, perNights: number | undefined) => void
-    updateMaxQuantity: (itemIdx: number, maxQuantity: number | undefined) => void
-    removeItem: (idx: number) => void
-    addItem: () => void
-    replaceItems: (items: Item[]) => void
-}) {
-    const [openQuantityIdx, setOpenQuantityIdx] = useState<number | null>(null)
-    const [reorderMode, setReorderMode] = useState(false)
-    const isDesktop = useIsDesktop()
-    const toggleQuantity = useCallback((idx: number) =>
-        setOpenQuantityIdx(prev => prev === idx ? null : idx), [])
-    // Reorder mode only makes sense with something to reorder; if there aren't
-    // at least two items the toggle is hidden and we render the normal editor.
-    const canReorder = items.length > 1
-    const inReorder = reorderMode && canReorder
-
-    // Normal editing mode shows the same section cards as the read-only list on
-    // the page behind, so the editor always previews how the packing list will
-    // group these items — and the same section is the same colour in both.
-    const groups = useMemo(() => buildSectionGroups(items, sectionDefaultLabel), [items, sectionDefaultLabel])
-
-    // Only worth drawing the cards once the list is actually split.
-    const hasSections = groups.length > 1
-
-    const renderRow = (entry: PositionedItem) => (
-        <ItemEditorRow
-            key={`item-${entry.index}`}
-            item={entry.item}
-            itemIdx={entry.index}
-            people={people}
-            allItemNames={allItemNames}
-            isDesktop={isDesktop}
-            quantityOpen={openQuantityIdx === entry.index}
-            onToggleQuantity={toggleQuantity}
-            updateItemText={updateItemText}
-            togglePerson={togglePerson}
-            toggleCommunal={toggleCommunal}
-            updatePerNight={updatePerNight}
-            updatePerNights={updatePerNights}
-            updateMaxQuantity={updateMaxQuantity}
-            removeItem={removeItem}
-        />
-    )
-
-    return (
-        <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
-            {items.length > 0 && (
-                <div className="flex items-center justify-between mb-2">
-                    <div className="text-xs font-medium text-gray-400 uppercase tracking-wide">Items</div>
-                    {canReorder && (
-                        <button
-                            type="button"
-                            onClick={() => setReorderMode(m => !m)}
-                            aria-pressed={reorderMode}
-                            className={`inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 transition-colors ${reorderMode ? 'bg-primary-600 text-white' : 'text-primary-600 hover:bg-primary-50'}`}
-                        >
-                            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
-                            </svg>
-                            {reorderMode ? 'Finish organising' : 'Organise items'}
-                        </button>
-                    )}
-                </div>
-            )}
-            {inReorder && (
-                <div className="space-y-2">
-                    <SectionedItemReorder
-                        items={items}
-                        defaultLabel={sectionDefaultLabel}
-                        suggestedSectionNames={suggestedSectionNames}
-                        scrollRef={scrollRef}
-                        onChange={replaceItems}
-                    />
-                </div>
-            )}
-            {!inReorder && !hasSections && (
-                <div className="space-y-2">
-                    {groups.flatMap(group => group.entries).map(renderRow)}
-                </div>
-            )}
-            {!inReorder && hasSections && (
-                <div className="space-y-3">
-                    {groups.map(group => {
-                        const accent = sectionAccent(group.label, group.label === sectionDefaultLabel)
-                        return (
-                            <div
-                                key={`section-${group.label}`}
-                                data-testid="editor-item-section"
-                                className={`rounded-lg border ${accent.border} overflow-hidden`}
-                            >
-                                <div className={`flex items-center gap-2 px-3 py-2 ${accent.header}`}>
-                                    <span className={`text-sm font-semibold ${accent.text} truncate`}>
-                                        {group.label}
-                                    </span>
-                                    <span className={`ml-auto shrink-0 text-[11px] font-medium ${accent.muted}`}>
-                                        {group.entries.length} item{group.entries.length === 1 ? '' : 's'}
-                                    </span>
-                                </div>
-                                <div className="p-2 space-y-2">{group.entries.map(renderRow)}</div>
-                            </div>
-                        )
-                    })}
-                </div>
-            )}
-            {!inReorder && (
-                <button
-                    type="button"
-                    onClick={addItem}
-                    className="mt-3 w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
-                >
-                    + Add Item
-                </button>
-            )}
-        </div>
-    )
-}
-
-// Lock background page scroll while a modal is open. Besides being correct
-// modal behaviour, on mobile it keeps the page — and the browser's URL bar —
-// from moving while a drag is happening inside the modal, which was the source
-// of the touch-drag jank (dnd-kit's own auto-scroll is already confined to the
-// item list; this stops the window scrolling underneath it).
-function useBodyScrollLock() {
-    useEffect(() => {
-        const body = document.body
-        const html = document.documentElement
-        const prev = { body: body.style.overflow, html: html.style.overflow, overscroll: body.style.overscrollBehavior }
-        // Lock both — the scrolling element is <body> on some browsers and
-        // <html> on others (notably mobile) — and stop scroll chaining.
-        body.style.overflow = 'hidden'
-        html.style.overflow = 'hidden'
-        body.style.overscrollBehavior = 'none'
-        return () => {
-            body.style.overflow = prev.body
-            html.style.overflow = prev.html
-            body.style.overscrollBehavior = prev.overscroll
-        }
-    }, [])
-}
-
-function OptionEditModal({ option, question, people, allItemNames, suggestedSectionNames, onSave, onClose }: {
+/**
+ * Naming an option — and nothing else.
+ *
+ * This modal used to carry a full item editor: every item's name, who it was
+ * for, how many, drag-reordering, section renames. All of that now happens on
+ * the page itself, in the list you are already looking at, so keeping a second
+ * copy here meant two ways to do each job with different save semantics — the
+ * page saves as you go, the modal only on Save — and no way to tell from the
+ * controls which one you were in.
+ *
+ * What is left is the one thing the page cannot do in place: the option's own
+ * name. Adding an option is the same act, so it is the same modal; its items
+ * are then added where it now sits.
+ */
+function OptionEditModal({ option, onSave, onClose }: {
     option: Option | null
-    question: Question | undefined
-    people: Person[]
-    allItemNames: string[]
-    suggestedSectionNames: string[]
     onSave: (updated: Option) => void
     onClose: () => void
 }) {
-    useBodyScrollLock()
     const [text, setText] = useState(option?.text ?? '')
-    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, addItem, replaceItems } = useItemListState(option?.items ?? [], people)
 
-    // Tracks the option text as it's typed, so the default section heading shows
-    // the name the generated list will actually use.
-    const sectionDefaultLabel = question
-        ? defaultCategoryFor(question, { id: option?.id ?? '', text, order: option?.order ?? 0, items: [] })
-        : text
-
-    const handleSave = () => onSave({
-        id: option?.id ?? crypto.randomUUID(),
-        order: option?.order ?? 0,
-        text: text.trim(),
-        items: renumberItemOrder(items, new Date().toISOString()),
-    })
+    const handleSave = () => {
+        if (!text.trim()) return
+        onSave({
+            id: option?.id ?? crypto.randomUUID(),
+            order: option?.order ?? 0,
+            text: text.trim(),
+            // Untouched: this modal has no opinion about items any more, and a
+            // new option starts empty for the composer on the page to fill.
+            items: option?.items ?? [],
+            ...(option?.emptySections ? { emptySections: option.emptySections } : {}),
+        })
+    }
 
     return (
         <div
@@ -1385,108 +1085,34 @@ function OptionEditModal({ option, question, people, allItemNames, suggestedSect
             onClick={onClose}
             onKeyDown={e => { if (e.key === 'Escape') onClose() }}
         >
-            <div
-                className="bg-white rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
-                onClick={e => e.stopPropagation()}
-            >
-                <div className="p-5 border-b border-gray-100 flex-shrink-0">
-                    <h2 className="text-lg font-semibold text-gray-900 mb-3">
+            <div className="bg-white rounded-xl shadow-xl w-full max-w-md" onClick={e => e.stopPropagation()}>
+                <div className="p-5">
+                    <h2 className="text-lg font-semibold text-gray-900 mb-4">
                         {option ? 'Edit Option' : 'Add Option'}
                     </h2>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Answer text</label>
                     <input
                         autoFocus
                         type="text"
                         value={text}
                         onChange={e => setText(e.target.value)}
-                        placeholder="Option text (e.g. Yes)"
-                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-                        onKeyDown={e => { if (e.key === 'Enter') addItem() }}
+                        placeholder="e.g. Yes"
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 mb-5"
+                        onKeyDown={e => { if (e.key === 'Enter') handleSave() }}
                     />
-                    {people.length > 1 && (
-                        <div className="flex items-center gap-3 flex-wrap mt-3">
-                            {people.map((person, i) => (
-                                <span key={person.id} className="flex items-center gap-1 text-xs text-gray-400">
-                                    <span className={`inline-flex items-center justify-center w-4 h-4 rounded-full text-[9px] font-bold ${AVATAR_ON[i % AVATAR_ON.length]}`}>
-                                        {person.name.charAt(0).toUpperCase()}
-                                    </span>
-                                    {person.name}
-                                </span>
-                            ))}
-                        </div>
-                    )}
-                </div>
-                <ItemListEditor
-                    items={items} people={people} allItemNames={allItemNames}
-                    scrollRef={scrollRef} updateItemText={updateItemText}
-                    sectionDefaultLabel={sectionDefaultLabel} suggestedSectionNames={suggestedSectionNames}
-                    togglePerson={togglePerson} toggleCommunal={toggleCommunal}
-                    updatePerNight={updatePerNight} updatePerNights={updatePerNights} updateMaxQuantity={updateMaxQuantity}
-                    removeItem={removeItem} addItem={addItem} replaceItems={replaceItems}
-                />
-                <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex gap-2 justify-end">
-                    <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
-                        Cancel
-                    </button>
-                    <button type="button" onClick={handleSave} className="px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700">
-                        {option ? 'Save changes' : 'Add option'}
-                    </button>
-                </div>
-            </div>
-        </div>
-    )
-}
-
-function AlwaysNeededModal({ initialItems, people, allItemNames, suggestedSectionNames, onSave, onClose }: {
-    initialItems: Item[]
-    people: Person[]
-    allItemNames: string[]
-    suggestedSectionNames: string[]
-    onSave: (items: Item[]) => void
-    onClose: () => void
-}) {
-    useBodyScrollLock()
-    const { items, scrollRef, updateItemText, togglePerson, toggleCommunal, updatePerNight, updatePerNights, updateMaxQuantity, removeItem, addItem, replaceItems } = useItemListState(initialItems, people)
-
-    return (
-        <div
-            className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
-            onClick={onClose}
-            onKeyDown={e => { if (e.key === 'Escape') onClose() }}
-        >
-            <div
-                className="bg-white rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
-                onClick={e => e.stopPropagation()}
-            >
-                <div className="p-5 border-b border-gray-100 flex-shrink-0">
-                    <h2 className="text-lg font-semibold text-gray-900">Always Needed Items</h2>
-                    {people.length > 1 && (
-                        <div className="flex items-center gap-3 flex-wrap mt-2">
-                            {people.map((person, i) => (
-                                <span key={person.id} className="flex items-center gap-1 text-xs text-gray-400">
-                                    <span className={`inline-flex items-center justify-center w-4 h-4 rounded-full text-[9px] font-bold ${AVATAR_ON[i % AVATAR_ON.length]}`}>
-                                        {person.name.charAt(0).toUpperCase()}
-                                    </span>
-                                    {person.name}
-                                </span>
-                            ))}
-                        </div>
-                    )}
-                </div>
-                <ItemListEditor
-                    items={items} people={people} allItemNames={allItemNames}
-                    scrollRef={scrollRef} updateItemText={updateItemText}
-                    sectionDefaultLabel={ALWAYS_NEEDED_CATEGORY} suggestedSectionNames={suggestedSectionNames}
-                    togglePerson={togglePerson} toggleCommunal={toggleCommunal}
-                    updatePerNight={updatePerNight} updatePerNights={updatePerNights} updateMaxQuantity={updateMaxQuantity}
-                    removeItem={removeItem} addItem={addItem} replaceItems={replaceItems}
-                />
-                <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex gap-2 justify-end">
-                    <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
-                        Cancel
-                    </button>
-                    <button type="button" onClick={() => onSave(renumberItemOrder(items, new Date().toISOString()))} className="px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700">
-                        Save changes
-                    </button>
+                    <div className="flex gap-2 justify-end">
+                        <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleSave}
+                            disabled={!text.trim()}
+                            className="px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {option ? 'Save changes' : 'Add option'}
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -1699,7 +1325,6 @@ export function QuestionsPage() {
     const [questionModal, setQuestionModal] = useState<{ question: Question | null } | null>(null)
     const [optionModal, setOptionModal] = useState<{ questionId: string; option: Option | null } | null>(null)
     const [peopleModal, setPeopleModal] = useState(false)
-    const [alwaysModal, setAlwaysModal] = useState(false)
     // Bracket changes made by hand in the people modal; offered the same
     // item-review flow as birthday-driven transitions, then cleared.
     const [manualPromotions, setManualPromotions] = useState<AgeTransition[]>([])
@@ -1937,6 +1562,36 @@ export function QuestionsPage() {
         await saveData({ ...data, alwaysNeededEmptySections: emptySections })
     }, [saveData])
 
+    // A drag reports the whole list back, already stamped with each item's new
+    // section by `applySectionLayout`, so this only has to renumber and save.
+    const handleOptionReorder = useCallback(async (questionId: string, optionId: string, reordered: Item[], emptySections: string[] | undefined) => {
+        const data = dataRef.current
+        if (!data) return
+        const now = new Date().toISOString()
+        const items = renumberItemOrder(reordered, now)
+        await saveData({
+            ...data,
+            questions: withQuestionOptions(data.questions, questionId, options =>
+                options.map(o => o.id === optionId
+                    ? withEmptySections({ ...o, items }, emptySections)
+                    : o), now),
+        })
+    }, [saveData])
+
+    const handleAlwaysReorder = useCallback(async (reordered: Item[], emptySections: string[] | undefined) => {
+        const data = dataRef.current
+        if (!data) return
+        const now = new Date().toISOString()
+        // The reorder view is given the active items, so the tombstones it never
+        // saw are carried through rather than dropped.
+        const deleted = (data.alwaysNeededItems ?? []).filter(i => i.deletedAt)
+        await saveData({
+            ...data,
+            alwaysNeededItems: [...renumberItemOrder(reordered, now), ...deleted],
+            alwaysNeededEmptySections: emptySections,
+        })
+    }, [saveData])
+
     const handleAlwaysItemDelete = useCallback(async (index: number) => {
         const data = dataRef.current
         if (!data) return
@@ -1972,19 +1627,6 @@ export function QuestionsPage() {
             alwaysNeededEmptySections: reconcileEmptySections(active, items, data.alwaysNeededEmptySections),
         })
     }, [saveData])
-
-    // The modal is handed the active items only, so anything it hands back
-    // missing was deleted in it — and the tombstones it never saw have to be put
-    // back. Saving its list verbatim did neither, which meant a delete made here
-    // came straight back on the next pod merge; see `tombstoneRemovedItems`.
-    const handleAlwaysSave = useCallback(async (newItems: Item[]) => {
-        if (!data) return
-        setAlwaysModal(false)
-        await saveData({
-            ...data,
-            alwaysNeededItems: tombstoneRemovedItems(data.alwaysNeededItems ?? [], newItems, new Date().toISOString()),
-        })
-    }, [data, saveData])
 
     const handlePeopleSave = useCallback(async (newPeople: Person[]) => {
         if (!data) return
@@ -2046,7 +1688,6 @@ export function QuestionsPage() {
     const openAddOption = useCallback((questionId: string) => setOptionModal({ questionId, option: null }), [])
     const openEditOption = useCallback((questionId: string, option: Option) => setOptionModal({ questionId, option }), [])
     const openPeopleModal = useCallback(() => setPeopleModal(true), [])
-    const openAlwaysModal = useCallback(() => setAlwaysModal(true), [])
 
     // The set as a dictionary of its own item names: what the add composers
     // offer as you type, and what the name fields offer as existing options.
@@ -2101,11 +1742,11 @@ export function QuestionsPage() {
                     allItemNames={allItemNames}
                     sectionNames={suggestedSectionNames}
                     suggestions={suggestions}
-                    onEdit={openAlwaysModal}
                     onItemChange={handleAlwaysItemChange}
                     onItemAdd={handleAlwaysItemAdd}
                     onItemDelete={handleAlwaysItemDelete}
                     onSectionAdd={handleAlwaysSectionAdd}
+                    onReorder={handleAlwaysReorder}
                 />
                 {activeQuestions.map((q, qi) => (
                     <QuestionSection
@@ -2127,6 +1768,7 @@ export function QuestionsPage() {
                         onItemAdd={handleOptionItemAdd}
                         onItemDelete={handleOptionItemDelete}
                         onSectionAdd={handleOptionSectionAdd}
+                        onReorder={handleOptionReorder}
                     />
                 ))}
                 <button
@@ -2147,22 +1789,8 @@ export function QuestionsPage() {
             {optionModal !== null && (
                 <OptionEditModal
                     option={optionModal.option}
-                    question={data?.questions.find(q => q.id === optionModal.questionId)}
-                    people={people}
-                    allItemNames={allItemNames}
-                    suggestedSectionNames={suggestedSectionNames}
                     onSave={handleOptionModalSave}
                     onClose={() => setOptionModal(null)}
-                />
-            )}
-            {alwaysModal && (
-                <AlwaysNeededModal
-                    initialItems={activeAlwaysNeededItems}
-                    people={people}
-                    allItemNames={allItemNames}
-                    suggestedSectionNames={suggestedSectionNames}
-                    onSave={handleAlwaysSave}
-                    onClose={() => setAlwaysModal(false)}
                 />
             )}
             {peopleModal && (

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -1065,6 +1065,7 @@ function OptionEditModal({ option, onSave, onClose }: {
     onClose: () => void
 }) {
     const [text, setText] = useState(option?.text ?? '')
+    const fieldId = useId()
 
     const handleSave = () => {
         if (!text.trim()) return
@@ -1090,8 +1091,9 @@ function OptionEditModal({ option, onSave, onClose }: {
                     <h2 className="text-lg font-semibold text-gray-900 mb-4">
                         {option ? 'Edit Option' : 'Add Option'}
                     </h2>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Answer text</label>
+                    <label htmlFor={fieldId} className="block text-sm font-medium text-gray-700 mb-1">Answer text</label>
                     <input
+                        id={fieldId}
                         autoFocus
                         type="text"
                         value={text}

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo, memo, Fragment } fro
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useDatabase } from '../components/DatabaseContext'
 import { SectionedItemReorder } from '../components/SectionedItemReorder'
-import { ALWAYS_NEEDED_CATEGORY, buildSectionGroups, defaultCategoryFor, sectionNamesIn, type PositionedItem } from '../edit-questions/item-sections'
+import { ALWAYS_NEEDED_CATEGORY, buildSectionGroups, defaultCategoryFor, reconcileEmptySections, sectionNamesIn, type PositionedItem } from '../edit-questions/item-sections'
 import { sectionAccent } from '../edit-questions/section-accent'
 import { DatabaseMigration } from '../services/migration'
 import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, newDraftQuestion, renumberItemOrder, AGE_RANGE_OPTIONS } from '../edit-questions/types'
@@ -193,16 +193,20 @@ export interface ItemAdding {
  * of every section on the page, which is the cost the read-only rows exist to
  * avoid.
  */
-const SectionedItemRows = memo(function SectionedItemRows({ items, people, defaultLabel, allItemNames = NO_NAMES, sectionNames = NO_NAMES, adding, onItemChange }: {
+const SectionedItemRows = memo(function SectionedItemRows({ items, people, defaultLabel, emptySections = NO_NAMES, allItemNames = NO_NAMES, sectionNames = NO_NAMES, adding, onItemChange, onItemDelete }: {
     items: Item[]
     people: Person[]
     defaultLabel: string
+    /** Sections of this list that have nothing in them yet — drawn as empty cards. */
+    emptySections?: string[]
     allItemNames?: string[]
     sectionNames?: string[]
     /** Omit to leave the list read-only — no ＋ buttons, no composer. */
     adding?: ItemAdding
     /** Omit to keep the list purely read-only — rows then aren't clickable. */
     onItemChange?: (index: number, edited: Item) => void
+    /** Omit to leave items undeletable. */
+    onItemDelete?: (index: number) => void
 }) {
     // Which row is expanded, by its position in `items` — the same flat index
     // every edit is addressed by. At most one is open, so a long list never
@@ -213,8 +217,13 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
     const [openComposer, setOpenComposer] = useState<string | null>(null)
     const closeComposer = useCallback(() => setOpenComposer(null), [])
 
-    const groups = useMemo(() => buildSectionGroups(items, defaultLabel), [items, defaultLabel])
-    const hasSections = groups.length > 1
+    const groups = useMemo(
+        () => buildSectionGroups(items, defaultLabel, emptySections),
+        [items, defaultLabel, emptySections])
+    // Worth drawing as cards once the list is genuinely split — or once its one
+    // group is something other than the default pile, which is what a list whose
+    // only section is a newly created empty one looks like.
+    const hasSections = groups.length > 1 || (groups[0] !== undefined && groups[0].label !== defaultLabel)
 
     // Sections the foot composer can file into: the ones this list already has,
     // plus every name used elsewhere in the set — so filing an item under
@@ -248,6 +257,14 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
         setOpenIndex(prev => prev === index ? null : index), [])
     const handleClose = useCallback(() => setOpenIndex(null), [])
 
+    // The row being edited has gone, and every index after it has shifted up, so
+    // the open editor is closed rather than left addressing its neighbour.
+    const handleDelete = useCallback(() => {
+        if (openAt === null) return
+        onItemDelete?.(openAt)
+        setOpenIndex(null)
+    }, [openAt, onItemDelete])
+
     const handleChange = useCallback((edited: Item) => {
         if (openAt === null) return
         const before = items[openAt]
@@ -279,6 +296,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                     sectionNames={sectionNames}
                     sectionDefaultLabel={defaultLabel}
                     onChange={handleChange}
+                    onDelete={onItemDelete ? handleDelete : undefined}
                     onClose={handleClose}
                 />
             )}
@@ -356,7 +374,17 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                                     </button>
                                 )}
                             </div>
-                            <div className="p-1 space-y-0.5">{group.entries.map(renderRow)}</div>
+                            <div className="p-1 space-y-0.5">
+                                {group.entries.length === 0 && openComposer !== group.label && (
+                                    // A section you have just made, before anything is
+                                    // in it. Says so rather than drawing a card with a
+                                    // blank body, which reads as a rendering fault.
+                                    <p className="px-1.5 py-1 text-xs text-gray-400 italic">
+                                        Nothing here yet — use ＋ to add the first item
+                                    </p>
+                                )}
+                                {group.entries.map(renderRow)}
+                            </div>
                             {openComposer === group.label && (
                                 <div className="px-1.5 pb-1.5 pt-0.5">{renderComposer(group.label, true)}</div>
                             )}
@@ -368,6 +396,17 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
         </div>
     )
 })
+
+/**
+ * Set an option's empty-section list, dropping the field when there is nothing
+ * to record. Nested objects don't pass through `toDocumentData`'s undefined
+ * filter — only the top level does — so an option would otherwise carry an
+ * `emptySections: undefined` key into storage.
+ */
+function withEmptySections(option: Option, emptySections: string[] | undefined): Option {
+    const { emptySections: _dropped, ...rest } = option
+    return emptySections?.length ? { ...rest, emptySections } : rest
+}
 
 function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete: () => void }) {
     return (
@@ -409,7 +448,7 @@ function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete:
     )
 }
 
-export function OptionSection({ option, people, sectionDefaultLabel, allItemNames, sectionNames, questionId, suggestions, onEdit, onDelete, onItemChange, onItemAdd }: {
+export function OptionSection({ option, people, sectionDefaultLabel, allItemNames, sectionNames, questionId, suggestions, onEdit, onDelete, onItemChange, onItemAdd, onItemDelete }: {
     option: Option
     people: Person[]
     /** What the packing list will call items here that carry no category. */
@@ -424,6 +463,8 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
     onItemChange?: (questionId: string, optionId: string, index: number, edited: Item) => void
     /** Omit to leave the list unaddable — no ＋ buttons appear. */
     onItemAdd?: (questionId: string, optionId: string, text: string, category: string | undefined) => void
+    /** Omit to leave items undeletable. */
+    onItemDelete?: (questionId: string, optionId: string, index: number) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(false)
     // Bound to this option's ids once, so the memoized row list isn't handed a
@@ -434,6 +475,11 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
             ? (index: number, edited: Item) => onItemChange(questionId, optionId, index, edited)
             : undefined,
         [onItemChange, questionId, optionId])
+    const handleItemDelete = useMemo(
+        () => onItemDelete && questionId
+            ? (index: number) => onItemDelete(questionId, optionId, index)
+            : undefined,
+        [onItemDelete, questionId, optionId])
     const adding = useMemo<ItemAdding | undefined>(
         () => onItemAdd && questionId && suggestions
             ? {
@@ -454,7 +500,8 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
     // nothing, and an answer with no items is exactly the one most in need of
     // somewhere to put the first.
     const isEmpty = option.items.length === 0
-    const canExpand = !isEmpty || adding !== undefined
+    // A section with nothing in it yet is still something to open onto.
+    const canExpand = !isEmpty || adding !== undefined || (option.emptySections?.length ?? 0) > 0
     const heading = (
         <>
             {!canExpand ? (
@@ -534,10 +581,12 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
                         items={option.items}
                         people={people}
                         defaultLabel={sectionDefaultLabel}
+                        emptySections={option.emptySections}
                         allItemNames={allItemNames}
                         sectionNames={sectionNames}
                         adding={adding}
                         onItemChange={handleItemChange}
+                        onItemDelete={handleItemDelete}
                     />
                 </div>
             )}
@@ -656,7 +705,7 @@ function QuestionContextMenu({ onMoveUp, onMoveDown, onEdit, onDelete }: {
 
 // Memoized with id-based handlers whose identity survives page re-renders, so
 // opening a modal (or a background sync tick) doesn't re-render every question.
-const QuestionSection = memo(function QuestionSection({ question, people, canMoveUp, canMoveDown, allItemNames, sectionNames, suggestions, onEdit, onDelete, onAddOption, onEditOption, onDeleteOption, onMove, onItemChange, onItemAdd }: {
+const QuestionSection = memo(function QuestionSection({ question, people, canMoveUp, canMoveDown, allItemNames, sectionNames, suggestions, onEdit, onDelete, onAddOption, onEditOption, onDeleteOption, onMove, onItemChange, onItemAdd, onItemDelete }: {
     question: Question
     people: Person[]
     canMoveUp: boolean
@@ -672,6 +721,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
     onMove: (id: string, direction: 'up' | 'down') => void
     onItemChange: (questionId: string, optionId: string, index: number, edited: Item) => void
     onItemAdd: (questionId: string, optionId: string, text: string, category: string | undefined) => void
+    onItemDelete: (questionId: string, optionId: string, index: number) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(true)
     const [showDeleteModal, setShowDeleteModal] = useState(false)
@@ -774,6 +824,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                             onDelete={() => onDeleteOption(question.id, option.id)}
                             onItemChange={onItemChange}
                             onItemAdd={onItemAdd}
+                            onItemDelete={onItemDelete}
                         />
                     ))}
                     <button
@@ -795,15 +846,17 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
     )
 })
 
-const AlwaysSection = memo(function AlwaysSection({ items, people, allItemNames, sectionNames, suggestions, onEdit, onItemChange, onItemAdd }: {
+const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections, allItemNames, sectionNames, suggestions, onEdit, onItemChange, onItemAdd, onItemDelete }: {
     items: Item[]
     people: Person[]
+    emptySections?: string[]
     allItemNames: string[]
     sectionNames: string[]
     suggestions: SuggestionIndex
     onEdit: () => void
     onItemChange: (index: number, edited: Item) => void
     onItemAdd: (text: string, category: string | undefined) => void
+    onItemDelete: (index: number) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(false)
     const adding = useMemo<ItemAdding>(
@@ -848,10 +901,12 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, allItemNames,
                         items={items}
                         people={people}
                         defaultLabel={ALWAYS_NEEDED_CATEGORY}
+                        emptySections={emptySections}
                         allItemNames={allItemNames}
                         sectionNames={sectionNames}
                         adding={adding}
                         onItemChange={onItemChange}
+                        onItemDelete={onItemDelete}
                     />
                 </div>
             )}
@@ -1688,7 +1743,9 @@ export function QuestionsPage() {
         await saveData({
             ...data,
             questions: withQuestionOptions(data.questions, questionId, options =>
-                options.map(o => o.id === optionId ? { ...o, items } : o), now),
+                options.map(o => o.id === optionId
+                    ? withEmptySections({ ...o, items }, reconcileEmptySections(o.items, items, o.emptySections))
+                    : o), now),
         })
     }, [saveData])
 
@@ -1714,7 +1771,9 @@ export function QuestionsPage() {
         await saveData({
             ...data,
             questions: withQuestionOptions(data.questions, questionId, options =>
-                options.map(o => o.id === optionId ? { ...o, items } : o), now),
+                options.map(o => o.id === optionId
+                    ? withEmptySections({ ...o, items }, reconcileEmptySections(o.items, items, o.emptySections))
+                    : o), now),
         })
     }, [saveData, newItem])
 
@@ -1728,8 +1787,50 @@ export function QuestionsPage() {
         const deleted = stored.filter(i => i.deletedAt)
         const now = new Date().toISOString()
         const items = appendItemToSection(active, newItem(text), category, ALWAYS_NEEDED_CATEGORY, now)
-        await saveData({ ...data, alwaysNeededItems: [...items, ...deleted] })
+        await saveData({
+            ...data,
+            alwaysNeededItems: [...items, ...deleted],
+            alwaysNeededEmptySections: reconcileEmptySections(active, items, data.alwaysNeededEmptySections),
+        })
     }, [saveData, newItem])
+
+    // An option's items are merged whole-question, so a delete here can simply
+    // remove the row — there is no per-item merge to resurrect it, which is why
+    // this needs no tombstone where the always-needed list below does.
+    const handleOptionItemDelete = useCallback(async (questionId: string, optionId: string, index: number) => {
+        const data = dataRef.current
+        if (!data) return
+        const question = data.questions.find(q => q.id === questionId)
+        const option = question?.options.find(o => o.id === optionId)
+        if (!question || !option || !option.items[index]) return
+        const now = new Date().toISOString()
+        const items = renumberItemOrder(option.items.filter((_, i) => i !== index), now)
+        await saveData({
+            ...data,
+            questions: withQuestionOptions(data.questions, questionId, options =>
+                options.map(o => o.id === optionId
+                    ? withEmptySections({ ...o, items }, reconcileEmptySections(o.items, items, o.emptySections))
+                    : o), now),
+        })
+    }, [saveData])
+
+    const handleAlwaysItemDelete = useCallback(async (index: number) => {
+        const data = dataRef.current
+        if (!data) return
+        const stored = data.alwaysNeededItems ?? []
+        const active = stored.filter(i => !i.deletedAt)
+        if (!active[index]) return
+        const now = new Date().toISOString()
+        // Tombstoned, not dropped: always-needed items merge per id, so an item
+        // that simply vanished from this side would come back from the pod.
+        const kept = renumberItemOrder(active.filter((_, i) => i !== index), now)
+        const items = tombstoneRemovedItems(stored, kept, now)
+        await saveData({
+            ...data,
+            alwaysNeededItems: items,
+            alwaysNeededEmptySections: reconcileEmptySections(active, kept, data.alwaysNeededEmptySections),
+        })
+    }, [saveData])
 
     const handleAlwaysItemChange = useCallback(async (index: number, edited: Item) => {
         const data = dataRef.current
@@ -1742,7 +1843,11 @@ export function QuestionsPage() {
         const deleted = stored.filter(i => i.deletedAt)
         const now = new Date().toISOString()
         const items = applyItemEdit(active, index, edited, ALWAYS_NEEDED_CATEGORY, now)
-        await saveData({ ...data, alwaysNeededItems: [...items, ...deleted] })
+        await saveData({
+            ...data,
+            alwaysNeededItems: [...items, ...deleted],
+            alwaysNeededEmptySections: reconcileEmptySections(active, items, data.alwaysNeededEmptySections),
+        })
     }, [saveData])
 
     // The modal is handed the active items only, so anything it hands back
@@ -1869,12 +1974,14 @@ export function QuestionsPage() {
                 <AlwaysSection
                     items={activeAlwaysNeededItems}
                     people={people}
+                    emptySections={data.alwaysNeededEmptySections}
                     allItemNames={allItemNames}
                     sectionNames={suggestedSectionNames}
                     suggestions={suggestions}
                     onEdit={openAlwaysModal}
                     onItemChange={handleAlwaysItemChange}
                     onItemAdd={handleAlwaysItemAdd}
+                    onItemDelete={handleAlwaysItemDelete}
                 />
                 {activeQuestions.map((q, qi) => (
                     <QuestionSection
@@ -1894,6 +2001,7 @@ export function QuestionsPage() {
                         onMove={handleMoveQuestion}
                         onItemChange={handleOptionItemChange}
                         onItemAdd={handleOptionItemAdd}
+                        onItemDelete={handleOptionItemDelete}
                     />
                 ))}
                 <button

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useCallback, useRef, useMemo, memo, Fragment } from 'react'
+import { useState, useEffect, useCallback, useId, useRef, useMemo, memo, Fragment } from 'react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useDatabase } from '../components/DatabaseContext'
 import { SectionedItemReorder } from '../components/SectionedItemReorder'
-import { ALWAYS_NEEDED_CATEGORY, buildSectionGroups, defaultCategoryFor, reconcileEmptySections, sectionNamesIn, type PositionedItem } from '../edit-questions/item-sections'
+import { ALWAYS_NEEDED_CATEGORY, addEmptySection, buildSectionGroups, defaultCategoryFor, reconcileEmptySections, sectionNamesIn, type PositionedItem } from '../edit-questions/item-sections'
 import { sectionAccent } from '../edit-questions/section-accent'
 import { DatabaseMigration } from '../services/migration'
 import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, newDraftQuestion, renumberItemOrder, AGE_RANGE_OPTIONS } from '../edit-questions/types'
@@ -162,6 +162,58 @@ const ItemRow = memo(function ItemRow({ item, people, index, isOpen, onOpen }: {
 /** Composer key for the one at the foot of a list, which picks its own section. */
 const LIST_COMPOSER = '__list__'
 
+const FOOT_BUTTON = 'py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors'
+
+/**
+ * Name a new section. Offers the names already used elsewhere in the set, so
+ * one section doesn't end up spelled two ways and split into two groups on the
+ * generated list.
+ */
+function AddSection({ suggestions, onAdd, onClose }: {
+    suggestions: readonly string[]
+    onAdd: (label: string) => void
+    onClose: () => void
+}) {
+    const [name, setName] = useState('')
+    const listId = useId()
+    const commit = () => {
+        const trimmed = name.trim()
+        if (trimmed) onAdd(trimmed)
+        else onClose()
+    }
+    return (
+        <div
+            data-testid="add-section"
+            className="flex gap-2"
+            onBlur={e => { if (!e.currentTarget.contains(e.relatedTarget) && !name.trim()) onClose() }}
+        >
+            <input
+                autoFocus
+                list={listId}
+                value={name}
+                onChange={e => setName(e.target.value)}
+                onKeyDown={e => {
+                    if (e.key === 'Enter') commit()
+                    if (e.key === 'Escape') onClose()
+                }}
+                aria-label="New section name"
+                placeholder="Section name (e.g. Toiletries)"
+                className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+            <datalist id={listId}>
+                {suggestions.map(label => <option key={label} value={label} />)}
+            </datalist>
+            <button
+                type="button"
+                onClick={commit}
+                className="shrink-0 px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700"
+            >
+                Add
+            </button>
+        </div>
+    )
+}
+
 /**
  * Everything one item list needs to add to itself. Passed as a single object so
  * a list that can't be added to (a foreign pod's, say) is `undefined` rather
@@ -193,7 +245,7 @@ export interface ItemAdding {
  * of every section on the page, which is the cost the read-only rows exist to
  * avoid.
  */
-const SectionedItemRows = memo(function SectionedItemRows({ items, people, defaultLabel, emptySections = NO_NAMES, allItemNames = NO_NAMES, sectionNames = NO_NAMES, adding, onItemChange, onItemDelete }: {
+const SectionedItemRows = memo(function SectionedItemRows({ items, people, defaultLabel, emptySections = NO_NAMES, allItemNames = NO_NAMES, sectionNames = NO_NAMES, adding, onItemChange, onItemDelete, onSectionAdd }: {
     items: Item[]
     people: Person[]
     defaultLabel: string
@@ -207,6 +259,8 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
     onItemChange?: (index: number, edited: Item) => void
     /** Omit to leave items undeletable. */
     onItemDelete?: (index: number) => void
+    /** Omit to leave the list unable to grow a section. */
+    onSectionAdd?: (label: string) => void
 }) {
     // Which row is expanded, by its position in `items` — the same flat index
     // every edit is addressed by. At most one is open, so a long list never
@@ -216,6 +270,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
     // the foot). Same one-at-a-time rule, for the same reason.
     const [openComposer, setOpenComposer] = useState<string | null>(null)
     const closeComposer = useCallback(() => setOpenComposer(null), [])
+    const [addingSection, setAddingSection] = useState(false)
 
     const groups = useMemo(
         () => buildSectionGroups(items, defaultLabel, emptySections),
@@ -306,18 +361,44 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
     // The foot of every list: one tap to a composer that asks where the item
     // goes. It replaces itself with the composer rather than sitting above it,
     // so the list never grows two add affordances at once.
+    //
+    // Beside it, the only place a section is made. It is deliberately a button
+    // and not a typed name in some other field: a section is a thing you create,
+    // and the moment that stopped being true was the moment "type a new name at
+    // an item" had to double as both moving that item and renaming its section.
     const listFooter = adding && (
         openComposer === LIST_COMPOSER
             ? <div className="mt-2">{renderComposer(defaultLabel, false)}</div>
-            : (
-                <button
-                    type="button"
-                    onClick={() => setOpenComposer(LIST_COMPOSER)}
-                    className="mt-2 w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
-                >
-                    + Add item
-                </button>
-            )
+            : addingSection
+                ? (
+                    <div className="mt-2">
+                        <AddSection
+                            suggestions={sectionOptions}
+                            onAdd={label => { onSectionAdd?.(label); setAddingSection(false) }}
+                            onClose={() => setAddingSection(false)}
+                        />
+                    </div>
+                )
+                : (
+                    <div className="mt-2 flex gap-2">
+                        <button
+                            type="button"
+                            onClick={() => setOpenComposer(LIST_COMPOSER)}
+                            className={`${FOOT_BUTTON} flex-1`}
+                        >
+                            + Add item
+                        </button>
+                        {onSectionAdd && (
+                            <button
+                                type="button"
+                                onClick={() => setAddingSection(true)}
+                                className={`${FOOT_BUTTON} shrink-0 px-3`}
+                            >
+                                + Add section
+                            </button>
+                        )}
+                    </div>
+                )
     )
 
     if (!hasSections) {
@@ -448,7 +529,7 @@ function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete:
     )
 }
 
-export function OptionSection({ option, people, sectionDefaultLabel, allItemNames, sectionNames, questionId, suggestions, onEdit, onDelete, onItemChange, onItemAdd, onItemDelete }: {
+export function OptionSection({ option, people, sectionDefaultLabel, allItemNames, sectionNames, questionId, suggestions, onEdit, onDelete, onItemChange, onItemAdd, onItemDelete, onSectionAdd }: {
     option: Option
     people: Person[]
     /** What the packing list will call items here that carry no category. */
@@ -465,6 +546,8 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
     onItemAdd?: (questionId: string, optionId: string, text: string, category: string | undefined) => void
     /** Omit to leave items undeletable. */
     onItemDelete?: (questionId: string, optionId: string, index: number) => void
+    /** Omit to leave the option unable to grow a section. */
+    onSectionAdd?: (questionId: string, optionId: string, label: string) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(false)
     // Bound to this option's ids once, so the memoized row list isn't handed a
@@ -480,6 +563,11 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
             ? (index: number) => onItemDelete(questionId, optionId, index)
             : undefined,
         [onItemDelete, questionId, optionId])
+    const handleSectionAdd = useMemo(
+        () => onSectionAdd && questionId
+            ? (label: string) => onSectionAdd(questionId, optionId, label)
+            : undefined,
+        [onSectionAdd, questionId, optionId])
     const adding = useMemo<ItemAdding | undefined>(
         () => onItemAdd && questionId && suggestions
             ? {
@@ -587,6 +675,7 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
                         adding={adding}
                         onItemChange={handleItemChange}
                         onItemDelete={handleItemDelete}
+                        onSectionAdd={handleSectionAdd}
                     />
                 </div>
             )}
@@ -705,7 +794,7 @@ function QuestionContextMenu({ onMoveUp, onMoveDown, onEdit, onDelete }: {
 
 // Memoized with id-based handlers whose identity survives page re-renders, so
 // opening a modal (or a background sync tick) doesn't re-render every question.
-const QuestionSection = memo(function QuestionSection({ question, people, canMoveUp, canMoveDown, allItemNames, sectionNames, suggestions, onEdit, onDelete, onAddOption, onEditOption, onDeleteOption, onMove, onItemChange, onItemAdd, onItemDelete }: {
+const QuestionSection = memo(function QuestionSection({ question, people, canMoveUp, canMoveDown, allItemNames, sectionNames, suggestions, onEdit, onDelete, onAddOption, onEditOption, onDeleteOption, onMove, onItemChange, onItemAdd, onItemDelete, onSectionAdd }: {
     question: Question
     people: Person[]
     canMoveUp: boolean
@@ -722,6 +811,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
     onItemChange: (questionId: string, optionId: string, index: number, edited: Item) => void
     onItemAdd: (questionId: string, optionId: string, text: string, category: string | undefined) => void
     onItemDelete: (questionId: string, optionId: string, index: number) => void
+    onSectionAdd: (questionId: string, optionId: string, label: string) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(true)
     const [showDeleteModal, setShowDeleteModal] = useState(false)
@@ -825,6 +915,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                             onItemChange={onItemChange}
                             onItemAdd={onItemAdd}
                             onItemDelete={onItemDelete}
+                            onSectionAdd={onSectionAdd}
                         />
                     ))}
                     <button
@@ -846,7 +937,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
     )
 })
 
-const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections, allItemNames, sectionNames, suggestions, onEdit, onItemChange, onItemAdd, onItemDelete }: {
+const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections, allItemNames, sectionNames, suggestions, onEdit, onItemChange, onItemAdd, onItemDelete, onSectionAdd }: {
     items: Item[]
     people: Person[]
     emptySections?: string[]
@@ -857,6 +948,7 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections
     onItemChange: (index: number, edited: Item) => void
     onItemAdd: (text: string, category: string | undefined) => void
     onItemDelete: (index: number) => void
+    onSectionAdd: (label: string) => void
 }) {
     const [isExpanded, setIsExpanded] = useState(false)
     const adding = useMemo<ItemAdding>(
@@ -907,6 +999,7 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections
                         adding={adding}
                         onItemChange={onItemChange}
                         onItemDelete={onItemDelete}
+                        onSectionAdd={onSectionAdd}
                     />
                 </div>
             )}
@@ -1814,6 +1907,36 @@ export function QuestionsPage() {
         })
     }, [saveData])
 
+    // Creating a section stores nothing but its name — there is nothing else to
+    // store until something is in it, and `addEmptySection` refuses a name that
+    // already exists rather than making a second section wearing it.
+    const handleOptionSectionAdd = useCallback(async (questionId: string, optionId: string, label: string) => {
+        const data = dataRef.current
+        if (!data) return
+        const question = data.questions.find(q => q.id === questionId)
+        const option = question?.options.find(o => o.id === optionId)
+        if (!question || !option) return
+        const now = new Date().toISOString()
+        const emptySections = addEmptySection(
+            option.emptySections, option.items, label, defaultCategoryFor(question, option))
+        if (emptySections === option.emptySections) return
+        await saveData({
+            ...data,
+            questions: withQuestionOptions(data.questions, questionId, options =>
+                options.map(o => o.id === optionId ? withEmptySections(o, emptySections) : o), now),
+        })
+    }, [saveData])
+
+    const handleAlwaysSectionAdd = useCallback(async (label: string) => {
+        const data = dataRef.current
+        if (!data) return
+        const active = (data.alwaysNeededItems ?? []).filter(i => !i.deletedAt)
+        const emptySections = addEmptySection(
+            data.alwaysNeededEmptySections, active, label, ALWAYS_NEEDED_CATEGORY)
+        if (emptySections === data.alwaysNeededEmptySections) return
+        await saveData({ ...data, alwaysNeededEmptySections: emptySections })
+    }, [saveData])
+
     const handleAlwaysItemDelete = useCallback(async (index: number) => {
         const data = dataRef.current
         if (!data) return
@@ -1982,6 +2105,7 @@ export function QuestionsPage() {
                     onItemChange={handleAlwaysItemChange}
                     onItemAdd={handleAlwaysItemAdd}
                     onItemDelete={handleAlwaysItemDelete}
+                    onSectionAdd={handleAlwaysSectionAdd}
                 />
                 {activeQuestions.map((q, qi) => (
                     <QuestionSection
@@ -2002,6 +2126,7 @@ export function QuestionsPage() {
                         onItemChange={handleOptionItemChange}
                         onItemAdd={handleOptionItemAdd}
                         onItemDelete={handleOptionItemDelete}
+                        onSectionAdd={handleOptionSectionAdd}
                     />
                 ))}
                 <button

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -162,6 +162,98 @@ const LIST_COMPOSER = '__list__'
 const REORDER_SAVE_DELAY_MS = 600
 
 /**
+ * Lock background page scroll while a modal is open.
+ *
+ * Besides being correct modal behaviour, it is what keeps the page — and on a
+ * phone the browser's URL bar — from moving while a drag is happening inside.
+ * A moving URL bar resizes the viewport, which moves every row the drag has
+ * already measured, mid-gesture.
+ */
+function useBodyScrollLock() {
+    useEffect(() => {
+        const body = document.body
+        const html = document.documentElement
+        const previous = {
+            body: body.style.overflow,
+            html: html.style.overflow,
+            overscroll: body.style.overscrollBehavior,
+        }
+        // Both: the scrolling element is <body> on some browsers and <html> on
+        // others (notably mobile). Chaining is stopped too.
+        body.style.overflow = 'hidden'
+        html.style.overflow = 'hidden'
+        body.style.overscrollBehavior = 'none'
+        return () => {
+            body.style.overflow = previous.body
+            html.style.overflow = previous.html
+            body.style.overscrollBehavior = previous.overscroll
+        }
+    }, [])
+}
+
+/**
+ * Reorganising an item list, as the only thing on the screen.
+ *
+ * It was tried inline, on the page, and it does not work: a drag needs a scroll
+ * container it owns, and inside the page that meant a scroll area nested in a
+ * scroll area, with neither obviously in charge of the gesture. Full-screen is
+ * not a step backwards to a modal-shaped editor — the modal that used to be
+ * here also edited every item, and that part stays on the page. This does one
+ * thing, and it needs the whole screen to do it.
+ *
+ * There is no Save. Like everything else on the page the moves are written as
+ * they are made (coalesced — see `useDeferredReorder`), and closing writes
+ * whatever is still in hand.
+ */
+function ReorganiseModal({ items, defaultLabel, emptySections, onChange, onClose }: {
+    items: Item[]
+    defaultLabel: string
+    emptySections: string[] | undefined
+    onChange: (items: Item[], emptySections: string[] | undefined) => void
+    onClose: () => void
+}) {
+    useBodyScrollLock()
+    const scrollRef = useRef<HTMLDivElement>(null)
+    return (
+        <div
+            className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
+            onClick={onClose}
+            onKeyDown={e => { if (e.key === 'Escape') onClose() }}
+        >
+            <div
+                role="dialog"
+                aria-label={`Organise ${defaultLabel} items`}
+                className="bg-white rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="p-5 border-b border-gray-100 flex-shrink-0">
+                    <h2 className="text-lg font-semibold text-gray-900">Organise items</h2>
+                    <p className="mt-0.5 text-sm text-gray-500 truncate">{defaultLabel}</p>
+                </div>
+                <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
+                    <SectionedItemReorder
+                        items={items}
+                        defaultLabel={defaultLabel}
+                        emptySections={emptySections}
+                        scrollRef={scrollRef}
+                        onChange={onChange}
+                    />
+                </div>
+                <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex justify-end">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700"
+                    >
+                        Finish organising
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+/**
  * Hold a reorder in hand for a moment before writing it.
  *
  * Every other edit on this page saves the instant it is made, and should: they
@@ -331,7 +423,6 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
     const closeComposer = useCallback(() => setOpenComposer(null), [])
     const [addingSection, setAddingSection] = useState(false)
     const [organising, setOrganising] = useState(false)
-    const organiseScrollRef = useRef<HTMLDivElement>(null)
     const { draft: organiseDraft, onChange: onOrganiseChange, flush: flushOrganise } =
         useDeferredReorder(onReorder)
 
@@ -471,58 +562,32 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
         <div className="flex justify-end mb-2">
             <button
                 type="button"
-                onClick={() => {
-                    // Leaving the mode writes whatever is still in hand, so
-                    // "Finish organising" means finished, not merely hidden.
-                    if (organising) flushOrganise()
-                    setOrganising(o => !o)
-                }}
-                aria-pressed={organising}
-                className={`inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 transition-colors ${organising ? 'bg-primary-600 text-white' : 'text-primary-600 hover:bg-primary-50'}`}
+                onClick={() => setOrganising(true)}
+                className="inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 text-primary-600 hover:bg-primary-50 transition-colors"
             >
                 <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
                 </svg>
-                {organising ? 'Finish organising' : 'Organise items'}
+                Organise items
             </button>
         </div>
     )
 
-    // Organising replaces the rows and nothing else: the footer stays, so adding
-    // an item or a section mid-reorganisation doesn't mean leaving the mode you
-    // are reorganising in.
-    if (organising && onReorder) {
-        // Rendered from the draft while one is in hand: the props behind it are
-        // a save cycle behind, and the list must not flicker back to the old
-        // order between the drop and the write.
-        const organiseItems = organiseDraft?.items ?? items
-        const organiseSections = organiseDraft
-            ? organiseDraft.emptySections
-            : (emptySections.length > 0 ? emptySections : undefined)
-        return (
-            <div>
-                {organiseToggle}
-                {/* The drag needs somewhere of its own to scroll. Given none,
-                    dnd-kit scrolls the window instead, which on a phone shows
-                    and hides the URL bar — resizing the viewport underneath a
-                    gesture that has already measured it. Bounded only when the
-                    list is long enough to need it. */}
-                <div
-                    ref={organiseScrollRef}
-                    className="max-h-[60vh] overflow-y-auto overscroll-contain"
-                >
-                    <SectionedItemReorder
-                        items={organiseItems}
-                        defaultLabel={defaultLabel}
-                        emptySections={organiseSections}
-                        scrollRef={organiseScrollRef}
-                        onChange={onOrganiseChange}
-                    />
-                </div>
-                {listFooter}
-            </div>
-        )
-    }
+    // A drag needs a scroll container of its own, and the only honest way to
+    // give it one is to be the whole screen for a moment. Nested inside the
+    // page it was a scroll area within a scroll area: neither one obviously in
+    // charge of a gesture, and unusable on a phone.
+    const organiseModal = organising && onReorder && (
+        <ReorganiseModal
+            items={organiseDraft?.items ?? items}
+            defaultLabel={defaultLabel}
+            emptySections={organiseDraft
+                ? organiseDraft.emptySections
+                : (emptySections.length > 0 ? emptySections : undefined)}
+            onChange={onOrganiseChange}
+            onClose={() => { flushOrganise(); setOrganising(false) }}
+        />
+    )
 
     if (!hasSections) {
         return (
@@ -530,6 +595,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                 {organiseToggle}
                 <div className="space-y-0.5">{groups.flatMap(group => group.entries).map(renderRow)}</div>
                 {listFooter}
+                {organiseModal}
             </div>
         )
     }
@@ -599,6 +665,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                 })}
             </div>
             {listFooter}
+            {organiseModal}
         </div>
     )
 })

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -157,6 +157,68 @@ const ItemRow = memo(function ItemRow({ item, people, index, isOpen, onOpen }: {
 /** Composer key for the one at the foot of a list, which picks its own section. */
 const LIST_COMPOSER = '__list__'
 
+/** How long a reorder rests before it is written. Long enough to absorb a run
+ *  of drags, short enough that walking away from the screen still saves. */
+const REORDER_SAVE_DELAY_MS = 600
+
+/**
+ * Hold a reorder in hand for a moment before writing it.
+ *
+ * Every other edit on this page saves the instant it is made, and should: they
+ * are one-shot, and the write is invisible. A drag is neither. Saving on each
+ * drop re-renders every question on the page and rebuilds the whole set's
+ * suggestion index — twice, since the save sets state optimistically and again
+ * when it lands — and it does so in the frame the item is released, which is
+ * the one frame the user is watching. Reorganising is also *iterative*: nobody
+ * moves one item and stops, so it paid that cost per drop and dropped frames
+ * the whole way through.
+ *
+ * So the drop updates a local copy and the page renders from it immediately;
+ * the write follows once the dragging stops. Anything still pending is flushed
+ * on the way out of the mode and on unmount, so leaving — by finishing, by
+ * collapsing the section, by navigating away — writes what you did.
+ */
+function useDeferredReorder(onReorder?: (items: Item[], emptySections: string[] | undefined) => void) {
+    type Pending = { items: Item[]; emptySections: string[] | undefined }
+    const [draft, setDraft] = useState<Pending | null>(null)
+    const pendingRef = useRef<Pending | null>(null)
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    // Read through a ref so `flush` keeps one identity for the life of the
+    // component — an unmount flush that depended on the handler would fire on
+    // every re-render that changed it.
+    const onReorderRef = useRef(onReorder)
+    onReorderRef.current = onReorder
+
+    const flush = useCallback(() => {
+        if (timerRef.current !== null) {
+            clearTimeout(timerRef.current)
+            timerRef.current = null
+        }
+        const pending = pendingRef.current
+        pendingRef.current = null
+        if (pending) onReorderRef.current?.(pending.items, pending.emptySections)
+    }, [])
+
+    const onChange = useCallback((items: Item[], emptySections: string[] | undefined) => {
+        const next = { items, emptySections }
+        setDraft(next)
+        pendingRef.current = next
+        if (timerRef.current !== null) clearTimeout(timerRef.current)
+        timerRef.current = setTimeout(flush, REORDER_SAVE_DELAY_MS)
+    }, [flush])
+
+    // Unmounting mid-reorganisation — a collapsed section, a route change — must
+    // not be how the reorder gets lost.
+    useEffect(() => flush, [flush])
+
+    const stop = useCallback(() => {
+        flush()
+        setDraft(null)
+    }, [flush])
+
+    return { draft, onChange, flush: stop }
+}
+
 const FOOT_BUTTON = 'py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors'
 
 /**
@@ -269,6 +331,9 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
     const closeComposer = useCallback(() => setOpenComposer(null), [])
     const [addingSection, setAddingSection] = useState(false)
     const [organising, setOrganising] = useState(false)
+    const organiseScrollRef = useRef<HTMLDivElement>(null)
+    const { draft: organiseDraft, onChange: onOrganiseChange, flush: flushOrganise } =
+        useDeferredReorder(onReorder)
 
     const groups = useMemo(
         () => buildSectionGroups(items, defaultLabel, emptySections),
@@ -406,7 +471,12 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
         <div className="flex justify-end mb-2">
             <button
                 type="button"
-                onClick={() => setOrganising(o => !o)}
+                onClick={() => {
+                    // Leaving the mode writes whatever is still in hand, so
+                    // "Finish organising" means finished, not merely hidden.
+                    if (organising) flushOrganise()
+                    setOrganising(o => !o)
+                }}
                 aria-pressed={organising}
                 className={`inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 transition-colors ${organising ? 'bg-primary-600 text-white' : 'text-primary-600 hover:bg-primary-50'}`}
             >
@@ -422,15 +492,33 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
     // an item or a section mid-reorganisation doesn't mean leaving the mode you
     // are reorganising in.
     if (organising && onReorder) {
+        // Rendered from the draft while one is in hand: the props behind it are
+        // a save cycle behind, and the list must not flicker back to the old
+        // order between the drop and the write.
+        const organiseItems = organiseDraft?.items ?? items
+        const organiseSections = organiseDraft
+            ? organiseDraft.emptySections
+            : (emptySections.length > 0 ? emptySections : undefined)
         return (
             <div>
                 {organiseToggle}
-                <SectionedItemReorder
-                    items={items}
-                    defaultLabel={defaultLabel}
-                    emptySections={emptySections.length > 0 ? emptySections : undefined}
-                    onChange={onReorder}
-                />
+                {/* The drag needs somewhere of its own to scroll. Given none,
+                    dnd-kit scrolls the window instead, which on a phone shows
+                    and hides the URL bar — resizing the viewport underneath a
+                    gesture that has already measured it. Bounded only when the
+                    list is long enough to need it. */}
+                <div
+                    ref={organiseScrollRef}
+                    className="max-h-[60vh] overflow-y-auto overscroll-contain"
+                >
+                    <SectionedItemReorder
+                        items={organiseItems}
+                        defaultLabel={defaultLabel}
+                        emptySections={organiseSections}
+                        scrollRef={organiseScrollRef}
+                        onChange={onOrganiseChange}
+                    />
+                </div>
                 {listFooter}
             </div>
         )

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -20,7 +20,7 @@ import { TemplateUpdatesCard } from '../components/TemplateUpdatesCard'
 import { LoadingState } from '../components/LoadingState'
 import { AgeTransition } from '../edit-questions/age-derivation'
 import { useIsDesktop } from '../hooks/useIsDesktop'
-import { appendItemToSection, applyItemEdit, withQuestionOptions } from '../edit-questions/item-edits'
+import { appendItemToSection, applyItemEdit, tombstoneRemovedItems, withQuestionOptions } from '../edit-questions/item-edits'
 import { ItemInlineEditor } from '../components/ItemInlineEditor'
 import { AddQuestionItem } from '../components/AddQuestionItem'
 import { ALWAYS_LIST_KEY, buildQuestionSetSuggestions, listKeyFor } from '../edit-questions/item-suggestions'
@@ -1745,10 +1745,17 @@ export function QuestionsPage() {
         await saveData({ ...data, alwaysNeededItems: [...items, ...deleted] })
     }, [saveData])
 
+    // The modal is handed the active items only, so anything it hands back
+    // missing was deleted in it — and the tombstones it never saw have to be put
+    // back. Saving its list verbatim did neither, which meant a delete made here
+    // came straight back on the next pod merge; see `tombstoneRemovedItems`.
     const handleAlwaysSave = useCallback(async (newItems: Item[]) => {
         if (!data) return
         setAlwaysModal(false)
-        await saveData({ ...data, alwaysNeededItems: newItems })
+        await saveData({
+            ...data,
+            alwaysNeededItems: tombstoneRemovedItems(data.alwaysNeededItems ?? [], newItems, new Date().toISOString()),
+        })
     }, [data, saveData])
 
     const handlePeopleSave = useCallback(async (newPeople: Person[]) => {

--- a/src/services/rdfSerialization.test.ts
+++ b/src/services/rdfSerialization.test.ts
@@ -325,6 +325,37 @@ describe('questionSetToDataset / datasetToQuestionSet', () => {
         expect(names).toContain('Bob')
     })
 
+    it('round-trips a section that has no items in it at all', () => {
+        // The case the field exists for: nothing carries this section's name, so
+        // without storing it the section would not survive the trip.
+        const result = roundTripQs(makeQuestionSet({
+            alwaysNeededItems: [],
+            alwaysNeededEmptySections: ['Documents'],
+        }))
+        expect(result.alwaysNeededEmptySections).toEqual(['Documents'])
+    })
+
+    it('round-trips an option’s empty section', () => {
+        const result = roundTripQs(makeQuestionSet({
+            questions: [{
+                id: 'q1', type: 'saved', text: 'Beach?', order: 0,
+                options: [{ id: 'o1', text: 'Yes', order: 0, items: [], emptySections: ['Beach kit'] }],
+            }],
+        }))
+        expect(result.questions[0].options[0].emptySections).toEqual(['Beach kit'])
+    })
+
+    it('omits both when no section is empty', () => {
+        const result = roundTripQs(makeQuestionSet({
+            questions: [{
+                id: 'q1', type: 'saved', text: 'Beach?', order: 0,
+                options: [{ id: 'o1', text: 'Yes', order: 0, items: [] }],
+            }],
+        }))
+        expect(result.alwaysNeededEmptySections).toBeUndefined()
+        expect(result.questions[0].options[0].emptySections).toBeUndefined()
+    })
+
     it('round-trips alwaysNeededItems with personSelections', () => {
         const qs = makeQuestionSet({
             alwaysNeededItems: [{

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -240,6 +240,10 @@ export function questionSetToDataset(qs: PackingListQuestionSet, datasetUrl: str
         for (const t of extras) ds = setThing(ds, t)
     }
 
+    for (const label of qs.alwaysNeededEmptySections ?? []) {
+        rootBuilder = rootBuilder.addStringNoLocale(PMU.alwaysNeededEmptySection, label)
+    }
+
     for (let i = 0; i < qs.alwaysNeededItems.length; i++) {
         const itemUrl = `${datasetUrl}#always-item-${i}`
         rootBuilder = rootBuilder.addUrl(PMU.hasAlwaysNeededItem, itemUrl)
@@ -280,11 +284,15 @@ export function datasetToQuestionSet(dataset: SolidDataset, datasetUrl: string):
         .map(url => thingToQuestionItem(dataset, url))
         .filter((item): item is Item => item !== null))
 
+    // Sorted for the same reason as an option's — see `thingToOption`.
+    const alwaysNeededEmptySections = getStringNoLocaleAll(rootThing, PMU.alwaysNeededEmptySection).sort()
+
     return {
         _id: '1',
         people,
         questions,
         alwaysNeededItems,
+        ...(alwaysNeededEmptySections.length > 0 ? { alwaysNeededEmptySections } : {}),
         ...(lastModified !== undefined ? { lastModified } : {}),
         ...(templateVersion !== undefined ? { templateVersion } : {}),
     }
@@ -402,6 +410,10 @@ function optionToThings(
         .addStringNoLocale(PMU.text, option.text)
         .addInteger(PMU.order, option.order)
 
+    for (const label of option.emptySections ?? []) {
+        optBuilder = optBuilder.addStringNoLocale(PMU.emptySection, label)
+    }
+
     for (let i = 0; i < option.items.length; i++) {
         const itemUrl = `${datasetUrl}#opt-item-${option.id}-${i}`
         optBuilder = optBuilder.addUrl(PMU.hasQuestionItem, itemUrl)
@@ -431,7 +443,18 @@ function thingToOption(dataset: SolidDataset, url: string): Option | null {
         .map(itemUrl => thingToQuestionItem(dataset, itemUrl))
         .filter((item): item is Item => item !== null))
 
-    return { id, text, order, items }
+    // Repeated strings are an unordered set in RDF, so these come back sorted
+    // rather than as written. They name sections with nothing in them, whose
+    // position is decided by where the reader puts them anyway.
+    const emptySections = getStringNoLocaleAll(thing, PMU.emptySection).sort()
+
+    return {
+        id,
+        text,
+        order,
+        items,
+        ...(emptySections.length > 0 ? { emptySections } : {}),
+    }
 }
 
 // Explicit order wins where present; items without one keep their URL-index

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -49,6 +49,9 @@ export const PMU = {
     hasPerson: `${PMU_NS}hasPerson`,
     hasQuestion: `${PMU_NS}hasQuestion`,
     hasAlwaysNeededItem: `${PMU_NS}hasAlwaysNeededItem`,
+    // One value per always-needed section that has no items in it yet. A section
+    // is otherwise only its items' categories, so an empty one would vanish.
+    alwaysNeededEmptySection: `${PMU_NS}alwaysNeededEmptySection`,
     // Wizard template version this set was last reconciled against
     templateVersion: `${PMU_NS}templateVersion`,
 
@@ -72,6 +75,8 @@ export const PMU = {
 
     // Option predicates
     hasQuestionItem: `${PMU_NS}hasQuestionItem`,
+    // One value per section of this option's items that has no items in it yet
+    emptySection: `${PMU_NS}emptySection`,
 
     // Item predicates (on option items and always-needed items)
     hasPersonSelection: `${PMU_NS}hasPersonSelection`,

--- a/src/test-utils/fullyPopulatedFixtures.ts
+++ b/src/test-utils/fullyPopulatedFixtures.ts
@@ -121,6 +121,9 @@ const fullyPopulatedOption: Required<Option> = {
     text: 'Sunny',
     items: [fullyPopulatedQuestionSetItem],
     order: 0,
+    // Single value for the same reason as `ageRanges` above: these are repeated
+    // strings on one Thing, and RDF multi-values come back as an unordered set.
+    emptySections: ['Beach kit'],
 }
 
 const fullyPopulatedQuestion: Required<SavedQuestion> = {
@@ -141,6 +144,7 @@ const fullyPopulatedQuestion: Required<SavedQuestion> = {
 export const fullyPopulatedQuestionSet: Required<Omit<PackingListQuestionSet, '_id' | '_rev'>> = {
     people: [fullyPopulatedPerson],
     alwaysNeededItems: [fullyPopulatedQuestionSetItem],
+    alwaysNeededEmptySections: ['Documents'],
     questions: [fullyPopulatedQuestion],
     lastModified: '2025-01-02T00:00:00.000Z',
     templateVersion: 3,


### PR DESCRIPTION
The Always Needed modal is handed the active items and hands back the list it
finished with, which was then saved as the whole of alwaysNeededItems. That
threw away two things: the tombstones the modal never saw, and any record that
an item removed in it had ever existed.

mergeQuestionSets merges always-needed items per id, and resolves an item
present on one side only by keeping it. So both losses came back on the next
pod sync — a delete made in the modal was undone, and an item deleted on
another device reappeared.

Fold the modal's list back into what was stored instead, marking removals with
deletedAt and carrying existing tombstones through, the same way handlePeopleSave
already does for people.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016jUsg1U81M1xYtRr8LvNUR