### PR TITLE
Let people put their packing list sections in their own order

### DIFF
--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -344,7 +344,9 @@ test.describe('B – Editing Questions', () => {
     const suggestion = page.getByRole('option', { name: /Sunscreen/ }).first()
     await expect(suggestion).toBeVisible({ timeout: 3_000 })
     await suggestion.click()
-    await expect(page.getByLabel('Section')).toHaveValue('Toiletries')
+    // Scoped to the composer: the page also carries a "Reorder sections"
+    // button, and getByLabel matches on substring.
+    await expect(page.getByTestId('add-question-item').getByLabel('Section')).toHaveValue('Toiletries')
 
     await field.press('Enter')
     const toiletries = page.getByTestId('item-section').filter({ hasText: 'Toiletries' }).first()

--- a/e2e/tests/k-schema-compat.spec.ts
+++ b/e2e/tests/k-schema-compat.spec.ts
@@ -54,8 +54,12 @@ test.describe('K – JSON Schema Compatibility', () => {
     await expect(personInputs.first()).toHaveValue('Alice', { timeout: 20_000 })
     await page.getByRole('button', { name: 'Cancel' }).click()
 
-    // The question from the fixture should be visible as text in the questions list
-    await expect(page.getByText('Will you be staying overnight?')).toBeVisible({ timeout: 10_000 })
+    // The question from the fixture should be in the questions list, as the
+    // card you can open. Matched by role rather than as loose text: this set
+    // carries no categories, so its sections are named after the questions
+    // themselves and the question text appears in the section-order strip too.
+    await expect(page.getByRole('button', { name: 'Will you be staying overnight?' }))
+      .toBeVisible({ timeout: 10_000 })
   })
 
   test('K2: individual packing list loads items from v1 JSON', async () => {

--- a/src/components/SectionOrderEditor.test.tsx
+++ b/src/components/SectionOrderEditor.test.tsx
@@ -18,13 +18,19 @@ describe('SectionOrderLegend', () => {
         expect(container.textContent).toBe('')
     })
 
-    // The strip scrolls rather than truncating, so a long order is all there —
-    // which is what keeps a screen reader from being told a shorter story than
-    // the one on screen.
-    it('names every section however many there are', () => {
+    it('counts the sections it has run out of chips to name', () => {
         const labels = Array.from({ length: 11 }, (_, i) => `Section ${i + 1}`)
         render(<SectionOrderLegend labels={labels} onEdit={vi.fn()} />)
-        for (const label of labels) expect(screen.getByText(label)).toBeTruthy()
+        expect(screen.getByText('Section 4')).toBeTruthy()
+        expect(screen.queryByText('Section 5')).toBeNull()
+        expect(screen.getByText('+7 more')).toBeTruthy()
+    })
+
+    // The narrow-screen line replaces the chips rather than joining them, so
+    // the order is still there in full when there is no room to draw it.
+    it('carries the whole order as one compact line', () => {
+        render(<SectionOrderLegend labels={['Documents', 'Toiletries', 'Clothes']} onEdit={vi.fn()} />)
+        expect(screen.getByText('Documents · Toiletries · Clothes')).toBeTruthy()
     })
 
     it('numbers the sections for a screen reader', () => {

--- a/src/components/SectionOrderEditor.test.tsx
+++ b/src/components/SectionOrderEditor.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react'
+import React from 'react'
+import { SectionOrderLegend, SectionOrderModal } from './SectionOrderEditor'
+
+afterEach(cleanup)
+
+describe('SectionOrderLegend', () => {
+    it('names the sections in order', () => {
+        render(<SectionOrderLegend labels={['Documents', 'Toiletries', 'Clothes']} onEdit={vi.fn()} />)
+        expect(screen.getByText('Documents')).toBeTruthy()
+        expect(screen.getByText('Toiletries')).toBeTruthy()
+        expect(screen.getByText('Clothes')).toBeTruthy()
+    })
+
+    it('says nothing at all when there is no order to show', () => {
+        const { container } = render(<SectionOrderLegend labels={['Essentials']} onEdit={vi.fn()} />)
+        expect(container.textContent).toBe('')
+    })
+
+    // The strip scrolls rather than truncating, so a long order is all there —
+    // which is what keeps a screen reader from being told a shorter story than
+    // the one on screen.
+    it('names every section however many there are', () => {
+        const labels = Array.from({ length: 11 }, (_, i) => `Section ${i + 1}`)
+        render(<SectionOrderLegend labels={labels} onEdit={vi.fn()} />)
+        for (const label of labels) expect(screen.getByText(label)).toBeTruthy()
+    })
+
+    it('numbers the sections for a screen reader', () => {
+        render(<SectionOrderLegend labels={['Documents', 'Clothes']} onEdit={vi.fn()} />)
+        expect(screen.getByText('1.')).toBeTruthy()
+        expect(screen.getByText('2.')).toBeTruthy()
+    })
+
+    it('opens the editor', () => {
+        const onEdit = vi.fn()
+        render(<SectionOrderLegend labels={['Documents', 'Clothes']} onEdit={onEdit} />)
+        fireEvent.click(screen.getByRole('button', { name: /reorder sections/i }))
+        expect(onEdit).toHaveBeenCalled()
+    })
+
+    it('offers no editor on a page that cannot save one', () => {
+        render(<SectionOrderLegend labels={['Documents', 'Clothes']} />)
+        expect(screen.queryByRole('button', { name: /reorder sections/i })).toBeNull()
+        expect(screen.getByText('Documents')).toBeTruthy()
+    })
+})
+
+describe('SectionOrderModal', () => {
+    const labels = ['Documents', 'Toiletries', 'Clothes']
+
+    const renderModal = (onChange = vi.fn()) => {
+        render(<SectionOrderModal labels={labels} onChange={onChange} onClose={vi.fn()} />)
+        return onChange
+    }
+
+    it('lists every section', () => {
+        renderModal()
+        const dialog = screen.getByRole('dialog', { name: /reorder list sections/i })
+        for (const label of labels) expect(within(dialog).getByText(label)).toBeTruthy()
+    })
+
+    it('moves a section up', () => {
+        const onChange = renderModal()
+        fireEvent.click(screen.getByRole('button', { name: 'Move Clothes up' }))
+        expect(onChange).toHaveBeenCalledWith(['Documents', 'Clothes', 'Toiletries'])
+    })
+
+    it('moves a section down', () => {
+        const onChange = renderModal()
+        fireEvent.click(screen.getByRole('button', { name: 'Move Documents down' }))
+        expect(onChange).toHaveBeenCalledWith(['Toiletries', 'Documents', 'Clothes'])
+    })
+
+    // Nothing above the first row or below the last, so the arrows say so
+    // rather than silently doing nothing.
+    it('cannot move the first section up or the last one down', () => {
+        renderModal()
+        expect(screen.getByRole('button', { name: 'Move Documents up' }).hasAttribute('disabled')).toBe(true)
+        expect(screen.getByRole('button', { name: 'Move Clothes down' }).hasAttribute('disabled')).toBe(true)
+        expect(screen.getByRole('button', { name: 'Move Documents down' }).hasAttribute('disabled')).toBe(false)
+    })
+
+    it('closes on Done', () => {
+        const onClose = vi.fn()
+        render(<SectionOrderModal labels={labels} onChange={vi.fn()} onClose={onClose} />)
+        fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+        expect(onClose).toHaveBeenCalled()
+    })
+})

--- a/src/components/SectionOrderEditor.tsx
+++ b/src/components/SectionOrderEditor.tsx
@@ -1,0 +1,254 @@
+/**
+ * Arranging the sections a generated packing list is split into.
+ *
+ * This is the one arrangement on the questions page that belongs to no single
+ * question. A section spans questions — "Toiletries" is filled by the
+ * always-needed list and by two options besides — so it cannot be moved by
+ * dragging items inside any one of them, which is why the item reorder view
+ * refuses to drag its headers at all ("a section moves by moving its items").
+ * Here the section *is* the row, and there are no items in sight.
+ *
+ * See `edit-questions/section-order.ts` for what the order means and how a set
+ * that has never been arranged still has one.
+ */
+import { memo, useRef } from 'react'
+import {
+    DndContext,
+    closestCenter,
+    KeyboardSensor,
+    MouseSensor,
+    TouchSensor,
+    useSensor,
+    useSensors,
+    type DragEndEvent,
+    type Modifier,
+} from '@dnd-kit/core'
+import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { sectionAccent } from '../edit-questions/section-accent'
+import { moveSectionLabel } from '../edit-questions/section-order'
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
+
+// Drags only ever move rows up and down the list.
+const restrictToVerticalAxis: Modifier = ({ transform }) => ({ ...transform, x: 0 })
+
+/**
+ * The order, at a glance, above the sections it describes.
+ *
+ * Compact and always visible rather than tucked behind a menu, so the answer to
+ * "why is my list in this order" sits in eyeshot of the sections it is about.
+ * A named section wears the same colour here that it wears on every card below
+ * — the colour comes from the name — which is what lets the strip be scanned
+ * rather than read. Under two sections there is no order to show and nothing to
+ * arrange, so it says nothing at all.
+ *
+ * The chips scroll sideways rather than wrapping. Wrapping cost five lines
+ * above the first question on a phone, for something read once and then
+ * ignored; one line is what a strip introducing the page below it can afford,
+ * whatever the width. Nothing is hidden from a screen reader by that — every
+ * chip is in the document, and each says its position.
+ */
+export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onEdit }: {
+    labels: string[]
+    /** Omit on a read-only (foreign pod) page: the order is shown, not offered. */
+    onEdit?: () => void
+}) {
+    if (labels.length < 2) return null
+    return (
+        <div className="flex items-center gap-2 mb-4">
+            {/* On a phone the caption costs a third of the row it introduces,
+                and the coloured chips beside a "Reorder" button say what it
+                would have said. Still read out, just not drawn. */}
+            <span className="sr-only sm:not-sr-only sm:text-xs sm:text-gray-400 sm:shrink-0">List order</span>
+            <div className="flex items-center gap-1.5 flex-1 min-w-0 overflow-x-auto py-0.5">
+                {labels.map((label, i) => {
+                    const accent = sectionAccent(label, false)
+                    return (
+                        <span
+                            key={label}
+                            className={`inline-flex items-center gap-1 shrink-0 whitespace-nowrap rounded-full border ${accent.border} ${accent.header} pl-1.5 pr-2 py-0.5 text-[11px] ${accent.text}`}
+                        >
+                            <span className={`w-1.5 h-1.5 rounded-full ${accent.rail}`} aria-hidden="true" />
+                            <span className="sr-only">{`${i + 1}. `}</span>
+                            {label}
+                        </span>
+                    )
+                })}
+            </div>
+            {onEdit && (
+                <button
+                    type="button"
+                    onClick={onEdit}
+                    aria-label="Reorder sections"
+                    className="inline-flex items-center gap-1 shrink-0 text-[11px] font-medium rounded-full px-2 py-1 text-primary-600 hover:bg-primary-50 transition-colors"
+                >
+                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
+                    </svg>
+                    Reorder
+                </button>
+            )}
+        </div>
+    )
+})
+
+function SortableSectionRow({ label, position, total, onMove }: {
+    label: string
+    position: number
+    total: number
+    onMove: (to: number) => void
+}) {
+    const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: label })
+    const accent = sectionAccent(label, false)
+    return (
+        <div
+            ref={setNodeRef}
+            style={{ transform: CSS.Transform.toString(transform), transition }}
+            className={`flex items-center gap-1 rounded-lg border bg-white p-2 ${isDragging ? 'relative z-10 border-primary-400 shadow-md opacity-95' : accent.border}`}
+        >
+            <button
+                type="button"
+                ref={setActivatorNodeRef}
+                {...attributes}
+                {...listeners}
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-50 cursor-grab active:cursor-grabbing touch-none"
+                title="Drag to reorder"
+                aria-label={`Drag ${label} to reorder`}
+            >
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M7 4a1 1 0 100 2 1 1 0 000-2zM7 9a1 1 0 100 2 1 1 0 000-2zM7 14a1 1 0 100 2 1 1 0 000-2zM13 4a1 1 0 100 2 1 1 0 000-2zM13 9a1 1 0 100 2 1 1 0 000-2zM13 14a1 1 0 100 2 1 1 0 000-2z" />
+                </svg>
+            </button>
+            <span className={`w-1.5 h-5 rounded-full shrink-0 ${accent.rail}`} aria-hidden="true" />
+            <span className="flex-1 min-w-0 truncate text-sm text-gray-800 px-1">{label}</span>
+            {/* Named destinations rather than bare arrows: this is the path that
+                works from the keyboard, and "move up" alone doesn't say where. */}
+            <button
+                type="button"
+                disabled={position === 0}
+                onClick={() => onMove(position - 1)}
+                aria-label={`Move ${label} up`}
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:text-gray-200 disabled:border-gray-100 disabled:hover:bg-transparent transition-colors"
+            >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                </svg>
+            </button>
+            <button
+                type="button"
+                disabled={position === total - 1}
+                onClick={() => onMove(position + 1)}
+                aria-label={`Move ${label} down`}
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:text-gray-200 disabled:border-gray-100 disabled:hover:bg-transparent transition-colors"
+            >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
+        </div>
+    )
+}
+
+/**
+ * The section order, as the only thing on the screen.
+ *
+ * Full-screen for the same reason the item reorder is (a drag needs a scroll
+ * container it owns), and with no Save for the same reason too: like everything
+ * else on this page the moves are written as they are made.
+ */
+export function SectionOrderModal({ labels, onChange, onClose }: {
+    labels: string[]
+    onChange: (labels: string[]) => void
+    onClose: () => void
+}) {
+    useBodyScrollLock()
+    const scrollRef = useRef<HTMLDivElement>(null)
+
+    const sensors = useSensors(
+        useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+        useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    )
+
+    const handleDragEnd = ({ active, over }: DragEndEvent) => {
+        if (!over || active.id === over.id) return
+        onChange(moveSectionLabel(labels, labels.indexOf(String(active.id)), labels.indexOf(String(over.id))))
+    }
+
+    return (
+        <div
+            className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
+            onClick={onClose}
+            onKeyDown={e => { if (e.key === 'Escape') onClose() }}
+        >
+            <div
+                role="dialog"
+                aria-label="Reorder list sections"
+                className="bg-white rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="p-5 border-b border-gray-100 flex-shrink-0">
+                    <h2 className="text-lg font-semibold text-gray-900">Reorder sections</h2>
+                    <p className="mt-0.5 text-sm text-gray-500">
+                        The order your packing lists are grouped in. Applies to lists you create from now on.
+                    </p>
+                </div>
+                <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
+                    <div className="text-[11px] text-gray-400 mb-2 px-0.5">
+                        Drag the handle (press and hold on touch) to reorder, or use the arrows.
+                    </div>
+                    <DndContext
+                        sensors={sensors}
+                        collisionDetection={closestCenter}
+                        modifiers={[restrictToVerticalAxis]}
+                        // Only ever the modal's own scroll area — `true` would let
+                        // dnd-kit scroll every scrollable ancestor, the window
+                        // included, moving rows the gesture has already measured.
+                        autoScroll={{ canScroll: el => el === scrollRef.current }}
+                        accessibility={{
+                            screenReaderInstructions: {
+                                draggable: 'Press space to pick up the section, the arrow keys to move it '
+                                    + 'up or down the list, space again to drop it, and escape to cancel. '
+                                    + 'The arrow buttons on each row do the same thing one step at a time.',
+                            },
+                            announcements: {
+                                onDragStart: ({ active }) => `Picked up ${active.id}.`,
+                                onDragOver: ({ active, over }) => over && over.id !== active.id
+                                    ? `${active.id}, position ${labels.indexOf(String(over.id)) + 1} of ${labels.length}.`
+                                    : undefined,
+                                onDragEnd: ({ active, over }) => over
+                                    ? `Dropped ${active.id} at position ${labels.indexOf(String(over.id)) + 1} of ${labels.length}.`
+                                    : `Dropped ${active.id} back where it started.`,
+                                onDragCancel: ({ active }) => `Cancelled moving ${active.id}.`,
+                            },
+                        }}
+                        onDragEnd={handleDragEnd}
+                    >
+                        <SortableContext items={labels} strategy={verticalListSortingStrategy}>
+                            <div className="space-y-2">
+                                {labels.map((label, i) => (
+                                    <SortableSectionRow
+                                        key={label}
+                                        label={label}
+                                        position={i}
+                                        total={labels.length}
+                                        onMove={to => onChange(moveSectionLabel(labels, i, to))}
+                                    />
+                                ))}
+                            </div>
+                        </SortableContext>
+                    </DndContext>
+                </div>
+                <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex justify-end">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700"
+                    >
+                        Done
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/SectionOrderEditor.tsx
+++ b/src/components/SectionOrderEditor.tsx
@@ -32,6 +32,9 @@ import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 // Drags only ever move rows up and down the list.
 const restrictToVerticalAxis: Modifier = ({ transform }) => ({ ...transform, x: 0 })
 
+/** How many chips are drawn before the strip stops naming them. */
+const CHIP_LIMIT = 4
+
 /**
  * The order, at a glance, above the sections it describes.
  *
@@ -42,11 +45,14 @@ const restrictToVerticalAxis: Modifier = ({ transform }) => ({ ...transform, x: 
  * rather than read. Under two sections there is no order to show and nothing to
  * arrange, so it says nothing at all.
  *
- * The chips scroll sideways rather than wrapping. Wrapping cost five lines
- * above the first question on a phone, for something read once and then
- * ignored; one line is what a strip introducing the page below it can afford,
- * whatever the width. Nothing is hidden from a screen reader by that — every
- * chip is in the document, and each says its position.
+ * On a phone the chips give way to the same names as one truncated line. Nine
+ * chips wrap to five lines at 390px, which is a lot of screen for something
+ * read once — but the reason it is not simply a sideways-scrolling row of chips
+ * instead is worse than cosmetic: a scrollable element wider than the screen
+ * makes Chrome widen the *layout viewport* to fit its content, and every
+ * `position: fixed` overlay on the page — this one, and the item reorganiser —
+ * is then laid out against that width and lands off-screen. Truncation clips
+ * without scrolling, so it cannot do that.
  */
 export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onEdit }: {
     labels: string[]
@@ -54,19 +60,21 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
     onEdit?: () => void
 }) {
     if (labels.length < 2) return null
+    const shown = labels.slice(0, CHIP_LIMIT)
+    const hidden = labels.length - shown.length
     return (
         <div className="flex items-center gap-2 mb-4">
             {/* On a phone the caption costs a third of the row it introduces,
-                and the coloured chips beside a "Reorder" button say what it
-                would have said. Still read out, just not drawn. */}
+                and the names beside a "Reorder" button say what it would have
+                said. Still read out, just not drawn. */}
             <span className="sr-only sm:not-sr-only sm:text-xs sm:text-gray-400 sm:shrink-0">List order</span>
-            <div className="flex items-center gap-1.5 flex-1 min-w-0 overflow-x-auto py-0.5">
-                {labels.map((label, i) => {
+            <div className="hidden sm:flex sm:flex-wrap sm:items-center sm:gap-1.5 sm:min-w-0">
+                {shown.map((label, i) => {
                     const accent = sectionAccent(label, false)
                     return (
                         <span
                             key={label}
-                            className={`inline-flex items-center gap-1 shrink-0 whitespace-nowrap rounded-full border ${accent.border} ${accent.header} pl-1.5 pr-2 py-0.5 text-[11px] ${accent.text}`}
+                            className={`inline-flex items-center gap-1 whitespace-nowrap rounded-full border ${accent.border} ${accent.header} pl-1.5 pr-2 py-0.5 text-[11px] ${accent.text}`}
                         >
                             <span className={`w-1.5 h-1.5 rounded-full ${accent.rail}`} aria-hidden="true" />
                             <span className="sr-only">{`${i + 1}. `}</span>
@@ -74,15 +82,22 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
                         </span>
                     )
                 })}
+                {hidden > 0 && <span className="text-[11px] text-gray-400">+{hidden} more</span>}
             </div>
+            <span className="sm:hidden flex-1 min-w-0 truncate text-[11px] text-gray-400">
+                {labels.join(' · ')}
+            </span>
             {onEdit && (
                 <button
                     type="button"
                     onClick={onEdit}
                     aria-label="Reorder sections"
-                    className="inline-flex items-center gap-1 shrink-0 text-[11px] font-medium rounded-full px-2 py-1 text-primary-600 hover:bg-primary-50 transition-colors"
+                    // A full-size touch target, like every other control the
+                    // page expects a thumb to find. At the strip's own scale it
+                    // was 24px tall, and missing it looked like a dead button.
+                    className="inline-flex items-center justify-center gap-1 shrink-0 h-11 px-3 text-[11px] font-medium rounded-lg text-primary-600 hover:bg-primary-50 active:bg-primary-100 transition-colors"
                 >
-                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
                     </svg>
                     Reorder
@@ -190,7 +205,7 @@ export function SectionOrderModal({ labels, onChange, onClose }: {
                 <div className="p-5 border-b border-gray-100 flex-shrink-0">
                     <h2 className="text-lg font-semibold text-gray-900">Reorder sections</h2>
                     <p className="mt-0.5 text-sm text-gray-500">
-                        The order your packing lists are grouped in. Applies to lists you create from now on.
+                        The order your packing lists are grouped in — every list, including the ones you already have.
                     </p>
                 </div>
                 <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">

--- a/src/create-packing-list/types.ts
+++ b/src/create-packing-list/types.ts
@@ -21,14 +21,9 @@ export interface PackingList {
     // back to reconstructing the inputs from their items' question/option ids.
     questionAnswers?: Array<{ questionId: string; selectedOptionIds: string[] }>
     selectedPeopleIds?: string[]
-    // The order this list's sections are shown in, copied from the question set
-    // at generation time (see `section-order.ts`). Stamped on the list rather
-    // than read live from the question set so that a list shared from someone
-    // else's pod arrives in the order its owner arranged, and so that changing
-    // the order later doesn't reshuffle a list somebody is packing from.
-    // Absent — as on every list generated before this existed, and on any set
-    // whose owner never chose an order — means the `CATEGORY_ORDER` default.
-    sectionOrder?: string[]
+    // A list deliberately carries no section order of its own: the order lives
+    // on the question set and is read live when the list is shown, so that
+    // changing it reaches every list at once. See `useSectionOrder`.
 }
 
 export interface PackingListItem {

--- a/src/create-packing-list/types.ts
+++ b/src/create-packing-list/types.ts
@@ -21,6 +21,14 @@ export interface PackingList {
     // back to reconstructing the inputs from their items' question/option ids.
     questionAnswers?: Array<{ questionId: string; selectedOptionIds: string[] }>
     selectedPeopleIds?: string[]
+    // The order this list's sections are shown in, copied from the question set
+    // at generation time (see `section-order.ts`). Stamped on the list rather
+    // than read live from the question set so that a list shared from someone
+    // else's pod arrives in the order its owner arranged, and so that changing
+    // the order later doesn't reshuffle a list somebody is packing from.
+    // Absent — as on every list generated before this existed, and on any set
+    // whose owner never chose an order — means the `CATEGORY_ORDER` default.
+    sectionOrder?: string[]
 }
 
 export interface PackingListItem {

--- a/src/edit-questions/section-order.test.ts
+++ b/src/edit-questions/section-order.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest'
+import { ALWAYS_NEEDED_CATEGORY, CATEGORIES } from './item-sections'
+import { moveSectionLabel, orderedSectionLabels, reconcileSectionOrder, sectionLabelsOf } from './section-order'
+import type { Item, PackingListQuestionSet, Option, SavedQuestion } from './types'
+
+function item(text: string, category?: string, order?: number): Item {
+    return { id: `item-${text}`, text, personSelections: [], ...(category ? { category } : {}), ...(order !== undefined ? { order } : {}) }
+}
+
+function option(overrides: Partial<Option> & { id: string }): Option {
+    return { text: 'Yes', order: 0, items: [], ...overrides }
+}
+
+function question(overrides: Partial<SavedQuestion> & { id: string }): SavedQuestion {
+    return { type: 'saved', text: 'A question?', order: 0, options: [], ...overrides }
+}
+
+function questionSet(overrides: Partial<PackingListQuestionSet> = {}): PackingListQuestionSet {
+    return { people: [], alwaysNeededItems: [], questions: [], ...overrides }
+}
+
+describe('sectionLabelsOf', () => {
+    it('lists the always-needed default when uncategorised items are there', () => {
+        const qs = questionSet({ alwaysNeededItems: [item('Passport')] })
+        expect(sectionLabelsOf(qs)).toEqual([ALWAYS_NEEDED_CATEGORY])
+    })
+
+    it('lists each section an item names for itself', () => {
+        const qs = questionSet({
+            alwaysNeededItems: [item('Toothbrush', CATEGORIES.toiletries), item('Socks', CATEGORIES.clothes)],
+        })
+        expect(sectionLabelsOf(qs)).toEqual([CATEGORIES.toiletries, CATEGORIES.clothes])
+    })
+
+    it('falls back to the option text for uncategorised items under a multiple-choice question', () => {
+        const qs = questionSet({
+            questions: [question({
+                id: 'q1',
+                questionType: 'multiple-choice',
+                options: [option({ id: 'o1', text: 'Beach', items: [item('Towel')] })],
+            })],
+        })
+        expect(sectionLabelsOf(qs)).toEqual(['Beach'])
+    })
+
+    it('falls back to the question text for uncategorised items under a single-choice question', () => {
+        const qs = questionSet({
+            questions: [question({
+                id: 'q1',
+                text: 'Camping?',
+                options: [option({ id: 'o1', items: [item('Tent')] })],
+            })],
+        })
+        expect(sectionLabelsOf(qs)).toEqual(['Camping?'])
+    })
+
+    it('includes sections that have been created but have nothing in them yet', () => {
+        const qs = questionSet({
+            alwaysNeededItems: [item('Passport')],
+            alwaysNeededEmptySections: ['Beach kit'],
+        })
+        expect(sectionLabelsOf(qs)).toEqual([ALWAYS_NEEDED_CATEGORY, 'Beach kit'])
+    })
+
+    it('names each section once however many questions it spans', () => {
+        const qs = questionSet({
+            alwaysNeededItems: [item('Toothbrush', CATEGORIES.toiletries)],
+            questions: [question({
+                id: 'q1',
+                options: [option({ id: 'o1', items: [item('Shampoo', CATEGORIES.toiletries)] })],
+            })],
+        })
+        expect(sectionLabelsOf(qs)).toEqual([CATEGORIES.toiletries])
+    })
+
+    it('orders template sections the way the packing list does, whatever the question order', () => {
+        const qs = questionSet({
+            questions: [
+                question({
+                    id: 'q1',
+                    order: 0,
+                    options: [option({ id: 'o1', items: [item('Tent', CATEGORIES.kit)] })],
+                }),
+                question({
+                    id: 'q2',
+                    order: 1,
+                    options: [option({ id: 'o2', items: [item('Passport', CATEGORIES.documents)] })],
+                }),
+            ],
+        })
+        expect(sectionLabelsOf(qs)).toEqual([CATEGORIES.documents, CATEGORIES.kit])
+    })
+
+    it('puts sections it has no opinion about after the template ones, in question order', () => {
+        const qs = questionSet({
+            questions: [
+                question({
+                    id: 'q1',
+                    order: 1,
+                    options: [option({ id: 'o1', items: [item('Board games', 'Rainy day')] })],
+                }),
+                question({
+                    id: 'q2',
+                    order: 0,
+                    options: [option({ id: 'o2', items: [item('Surfboard', 'Surf')] })],
+                }),
+            ],
+            alwaysNeededItems: [item('Passport', CATEGORIES.documents)],
+        })
+        expect(sectionLabelsOf(qs)).toEqual([CATEGORIES.documents, 'Surf', 'Rainy day'])
+    })
+
+    it('ignores deleted questions and deleted items', () => {
+        const qs = questionSet({
+            alwaysNeededItems: [{ ...item('Old', 'Gone'), deletedAt: '2025-01-01T00:00:00.000Z' }],
+            questions: [
+                question({
+                    id: 'q1',
+                    deletedAt: '2025-01-01T00:00:00.000Z',
+                    options: [option({ id: 'o1', items: [item('Removed', 'Also gone')] })],
+                }),
+            ],
+        })
+        expect(sectionLabelsOf(qs)).toEqual([])
+    })
+})
+
+describe('orderedSectionLabels', () => {
+    const qs = questionSet({
+        alwaysNeededItems: [
+            item('Passport', CATEGORIES.documents),
+            item('Toothbrush', CATEGORIES.toiletries),
+            item('Socks', CATEGORIES.clothes),
+        ],
+    })
+
+    it('uses the default order when the user has not chosen one', () => {
+        expect(orderedSectionLabels(qs)).toEqual(sectionLabelsOf(qs))
+    })
+
+    it('follows the stored order', () => {
+        const ordered = orderedSectionLabels({
+            ...qs,
+            sectionOrder: [CATEGORIES.clothes, CATEGORIES.documents, CATEGORIES.toiletries],
+        })
+        expect(ordered).toEqual([CATEGORIES.clothes, CATEGORIES.documents, CATEGORIES.toiletries])
+    })
+
+    it('puts a section the stored order has never seen at the end', () => {
+        const ordered = orderedSectionLabels({
+            ...qs,
+            sectionOrder: [CATEGORIES.clothes, CATEGORIES.documents],
+        })
+        expect(ordered).toEqual([CATEGORIES.clothes, CATEGORIES.documents, CATEGORIES.toiletries])
+    })
+
+    it('ignores stored names whose section no longer exists', () => {
+        const ordered = orderedSectionLabels({
+            ...qs,
+            sectionOrder: ['Long gone', CATEGORIES.clothes, CATEGORIES.documents, CATEGORIES.toiletries],
+        })
+        expect(ordered).toEqual([CATEGORIES.clothes, CATEGORIES.documents, CATEGORIES.toiletries])
+    })
+})
+
+describe('reconcileSectionOrder', () => {
+    const stored = ['Essentials', 'Toiletries', 'Clothes']
+
+    it('leaves an order alone when the sections are unchanged', () => {
+        expect(reconcileSectionOrder(stored, stored, [...stored])).toEqual(stored)
+    })
+
+    it('keeps a renamed section in the slot the user put it in', () => {
+        const after = ['Essentials', 'Wash bag', 'Clothes']
+        expect(reconcileSectionOrder(stored, stored, after)).toEqual(['Essentials', 'Wash bag', 'Clothes'])
+    })
+
+    it('leaves a removed section in place, so undoing the removal restores its slot', () => {
+        expect(reconcileSectionOrder(stored, stored, ['Essentials', 'Clothes'])).toEqual(stored)
+    })
+
+    it('does not guess when several sections changed at once', () => {
+        const after = ['Essentials', 'Wash bag', 'Outfits']
+        expect(reconcileSectionOrder(stored, stored, after)).toEqual(stored)
+    })
+
+    it('has nothing to do when the user has chosen no order', () => {
+        expect(reconcileSectionOrder(undefined, stored, ['Essentials'])).toBeUndefined()
+    })
+})
+
+describe('moveSectionLabel', () => {
+    const labels = ['Documents', 'Toiletries', 'Clothes']
+
+    it('moves a section up', () => {
+        expect(moveSectionLabel(labels, 2, 1)).toEqual(['Documents', 'Clothes', 'Toiletries'])
+    })
+
+    it('moves a section down', () => {
+        expect(moveSectionLabel(labels, 0, 2)).toEqual(['Toiletries', 'Clothes', 'Documents'])
+    })
+
+    it('leaves the list alone when the move goes nowhere', () => {
+        expect(moveSectionLabel(labels, 1, 1)).toBe(labels)
+    })
+
+    it('leaves the list alone when the move goes off the end', () => {
+        expect(moveSectionLabel(labels, 2, 3)).toBe(labels)
+        expect(moveSectionLabel(labels, 0, -1)).toBe(labels)
+    })
+})

--- a/src/edit-questions/section-order.ts
+++ b/src/edit-questions/section-order.ts
@@ -1,0 +1,130 @@
+/**
+ * The order the sections of a generated packing list come in.
+ *
+ * A section spans questions — "Toiletries" is filled by the always-needed list
+ * and by two options besides — so its position cannot be read off any one
+ * question, and dragging items around inside a question is the wrong gesture
+ * for moving a whole section. Until this existed, the order came from
+ * `CATEGORY_ORDER`: a constant, which no user could change, and which pinned
+ * every section the built-in template ships ahead of every section a user
+ * named. Renaming a section out of that list was the only way to move it.
+ *
+ * So the order is stored as its own thing — `PackingListQuestionSet.sectionOrder`,
+ * a plain list of section names, independent of the questions — and edited in
+ * one place on the questions page. It stays a *preference*, not a schema: names
+ * it doesn't mention still appear (at the end), and names it mentions that no
+ * longer exist are ignored rather than pruned, so a section that is briefly
+ * empty doesn't lose the slot the user put it in.
+ *
+ * `CATEGORY_ORDER` keeps its job as the default. A set with no stored order
+ * behaves exactly as it did before, down to the field being absent from the
+ * document.
+ */
+import { ALWAYS_NEEDED_CATEGORY, CATEGORY_ORDER, defaultCategoryFor } from './item-sections'
+import type { Item, PackingListQuestionSet } from './types'
+
+/** Explicit order wins; items without one keep their array position. */
+function inItemOrder(items: Item[]): Item[] {
+    return items
+        .map((item, index) => ({ item, key: item.order ?? index }))
+        .sort((a, b) => a.key - b.key)
+        .map(({ item }) => item)
+}
+
+function byOrder<T extends { order: number }>(a: T, b: T): number {
+    return a.order - b.order
+}
+
+function isActive(item: Item): boolean {
+    return !item.deletedAt
+}
+
+/**
+ * Every section a generated list can show, in the order it would show them
+ * were the user to express no preference.
+ *
+ * The walk mirrors `generatePackingListItems` — questions by their order, then
+ * options, then items, with the always-needed list last, because that is the
+ * order the two halves are concatenated in when a list is built. That walk
+ * decides where a section a user named lands; sections the template ships are
+ * then lifted to the front in `CATEGORY_ORDER`, which is what the packing list
+ * view does today and so what "no preference" has to keep meaning.
+ */
+export function sectionLabelsOf(qs: PackingListQuestionSet): string[] {
+    const labels: string[] = []
+    const add = (label: string) => {
+        if (label && !labels.includes(label)) labels.push(label)
+    }
+
+    const addItemList = (items: Item[], fallback: string) => {
+        for (const item of inItemOrder(items.filter(isActive))) add(item.category ?? fallback)
+    }
+
+    for (const question of [...(qs.questions ?? [])].filter(q => !q.deletedAt).sort(byOrder)) {
+        for (const option of [...question.options].sort(byOrder)) {
+            addItemList(option.items, defaultCategoryFor(question, option))
+            for (const label of option.emptySections ?? []) add(label)
+        }
+    }
+
+    addItemList(qs.alwaysNeededItems ?? [], ALWAYS_NEEDED_CATEGORY)
+    for (const label of qs.alwaysNeededEmptySections ?? []) add(label)
+
+    // A stable sort by rank alone: labels `CATEGORY_ORDER` says nothing about
+    // share the last rank and so keep the discovery order above.
+    const rank = (label: string) => {
+        const index = CATEGORY_ORDER.indexOf(label)
+        return index === -1 ? CATEGORY_ORDER.length : index
+    }
+    return labels
+        .map((label, index) => ({ label, index }))
+        .sort((a, b) => (rank(a.label) - rank(b.label)) || (a.index - b.index))
+        .map(({ label }) => label)
+}
+
+/**
+ * The section order in effect: what the questions page shows, and what a new
+ * list is stamped with.
+ *
+ * Stored names that no longer name a section are dropped, and sections the
+ * stored order has never seen are appended in their default order — a new
+ * section goes last until the user moves it, rather than appearing somewhere
+ * they didn't put it.
+ */
+export function orderedSectionLabels(qs: PackingListQuestionSet): string[] {
+    const all = sectionLabelsOf(qs)
+    if (!qs.sectionOrder?.length) return all
+    const stored = qs.sectionOrder.filter(label => all.includes(label))
+    return [...stored, ...all.filter(label => !stored.includes(label))]
+}
+
+/** Move the entry at `from` to `to`, leaving the rest in order. */
+export function moveSectionLabel(labels: string[], from: number, to: number): string[] {
+    if (from === to || from < 0 || to < 0 || from >= labels.length || to >= labels.length) return labels
+    const next = [...labels]
+    const [moved] = next.splice(from, 1)
+    next.splice(to, 0, moved)
+    return next
+}
+
+/**
+ * Keep a stored order in step with an edit that changed which sections exist.
+ *
+ * The case that matters is a rename: the section is the same section, so it
+ * must keep the slot the user chose for it, but a rename reaches this code as
+ * nothing more than one name disappearing while another appears. That is the
+ * only shape acted on. Anything less clear-cut is left alone — a name whose
+ * section is gone costs nothing (`orderedSectionLabels` ignores it) and keeping
+ * it means removing a section by accident doesn't also lose its position.
+ */
+export function reconcileSectionOrder(
+    stored: string[] | undefined,
+    before: string[],
+    after: string[],
+): string[] | undefined {
+    if (!stored?.length) return undefined
+    const gone = before.filter(label => !after.includes(label))
+    const fresh = after.filter(label => !before.includes(label))
+    if (gone.length !== 1 || fresh.length !== 1) return stored
+    return stored.map(label => label === gone[0] ? fresh[0] : label)
+}

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -146,6 +146,10 @@ export const PackingListQuestionSetSchema = z.object({
   // `emptySections`, for the one item list that doesn't belong to an option.
   alwaysNeededEmptySections: z.array(z.string()).optional(),
   questions: z.array(QuestionSchema),
+  // The order the sections of a generated packing list come in — see
+  // `section-order.ts`. Optional and additive: absent means the built-in
+  // `CATEGORY_ORDER` default, which is what every set had before this existed.
+  sectionOrder: z.array(z.string()).optional(),
   lastModified: z.string().optional(), // ISO timestamp for sync conflict resolution
   // Version of the wizard template this set was generated from / last
   // reconciled against. Absent means pre-versioning (treated as 0), so the

--- a/src/hooks/useBodyScrollLock.ts
+++ b/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+
+/**
+ * Lock background page scroll while a modal is open.
+ *
+ * Besides being correct modal behaviour, it is what keeps the page — and on a
+ * phone the browser's URL bar — from moving while a drag is happening inside.
+ * A moving URL bar resizes the viewport, which moves every row the drag has
+ * already measured, mid-gesture.
+ */
+export function useBodyScrollLock() {
+    useEffect(() => {
+        const body = document.body
+        const html = document.documentElement
+        const previous = {
+            body: body.style.overflow,
+            html: html.style.overflow,
+            overscroll: body.style.overscrollBehavior,
+        }
+        // Both: the scrolling element is <body> on some browsers and <html> on
+        // others (notably mobile). Chaining is stopped too.
+        body.style.overflow = 'hidden'
+        html.style.overflow = 'hidden'
+        body.style.overscrollBehavior = 'none'
+        return () => {
+            body.style.overflow = previous.body
+            html.style.overflow = previous.html
+            body.style.overscrollBehavior = previous.overscroll
+        }
+    }, [])
+}

--- a/src/hooks/useSectionOrder.test.ts
+++ b/src/hooks/useSectionOrder.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useSectionOrder } from './useSectionOrder'
+import { CATEGORY_ORDER } from '../edit-questions/item-sections'
+import type { PackingListQuestionSet } from '../edit-questions/types'
+import type { PackingAppDatabase } from '../services/database'
+
+const questionSet = (overrides: Partial<PackingListQuestionSet> = {}): PackingListQuestionSet => ({
+    people: [],
+    alwaysNeededItems: [
+        { text: 'Passport', personSelections: [], category: 'Documents & Money' },
+        { text: 'Socks', personSelections: [], category: 'Clothes' },
+    ],
+    questions: [],
+    ...overrides,
+})
+
+const dbReturning = (result: Promise<PackingListQuestionSet>) =>
+    ({ getQuestionSet: vi.fn().mockReturnValue(result) }) as unknown as PackingAppDatabase
+
+describe('useSectionOrder', () => {
+    it('uses the built-in default before the question set has loaded', () => {
+        const { result } = renderHook(() => useSectionOrder(dbReturning(new Promise(() => {}))))
+        expect(result.current).toBe(CATEGORY_ORDER)
+    })
+
+    it('follows the order the user arranged', async () => {
+        const { result } = renderHook(() => useSectionOrder(dbReturning(
+            Promise.resolve(questionSet({ sectionOrder: ['Clothes', 'Documents & Money'] })))))
+        await waitFor(() => expect(result.current).toEqual(['Clothes', 'Documents & Money']))
+    })
+
+    // Not the labels this set happens to contain: an unarranged set has always
+    // grouped its lists by the built-in default, and must keep doing so.
+    it('keeps the built-in default when no order has been arranged', async () => {
+        const { result } = renderHook(() => useSectionOrder(dbReturning(Promise.resolve(questionSet()))))
+        await waitFor(() => expect(result.current).toBe(CATEGORY_ORDER))
+    })
+
+    it('falls back to the default when there is no question set to read', async () => {
+        const { result } = renderHook(() => useSectionOrder(dbReturning(Promise.reject(new Error('missing')))))
+        await waitFor(() => expect(result.current).toBe(CATEGORY_ORDER))
+    })
+
+    it('does nothing without a database', () => {
+        const { result } = renderHook(() => useSectionOrder(undefined))
+        expect(result.current).toBe(CATEGORY_ORDER)
+    })
+})

--- a/src/hooks/useSectionOrder.ts
+++ b/src/hooks/useSectionOrder.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import { CATEGORY_ORDER } from '../edit-questions/item-sections'
+import { orderedSectionLabels } from '../edit-questions/section-order'
+import type { PackingAppDatabase } from '../services/database'
+
+/**
+ * The order to group a packing list's sections in: the one setting on the
+ * questions page, read live.
+ *
+ * Live rather than copied onto each list at generation, because the setting is
+ * global — it is a statement about how this person wants *every* list grouped,
+ * including the ones they already have. A copy would freeze each list at the
+ * order in force the day it was made, so fixing the order would only ever fix
+ * the next trip, and the list already open in front of you would stay wrong.
+ *
+ * That applies to a list shared from someone else's pod too: you are looking at
+ * it, so it is grouped the way you asked for. Sections their question set has
+ * and yours doesn't are not in the order at all, and fall in after the ones
+ * that are — the same way any unlisted section does.
+ *
+ * Falls back to the built-in default until the question set has loaded, and for
+ * anyone who has never arranged their sections.
+ */
+export function useSectionOrder(db: PackingAppDatabase | undefined): readonly string[] {
+    const [sectionOrder, setSectionOrder] = useState<readonly string[]>(CATEGORY_ORDER)
+
+    useEffect(() => {
+        if (!db) return
+        let cancelled = false
+        Promise.resolve()
+            .then(() => db.getQuestionSet())
+            .then(questionSet => {
+                if (cancelled) return
+                // No stored order means no preference, and the built-in default
+                // is what the list has always used — not the labels this set
+                // happens to contain in the order they were found.
+                setSectionOrder(questionSet.sectionOrder?.length
+                    ? orderedSectionLabels(questionSet)
+                    : CATEGORY_ORDER)
+            })
+            .catch(() => { if (!cancelled) setSectionOrder(CATEGORY_ORDER) })
+        return () => { cancelled = true }
+    }, [db])
+
+    return sectionOrder
+}

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -685,56 +685,6 @@ describe('CreatePackingList – pod sync on creation', () => {
     })
 })
 
-describe('CreatePackingList – section order stamped on the new list', () => {
-    beforeEach(() => {
-        vi.clearAllMocks()
-        mockUseSolidPod.mockReturnValue({ isLoggedIn: false } as ReturnType<typeof useSolidPod>)
-        mockUseToast.mockReturnValue({ showToast: vi.fn() } as ReturnType<typeof useToast>)
-    })
-
-    afterEach(() => {
-        cleanup()
-    })
-
-    const createListWith = async (questionSet: PackingListQuestionSet) => {
-        const db = makeDb({
-            getQuestionSet: vi.fn().mockResolvedValue(questionSet),
-            getAllPackingLists: vi.fn().mockResolvedValue([]),
-        })
-        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
-
-        renderCreatePackingList()
-        await waitFor(() => screen.getByText(/Answer the questions below/i))
-        fireEvent.change(screen.getByPlaceholderText(/enter a name/i), { target: { value: 'Trip' } })
-        fireEvent.click(screen.getByRole('radio', { name: /beach/i }))
-        fireEvent.click(screen.getByRole('button', { name: /create packing list/i }))
-
-        await waitFor(() => expect(vi.mocked(db.savePackingList)).toHaveBeenCalled())
-        return vi.mocked(db.savePackingList).mock.calls[0][0] as PackingList
-    }
-
-    // The list carries its own copy so it stays in the order its owner arranged
-    // even when it is read from someone else's pod, or after the order changes.
-    it('copies the order the owner arranged', async () => {
-        const saved = await createListWith({
-            ...testQuestionSet,
-            alwaysNeededItems: [
-                { text: 'Passport', personSelections: [], category: 'Documents & Money' },
-                { text: 'Socks', personSelections: [], category: 'Clothes' },
-            ],
-            sectionOrder: ['Clothes', 'Documents & Money'],
-        })
-        expect(saved.sectionOrder).toEqual(['Clothes', 'Documents & Money'])
-    })
-
-    // Freezing the default into data would mean a later change to the default
-    // could never reach a list again.
-    it('leaves the field off when the owner never arranged one', async () => {
-        const saved = await createListWith(testQuestionSet)
-        expect(saved.sectionOrder).toBeUndefined()
-    })
-})
-
 // ─── getUnreviewedDeletedItems ────────────────────────────────────────────────
 
 const makeDeletedItem = (overrides: Partial<PackingListItem> = {}): PackingListItem => ({

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -685,6 +685,56 @@ describe('CreatePackingList – pod sync on creation', () => {
     })
 })
 
+describe('CreatePackingList – section order stamped on the new list', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({ isLoggedIn: false } as ReturnType<typeof useSolidPod>)
+        mockUseToast.mockReturnValue({ showToast: vi.fn() } as ReturnType<typeof useToast>)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    const createListWith = async (questionSet: PackingListQuestionSet) => {
+        const db = makeDb({
+            getQuestionSet: vi.fn().mockResolvedValue(questionSet),
+            getAllPackingLists: vi.fn().mockResolvedValue([]),
+        })
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+        fireEvent.change(screen.getByPlaceholderText(/enter a name/i), { target: { value: 'Trip' } })
+        fireEvent.click(screen.getByRole('radio', { name: /beach/i }))
+        fireEvent.click(screen.getByRole('button', { name: /create packing list/i }))
+
+        await waitFor(() => expect(vi.mocked(db.savePackingList)).toHaveBeenCalled())
+        return vi.mocked(db.savePackingList).mock.calls[0][0] as PackingList
+    }
+
+    // The list carries its own copy so it stays in the order its owner arranged
+    // even when it is read from someone else's pod, or after the order changes.
+    it('copies the order the owner arranged', async () => {
+        const saved = await createListWith({
+            ...testQuestionSet,
+            alwaysNeededItems: [
+                { text: 'Passport', personSelections: [], category: 'Documents & Money' },
+                { text: 'Socks', personSelections: [], category: 'Clothes' },
+            ],
+            sectionOrder: ['Clothes', 'Documents & Money'],
+        })
+        expect(saved.sectionOrder).toEqual(['Clothes', 'Documents & Money'])
+    })
+
+    // Freezing the default into data would mean a later change to the default
+    // could never reach a list again.
+    it('leaves the field off when the owner never arranged one', async () => {
+        const saved = await createListWith(testQuestionSet)
+        expect(saved.sectionOrder).toBeUndefined()
+    })
+})
+
 // ─── getUnreviewedDeletedItems ────────────────────────────────────────────────
 
 const makeDeletedItem = (overrides: Partial<PackingListItem> = {}): PackingListItem => ({

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -15,7 +15,6 @@ import { usePodSync } from '../hooks/usePodSync'
 import { questionSetToDataset, datasetToQuestionSet, packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { useForeignPod } from '../components/ForeignPodContext'
 import { generateQuestionBasedItems, generateAlwaysNeededItems, withItemOrder } from '../create-packing-list/generatePackingListItems'
-import { orderedSectionLabels } from '../edit-questions/section-order'
 import { AgePromotionCard } from '../components/AgePromotionCard'
 import { LoadingState } from '../components/LoadingState'
 import { tripDatesOutOfOrder } from '../create-packing-list/tripDetails'
@@ -610,19 +609,14 @@ export function CreatePackingList() {
             }))
             .filter(qa => qa.questionId && qa.selectedOptionIds.length > 0)
 
-        // Only when the owner has actually arranged their sections. Stamping the
-        // default on every list instead would freeze today's ordering into data,
-        // and then a change to the default could never reach a list again.
-        const sectionOrder = questionSet.sectionOrder?.length
-            ? orderedSectionLabels(questionSet)
-            : undefined
-
+        // No section order is recorded here on purpose: it belongs to the
+        // question set and is read live when the list is shown, so that
+        // changing it reaches every list at once. See `useSectionOrder`.
         const packingList: PackingList = {
             id: crypto.randomUUID(),
             name: data.name,
             createdAt: new Date().toISOString(),
             lastModified: new Date().toISOString(),
-            ...(sectionOrder !== undefined ? { sectionOrder } : {}),
             ...(nights !== undefined ? { nights } : {}),
             ...(destination !== undefined ? { destination } : {}),
             ...(startDate !== undefined ? { startDate } : {}),

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -15,6 +15,7 @@ import { usePodSync } from '../hooks/usePodSync'
 import { questionSetToDataset, datasetToQuestionSet, packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { useForeignPod } from '../components/ForeignPodContext'
 import { generateQuestionBasedItems, generateAlwaysNeededItems, withItemOrder } from '../create-packing-list/generatePackingListItems'
+import { orderedSectionLabels } from '../edit-questions/section-order'
 import { AgePromotionCard } from '../components/AgePromotionCard'
 import { LoadingState } from '../components/LoadingState'
 import { tripDatesOutOfOrder } from '../create-packing-list/tripDetails'
@@ -609,11 +610,19 @@ export function CreatePackingList() {
             }))
             .filter(qa => qa.questionId && qa.selectedOptionIds.length > 0)
 
+        // Only when the owner has actually arranged their sections. Stamping the
+        // default on every list instead would freeze today's ordering into data,
+        // and then a change to the default could never reach a list again.
+        const sectionOrder = questionSet.sectionOrder?.length
+            ? orderedSectionLabels(questionSet)
+            : undefined
+
         const packingList: PackingList = {
             id: crypto.randomUUID(),
             name: data.name,
             createdAt: new Date().toISOString(),
             lastModified: new Date().toISOString(),
+            ...(sectionOrder !== undefined ? { sectionOrder } : {}),
             ...(nights !== undefined ? { nights } : {}),
             ...(destination !== undefined ? { destination } : {}),
             ...(startDate !== undefined ? { startDate } : {}),

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -2,7 +2,10 @@ import { useState, useEffect, useCallback, useId, useRef, useMemo, memo, Fragmen
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useDatabase } from '../components/DatabaseContext'
 import { SectionedItemReorder } from '../components/SectionedItemReorder'
+import { SectionOrderLegend, SectionOrderModal } from '../components/SectionOrderEditor'
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 import { ALWAYS_NEEDED_CATEGORY, addEmptySection, buildSectionGroups, defaultCategoryFor, reconcileEmptySections, sectionNamesIn, type PositionedItem } from '../edit-questions/item-sections'
+import { orderedSectionLabels, reconcileSectionOrder, sectionLabelsOf } from '../edit-questions/section-order'
 import { sectionAccent } from '../edit-questions/section-accent'
 import { DatabaseMigration } from '../services/migration'
 import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, newDraftQuestion, renumberItemOrder, AGE_RANGE_OPTIONS } from '../edit-questions/types'
@@ -160,36 +163,6 @@ const LIST_COMPOSER = '__list__'
 /** How long a reorder rests before it is written. Long enough to absorb a run
  *  of drags, short enough that walking away from the screen still saves. */
 const REORDER_SAVE_DELAY_MS = 600
-
-/**
- * Lock background page scroll while a modal is open.
- *
- * Besides being correct modal behaviour, it is what keeps the page — and on a
- * phone the browser's URL bar — from moving while a drag is happening inside.
- * A moving URL bar resizes the viewport, which moves every row the drag has
- * already measured, mid-gesture.
- */
-function useBodyScrollLock() {
-    useEffect(() => {
-        const body = document.body
-        const html = document.documentElement
-        const previous = {
-            body: body.style.overflow,
-            html: html.style.overflow,
-            overscroll: body.style.overscrollBehavior,
-        }
-        // Both: the scrolling element is <body> on some browsers and <html> on
-        // others (notably mobile). Chaining is stopped too.
-        body.style.overflow = 'hidden'
-        html.style.overflow = 'hidden'
-        body.style.overscrollBehavior = 'none'
-        return () => {
-            body.style.overflow = previous.body
-            html.style.overflow = previous.html
-            body.style.overscrollBehavior = previous.overscroll
-        }
-    }, [])
-}
 
 /**
  * Reorganising an item list, as the only thing on the screen.
@@ -679,6 +652,25 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
 function withEmptySections(option: Option, emptySections: string[] | undefined): Option {
     const { emptySections: _dropped, ...rest } = option
     return emptySections?.length ? { ...rest, emptySections } : rest
+}
+
+/**
+ * Carry a chosen section order across an edit that renamed a section.
+ *
+ * Renaming happens inside the item reorder view, which reports its work back as
+ * a list of items and nothing else — so by the time it reaches the page, a
+ * rename is indistinguishable from any other change to which sections exist.
+ * Comparing the section names before and after is what recovers it; see
+ * `reconcileSectionOrder` for the (deliberately narrow) rule that applies.
+ */
+function withReconciledSectionOrder(
+    previous: PackingListQuestionSet,
+    next: PackingListQuestionSet,
+): PackingListQuestionSet {
+    if (!previous.sectionOrder?.length) return next
+    const sectionOrder = reconcileSectionOrder(
+        previous.sectionOrder, sectionLabelsOf(previous), sectionLabelsOf(next))
+    return sectionOrder === previous.sectionOrder ? next : { ...next, sectionOrder }
 }
 
 function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete: () => void }) {
@@ -1482,6 +1474,7 @@ export function QuestionsPage() {
     const [questionModal, setQuestionModal] = useState<{ question: Question | null } | null>(null)
     const [optionModal, setOptionModal] = useState<{ questionId: string; option: Option | null } | null>(null)
     const [peopleModal, setPeopleModal] = useState(false)
+    const [sectionOrderModal, setSectionOrderModal] = useState(false)
     // Bracket changes made by hand in the people modal; offered the same
     // item-review flow as birthday-driven transitions, then cleared.
     const [manualPromotions, setManualPromotions] = useState<AgeTransition[]>([])
@@ -1726,13 +1719,13 @@ export function QuestionsPage() {
         if (!data) return
         const now = new Date().toISOString()
         const items = renumberItemOrder(reordered, now)
-        await saveData({
+        await saveData(withReconciledSectionOrder(data, {
             ...data,
             questions: withQuestionOptions(data.questions, questionId, options =>
                 options.map(o => o.id === optionId
                     ? withEmptySections({ ...o, items }, emptySections)
                     : o), now),
-        })
+        }))
     }, [saveData])
 
     const handleAlwaysReorder = useCallback(async (reordered: Item[], emptySections: string[] | undefined) => {
@@ -1742,11 +1735,17 @@ export function QuestionsPage() {
         // The reorder view is given the active items, so the tombstones it never
         // saw are carried through rather than dropped.
         const deleted = (data.alwaysNeededItems ?? []).filter(i => i.deletedAt)
-        await saveData({
+        await saveData(withReconciledSectionOrder(data, {
             ...data,
             alwaysNeededItems: [...renumberItemOrder(reordered, now), ...deleted],
             alwaysNeededEmptySections: emptySections,
-        })
+        }))
+    }, [saveData])
+
+    const handleSectionOrderChange = useCallback(async (sectionOrder: string[]) => {
+        const data = dataRef.current
+        if (!data) return
+        await saveData({ ...data, sectionOrder })
     }, [saveData])
 
     const handleAlwaysItemDelete = useCallback(async (index: number) => {
@@ -1845,6 +1844,7 @@ export function QuestionsPage() {
     const openAddOption = useCallback((questionId: string) => setOptionModal({ questionId, option: null }), [])
     const openEditOption = useCallback((questionId: string, option: Option) => setOptionModal({ questionId, option }), [])
     const openPeopleModal = useCallback(() => setPeopleModal(true), [])
+    const openSectionOrderModal = useCallback(() => setSectionOrderModal(true), [])
 
     // The set as a dictionary of its own item names: what the add composers
     // offer as you type, and what the name fields offer as existing options.
@@ -1858,6 +1858,11 @@ export function QuestionsPage() {
     // suggestions so the same section spelled two ways doesn't split into two
     // groups on the packing list.
     const suggestedSectionNames = useMemo(() => data ? sectionNamesIn(data) : [], [data])
+
+    // Every section a generated list will show, in the order it will show them.
+    // Derived rather than stored as-is: the stored order is only a preference,
+    // and sections come and go underneath it as items are edited.
+    const sectionLabels = useMemo(() => data ? orderedSectionLabels(data) : [], [data])
 
     // Memoized so their identity is stable across re-renders that don't change
     // the data (modal opens, sync ticks) — they feed the memoized sections.
@@ -1892,6 +1897,7 @@ export function QuestionsPage() {
                 )}
                 {!isForeign && <TemplateUpdatesCard questionSet={data} onApply={saveData} />}
                 <PersonLegend people={people} onEdit={openPeopleModal} />
+                <SectionOrderLegend labels={sectionLabels} onEdit={openSectionOrderModal} />
                 <AlwaysSection
                     items={activeAlwaysNeededItems}
                     people={people}
@@ -1948,6 +1954,13 @@ export function QuestionsPage() {
                     option={optionModal.option}
                     onSave={handleOptionModalSave}
                     onClose={() => setOptionModal(null)}
+                />
+            )}
+            {sectionOrderModal && (
+                <SectionOrderModal
+                    labels={sectionLabels}
+                    onChange={handleSectionOrderChange}
+                    onClose={() => setSectionOrderModal(false)}
                 />
             )}
             {peopleModal && (

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1455,6 +1455,31 @@ describe('grouping honours generated item order', () => {
         expect(groups.map(g => g.label)).toEqual(['Essentials', 'Hiking', 'Beach', 'Other'])
     })
 
+    it('follows the list\'s own section order when it has one', () => {
+        const groups = groupByCategory([
+            mk({ itemText: 'Sunscreen', category: 'Essentials', order: 0 }),
+            mk({ itemText: 'Towel', category: 'Beach', order: 1 }),
+            mk({ itemText: 'Boots', category: 'Hiking', order: 2 }),
+        ], ['Hiking', 'Beach', 'Essentials'])
+        expect(groups.map(g => g.label)).toEqual(['Hiking', 'Beach', 'Essentials'])
+    })
+
+    it('keeps Other last even when the list has its own section order', () => {
+        const groups = groupByCategory([
+            mk({ itemText: 'Mystery', category: undefined, order: 0 }),
+            mk({ itemText: 'Boots', category: 'Hiking', order: 1 }),
+        ], ['Hiking'])
+        expect(groups.map(g => g.label)).toEqual(['Hiking', 'Other'])
+    })
+
+    it('puts a section the order says nothing about after the ones it names', () => {
+        const groups = groupByCategory([
+            mk({ itemText: 'Kite', category: 'Added by hand', order: 0 }),
+            mk({ itemText: 'Boots', category: 'Hiking', order: 1 }),
+        ], ['Hiking'])
+        expect(groups.map(g => g.label)).toEqual(['Hiking', 'Added by hand'])
+    })
+
     it('keeps legacy category ordering alphabetical when no items carry order', () => {
         const groups = groupByCategory([
             mk({ itemText: 'Towel', category: 'Beach' }),

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -27,6 +27,7 @@ import { tapFeedback } from '../utils/haptics'
 import { prefersReducedMotion } from '../utils/prefersReducedMotion'
 import { groupItemsByCategory, sortByOrder, type CategoryAccessors } from '../utils/groupByCategory'
 import { CATEGORY_ORDER } from '../edit-questions/item-sections'
+import { useSectionOrder } from '../hooks/useSectionOrder'
 import { AddItemComposer, UNCATEGORISED_LABEL, type AddItemTarget, type PersonOption } from '../components/AddItemComposer'
 import { buildSuggestionIndex } from '../utils/itemSuggestions'
 import { useIsDesktop } from '../hooks/useIsDesktop'
@@ -290,6 +291,10 @@ export function ViewPackingList() {
     const { isLoggedIn, session } = useSolidPod()
     const { showToast } = useToast()
     const { db } = useDatabase()
+    // Read from the question set on every visit, not copied onto the list when
+    // it was generated — the order is one global setting, so changing it has to
+    // reach the lists that already exist. See `useSectionOrder`.
+    const sectionOrder = useSectionOrder(db)
     const { sharedListsWithMe, saveSharedListsWithMe } = useSharedListsSync()
     const effectiveOwnerWebId = ownerWebIdFromUrl ?? packingList?.ownerWebId
     const ownerDisplayName = useOwnerDisplayName(foreignPodUrl, effectiveOwnerWebId, session)
@@ -358,11 +363,6 @@ export function ViewPackingList() {
         () => buildSuggestionIndex(packingList?.items ?? [], packingList?.deletedItems ?? []),
         [packingList?.items, packingList?.deletedItems],
     )
-
-    // The order this list shows its sections in, stamped on at generation from
-    // whatever its owner arranged on their questions page. A list from before
-    // that existed carries none and falls back to the built-in default.
-    const sectionOrder = packingList?.sectionOrder ?? CATEGORY_ORDER
 
     // The sections a new item can be filed into: the ones this list already
     // shows, in the order it shows them, plus the catch-all. Offering sections

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -107,10 +107,19 @@ function sortByItemOrder(items: PackingListItem[]): PackingListItem[] {
     return sortByOrder(items, PACKING_ITEM_ACCESSORS)
 }
 
-export function groupByCategory(items: PackingListItem[]) {
+/**
+ * `sectionOrder` is the list's own copy of the order its owner arranged their
+ * sections in (see `section-order.ts`). Lists generated before that existed —
+ * and lists whose owner never chose an order — pass nothing and get the
+ * built-in default, which is what every list used to get.
+ */
+export function groupByCategory(
+    items: PackingListItem[],
+    sectionOrder: readonly string[] = CATEGORY_ORDER,
+) {
     return groupItemsByCategory(items, PACKING_ITEM_ACCESSORS, {
         uncategorisedLabel: UNCATEGORISED_LABEL,
-        order: CATEGORY_ORDER,
+        order: sectionOrder,
         pinLast: UNCATEGORISED_LABEL,
     })
 }
@@ -350,14 +359,19 @@ export function ViewPackingList() {
         [packingList?.items, packingList?.deletedItems],
     )
 
+    // The order this list shows its sections in, stamped on at generation from
+    // whatever its owner arranged on their questions page. A list from before
+    // that existed carries none and falls back to the built-in default.
+    const sectionOrder = packingList?.sectionOrder ?? CATEGORY_ORDER
+
     // The sections a new item can be filed into: the ones this list already
     // shows, in the order it shows them, plus the catch-all. Offering sections
     // the list doesn't use would invent cards no one asked for — new sections
     // belong to the question set, where they can be arranged.
     const categoryOptions = useMemo(() => {
-        const labels = groupByCategory(packingList?.items ?? []).map(group => group.label)
+        const labels = groupByCategory(packingList?.items ?? [], sectionOrder).map(group => group.label)
         return labels.includes(UNCATEGORISED_LABEL) ? labels : [...labels, UNCATEGORISED_LABEL]
-    }, [packingList?.items])
+    }, [packingList?.items, sectionOrder])
 
     const peopleOptions = useMemo<PersonOption[]>(() => {
         const byName = new Map<string, string>()
@@ -1140,11 +1154,11 @@ export function ViewPackingList() {
         listSections = [...sharedSections, ...regularSections, ...guestSections]
     } else {
         const visibleByCategory = new Map(
-            groupByCategory(filteredItems.filter(i => !i.communal)).map(({ label, items }) => [label, items])
+            groupByCategory(filteredItems.filter(i => !i.communal), sectionOrder).map(({ label, items }) => [label, items])
         )
         // Categories come from every item, not just the visible ones, so a fully
         // packed category keeps its celebratory card instead of disappearing.
-        const categorySections: ListSection[] = groupByCategory(packingList.items.filter(i => !i.communal))
+        const categorySections: ListSection[] = groupByCategory(packingList.items.filter(i => !i.communal), sectionOrder)
             .filter(({ label }) => visibleByCategory.has(label) || isSectionComplete(categoryStats[label]))
             .map(({ label }) => ({
                 key: label,
@@ -1475,7 +1489,7 @@ export function ViewPackingList() {
                             const completeLabel = isShared ? 'shared items' : isCategorySection ? title : section.name
                             const collapseLabelTarget = isShared ? 'the shared items' : isCategorySection ? title : `${section.name}'s`
                             const innerGroups = (isShared || !isCategorySection)
-                                ? groupByCategory(items)
+                                ? groupByCategory(items, sectionOrder)
                                 : groupByPerson(items)
                             const isSectionCollapsed = collapsedSections.has(sectionKey)
                             return (

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -25,48 +25,6 @@ import type {
 } from '../edit-questions/types'
 import { AgeRangeSchema } from '../edit-questions/types'
 
-// ── Section order ─────────────────────────────────────────────────────────────
-
-/**
- * The section order, written as one Thing per name carrying its position.
- *
- * Every other repeated string in this file (`emptySections`, `selectedPersonId`)
- * is a set, and is read back sorted because RDF gives no order back. A section
- * order is the opposite: the order *is* the value, so each entry has to say
- * where it goes, the same way an option carries its own `order`.
- */
-function sectionOrderThings(
-    labels: string[],
-    datasetUrl: string,
-): { urls: string[]; things: Thing[] } {
-    const urls: string[] = []
-    const things: Thing[] = []
-    labels.forEach((label, index) => {
-        const url = `${datasetUrl}#section-order-${index}`
-        urls.push(url)
-        things.push(buildThing({ url })
-            .addUrl(RDF.type, PMU.SectionOrderEntry)
-            .addStringNoLocale(PMU.text, label)
-            .addInteger(PMU.order, index)
-            .build())
-    })
-    return { urls, things }
-}
-
-function readSectionOrder(dataset: SolidDataset, rootThing: Thing): string[] {
-    return getUrlAll(rootThing, PMU.hasSectionOrderEntry)
-        .map(url => {
-            const thing = getThing(dataset, url)
-            if (!thing) return null
-            const label = getStringNoLocale(thing, PMU.text)
-            if (label === null) return null
-            return { label, order: getInteger(thing, PMU.order) ?? 0 }
-        })
-        .filter((entry): entry is { label: string; order: number } => entry !== null)
-        .sort((a, b) => a.order - b.order)
-        .map(({ label }) => label)
-}
-
 // ── PackingList ───────────────────────────────────────────────────────────────
 
 export function packingListToDataset(list: PackingList, datasetUrl: string): SolidDataset {
@@ -121,12 +79,6 @@ export function packingListToDataset(list: PackingList, datasetUrl: string): Sol
         rootBuilder = rootBuilder.addStringNoLocale(PMU.selectedPersonId, personId)
     }
 
-    {
-        const { urls, things } = sectionOrderThings(list.sectionOrder ?? [], datasetUrl)
-        for (const url of urls) rootBuilder = rootBuilder.addUrl(PMU.hasSectionOrderEntry, url)
-        for (const t of things) ds = setThing(ds, t)
-    }
-
     for (const answer of (list.questionAnswers ?? [])) {
         const answerUrl = `${datasetUrl}#answer-${answer.questionId}`
         rootBuilder = rootBuilder.addUrl(PMU.hasAnswer, answerUrl)
@@ -175,7 +127,6 @@ export function datasetToPackingList(dataset: SolidDataset, datasetUrl: string):
         .filter((g): g is { id: string; name: string } => g !== null)
 
     const selectedPeopleIds = getStringNoLocaleAll(rootThing, PMU.selectedPersonId)
-    const sectionOrder = readSectionOrder(dataset, rootThing)
 
     const questionAnswers = getUrlAll(rootThing, PMU.hasAnswer)
         .map(url => {
@@ -201,7 +152,6 @@ export function datasetToPackingList(dataset: SolidDataset, datasetUrl: string):
         ...(guests.length > 0 ? { guests } : {}),
         ...(selectedPeopleIds.length > 0 ? { selectedPeopleIds } : {}),
         ...(questionAnswers.length > 0 ? { questionAnswers } : {}),
-        ...(sectionOrder.length > 0 ? { sectionOrder } : {}),
     }
 }
 
@@ -258,6 +208,52 @@ function thingToPackingListItem(thing: Thing | null, url: string): PackingListIt
         ...(order !== null ? { order } : {}),
         ...(itemLastModified !== undefined ? { lastModified: itemLastModified } : {}),
     }
+}
+
+// ── Section order ─────────────────────────────────────────────────────────────
+
+/**
+ * The section order, written as one Thing per name carrying its position.
+ *
+ * Every other repeated string in this file (`emptySections`, `selectedPersonId`)
+ * is a set, and is read back sorted because RDF gives no order back. A section
+ * order is the opposite: the order *is* the value, so each entry has to say
+ * where it goes, the same way an option carries its own `order`.
+ *
+ * It lives on the question set alone. A packing list carries no copy — the
+ * order is read live when a list is shown, so that changing it reaches every
+ * list at once.
+ */
+function sectionOrderThings(
+    labels: string[],
+    datasetUrl: string,
+): { urls: string[]; things: Thing[] } {
+    const urls: string[] = []
+    const things: Thing[] = []
+    labels.forEach((label, index) => {
+        const url = `${datasetUrl}#section-order-${index}`
+        urls.push(url)
+        things.push(buildThing({ url })
+            .addUrl(RDF.type, PMU.SectionOrderEntry)
+            .addStringNoLocale(PMU.text, label)
+            .addInteger(PMU.order, index)
+            .build())
+    })
+    return { urls, things }
+}
+
+function readSectionOrder(dataset: SolidDataset, rootThing: Thing): string[] {
+    return getUrlAll(rootThing, PMU.hasSectionOrderEntry)
+        .map(url => {
+            const thing = getThing(dataset, url)
+            if (!thing) return null
+            const label = getStringNoLocale(thing, PMU.text)
+            if (label === null) return null
+            return { label, order: getInteger(thing, PMU.order) ?? 0 }
+        })
+        .filter((entry): entry is { label: string; order: number } => entry !== null)
+        .sort((a, b) => a.order - b.order)
+        .map(({ label }) => label)
 }
 
 // ── QuestionSet ───────────────────────────────────────────────────────────────

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -25,6 +25,48 @@ import type {
 } from '../edit-questions/types'
 import { AgeRangeSchema } from '../edit-questions/types'
 
+// ── Section order ─────────────────────────────────────────────────────────────
+
+/**
+ * The section order, written as one Thing per name carrying its position.
+ *
+ * Every other repeated string in this file (`emptySections`, `selectedPersonId`)
+ * is a set, and is read back sorted because RDF gives no order back. A section
+ * order is the opposite: the order *is* the value, so each entry has to say
+ * where it goes, the same way an option carries its own `order`.
+ */
+function sectionOrderThings(
+    labels: string[],
+    datasetUrl: string,
+): { urls: string[]; things: Thing[] } {
+    const urls: string[] = []
+    const things: Thing[] = []
+    labels.forEach((label, index) => {
+        const url = `${datasetUrl}#section-order-${index}`
+        urls.push(url)
+        things.push(buildThing({ url })
+            .addUrl(RDF.type, PMU.SectionOrderEntry)
+            .addStringNoLocale(PMU.text, label)
+            .addInteger(PMU.order, index)
+            .build())
+    })
+    return { urls, things }
+}
+
+function readSectionOrder(dataset: SolidDataset, rootThing: Thing): string[] {
+    return getUrlAll(rootThing, PMU.hasSectionOrderEntry)
+        .map(url => {
+            const thing = getThing(dataset, url)
+            if (!thing) return null
+            const label = getStringNoLocale(thing, PMU.text)
+            if (label === null) return null
+            return { label, order: getInteger(thing, PMU.order) ?? 0 }
+        })
+        .filter((entry): entry is { label: string; order: number } => entry !== null)
+        .sort((a, b) => a.order - b.order)
+        .map(({ label }) => label)
+}
+
 // ── PackingList ───────────────────────────────────────────────────────────────
 
 export function packingListToDataset(list: PackingList, datasetUrl: string): SolidDataset {
@@ -79,6 +121,12 @@ export function packingListToDataset(list: PackingList, datasetUrl: string): Sol
         rootBuilder = rootBuilder.addStringNoLocale(PMU.selectedPersonId, personId)
     }
 
+    {
+        const { urls, things } = sectionOrderThings(list.sectionOrder ?? [], datasetUrl)
+        for (const url of urls) rootBuilder = rootBuilder.addUrl(PMU.hasSectionOrderEntry, url)
+        for (const t of things) ds = setThing(ds, t)
+    }
+
     for (const answer of (list.questionAnswers ?? [])) {
         const answerUrl = `${datasetUrl}#answer-${answer.questionId}`
         rootBuilder = rootBuilder.addUrl(PMU.hasAnswer, answerUrl)
@@ -127,6 +175,7 @@ export function datasetToPackingList(dataset: SolidDataset, datasetUrl: string):
         .filter((g): g is { id: string; name: string } => g !== null)
 
     const selectedPeopleIds = getStringNoLocaleAll(rootThing, PMU.selectedPersonId)
+    const sectionOrder = readSectionOrder(dataset, rootThing)
 
     const questionAnswers = getUrlAll(rootThing, PMU.hasAnswer)
         .map(url => {
@@ -152,6 +201,7 @@ export function datasetToPackingList(dataset: SolidDataset, datasetUrl: string):
         ...(guests.length > 0 ? { guests } : {}),
         ...(selectedPeopleIds.length > 0 ? { selectedPeopleIds } : {}),
         ...(questionAnswers.length > 0 ? { questionAnswers } : {}),
+        ...(sectionOrder.length > 0 ? { sectionOrder } : {}),
     }
 }
 
@@ -244,6 +294,12 @@ export function questionSetToDataset(qs: PackingListQuestionSet, datasetUrl: str
         rootBuilder = rootBuilder.addStringNoLocale(PMU.alwaysNeededEmptySection, label)
     }
 
+    {
+        const { urls, things } = sectionOrderThings(qs.sectionOrder ?? [], datasetUrl)
+        for (const url of urls) rootBuilder = rootBuilder.addUrl(PMU.hasSectionOrderEntry, url)
+        for (const t of things) ds = setThing(ds, t)
+    }
+
     for (let i = 0; i < qs.alwaysNeededItems.length; i++) {
         const itemUrl = `${datasetUrl}#always-item-${i}`
         rootBuilder = rootBuilder.addUrl(PMU.hasAlwaysNeededItem, itemUrl)
@@ -287,12 +343,17 @@ export function datasetToQuestionSet(dataset: SolidDataset, datasetUrl: string):
     // Sorted for the same reason as an option's — see `thingToOption`.
     const alwaysNeededEmptySections = getStringNoLocaleAll(rootThing, PMU.alwaysNeededEmptySection).sort()
 
+    // Not sorted, unlike the empty sections above — each entry carries its own
+    // position, which is the only reason this field is stored as Things at all.
+    const sectionOrder = readSectionOrder(dataset, rootThing)
+
     return {
         _id: '1',
         people,
         questions,
         alwaysNeededItems,
         ...(alwaysNeededEmptySections.length > 0 ? { alwaysNeededEmptySections } : {}),
+        ...(sectionOrder.length > 0 ? { sectionOrder } : {}),
         ...(lastModified !== undefined ? { lastModified } : {}),
         ...(templateVersion !== undefined ? { templateVersion } : {}),
     }

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -16,12 +16,6 @@ export const PMU = {
     PersonSelection: `${PMU_NS}PersonSelection`,
     SectionOrderEntry: `${PMU_NS}SectionOrderEntry`,
 
-    // Shared by PackingList and QuestionSet: the order the list's sections are
-    // shown in. One Thing per section name carrying its position, because a
-    // repeated string on the root Thing comes back as an unordered set and an
-    // order is precisely what this field is.
-    hasSectionOrderEntry: `${PMU_NS}hasSectionOrderEntry`,
-
     // PackingList predicates
     hasItem: `${PMU_NS}hasItem`,
     hasDeletedItem: `${PMU_NS}hasDeletedItem`,
@@ -59,6 +53,10 @@ export const PMU = {
     // One value per always-needed section that has no items in it yet. A section
     // is otherwise only its items' categories, so an empty one would vanish.
     alwaysNeededEmptySection: `${PMU_NS}alwaysNeededEmptySection`,
+    // The order a generated list's sections are shown in. One Thing per section
+    // name carrying its position, because a repeated string on the root Thing
+    // comes back as an unordered set and an order is precisely what this is.
+    hasSectionOrderEntry: `${PMU_NS}hasSectionOrderEntry`,
     // Wizard template version this set was last reconciled against
     templateVersion: `${PMU_NS}templateVersion`,
 

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -14,6 +14,13 @@ export const PMU = {
     QuestionItem: `${PMU_NS}QuestionItem`,
     Person: `${PMU_NS}Person`,
     PersonSelection: `${PMU_NS}PersonSelection`,
+    SectionOrderEntry: `${PMU_NS}SectionOrderEntry`,
+
+    // Shared by PackingList and QuestionSet: the order the list's sections are
+    // shown in. One Thing per section name carrying its position, because a
+    // repeated string on the root Thing comes back as an unordered set and an
+    // order is precisely what this field is.
+    hasSectionOrderEntry: `${PMU_NS}hasSectionOrderEntry`,
 
     // PackingList predicates
     hasItem: `${PMU_NS}hasItem`,

--- a/src/test-utils/fullyPopulatedFixtures.ts
+++ b/src/test-utils/fullyPopulatedFixtures.ts
@@ -68,10 +68,6 @@ export const fullyPopulatedPackingList: Required<Omit<PackingList, '_rev'>> = {
     guests: [{ id: 'guest-1', name: 'Zoe' }],
     questionAnswers: [{ questionId: 'q1', selectedOptionIds: ['opt1', 'opt2'] }],
     selectedPeopleIds: ['person-1', 'person-2'],
-    // Deliberately several values, and deliberately not alphabetical: a section
-    // order is the one repeated field whose *order* is the whole point, so the
-    // round-trip assertions have to be order-dependent here.
-    sectionOrder: ['Toiletries', 'Essentials', 'Beach kit'],
 }
 
 /**
@@ -150,8 +146,9 @@ export const fullyPopulatedQuestionSet: Required<Omit<PackingListQuestionSet, '_
     alwaysNeededItems: [fullyPopulatedQuestionSetItem],
     alwaysNeededEmptySections: ['Documents'],
     questions: [fullyPopulatedQuestion],
-    // Several values, in a deliberately non-alphabetical order — see the note
-    // on the packing list's copy of this field.
+    // Deliberately several values, and deliberately not alphabetical: a section
+    // order is the one repeated field whose *order* is the whole point, so the
+    // round-trip assertions have to be order-dependent here.
     sectionOrder: ['Toiletries', 'Essentials', 'Beach kit'],
     lastModified: '2025-01-02T00:00:00.000Z',
     templateVersion: 3,

--- a/src/test-utils/fullyPopulatedFixtures.ts
+++ b/src/test-utils/fullyPopulatedFixtures.ts
@@ -68,6 +68,10 @@ export const fullyPopulatedPackingList: Required<Omit<PackingList, '_rev'>> = {
     guests: [{ id: 'guest-1', name: 'Zoe' }],
     questionAnswers: [{ questionId: 'q1', selectedOptionIds: ['opt1', 'opt2'] }],
     selectedPeopleIds: ['person-1', 'person-2'],
+    // Deliberately several values, and deliberately not alphabetical: a section
+    // order is the one repeated field whose *order* is the whole point, so the
+    // round-trip assertions have to be order-dependent here.
+    sectionOrder: ['Toiletries', 'Essentials', 'Beach kit'],
 }
 
 /**
@@ -146,6 +150,9 @@ export const fullyPopulatedQuestionSet: Required<Omit<PackingListQuestionSet, '_
     alwaysNeededItems: [fullyPopulatedQuestionSetItem],
     alwaysNeededEmptySections: ['Documents'],
     questions: [fullyPopulatedQuestion],
+    // Several values, in a deliberately non-alphabetical order — see the note
+    // on the packing list's copy of this field.
+    sectionOrder: ['Toiletries', 'Essentials', 'Beach kit'],
     lastModified: '2025-01-02T00:00:00.000Z',
     templateVersion: 3,
 }


### PR DESCRIPTION
## The problem

The order a generated list's sections come in was decided by `CATEGORY_ORDER` in `item-sections.ts` — a hardcoded list of twelve labels that pins every section the built-in template ships ahead of every section a user named, with `Essentials` always first. No user could change any of it. Renaming a section out of that list was the only way to move it (a trap, not a feature), and the always-needed section could not be moved at all.

Dragging items was never going to fix this. A section spans questions — Toiletries is filled by the always-needed list and by two options besides — so its position cannot be read off any one question. That is exactly why the item reorder view refuses to drag its headers: *"a section moves by moving its items."*

## The approach

The order becomes its own thing, independent of the questions: `PackingListQuestionSet.sectionOrder`, a plain list of section names, arranged in one place on the questions page.

It is **global**. Not copied onto each list at generation — read live from the question set whenever a list is shown, so changing it reaches every list you already have, not just the next one you make. A list shared from another pod is grouped the way the person looking at it asked for; sections their question set has and yours doesn't fall in after the ones the order names.

It stays a **preference, not a schema**. Names it doesn't mention still appear (at the end); names it mentions that no longer exist are ignored rather than pruned, so a section that is briefly empty doesn't lose its slot. `CATEGORY_ORDER` keeps its job as the default — a set with no stored order behaves exactly as before, down to the field being absent from the document.

## What changed

**`src/edit-questions/section-order.ts`** (new) — derives every section a generated list can show and in what default order (the same walk `generatePackingListItems` makes, then `CATEGORY_ORDER` lifted to the front), applies the stored order over it, and reconciles that order across a rename.

**`src/hooks/useSectionOrder.ts`** (new) — resolves the order for the list being viewed, from the viewer's own question set, falling back to `CATEGORY_ORDER` while it loads and for anyone who has never arranged their sections.

**`src/components/SectionOrderEditor.tsx`** (new) — a strip under the people legend showing the order at a glance, and a full-screen reorder view: drag handles, plus per-row arrows for the keyboard and for touch.

**Persistence** — one new optional field on the question set, round-tripping through PouchDB (carried by `toDocumentData`'s omit-list, no change needed) and RDF. A section order is the one repeated field whose *order* is the value, so each entry is its own Thing carrying its position rather than a repeated string, which RDF hands back as an unordered set. The fully-populated fixture uses three deliberately out-of-order names so the round-trip assertions actually test that.

**`useBodyScrollLock`** moved from `questions-page.tsx` into `src/hooks/` so both modals can use it. No behaviour change.

## A mobile bug worth reading about

The strip's chips were first built as a sideways-scrolling row, to keep it to one line at any width. That broke every modal on the page.

A scrollable element wider than the screen makes Chrome widen the **layout viewport** to fit its content — measured at 956px on a 390px phone. Every `position: fixed` overlay is then laid out against that width, so the reorder view *and* the pre-existing "Organise items" modal rendered off the bottom-right corner. Tapping "Reorder" genuinely appeared to do nothing.

The chips no longer scroll: four of them plus a count on a wide screen, and on a phone the same names as one truncated line — truncation clips without being scrollable, so it can't inflate the viewport. Measured back at 390px, with both modals centred again. The "Reorder" control was also 24px tall, well under a thumb; it now matches the 44px targets the rest of the page uses.

## Testing

`npm test` — 1331 passing, including 22 unit tests for the ordering rules, 12 component tests for the strip and modal, 5 for the resolution hook, and 3 for the view's grouping. Round-trip guards through PouchDB and RDF pick up the new field automatically via `fullyPopulatedFixtures`. `eslint` clean (13 pre-existing warnings, unchanged).

Verified in the running app on an emulated phone (iPhone 13, real touch events) and at 1200px:
- Creating a list, *then* moving `Kit & Gear` to the top, puts it first on that same already-created list.
- Layout viewport stays 390px; the reorder view and the item reorganiser are both centred.
- The "Reorder" control measures 44px tall and opens the view on tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwqKDhKbhZkwMVGxpT96E5