### PR TITLE
Make a big family list manageable without shrinking anyone else's view

### DIFF
--- a/e2e/tests/f-sync.spec.ts
+++ b/e2e/tests/f-sync.spec.ts
@@ -53,9 +53,21 @@ test.describe('F – Solid Pod Sync', () => {
     await page.waitForURL(/#\/view-lists\//, { timeout: 10_000 })
   }
 
+  // A list long enough to arrive as a wall of cards opens folded the first time
+  // it is seen, so there is no item to reach for until it is opened.
+  async function openAllSections(target: import('@playwright/test').Page = page) {
+    // waitForURL fires on the URL change, before the view has rendered — wait for
+    // a control that is there whether the list arrived folded or not, otherwise
+    // this looks for the Expand all button before there is one.
+    await expect(target.getByRole('button', { name: /Show Packed/i })).toBeVisible({ timeout: 15_000 })
+    const expandAll = target.getByRole('button', { name: /^Expand all$/ }).first()
+    if (await expandAll.count() > 0) await expandAll.click()
+  }
+
   // Sync to Pod by checking an item (triggers saveWithSyncPrevention → saveToPod).
   // The green indicator disappearing confirms the pod PUT completed — no extra waitForTimeout needed.
   async function syncListToPod() {
+    await openAllSections()
     await page.locator('input[type="checkbox"]').first().click()
     await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
     await expect(page.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
@@ -118,6 +130,7 @@ test.describe('F – Solid Pod Sync', () => {
 
   test('F5: rapid checkbox ticks persist without 409 conflict (stale-rev regression)', async () => {
     await createList(`Rapid Check Test ${Date.now()}`)
+    await openAllSections()
     await page.getByRole('button', { name: 'Show Packed' }).click()
 
     const checkboxes = page.locator('input[type="checkbox"]')
@@ -161,6 +174,7 @@ test.describe('F – Solid Pod Sync', () => {
 
   test('F6: custom item added via suggestion card persists in question set after pod sync', async () => {
     await createList(`Suggestion Save Trip ${Date.now()}`)
+    await openAllSections()
     // Confirm list content is loaded before interacting (waitForURL fires on URL match, not content render)
     await expect(page.locator('input[type="checkbox"]').first()).toBeVisible({ timeout: 15_000 })
 
@@ -208,6 +222,8 @@ test.describe('F – Solid Pod Sync', () => {
     await page2.waitForURL(/#\/view-lists\//, { timeout: 8_000 })
     // Wait for list view to load — Show Packed button appears when items are ready (no networkidle)
     await expect(page2.getByRole('button', { name: /Show Packed/i })).toBeVisible({ timeout: 15_000 })
+    // Fresh context, so this is a first open here too — the list arrives folded
+    await openAllSections(page2)
     await page2.getByRole('button', { name: /Show Packed/i }).click()
     await expect(page2.locator('input[type="checkbox"]:checked').first()).toBeVisible({ timeout: 10_000 })
     await context2.close()

--- a/e2e/tests/f-sync.spec.ts
+++ b/e2e/tests/f-sync.spec.ts
@@ -149,7 +149,9 @@ test.describe('F – Solid Pod Sync', () => {
       await expect(page.locator('span.text-red-600')).not.toBeVisible()
 
       await page.reload()
-      await page.getByRole('button', { name: 'Show Packed' }).click()
+      // The list reopens as it was left, so packed items are already showing —
+      // clicking "Show Packed" again would be clicking "Hide Packed".
+      await expect(page.getByRole('button', { name: 'Hide Packed' })).toBeVisible({ timeout: 10_000 })
       await expect(page.locator(`input[name="${box0Name}"]`)).toBeChecked({ timeout: 5_000 })
       await expect(page.locator(`input[name="${box1Name}"]`)).toBeChecked({ timeout: 5_000 })
     } finally {

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -2568,3 +2568,159 @@ describe('ViewPackingList folding sections away', () => {
         })
     })
 })
+
+describe('ViewPackingList opening a long list for the first time', () => {
+    // Six people so the list has plenty to fold, and 36 items so it clears the
+    // "long enough to arrive as a wall" threshold.
+    const people = ['Alice', 'Bob', 'Cara', 'Dev', 'Eve', 'Finn']
+    function bigList(id: string, itemsPerPerson: number) {
+        return {
+            id,
+            name: 'Big Trip',
+            createdAt: '2026-01-01T00:00:00Z',
+            items: people.flatMap((person, p) =>
+                Array.from({ length: itemsPerPerson }, (_, i) => ({
+                    id: `${person}-${i}`,
+                    itemText: `${person} item ${i}`,
+                    personName: person,
+                    personId: `p${p}`,
+                    questionId: 'q1',
+                    optionId: 'o1',
+                    category: 'Clothes',
+                    packed: false,
+                })),
+            ),
+        }
+    }
+
+    function mockList(list: ReturnType<typeof bigList>) {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...list, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getPackingList: vi.fn().mockResolvedValue(list),
+                savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+                getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }),
+            } as unknown as PackingAppDatabase,
+        })
+    }
+
+    function renderList(listId: string) {
+        return render(
+            <MemoryRouter initialEntries={[`/view-list/${listId}`]}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+    }
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('opens a long list folded', async () => {
+        mockList(bigList('big-1', 6))
+        renderList('big-1')
+        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+
+        expect(screen.queryByText('Alice item 0')).toBeNull()
+        expect(screen.getByRole('button', { name: /expand alice's list/i })).toBeTruthy()
+    })
+
+    it('keeps every section and its count on the page', async () => {
+        mockList(bigList('big-2', 6))
+        renderList('big-2')
+        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+
+        for (const person of people) {
+            expect(screen.getByRole('button', { name: new RegExp(`expand ${person}'s list`, 'i') }).textContent)
+                .toContain('0 / 6')
+        }
+    })
+
+    it('says why the list arrived folded, and offers the way out', async () => {
+        mockList(bigList('big-3', 6))
+        renderList('big-3')
+        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+
+        const note = screen.getByTestId('folded-on-open-note')
+        expect(note.textContent).toContain('all 6 sections start folded')
+
+        fireEvent.click(within(note).getByRole('button', { name: /expand all/i }))
+
+        expect(screen.getByText('Alice item 0')).toBeTruthy()
+        expect(screen.queryByTestId('folded-on-open-note')).toBeNull()
+    })
+
+    it('drops the note as soon as the user opens a section themselves', async () => {
+        mockList(bigList('big-4', 6))
+        renderList('big-4')
+        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /expand alice's list/i }))
+
+        expect(screen.queryByTestId('folded-on-open-note')).toBeNull()
+    })
+
+    it('leaves a short list open', async () => {
+        // Six people, one item each — plenty of sections, but no wall
+        mockList(bigList('small-1', 1))
+        renderList('small-1')
+        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+
+        expect(screen.getByText('Alice item 0')).toBeTruthy()
+        expect(screen.queryByTestId('folded-on-open-note')).toBeNull()
+    })
+
+    it('leaves a long list with a single section open, having nothing to fold into', async () => {
+        const list = bigList('solo-1', 6)
+        mockList({ ...list, items: list.items.map(item => ({ ...item, personName: 'Alice', personId: 'p0' })) })
+        renderList('solo-1')
+        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+
+        expect(screen.getByText('Alice item 0')).toBeTruthy()
+    })
+
+    it('does not fold a list the user has opened before', async () => {
+        mockList(bigList('big-5', 6))
+        const { unmount } = renderList('big-5')
+        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        fireEvent.click(within(screen.getByTestId('folded-on-open-note')).getByRole('button', { name: /expand all/i }))
+        unmount()
+
+        renderList('big-5')
+        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+
+        // Their arrangement wins, even though it matches the plain defaults
+        expect(screen.getByText('Alice item 0')).toBeTruthy()
+        expect(screen.queryByTestId('folded-on-open-note')).toBeNull()
+    })
+
+    it('reopens folded if that is how the user left it', async () => {
+        mockList(bigList('big-6', 6))
+        const { unmount } = renderList('big-6')
+        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        unmount()
+
+        renderList('big-6')
+        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+
+        expect(screen.queryByText('Alice item 0')).toBeNull()
+        // Second time around it is their arrangement, not something to explain
+        expect(screen.queryByTestId('folded-on-open-note')).toBeNull()
+    })
+})

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -104,6 +104,13 @@ function renderComponent() {
     )
 }
 
+// The list view remembers how it was left (folded sections, view mode, whether
+// packed items are showing) per list id in localStorage. Tests reuse the same
+// ids, so without this each one inherits the last one's folded sections.
+beforeEach(() => {
+    localStorage.clear()
+})
+
 describe('ViewPackingList item deletion confirmation', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({
@@ -540,8 +547,20 @@ describe('progress indicators', () => {
         renderProgressComponent()
         await waitFor(() => expect(screen.getByText('Sunscreen')).toBeTruthy())
 
-        const badges = screen.getAllByText(/1 \/ 2/)
-        expect(badges.length).toBe(2)
+        // The groups inside each card carry counts of their own, so the
+        // assertion is scoped to the section headers themselves.
+        expect(screen.getByRole('button', { name: /collapse alice's list/i }).textContent).toContain('1 / 2')
+        expect(screen.getByRole('button', { name: /collapse bob's list/i }).textContent).toContain('1 / 2')
+    })
+
+    it('counts every item in a group, not just the ones on screen', async () => {
+        renderProgressComponent()
+        await waitFor(() => expect(screen.getByText('Sunscreen')).toBeTruthy())
+
+        // Alice's packed Passport is hidden, but her "Other" group is still
+        // half done — showing "1" there would read as a group barely started.
+        const aliceGroup = screen.getAllByRole('button', { name: /collapse other/i })[0]
+        expect(aliceGroup.textContent).toContain('1 / 2')
     })
 })
 
@@ -2272,5 +2291,280 @@ describe('ViewPackingList adding items', () => {
 
         fireEvent.change(composerFor("Alice's items").input, { target: { value: 'ten' } })
         expect(screen.queryByRole('option', { name: /Tent/ })).toBeNull()
+    })
+})
+
+// ─── Keeping a big list manageable ──────────────────────────────────────────
+
+describe('ViewPackingList folding sections away', () => {
+    // A family-shaped list: Alice is done, Bob is halfway, Cara hasn't started.
+    // Three sections so "collapse all" has something to say, and the list is
+    // never finished by one tick — the all-packed celebration has its own rules.
+    const familyList = {
+        id: 'test-list-family',
+        name: 'Family Trip',
+        createdAt: '2026-01-01T00:00:00Z',
+        items: [
+            { id: 'a1', itemText: 'Passport', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', category: 'Documents', packed: true },
+            { id: 'a2', itemText: 'Sunhat', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: true },
+            { id: 'b1', itemText: 'Wellies', personName: 'Bob', personId: 'p2', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: true },
+            { id: 'b2', itemText: 'Toothbrush', personName: 'Bob', personId: 'p2', questionId: 'q1', optionId: 'o1', category: 'Toiletries', packed: false },
+            { id: 'c1', itemText: 'Armbands', personName: 'Cara', personId: 'p3', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: false },
+            { id: 'c2', itemText: 'Teddy', personName: 'Cara', personId: 'p3', questionId: 'q1', optionId: 'o1', category: 'Other', packed: false },
+        ],
+    }
+
+    function mockList(list: typeof familyList) {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...list, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getPackingList: vi.fn().mockResolvedValue(list),
+                savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+                getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }),
+            } as unknown as PackingAppDatabase,
+        })
+    }
+
+    function renderList(listId = 'test-list-family') {
+        return render(
+            <MemoryRouter initialEntries={[`/view-list/${listId}`]}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+    }
+
+    function checkboxFor(itemText: string) {
+        return screen.getByText(itemText).closest('label')!.querySelector('input')!
+    }
+
+    beforeEach(() => {
+        mockList(familyList)
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    describe('when everything in a section is packed', () => {
+        it('folds a section that was already finished when the list opened', async () => {
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+            expect(screen.getByRole('button', { name: /expand alice's list/i })).toBeTruthy()
+        })
+
+        it('leaves a section with items still to pack open', async () => {
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+            expect(screen.getByText('Toothbrush')).toBeTruthy()
+            expect(screen.getByText('Armbands')).toBeTruthy()
+        })
+
+        it('keeps the folded section on the page with its count and its celebration', async () => {
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+            const header = screen.getByRole('button', { name: /expand alice's list/i })
+            expect(header.textContent).toContain("Alice's Items")
+            expect(header.textContent).toContain('2 / 2')
+            expect(screen.getByLabelText(/all packed for alice/i)).toBeTruthy()
+        })
+
+        it('folds a section that is finished in front of the user', async () => {
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+            fireEvent.click(checkboxFor('Toothbrush'))
+
+            await waitFor(
+                () => expect(screen.getByRole('button', { name: /expand bob's list/i })).toBeTruthy(),
+                { timeout: 3000 },
+            )
+        })
+
+        it('leaves a section the user reopened open when something else is packed', async () => {
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /expand alice's list/i }))
+
+            fireEvent.click(checkboxFor('Toothbrush'))
+            await waitFor(
+                () => expect(screen.getByRole('button', { name: /expand bob's list/i })).toBeTruthy(),
+                { timeout: 3000 },
+            )
+
+            expect(screen.getByRole('button', { name: /collapse alice's list/i })).toBeTruthy()
+        })
+
+        it('folds a section again once it is packed back up', async () => {
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
+
+            // Unpacking reopens Alice; packing it back folds her away again
+            fireEvent.click(checkboxFor('Sunhat'))
+            fireEvent.click(screen.getByRole('button', { name: 'Hide Packed' }))
+            expect(screen.getByRole('button', { name: /collapse alice's list/i })).toBeTruthy()
+
+            fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
+            fireEvent.click(checkboxFor('Sunhat'))
+            fireEvent.click(screen.getByRole('button', { name: 'Hide Packed' }))
+
+            await waitFor(
+                () => expect(screen.getByRole('button', { name: /expand alice's list/i })).toBeTruthy(),
+                { timeout: 3000 },
+            )
+        })
+    })
+
+    describe('showing packed items', () => {
+        it('hands back the sections the page folded', async () => {
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            expect(screen.getByRole('button', { name: /expand alice's list/i })).toBeTruthy()
+
+            fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
+
+            expect(screen.getByText('Passport')).toBeTruthy()
+            expect(screen.getByRole('button', { name: /collapse alice's list/i })).toBeTruthy()
+        })
+
+        it('leaves a section the user folded by hand alone', async () => {
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /collapse cara's list/i }))
+
+            fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
+
+            expect(screen.getByRole('button', { name: /expand cara's list/i })).toBeTruthy()
+        })
+    })
+
+    describe('collapse all / expand all', () => {
+        it('folds every section', async () => {
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+            fireEvent.click(screen.getByRole('button', { name: /collapse all/i }))
+
+            expect(screen.queryByText('Toothbrush')).toBeNull()
+            expect(screen.queryByText('Armbands')).toBeNull()
+        })
+
+        it('opens every section, including the ones folded automatically', async () => {
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /collapse all/i }))
+
+            fireEvent.click(screen.getByRole('button', { name: /expand all/i }))
+
+            expect(screen.getByText('Toothbrush')).toBeTruthy()
+            expect(screen.getByRole('button', { name: /collapse alice's list/i })).toBeTruthy()
+        })
+
+        it('does not re-fold a finished section after the user opens everything', async () => {
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /collapse all/i }))
+            fireEvent.click(screen.getByRole('button', { name: /expand all/i }))
+
+            fireEvent.click(checkboxFor('Armbands'))
+            await new Promise(resolve => setTimeout(resolve, 1200))
+
+            expect(screen.getByRole('button', { name: /collapse alice's list/i })).toBeTruthy()
+        })
+
+        it('is not offered when the list has only one section', async () => {
+            mockList({
+                ...familyList,
+                id: 'test-list-solo',
+                items: [familyList.items[4]],
+            })
+            renderList('test-list-solo')
+            await waitFor(() => expect(screen.getByText('Armbands')).toBeTruthy())
+
+            expect(screen.queryByRole('button', { name: /collapse all/i })).toBeNull()
+        })
+    })
+
+    describe('remembering how the list was left', () => {
+        it('reopens with the sections the user folded still folded', async () => {
+            const { unmount } = renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /collapse cara's list/i }))
+            unmount()
+
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+            expect(screen.getByRole('button', { name: /expand cara's list/i })).toBeTruthy()
+        })
+
+        it('reopens in the view mode the user chose', async () => {
+            const { unmount } = renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /question view/i }))
+            unmount()
+
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+            expect(screen.getByRole('button', { name: /question view/i }).getAttribute('aria-pressed')).toBe('true')
+        })
+
+        it('reopens still showing packed items', async () => {
+            const { unmount } = renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
+            unmount()
+
+            renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+            expect(screen.getByText('Passport')).toBeTruthy()
+        })
+
+        it('reopens a folded group inside a section still folded', async () => {
+            const { unmount } = renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /collapse toiletries/i }))
+            expect(screen.queryByText('Toothbrush')).toBeNull()
+            unmount()
+
+            renderList()
+            await waitFor(() => expect(screen.getByText('Armbands')).toBeTruthy())
+
+            expect(screen.queryByText('Toothbrush')).toBeNull()
+        })
+
+        it('does not carry one list\'s folded sections onto another', async () => {
+            const { unmount } = renderList()
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /collapse cara's list/i }))
+            unmount()
+
+            mockList({ ...familyList, id: 'test-list-other' })
+            renderList('test-list-other')
+            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+            expect(screen.getByRole('button', { name: /collapse cara's list/i })).toBeTruthy()
+        })
     })
 })

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -30,7 +30,7 @@ import { CATEGORY_ORDER } from '../edit-questions/item-sections'
 import { AddItemComposer, UNCATEGORISED_LABEL, type AddItemTarget, type PersonOption } from '../components/AddItemComposer'
 import { buildSuggestionIndex } from '../utils/itemSuggestions'
 import { useIsDesktop } from '../hooks/useIsDesktop'
-import { loadListViewPreferences, saveListViewPreferences, type ListViewMode } from '../utils/listViewPreferences'
+import { loadListViewPreferences, saveListViewPreferences, hasStoredListViewPreferences, type ListViewMode } from '../utils/listViewPreferences'
 
 type FormData = {
     items: Record<string, boolean>
@@ -56,6 +56,13 @@ const ITEM_FLOURISH_MS = 450
 // finishing — the item flourish, plus a beat to read the "All packed!" badge —
 // before it folds itself away.
 const SECTION_FOLD_DELAY_MS = 900
+
+// How long a list has to be before it arrives folded. Roughly "more rows than
+// fit on a screen": below this the wall the folding exists to prevent isn't
+// there, and a freshly generated list is better off showing the user what it
+// made them. Only ever applies to a list's first open — see
+// hasStoredListViewPreferences.
+const FOLD_ON_OPEN_MIN_ITEMS = 30
 
 // Joins section keys into a single comparable value. Section keys are people's
 // names and category labels, so the separator has to be something neither can
@@ -163,6 +170,12 @@ export function ViewPackingList() {
     // items were showing. Read once, synchronously, so a list opens folded the
     // way it was closed rather than flashing its full self first.
     const [storedPreferences] = useState(() => loadListViewPreferences(id))
+    // Whether this list has been opened here before. Read before the first save
+    // writes an entry, so it stays true to its name for the whole visit.
+    const [listSeenBefore] = useState(() => hasStoredListViewPreferences(id))
+    // True while a first-open fold is still exactly as this page left it — the
+    // one moment worth explaining, and only until the user touches anything.
+    const [foldedOnOpen, setFoldedOnOpen] = useState(false)
     const [showPacked, setShowPacked] = useState(storedPreferences.showPacked)
     const [viewMode, setViewMode] = useState<ListViewMode>(storedPreferences.viewMode)
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
@@ -185,6 +198,8 @@ export function ViewPackingList() {
     // Sections finished before the user arrived fold without ceremony; after the
     // first pass, folding waits for the celebration to be seen.
     const hasFoldedOnOpenRef = useRef(false)
+    // The first-open fold happens once per mount at most, whatever else changes.
+    const hasSeededFoldRef = useRef(false)
     const [showAddGuest, setShowAddGuest] = useState(false)
     // Reveals an empty Shared Items section on lists that have no communal
     // items yet; once an item is added the section persists from the data.
@@ -249,12 +264,16 @@ export function ViewPackingList() {
             return next
         })
 
-    const toggleSection = (sectionKey: string) =>
+    const toggleSection = (sectionKey: string) => {
+        // Once the user has arranged the list themselves, the note explaining
+        // how it arrived has nothing left to explain.
+        setFoldedOnOpen(false)
         setCollapsedSections(prev => {
             const next = new Set(prev)
             if (next.has(sectionKey)) { next.delete(sectionKey) } else { next.add(sectionKey) }
             return next
         })
+    }
 
     const handleCheckAll = (items: PackingListItem[]) =>
         items.forEach(item => setValue(`items.${item.id}`, true))
@@ -939,6 +958,30 @@ export function ViewPackingList() {
     // below from being cancelled and restarted by every unrelated re-render.
     const completeSectionSignature = completeSectionKeys.join(KEY_SEPARATOR)
 
+    // A list long enough to arrive as a wall of cards opens folded — but only
+    // the very first time it is seen on this device. Every open after that is
+    // the user's own arrangement, including the arrangement "everything open",
+    // so this can never override a choice they've made. Short lists are left
+    // alone: a freshly generated list is a thing worth showing someone, and
+    // folding it would trade the payoff for tidiness it doesn't need.
+    useLayoutEffect(() => {
+        if (listSeenBefore || hasSeededFoldRef.current || !listItems) return
+        if (listItems.length <= FOLD_ON_OPEN_MIN_ITEMS) return
+
+        const sectionKeys = new Set(
+            listItems.map(item => (item.communal ? SHARED_SECTION_KEY : item.personName)),
+        )
+        // Guests with nothing in them yet still have a card to fold
+        for (const guest of packingList?.guests ?? []) sectionKeys.add(guest.name)
+        // Nothing to fold *into* — one long section stays open, since folding it
+        // would leave the user looking at a single closed box.
+        if (sectionKeys.size < 2) return
+
+        hasSeededFoldRef.current = true
+        setCollapsedSections(prev => new Set([...prev, ...sectionKeys]))
+        setFoldedOnOpen(true)
+    }, [listSeenBefore, listItems, packingList?.guests])
+
     // Showing packed items is a request to see everything, so it hands back the
     // sections this page folded away — but not the ones the user folded, which
     // are none of our business.
@@ -1122,6 +1165,7 @@ export function ViewPackingList() {
     const everySectionFolded = listSections.length > 0 && foldableSections.length === 0
     const showFoldAllControl = listSections.length > 1
     const toggleAllSections = () => {
+        setFoldedOnOpen(false)
         if (everySectionFolded) {
             // Expanding by hand settles the matter: sections that are already
             // finished are marked as dealt with so they don't fold straight back.
@@ -1340,6 +1384,27 @@ export function ViewPackingList() {
                             <p className="text-2xl font-bold text-white drop-shadow-sm">You're all packed!</p>
                             <p className="text-emerald-100 mt-1 text-sm font-medium">Everything's ready — time for adventure!</p>
                         </div>
+                    </div>
+                </div>
+            )}
+
+            {/* The one time the page arranges the list for the user, it says so and
+                hands back the undo in the same breath — same bargain as the hidden
+                packed items note below. It goes the moment they arrange anything
+                themselves, so it never becomes furniture. */}
+            {foldedOnOpen && everySectionFolded && (
+                <div data-testid="folded-on-open-note" className="w-full max-w-screen-2xl mb-4">
+                    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3">
+                        <p className="text-sm text-blue-800">
+                            A long list, so all {listSections.length} sections start folded — tap any heading to open one.
+                        </p>
+                        <button
+                            type="button"
+                            onClick={toggleAllSections}
+                            className="shrink-0 rounded-md border border-blue-300 bg-white px-3 py-1.5 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100"
+                        >
+                            Expand all
+                        </button>
                     </div>
                 </div>
             )}

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
+import { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useDebouncedCallback } from 'use-debounce'
 import { PackingList, PackingListItem } from '../create-packing-list/types'
@@ -30,6 +30,7 @@ import { CATEGORY_ORDER } from '../edit-questions/item-sections'
 import { AddItemComposer, UNCATEGORISED_LABEL, type AddItemTarget, type PersonOption } from '../components/AddItemComposer'
 import { buildSuggestionIndex } from '../utils/itemSuggestions'
 import { useIsDesktop } from '../hooks/useIsDesktop'
+import { loadListViewPreferences, saveListViewPreferences, type ListViewMode } from '../utils/listViewPreferences'
 
 type FormData = {
     items: Record<string, boolean>
@@ -50,6 +51,16 @@ const SECTIONS_EXIT_MS = 550
 // "hide packed items" filter takes it — long enough to see, short enough that
 // the next item is never waiting on it.
 const ITEM_FLOURISH_MS = 450
+
+// A section that finishes in front of the user gets long enough to be seen
+// finishing — the item flourish, plus a beat to read the "All packed!" badge —
+// before it folds itself away.
+const SECTION_FOLD_DELAY_MS = 900
+
+// Joins section keys into a single comparable value. Section keys are people's
+// names and category labels, so the separator has to be something neither can
+// contain — a space or a comma would make "Ann Lee" and "Ann, Lee" the same set.
+const KEY_SEPARATOR = '\u001f'
 
 // Spread across the viewport with staggered starts so the confetti doesn't fall
 // as one rank. Fixed rather than random so the effect is identical every run.
@@ -102,6 +113,13 @@ function categoryFromLabel(label: string): string | undefined {
     return label === UNCATEGORISED_LABEL ? undefined : label
 }
 
+interface SectionStats { packed: number; total: number }
+
+/** A section is worth celebrating — and worth folding away — once every item in it is packed. */
+function isSectionComplete(stats?: SectionStats): boolean {
+    return stats !== undefined && stats.total > 0 && stats.packed === stats.total
+}
+
 export function groupByPerson(items: PackingListItem[]) {
     const map = new Map<string, PackingListItem[]>()
     for (const item of items) {
@@ -141,8 +159,12 @@ export function ViewPackingList() {
     // Used to surface a real error to the user instead of hanging on "Loading…"
     // when a foreign-pod fetch fails.
     const hasLoadedRef = useRef(false)
-    const [showPacked, setShowPacked] = useState(false)
-    const [viewMode, setViewMode] = useState<'person' | 'question'>('person')
+    // How this list was last left — folded sections, view mode, whether packed
+    // items were showing. Read once, synchronously, so a list opens folded the
+    // way it was closed rather than flashing its full self first.
+    const storedPreferences = useRef(loadListViewPreferences(id)).current
+    const [showPacked, setShowPacked] = useState(storedPreferences.showPacked)
+    const [viewMode, setViewMode] = useState<ListViewMode>(storedPreferences.viewMode)
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
     // Which section has an add-item composer open inside it. Only one is mounted
     // at a time: a composer per group would put an input in front of every
@@ -152,8 +174,17 @@ export function ViewPackingList() {
     const [editingItemId, setEditingItemId] = useState<string | null>(null)
     const [editingItemText, setEditingItemText] = useState<string>('')
     const [editingItemQuantity, setEditingItemQuantity] = useState<string>('')
-    const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
-    const [collapsedPersons, setCollapsedPersons] = useState<Set<string>>(new Set())
+    // Groups within a section, keyed `sectionKey::groupLabel`
+    const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set(storedPreferences.collapsedGroups))
+    // Top-level sections: a person, a category, or the shared section
+    const [collapsedSections, setCollapsedSections] = useState<Set<string>>(() => new Set(storedPreferences.collapsedSections))
+    // Sections this page folded away on the user's behalf once everything in
+    // them was packed. Tracked apart from the folded set so a section is only
+    // ever auto-folded once: reopen it and it stays open.
+    const autoFoldedRef = useRef<Set<string>>(new Set())
+    // Sections finished before the user arrived fold without ceremony; after the
+    // first pass, folding waits for the celebration to be seen.
+    const hasFoldedOnOpenRef = useRef(false)
     const [showAddGuest, setShowAddGuest] = useState(false)
     // Reveals an empty Shared Items section on lists that have no communal
     // items yet; once an item is added the section persists from the data.
@@ -198,18 +229,30 @@ export function ViewPackingList() {
         return () => clearTimeout(timer)
     }, [flourish])
 
+    // Remember how the list was left. Cheap enough to write on every change —
+    // four scalars and two key lists — and writing eagerly means a list closed
+    // by killing the tab is remembered just as well as one navigated away from.
+    useEffect(() => {
+        saveListViewPreferences(id, {
+            viewMode,
+            showPacked,
+            collapsedSections: [...collapsedSections],
+            collapsedGroups: [...collapsedGroups],
+        })
+    }, [id, viewMode, showPacked, collapsedSections, collapsedGroups])
 
-    const toggleCategory = (key: string) =>
-        setCollapsedCategories(prev => {
+
+    const toggleGroup = (key: string) =>
+        setCollapsedGroups(prev => {
             const next = new Set(prev)
             if (next.has(key)) { next.delete(key) } else { next.add(key) }
             return next
         })
 
-    const togglePerson = (personName: string) =>
-        setCollapsedPersons(prev => {
+    const toggleSection = (sectionKey: string) =>
+        setCollapsedSections(prev => {
             const next = new Set(prev)
-            if (next.has(personName)) { next.delete(personName) } else { next.add(personName) }
+            if (next.has(sectionKey)) { next.delete(sectionKey) } else { next.add(sectionKey) }
             return next
         })
 
@@ -742,14 +785,14 @@ export function ViewPackingList() {
             // views key the same group the opposite way round.
             const sectionKey = target.communal ? SHARED_SECTION_KEY : target.personName
             const categoryLabel = target.category ?? UNCATEGORISED_LABEL
-            setCollapsedCategories(prev => {
+            setCollapsedGroups(prev => {
                 const keysToExpand = [`${sectionKey}::${categoryLabel}`, `${categoryLabel}::${target.personName}`]
                 if (!keysToExpand.some(k => prev.has(k))) return prev
                 const next = new Set(prev)
                 for (const k of keysToExpand) next.delete(k)
                 return next
             })
-            setCollapsedPersons(prev => {
+            setCollapsedSections(prev => {
                 if (!prev.has(sectionKey) && !prev.has(categoryLabel)) return prev
                 const next = new Set(prev)
                 next.delete(sectionKey)
@@ -818,6 +861,142 @@ export function ViewPackingList() {
         })
     }
 
+    const listItems = packingList?.items
+    const totalCount = listItems?.length ?? 0
+    const packedCount = useMemo(
+        () => listItems?.filter(item => watchedItems[item.id]).length ?? 0,
+        [listItems, watchedItems],
+    )
+    const allPacked = totalCount > 0 && packedCount === totalCount
+    // The form hydrates a beat after the list loads; until it does every item
+    // looks unpacked, and acting on that would fold nothing and celebrate
+    // nothing on a list that is in fact half done.
+    const formHydrated = totalCount === 0 || Object.keys(watchedItems).length > 0
+
+    // Per-section and per-group stats are wanted by the auto-fold effect as well
+    // as by the rendering below, so they're derived here rather than inline in
+    // the JSX — effects can't live after the early returns.
+    const sectionStats = useMemo(() => {
+        const stats: Record<string, SectionStats> = {}
+        for (const item of listItems ?? []) {
+            const key = item.communal ? SHARED_SECTION_KEY : item.personName
+            stats[key] ??= { packed: 0, total: 0 }
+            stats[key].total++
+            if (watchedItems[item.id]) stats[key].packed++
+        }
+        return stats
+    }, [listItems, watchedItems])
+
+    // Stats per category, used by question-centric top-level sections
+    const categoryStats = useMemo(() => {
+        const stats: Record<string, SectionStats> = {}
+        for (const item of listItems ?? []) {
+            if (item.communal) continue
+            const key = item.category ?? UNCATEGORISED_LABEL
+            stats[key] ??= { packed: 0, total: 0 }
+            stats[key].total++
+            if (watchedItems[item.id]) stats[key].packed++
+        }
+        return stats
+    }, [listItems, watchedItems])
+
+    // Stats for the groups *inside* a section. Both views are keyed here because
+    // both are one toggle away: person view groups a person's items by category,
+    // question view groups a category's items by person, and the shared section
+    // groups by category whichever view is on.
+    const groupStats = useMemo(() => {
+        const stats: Record<string, SectionStats> = {}
+        const count = (key: string, packed: boolean) => {
+            stats[key] ??= { packed: 0, total: 0 }
+            stats[key].total++
+            if (packed) stats[key].packed++
+        }
+        for (const item of listItems ?? []) {
+            const category = item.category ?? UNCATEGORISED_LABEL
+            const packed = !!watchedItems[item.id]
+            if (item.communal) {
+                count(`${SHARED_SECTION_KEY}::${category}`, packed)
+                continue
+            }
+            count(`${item.personName}::${category}`, packed)
+            count(`${category}::${item.personName || 'Unassigned'}`, packed)
+        }
+        return stats
+    }, [listItems, watchedItems])
+
+    // Which top-level sections have nothing left to pack, keyed the way the
+    // active view keys them. Sorted so the value is stable enough to compare.
+    const completeSectionKeys = useMemo(() => {
+        const stats = viewMode === 'person'
+            ? sectionStats
+            : { ...categoryStats, [SHARED_SECTION_KEY]: sectionStats[SHARED_SECTION_KEY] }
+        return Object.entries(stats)
+            .filter(([, sectionStat]) => isSectionComplete(sectionStat))
+            .map(([key]) => key)
+            .sort()
+    }, [viewMode, sectionStats, categoryStats])
+    // Depending on the joined form rather than the array keeps the fold timer
+    // below from being cancelled and restarted by every unrelated re-render.
+    const completeSectionSignature = completeSectionKeys.join(KEY_SEPARATOR)
+
+    // Showing packed items is a request to see everything, so it hands back the
+    // sections this page folded away — but not the ones the user folded, which
+    // are none of our business.
+    useEffect(() => {
+        if (!showPacked || autoFoldedRef.current.size === 0) return
+        const unfold = [...autoFoldedRef.current]
+        autoFoldedRef.current.clear()
+        setCollapsedSections(prev => {
+            if (!unfold.some(key => prev.has(key))) return prev
+            const next = new Set(prev)
+            for (const key of unfold) next.delete(key)
+            return next
+        })
+    }, [showPacked])
+
+    // A section with everything packed and packed items hidden is an empty card
+    // taking up a column — on a family list that's most of the page by the end
+    // of the evening. Fold it down to its header, where the count and the
+    // celebration still are, and leave it one tap from opening.
+    //
+    // Laid out before paint rather than after: a list opened with three people
+    // already done would otherwise show their full cards for a frame and then
+    // snatch them away, which reads as a glitch rather than as tidying up.
+    useLayoutEffect(() => {
+        if (!formHydrated || showPacked) return
+        // The whole list finishing has its own choreography; folding sections
+        // out from under it would fight the fold-away and the banner.
+        if (allPacked) return
+
+        const complete = new Set(completeSectionSignature ? completeSectionSignature.split(KEY_SEPARATOR) : [])
+        // Unpacking something makes a section eligible to fold again later
+        for (const key of autoFoldedRef.current) {
+            if (!complete.has(key)) autoFoldedRef.current.delete(key)
+        }
+        const toFold = [...complete].filter(key => !autoFoldedRef.current.has(key))
+        if (toFold.length === 0) return
+
+        const fold = () => {
+            for (const key of toFold) autoFoldedRef.current.add(key)
+            setCollapsedSections(prev => {
+                const next = new Set(prev)
+                for (const key of toFold) next.add(key)
+                return next
+            })
+        }
+
+        // Sections already finished when the list opened have no moment to
+        // watch, so they're folded before the first paint the user sees. One
+        // finished in front of them gets its beat first.
+        if (!hasFoldedOnOpenRef.current) {
+            hasFoldedOnOpenRef.current = true
+            fold()
+            return
+        }
+        const timer = setTimeout(fold, SECTION_FOLD_DELAY_MS)
+        return () => clearTimeout(timer)
+    }, [completeSectionSignature, formHydrated, showPacked, allPacked])
+
     if (isLoading) {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
@@ -845,10 +1024,7 @@ export function ViewPackingList() {
         ? packingList.items.filter(item => watchedItems[item.id]).length
         : 0
 
-    const totalCount = packingList.items.length
-    const packedCount = packingList.items.filter(item => watchedItems[item.id]).length
     const percentComplete = totalCount > 0 ? Math.round((packedCount / totalCount) * 100) : 0
-    const allPacked = totalCount > 0 && packedCount === totalCount
     // A sliver of fill so the first item packed is visibly worth something, but
     // nothing at all while the list is untouched
     const progressWidth = packedCount === 0 ? 0 : Math.max(percentComplete, 4)
@@ -868,32 +1044,10 @@ export function ViewPackingList() {
     const foldPending = allPacked && wasAllPackedRef.current === false && !showPacked
     const bannerHidden = sectionsExiting || foldPending
 
-    const sectionStats = packingList.items.reduce((acc, item) => {
-        const key = item.communal ? SHARED_SECTION_KEY : item.personName
-        if (!acc[key]) acc[key] = { packed: 0, total: 0 }
-        acc[key].total++
-        if (watchedItems[item.id]) acc[key].packed++
-        return acc
-    }, {} as Record<string, { packed: number; total: number }>)
-
-    // Stats per category, used by question-centric top-level sections
-    const categoryStats = packingList.items.reduce((acc, item) => {
-        if (item.communal) return acc
-        const key = item.category ?? 'Other'
-        if (!acc[key]) acc[key] = { packed: 0, total: 0 }
-        acc[key].total++
-        if (watchedItems[item.id]) acc[key].packed++
-        return acc
-    }, {} as Record<string, { packed: number; total: number }>)
-
     const guestNames = new Set((packingList.guests ?? []).map(g => g.name))
     const personIdByName = new Map(peopleOptions.map(person => [person.name, person.id]))
     // Only worth offering a section picker once the list has sections to pick.
     const sectionChoices = categoryOptions.length > 1 ? categoryOptions : undefined
-
-    // A section is worth celebrating once every item in it is packed
-    const isSectionComplete = (stats?: { packed: number; total: number }) =>
-        stats !== undefined && stats.total > 0 && stats.packed === stats.total
 
     // Build grouped item map, seeding guest names so their sections exist even when empty
     const groupedItems: Record<string, PackingListItem[]> = {}
@@ -960,6 +1114,31 @@ export function ViewPackingList() {
     }
 
     const tripDates = formatTripDates(packingList.startDate, packingList.endDate)
+
+    // One tap between "show me only what I'm packing right now" and the whole
+    // list laid out. Worth a control of its own only once there is more than one
+    // card to fold.
+    const foldableSections = listSections.filter(section => !collapsedSections.has(section.key))
+    const everySectionFolded = listSections.length > 0 && foldableSections.length === 0
+    const showFoldAllControl = listSections.length > 1
+    const toggleAllSections = () => {
+        if (everySectionFolded) {
+            // Expanding by hand settles the matter: sections that are already
+            // finished are marked as dealt with so they don't fold straight back.
+            for (const key of completeSectionKeys) autoFoldedRef.current.add(key)
+            setCollapsedSections(prev => {
+                const next = new Set(prev)
+                for (const section of listSections) next.delete(section.key)
+                return next
+            })
+            return
+        }
+        setCollapsedSections(prev => {
+            const next = new Set(prev)
+            for (const section of listSections) next.add(section.key)
+            return next
+        })
+    }
 
     return (
         <>
@@ -1083,6 +1262,19 @@ export function ViewPackingList() {
                                 )}
                             </div>
                             <div className="w-full sm:w-auto flex items-center justify-end gap-2">
+                                {showFoldAllControl && (
+                                    <button
+                                        type="button"
+                                        onClick={toggleAllSections}
+                                        title={everySectionFolded ? 'Open every section' : 'Fold every section down to its header'}
+                                        className="shrink-0 flex items-center gap-1 rounded-md border border-gray-300 bg-white px-2.5 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                                    >
+                                        <span aria-hidden="true" className="text-xs text-gray-400">{everySectionFolded ? '▼' : '▶'}</span>
+                                        {/* The word "all" is what tips this row onto a second
+                                            line on a phone, and the icon already says it. */}
+                                        {everySectionFolded ? (isDesktop ? 'Expand all' : 'Expand') : (isDesktop ? 'Collapse all' : 'Collapse')}
+                                    </button>
+                                )}
                                 <div className="flex items-center rounded-md border border-gray-300 overflow-hidden" role="group" aria-label="View mode">
                                     <button
                                         type="button"
@@ -1232,11 +1424,11 @@ export function ViewPackingList() {
                                         ) : (
                                             <button
                                                 type="button"
-                                                aria-label={`${collapsedPersons.has(sectionKey) ? 'Expand' : 'Collapse'} ${collapseLabelTarget} list`}
-                                                onClick={() => togglePerson(sectionKey)}
+                                                aria-label={`${collapsedSections.has(sectionKey) ? 'Expand' : 'Collapse'} ${collapseLabelTarget} list`}
+                                                onClick={() => toggleSection(sectionKey)}
                                                 className="flex items-center gap-2 flex-1 text-left"
                                             >
-                                                <span className="text-sm text-gray-400">{collapsedPersons.has(sectionKey) ? '▶' : '▼'}</span>
+                                                <span className="text-sm text-gray-400">{collapsedSections.has(sectionKey) ? '▶' : '▼'}</span>
                                                 <span className="text-xl font-semibold text-gray-800">{title}</span>
                                                 <span className="ml-1 text-sm font-normal text-gray-500">{stats.packed} / {stats.total}</span>
                                             </button>
@@ -1281,7 +1473,7 @@ export function ViewPackingList() {
                                         )}
                                     </div>
                                 </div>
-                                {!collapsedPersons.has(sectionKey) && <div>
+                                {!collapsedSections.has(sectionKey) && <div>
                                     {/* Every card can be typed into directly. What varies is which
                                         part of the target the card already knows: a person's card
                                         knows who, and asks which section; a section's card knows
@@ -1306,7 +1498,11 @@ export function ViewPackingList() {
                                     )}
                                     {innerGroups.map(({ label, items: catItems }) => {
                                         const categoryKey = `${sectionKey}::${label}`
-                                        const isCollapsed = collapsedCategories.has(categoryKey)
+                                        const isCollapsed = collapsedGroups.has(categoryKey)
+                                        // Counted over every item in the group, not the ones on
+                                        // screen: with packed items hidden, "2" next to a group
+                                        // seven-ninths done reads as a group barely started.
+                                        const groupStat = groupStats[categoryKey] ?? { packed: catItems.length, total: catItems.length }
                                         // Both views end up describing the same place; only which
                                         // half the card supplies changes.
                                         const groupLabel = isCategorySection
@@ -1331,12 +1527,12 @@ export function ViewPackingList() {
                                                     <button
                                                         type="button"
                                                         aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${label}`}
-                                                        onClick={() => toggleCategory(categoryKey)}
+                                                        onClick={() => toggleGroup(categoryKey)}
                                                         className="flex items-center gap-1 text-left text-sm font-semibold text-gray-600 hover:text-gray-900"
                                                     >
                                                         <span>{isCollapsed ? '▶' : '▼'}</span>
                                                         <span>{label}</span>
-                                                        <span className="text-xs font-normal text-gray-400 ml-1">({catItems.length})</span>
+                                                        <span className="text-xs font-normal text-gray-400 ml-1">{groupStat.packed} / {groupStat.total}</span>
                                                     </button>
                                                     {!isCollapsed && (
                                                         <div className="flex shrink-0 items-center gap-2">

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -162,7 +162,7 @@ export function ViewPackingList() {
     // How this list was last left — folded sections, view mode, whether packed
     // items were showing. Read once, synchronously, so a list opens folded the
     // way it was closed rather than flashing its full self first.
-    const storedPreferences = useRef(loadListViewPreferences(id)).current
+    const [storedPreferences] = useState(() => loadListViewPreferences(id))
     const [showPacked, setShowPacked] = useState(storedPreferences.showPacked)
     const [viewMode, setViewMode] = useState<ListViewMode>(storedPreferences.viewMode)
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
@@ -1240,7 +1240,10 @@ export function ViewPackingList() {
                             <span className={`text-sm font-medium whitespace-nowrap ${allPacked ? 'text-emerald-600' : 'text-gray-600'}`}>
                                 {allPacked ? '🎉 All packed!' : `${packedCount} / ${totalCount} packed (${percentComplete}%)`}
                             </span>
-                            <div className="flex-1 min-w-0 flex items-center gap-2">
+                            {/* The bar shrinks to its minimum before the encouragement
+                                gives way, and at 320px the encouragement takes a line of
+                                its own rather than running off the side of the phone. */}
+                            <div className="flex-1 min-w-0 flex flex-wrap items-center gap-x-2 gap-y-1">
                                 <div
                                     role="progressbar"
                                     aria-label="Packing progress"
@@ -1261,7 +1264,7 @@ export function ViewPackingList() {
                                     </span>
                                 )}
                             </div>
-                            <div className="w-full sm:w-auto flex items-center justify-end gap-2">
+                            <div className="w-full sm:w-auto flex flex-wrap items-center justify-end gap-2">
                                 {showFoldAllControl && (
                                     <button
                                         type="button"
@@ -1269,28 +1272,36 @@ export function ViewPackingList() {
                                         title={everySectionFolded ? 'Open every section' : 'Fold every section down to its header'}
                                         className="shrink-0 flex items-center gap-1 rounded-md border border-gray-300 bg-white px-2.5 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
                                     >
-                                        <span aria-hidden="true" className="text-xs text-gray-400">{everySectionFolded ? '▼' : '▶'}</span>
+                                        {/* Same glyph the section headers use for the same
+                                            state, so the toolbar and the cards never point
+                                            opposite ways at each other. */}
+                                        <span aria-hidden="true" className="text-xs text-gray-400">{everySectionFolded ? '▶' : '▼'}</span>
                                         {/* The word "all" is what tips this row onto a second
                                             line on a phone, and the icon already says it. */}
                                         {everySectionFolded ? (isDesktop ? 'Expand all' : 'Expand') : (isDesktop ? 'Collapse all' : 'Collapse')}
                                     </button>
                                 )}
-                                <div className="flex items-center rounded-md border border-gray-300 overflow-hidden" role="group" aria-label="View mode">
+                                {/* "View" is what the group is labelled; repeating it in both
+                                    buttons is what pushes this row off a 390px screen. The
+                                    accessible name keeps the full wording either way. */}
+                                <div className="flex shrink-0 items-center rounded-md border border-gray-300 overflow-hidden" role="group" aria-label="View mode">
                                     <button
                                         type="button"
                                         aria-pressed={viewMode === 'person'}
+                                        aria-label="Person View"
                                         onClick={() => setViewMode('person')}
-                                        className={`px-3 py-1.5 text-sm font-medium transition-colors ${viewMode === 'person' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                                        className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors ${viewMode === 'person' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
                                     >
-                                        Person View
+                                        {isDesktop ? 'Person View' : 'Person'}
                                     </button>
                                     <button
                                         type="button"
                                         aria-pressed={viewMode === 'question'}
+                                        aria-label="Question View"
                                         onClick={() => setViewMode('question')}
-                                        className={`px-3 py-1.5 text-sm font-medium transition-colors border-l border-gray-300 ${viewMode === 'question' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                                        className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors border-l border-gray-300 ${viewMode === 'question' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
                                     >
-                                        Question View
+                                        {isDesktop ? 'Question View' : 'Question'}
                                     </button>
                                 </div>
                                 <Button
@@ -1401,9 +1412,13 @@ export function ViewPackingList() {
                             const innerGroups = (isShared || !isCategorySection)
                                 ? groupByCategory(items)
                                 : groupByPerson(items)
+                            const isSectionCollapsed = collapsedSections.has(sectionKey)
                             return (
                             <div key={sectionKey} className={`border rounded-lg p-4 shadow-sm mb-4 transition-colors duration-300 ${isComplete ? 'border-emerald-300 bg-emerald-50' : `bg-white ${isGuest ? 'border-amber-200' : isShared ? 'border-blue-200' : 'border-gray-200'}`}`} style={{ breakInside: 'avoid' }}>
-                                <div className="mb-4 pb-2 border-b border-gray-200">
+                                {/* The rule under the heading separates it from the items
+                                    below; a folded card has none, so it would just be a
+                                    line ruling off empty space. */}
+                                <div className={isSectionCollapsed ? undefined : 'mb-4 pb-2 border-b border-gray-200'}>
                                     <div className="flex flex-wrap items-center gap-1 min-h-[2rem]">
                                         {isGuest && renamingGuestId === guestId ? (
                                             <>
@@ -1424,13 +1439,15 @@ export function ViewPackingList() {
                                         ) : (
                                             <button
                                                 type="button"
-                                                aria-label={`${collapsedSections.has(sectionKey) ? 'Expand' : 'Collapse'} ${collapseLabelTarget} list`}
+                                                aria-label={`${isSectionCollapsed ? 'Expand' : 'Collapse'} ${collapseLabelTarget} list`}
                                                 onClick={() => toggleSection(sectionKey)}
-                                                className="flex items-center gap-2 flex-1 text-left"
+                                                className="flex items-center gap-2 flex-1 min-w-0 text-left"
                                             >
-                                                <span className="text-sm text-gray-400">{collapsedSections.has(sectionKey) ? '▶' : '▼'}</span>
+                                                <span className="shrink-0 text-sm text-gray-400">{isSectionCollapsed ? '▶' : '▼'}</span>
                                                 <span className="text-xl font-semibold text-gray-800">{title}</span>
-                                                <span className="ml-1 text-sm font-normal text-gray-500">{stats.packed} / {stats.total}</span>
+                                                {/* Never let a count break across lines — "9 /" above "9" is
+                                                    a fraction the eye has to reassemble. */}
+                                                <span className="ml-1 shrink-0 whitespace-nowrap text-sm font-normal text-gray-500">{stats.packed} / {stats.total}</span>
                                             </button>
                                         )}
                                         {isComplete && (
@@ -1473,7 +1490,7 @@ export function ViewPackingList() {
                                         )}
                                     </div>
                                 </div>
-                                {!collapsedSections.has(sectionKey) && <div>
+                                {!isSectionCollapsed && <div>
                                     {/* Every card can be typed into directly. What varies is which
                                         part of the target the card already knows: a person's card
                                         knows who, and asks which section; a section's card knows
@@ -1532,7 +1549,7 @@ export function ViewPackingList() {
                                                     >
                                                         <span>{isCollapsed ? '▶' : '▼'}</span>
                                                         <span>{label}</span>
-                                                        <span className="text-xs font-normal text-gray-400 ml-1">{groupStat.packed} / {groupStat.total}</span>
+                                                        <span className="ml-1 shrink-0 whitespace-nowrap text-xs font-normal text-gray-400">{groupStat.packed} / {groupStat.total}</span>
                                                     </button>
                                                     {!isCollapsed && (
                                                         <div className="flex shrink-0 items-center gap-2">

--- a/src/utils/listViewPreferences.test.ts
+++ b/src/utils/listViewPreferences.test.ts
@@ -4,6 +4,7 @@ import {
     loadListViewPreferences,
     saveListViewPreferences,
     listViewPreferencesKey,
+    hasStoredListViewPreferences,
 } from './listViewPreferences'
 
 describe('listViewPreferences', () => {
@@ -115,19 +116,41 @@ describe('listViewPreferences', () => {
             expect(setItem).not.toHaveBeenCalled()
         })
 
-        it('does not leave an entry behind for a list left at its defaults', () => {
+        it('keeps an entry for a list left at its defaults, so it counts as seen', () => {
             saveListViewPreferences('list-1', DEFAULT_LIST_VIEW_PREFERENCES)
 
-            expect(localStorage.getItem(listViewPreferencesKey('list-1'))).toBeNull()
+            expect(hasStoredListViewPreferences('list-1')).toBe(true)
         })
 
-        it('clears a stored entry once the list is back to its defaults', () => {
+        it('still counts as seen once the user opens everything back up', () => {
             saveListViewPreferences('list-1', { ...DEFAULT_LIST_VIEW_PREFERENCES, collapsedSections: ['Alice'] })
-            expect(localStorage.getItem(listViewPreferencesKey('list-1'))).not.toBeNull()
-
             saveListViewPreferences('list-1', DEFAULT_LIST_VIEW_PREFERENCES)
 
-            expect(localStorage.getItem(listViewPreferencesKey('list-1'))).toBeNull()
+            expect(hasStoredListViewPreferences('list-1')).toBe(true)
+        })
+    })
+
+    describe('knowing whether a list has been opened before', () => {
+        it('is false for a list never opened', () => {
+            expect(hasStoredListViewPreferences('list-1')).toBe(false)
+        })
+
+        it('is false without a list id', () => {
+            expect(hasStoredListViewPreferences(undefined)).toBe(false)
+        })
+
+        it('is true once the list has been saved', () => {
+            saveListViewPreferences('list-1', DEFAULT_LIST_VIEW_PREFERENCES)
+
+            expect(hasStoredListViewPreferences('list-1')).toBe(true)
+        })
+
+        it('treats unreadable storage as never opened rather than throwing', () => {
+            vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+                throw new Error('SecurityError')
+            })
+
+            expect(hasStoredListViewPreferences('list-1')).toBe(false)
         })
     })
 })

--- a/src/utils/listViewPreferences.test.ts
+++ b/src/utils/listViewPreferences.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+    DEFAULT_LIST_VIEW_PREFERENCES,
+    loadListViewPreferences,
+    saveListViewPreferences,
+    listViewPreferencesKey,
+} from './listViewPreferences'
+
+describe('listViewPreferences', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    describe('loading', () => {
+        it('returns the defaults for a list that has never been opened', () => {
+            expect(loadListViewPreferences('list-1')).toEqual(DEFAULT_LIST_VIEW_PREFERENCES)
+        })
+
+        it('returns the defaults when there is no list id', () => {
+            expect(loadListViewPreferences(undefined)).toEqual(DEFAULT_LIST_VIEW_PREFERENCES)
+        })
+
+        it('reads back what was saved', () => {
+            saveListViewPreferences('list-1', {
+                viewMode: 'question',
+                showPacked: true,
+                collapsedSections: ['Alice', '__shared__'],
+                collapsedGroups: ['Alice::Clothes'],
+            })
+
+            expect(loadListViewPreferences('list-1')).toEqual({
+                viewMode: 'question',
+                showPacked: true,
+                collapsedSections: ['Alice', '__shared__'],
+                collapsedGroups: ['Alice::Clothes'],
+            })
+        })
+
+        it('keeps each list\'s preferences separate', () => {
+            saveListViewPreferences('list-1', { ...DEFAULT_LIST_VIEW_PREFERENCES, collapsedSections: ['Alice'] })
+
+            expect(loadListViewPreferences('list-2')).toEqual(DEFAULT_LIST_VIEW_PREFERENCES)
+        })
+    })
+
+    describe('surviving bad stored data', () => {
+        it('falls back to the defaults when the stored value is not JSON', () => {
+            localStorage.setItem(listViewPreferencesKey('list-1'), 'not json{')
+
+            expect(loadListViewPreferences('list-1')).toEqual(DEFAULT_LIST_VIEW_PREFERENCES)
+        })
+
+        it('falls back to the defaults when the stored value is not an object', () => {
+            localStorage.setItem(listViewPreferencesKey('list-1'), '"just a string"')
+
+            expect(loadListViewPreferences('list-1')).toEqual(DEFAULT_LIST_VIEW_PREFERENCES)
+        })
+
+        it('ignores a view mode it does not recognise', () => {
+            localStorage.setItem(listViewPreferencesKey('list-1'), JSON.stringify({ viewMode: 'sideways' }))
+
+            expect(loadListViewPreferences('list-1').viewMode).toBe('person')
+        })
+
+        it('ignores collapsed keys that are not strings', () => {
+            localStorage.setItem(
+                listViewPreferencesKey('list-1'),
+                JSON.stringify({ collapsedSections: ['Alice', 7, null, 'Bob'], collapsedGroups: 'nope' }),
+            )
+
+            const prefs = loadListViewPreferences('list-1')
+            expect(prefs.collapsedSections).toEqual(['Alice', 'Bob'])
+            expect(prefs.collapsedGroups).toEqual([])
+        })
+
+        it('fills in fields the stored value is missing', () => {
+            localStorage.setItem(listViewPreferencesKey('list-1'), JSON.stringify({ showPacked: true }))
+
+            expect(loadListViewPreferences('list-1')).toEqual({
+                ...DEFAULT_LIST_VIEW_PREFERENCES,
+                showPacked: true,
+            })
+        })
+    })
+
+    describe('when storage is unavailable', () => {
+        it('returns the defaults rather than throwing on read', () => {
+            vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+                throw new Error('SecurityError')
+            })
+
+            expect(() => loadListViewPreferences('list-1')).not.toThrow()
+            expect(loadListViewPreferences('list-1')).toEqual(DEFAULT_LIST_VIEW_PREFERENCES)
+        })
+
+        it('swallows the failure on write', () => {
+            vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+                throw new Error('QuotaExceededError')
+            })
+
+            expect(() => saveListViewPreferences('list-1', DEFAULT_LIST_VIEW_PREFERENCES)).not.toThrow()
+        })
+    })
+
+    describe('saving', () => {
+        it('does nothing without a list id', () => {
+            const setItem = vi.spyOn(Storage.prototype, 'setItem')
+
+            saveListViewPreferences(undefined, DEFAULT_LIST_VIEW_PREFERENCES)
+
+            expect(setItem).not.toHaveBeenCalled()
+        })
+
+        it('does not leave an entry behind for a list left at its defaults', () => {
+            saveListViewPreferences('list-1', DEFAULT_LIST_VIEW_PREFERENCES)
+
+            expect(localStorage.getItem(listViewPreferencesKey('list-1'))).toBeNull()
+        })
+
+        it('clears a stored entry once the list is back to its defaults', () => {
+            saveListViewPreferences('list-1', { ...DEFAULT_LIST_VIEW_PREFERENCES, collapsedSections: ['Alice'] })
+            expect(localStorage.getItem(listViewPreferencesKey('list-1'))).not.toBeNull()
+
+            saveListViewPreferences('list-1', DEFAULT_LIST_VIEW_PREFERENCES)
+
+            expect(localStorage.getItem(listViewPreferencesKey('list-1'))).toBeNull()
+        })
+    })
+})

--- a/src/utils/listViewPreferences.ts
+++ b/src/utils/listViewPreferences.ts
@@ -1,0 +1,101 @@
+/**
+ * How the user last left a particular packing list: which view they were in,
+ * whether packed items were showing, and which sections they had folded away.
+ *
+ * A big family list is only manageable once you can put away the parts you
+ * aren't packing right now — and that's worthless if the app forgets the moment
+ * you navigate back to the lists index. This is per-list rather than global
+ * because "everyone collapsed except Ellie" is a fact about one trip, not a
+ * preference about the app.
+ *
+ * Kept in localStorage rather than on the list itself: it's a device-local view
+ * state, not list data, and pushing it to the pod would have one person's
+ * folded sections rearrange the list under a collaborator who is packing a
+ * different bag.
+ */
+
+export type ListViewMode = 'person' | 'question'
+
+export interface ListViewPreferences {
+    viewMode: ListViewMode
+    showPacked: boolean
+    /** Keys of folded top-level sections — a person, a category, or the shared section. */
+    collapsedSections: string[]
+    /** Keys of folded groups within a section, in `sectionKey::groupLabel` form. */
+    collapsedGroups: string[]
+}
+
+export const DEFAULT_LIST_VIEW_PREFERENCES: ListViewPreferences = {
+    viewMode: 'person',
+    showPacked: false,
+    collapsedSections: [],
+    collapsedGroups: [],
+}
+
+const KEY_PREFIX = 'pack-me-up:list-view:'
+
+export function listViewPreferencesKey(listId: string): string {
+    return `${KEY_PREFIX}${listId}`
+}
+
+function stringsOnly(value: unknown): string[] {
+    return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
+}
+
+function isDefault(prefs: ListViewPreferences): boolean {
+    return prefs.viewMode === DEFAULT_LIST_VIEW_PREFERENCES.viewMode
+        && prefs.showPacked === DEFAULT_LIST_VIEW_PREFERENCES.showPacked
+        && prefs.collapsedSections.length === 0
+        && prefs.collapsedGroups.length === 0
+}
+
+/**
+ * Never throws and never returns a partial object: a corrupt or half-written
+ * entry costs the user their folded sections, which is not worth failing a list
+ * render over. Storage itself can throw outright (Safari private browsing), so
+ * every access is guarded rather than feature-detected.
+ */
+export function loadListViewPreferences(listId: string | undefined): ListViewPreferences {
+    if (!listId) return DEFAULT_LIST_VIEW_PREFERENCES
+
+    let raw: string | null = null
+    try {
+        raw = localStorage.getItem(listViewPreferencesKey(listId))
+    } catch {
+        return DEFAULT_LIST_VIEW_PREFERENCES
+    }
+    if (!raw) return DEFAULT_LIST_VIEW_PREFERENCES
+
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(raw)
+    } catch {
+        return DEFAULT_LIST_VIEW_PREFERENCES
+    }
+    if (typeof parsed !== 'object' || parsed === null) return DEFAULT_LIST_VIEW_PREFERENCES
+
+    const stored = parsed as Partial<Record<keyof ListViewPreferences, unknown>>
+    return {
+        viewMode: stored.viewMode === 'question' ? 'question' : 'person',
+        showPacked: stored.showPacked === true,
+        collapsedSections: stringsOnly(stored.collapsedSections),
+        collapsedGroups: stringsOnly(stored.collapsedGroups),
+    }
+}
+
+export function saveListViewPreferences(listId: string | undefined, prefs: ListViewPreferences): void {
+    if (!listId) return
+    try {
+        // A list sitting at the defaults has nothing worth remembering, so it
+        // leaves no entry behind — otherwise every list ever opened would
+        // accumulate one.
+        if (isDefault(prefs)) {
+            localStorage.removeItem(listViewPreferencesKey(listId))
+            return
+        }
+        localStorage.setItem(listViewPreferencesKey(listId), JSON.stringify(prefs))
+    } catch {
+        // Storage full or blocked — the list still works, it just won't
+        // remember how it was left.
+    }
+}

--- a/src/utils/listViewPreferences.ts
+++ b/src/utils/listViewPreferences.ts
@@ -42,11 +42,23 @@ function stringsOnly(value: unknown): string[] {
     return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
 }
 
-function isDefault(prefs: ListViewPreferences): boolean {
-    return prefs.viewMode === DEFAULT_LIST_VIEW_PREFERENCES.viewMode
-        && prefs.showPacked === DEFAULT_LIST_VIEW_PREFERENCES.showPacked
-        && prefs.collapsedSections.length === 0
-        && prefs.collapsedGroups.length === 0
+/**
+ * Whether this list has been opened on this device before.
+ *
+ * The list view folds a big list down on its *first* open only; every open
+ * after that belongs to whatever the user last chose, including choosing to
+ * have everything open. That's why an entry is written even when it matches the
+ * defaults exactly — the entry itself is the record that the user has seen this
+ * list, and deleting it would have the list fold itself up again on the next
+ * visit as if for the first time.
+ */
+export function hasStoredListViewPreferences(listId: string | undefined): boolean {
+    if (!listId) return false
+    try {
+        return localStorage.getItem(listViewPreferencesKey(listId)) !== null
+    } catch {
+        return false
+    }
 }
 
 /**
@@ -86,13 +98,6 @@ export function loadListViewPreferences(listId: string | undefined): ListViewPre
 export function saveListViewPreferences(listId: string | undefined, prefs: ListViewPreferences): void {
     if (!listId) return
     try {
-        // A list sitting at the defaults has nothing worth remembering, so it
-        // leaves no entry behind — otherwise every list ever opened would
-        // accumulate one.
-        if (isDefault(prefs)) {
-            localStorage.removeItem(listViewPreferencesKey(listId))
-            return
-        }
         localStorage.setItem(listViewPreferencesKey(listId), JSON.stringify(prefs))
     } catch {
         // Storage full or blocked — the list still works, it just won't


### PR DESCRIPTION
A packing list for a family of five arrives as a wall of cards — 64 items, 2700px of page — and the tools for cutting it down don't survive leaving the page. Collapsing four people so you can pack one bag is undone the moment you navigate back to the lists index.

Every change here is either state that remembers a choice the user already made, or a fold the user is told about and can undo in one tap. Folded sections stay fully visible as headers with their counts, so nothing ever looks lost.

## What changed

**A long list opens folded, once.** Above ~30 items and more than one section, a list arrives with every section closed — name and count on each heading. This is the answer to the original complaint, and until now it was a button the user had to find first. Three things keep it from being a default that overrides people:

- **First open only.** Every open after that is whatever the user last arranged, including "everything open". A list at its plain defaults now keeps its stored entry rather than deleting it — the entry *is* the record that the list has been seen, and without it a list the user deliberately opened up would fold itself again next visit.
- **Only when it's actually a wall.** A short list is left alone; a freshly generated list is worth showing someone. A one-person list stays open however long, since folding it would leave you looking at a single closed box.
- **It says so.** A note explains the list arrived folded and carries its own Expand all, and it goes the moment you open anything yourself.

**The list remembers how it was left.** View mode, whether packed items are showing, and which sections and groups are folded, per list id. It's `localStorage`, not list data: folded sections are a fact about how one person is packing tonight, and pushing them to the pod would rearrange the list under a collaborator packing a different bag. Corrupt or blocked storage costs you your folded sections, never a render.

**A section folds once everything in it is packed.** With packed items hidden, a finished section is an empty card holding a whole column. Folded, its header still carries the count and the "All packed!" celebration.

- A section is only ever auto-folded *once* — reopen it and it stays open.
- **Show Packed** hands back every section the page folded, and leaves the ones you folded by hand alone.
- Sections finished before you arrived fold before first paint; one finished in front of you gets ~900ms to be seen finishing.
- The whole list finishing still belongs to the existing fold-away and banner.

**Groups count every item in them, not the ones on screen.** A group seven-ninths packed read as `(2)` with packed items hidden. It now reads `7 / 9`, matching the section header above it.

**A Collapse all / Expand all control**, once there's more than one card to fold.

## Measured on a real 64-item, five-person list

| | Before | After |
|---|---|---|
| Desktop, first open | 2712px | 480px — six cards, counts, one note |
| Mobile 390px, first open | 4837px | the whole list on one screen |
| 21-item list, first open | unchanged | unchanged — no fold, no note |

## Polish found by driving it, not by testing it

Running the real app turned up four things the unit tests couldn't see:

- Folded cards kept the rule and padding that separate a heading from its items, so each one ruled off a strip of empty space.
- The controls row overflowed a 390px screen — "Question View" was clipped mid-word. The buttons drop "View" on phones and keep the full wording as their accessible name.
- Counts could break across lines: "9 /" above "9".
- At 320px the milestone encouragement ran off the side of the screen. **This one predates the branch** — it reproduces on `main` — but it's one line and it's in the strip being reworked.

The fold-all caret also pointed the opposite way to the sections it folds; it now uses the same glyph the section headers use for the same state.

## Testing

- 1223 unit tests pass. 29 new ones cover the first-open fold and its threshold, folding on completion, the Show Packed handback, collapse/expand all and per-list persistence, plus 18 on the preferences module (bad JSON, non-string keys, storage that throws).
- Full e2e suite passes (65 tests). Two changes were needed, both real consequences of the new behaviour rather than test noise: `f-sync` F5 reloads mid-test and clicked "Show Packed" a second time, which is now "Hide Packed"; and the F-suite's lists cross the threshold once F1 adds a second person, so its helpers open the sections before reaching for an item — including in the second browser context, where the list is also being seen for the first time.
- `npm run lint` unchanged from `main` (13 warnings, 0 errors).
- Verified by hand at 1440px, 390px and 320px — no horizontal overflow at any of them.