### PR TITLE
Pack the bag that stays with you, and pack for a festival

### DIFF
--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -306,17 +306,17 @@ test.describe('B – Editing Questions', () => {
     await setupWizardAndGoToQuestions(page)
     await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
 
-    const toiletries = page.getByTestId('item-section').filter({ hasText: 'Toiletries' }).first()
-    await expect(toiletries).toBeVisible({ timeout: 5_000 })
-    await toiletries.getByTestId('add-to-section').click()
+    const dayBag = page.getByTestId('item-section').filter({ hasText: 'Day Bag' }).first()
+    await expect(dayBag).toBeVisible({ timeout: 5_000 })
+    await dayBag.getByTestId('add-to-section').click()
 
-    const field = page.getByLabel('New item in Toiletries')
+    const field = page.getByLabel('New item in Day Bag')
     await expect(field).toBeVisible({ timeout: 3_000 })
     await field.fill('SectionAddTest')
     await field.press('Enter')
 
     // It lands under the heading it was typed into, not at the end of the list.
-    await expect(toiletries.getByText('SectionAddTest')).toBeVisible({ timeout: 5_000 })
+    await expect(dayBag.getByText('SectionAddTest')).toBeVisible({ timeout: 5_000 })
     // And the composer stays, cleared, because items go in in runs.
     await expect(field).toHaveValue('')
 
@@ -324,7 +324,7 @@ test.describe('B – Editing Questions', () => {
     await page.waitForTimeout(800)
     await page.reload()
     await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
-    const afterReload = page.getByTestId('item-section').filter({ hasText: 'Toiletries' }).first()
+    const afterReload = page.getByTestId('item-section').filter({ hasText: 'Day Bag' }).first()
     await expect(afterReload.getByText('SectionAddTest')).toBeVisible({ timeout: 5_000 })
   })
 
@@ -338,7 +338,7 @@ test.describe('B – Editing Questions', () => {
     const field = page.getByLabel(/^New item in /)
     await expect(field).toBeVisible({ timeout: 3_000 })
 
-    // "Sunscreen" lives under Toiletries in a question elsewhere in the set;
+    // "Sunscreen" lives under Day Bag in a question elsewhere in the set;
     // taking the suggestion is what files it there without a second trip.
     await field.fill('sunscr')
     const suggestion = page.getByRole('option', { name: /Sunscreen/ }).first()
@@ -346,11 +346,11 @@ test.describe('B – Editing Questions', () => {
     await suggestion.click()
     // Scoped to the composer: the page also carries a "Reorder sections"
     // button, and getByLabel matches on substring.
-    await expect(page.getByTestId('add-question-item').getByLabel('Section')).toHaveValue('Toiletries')
+    await expect(page.getByTestId('add-question-item').getByLabel('Section')).toHaveValue('Day Bag')
 
     await field.press('Enter')
-    const toiletries = page.getByTestId('item-section').filter({ hasText: 'Toiletries' }).first()
-    await expect(toiletries.getByText('Sunscreen')).toBeVisible({ timeout: 5_000 })
+    const dayBag = page.getByTestId('item-section').filter({ hasText: 'Day Bag' }).first()
+    await expect(dayBag.getByText('Sunscreen')).toBeVisible({ timeout: 5_000 })
   })
 
   test('B13: delete an item from the row you are editing', async ({ freshPage: page }) => {

--- a/plans/wizard-content-evaluation.md
+++ b/plans/wizard-content-evaluation.md
@@ -509,6 +509,17 @@ The principle is **irreplaceability descending, bulk ascending**, with rooms kep
 contiguous (bathroom → bedroom → nursery → kitchen → garage) so the family walks
 the house once. Under this mapping `Essentials` simply stops being used.
 
+> **Later revision — `Day Bag` leads, and by-bag is admitted once.** Shipped as
+> above, then revisited against actually packing with it. The rejection of
+> by-bag holds for *hold vs. boot*, which is transport-specific — but not for
+> the bag that stays with you, which exists on every trip under the same name.
+> Assembling it meant reading the whole list and remembering which rows counted.
+> `Day Bag` is now section 1, and it absorbed `Tech & Chargers` and
+> `Toys & Games` whole: both were day-bag contents wearing a functional label
+> (charger, power bank, headphones; colouring book, travel cards), and neither
+> had anything left once that half moved. Ten categories, not eleven. The
+> reasoning lives on `CATEGORIES` in `item-sections.ts`.
+
 Only populated categories appear, so a childless city break sees seven and a day
 trip four. In the default per-person view the largest single group today is 13
 rows (a female adult's share of "Will you be staying overnight?"); breaking that

--- a/src/edit-questions/example-data.test.ts
+++ b/src/edit-questions/example-data.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { createExampleData, ACTIVITY_OPTION_IDS, TEMPLATE_QUESTION_IDS, TRANSPORT_OPTION_IDS, ACCOMMODATION_OPTION_IDS, WIZARD_TEMPLATE_VERSION } from './example-data'
+import { CATEGORIES } from './item-sections'
 import { Person } from './types'
 
 const people: Person[] = [{ id: 'person-1', name: 'Alice', ageRange: 'Adult' }]
@@ -21,6 +22,149 @@ describe('ACTIVITY_OPTION_IDS', () => {
         expect(ACTIVITY_OPTION_IDS.skiing).toBe('activity-option-skiing')
         expect(ACTIVITY_OPTION_IDS.themePark).toBe('activity-option-theme-park')
         expect(ACTIVITY_OPTION_IDS.formalOccasions).toBe('activity-option-formal-occasions')
+        expect(ACTIVITY_OPTION_IDS.festival).toBe('activity-option-festival')
+    })
+})
+
+describe('createExampleData - the day bag', () => {
+    const family: Person[] = [
+        { id: 'a1', name: 'Alice', ageRange: 'Adult', gender: 'female' },
+        { id: 'c1', name: 'Cal', ageRange: 'Child' },
+        { id: 'b1', name: 'Bea', ageRange: 'Baby' },
+    ]
+
+    function everyItem(result: ReturnType<typeof createExampleData>) {
+        return [
+            ...result.alwaysNeededItems,
+            ...result.questions.flatMap(q => q.options.flatMap(o => o.items)),
+        ]
+    }
+
+    const categoryOf = (result: ReturnType<typeof createExampleData>, text: string) =>
+        everyItem(result).find(i => i.text === text)?.category
+
+    // The whole point of the section: these used to be spread over Tech,
+    // Toiletries, Food and Toys, so assembling the day bag meant reading the
+    // entire list and remembering which rows counted.
+    it('gathers what has to stay with you into one section', () => {
+        const result = createExampleData(family)
+        for (const text of [
+            'Wallet and bank cards',
+            'House keys',
+            'Phone',
+            'Phone charger',
+            'Power bank',
+            'Headphones',
+            'Hand sanitiser',
+            'Tissues',
+            'Snacks',
+            'Water bottle',
+            'Day bag / Backpack',
+            'Colouring book and pens',
+            'Playing cards/Travel games',
+            'Ear defenders',
+        ]) {
+            expect(categoryOf(result, text), `"${text}" should be in the day bag`)
+                .toBe(CATEGORIES.dayBag)
+        }
+    })
+
+    it('files the journey items from each transport option into the day bag', () => {
+        const result = createExampleData(family)
+        for (const text of [
+            'Boarding passes',
+            'Tickets',
+            'Medication in hand luggage',
+            'Hand luggage liquids bag',
+            'Downloaded films and music',
+            'Snacks for the journey',
+            'Travel sickness tablets',
+            'Car keys',
+            'Car charger',
+            'Milk or dummy for take-off and landing',
+        ]) {
+            expect(categoryOf(result, text), `"${text}" should be in the day bag`)
+                .toBe(CATEGORIES.dayBag)
+        }
+    })
+
+    // Bulk supplies are packed once and not opened again until you arrive, so
+    // they stay in the sections that map onto a room at home.
+    it('leaves the bulk of the packing in its functional section', () => {
+        const result = createExampleData(family)
+        expect(categoryOf(result, 'Underwear')).toBe(CATEGORIES.clothes)
+        expect(categoryOf(result, 'Toothbrush')).toBe(CATEGORIES.toiletries)
+        expect(categoryOf(result, 'Nappies (pack/supply)')).toBe(CATEGORIES.nappies)
+        expect(categoryOf(result, 'Passport')).toBe(CATEGORIES.documents)
+        expect(categoryOf(result, 'First aid kit')).toBe(CATEGORIES.medical)
+        expect(categoryOf(result, 'Tent')).toBe(CATEGORIES.kit)
+    })
+
+    it('files every template item into one of the template sections', () => {
+        const known = new Set<string>(Object.values(CATEGORIES))
+        for (const item of everyItem(createExampleData(family))) {
+            expect(known, `"${item.text}" is in "${item.category}"`).toContain(item.category)
+        }
+    })
+})
+
+describe('createExampleData - festivals', () => {
+    const family: Person[] = [
+        { id: 'a1', name: 'Alice', ageRange: 'Adult', gender: 'female' },
+        { id: 'c1', name: 'Cal', ageRange: 'Child' },
+    ]
+
+    const festivalItems = (result: ReturnType<typeof createExampleData>) =>
+        result.questions
+            .find(q => q.id === TEMPLATE_QUESTION_IDS.activities)!
+            .options.find(o => o.id === ACTIVITY_OPTION_IDS.festival)!.items
+
+    it('offers a festival as an activity, so it can be combined with camping', () => {
+        const result = createExampleData(family)
+        const activities = result.questions.find(q => q.id === TEMPLATE_QUESTION_IDS.activities)!
+        const festival = activities.options.find(o => o.id === ACTIVITY_OPTION_IDS.festival)
+        expect(festival).toBeTruthy()
+        expect(festival!.text).toBe('Festival or live music')
+    })
+
+    it('packs the things a festival needs and nothing else does', () => {
+        const texts = festivalItems(createExampleData(family)).map(i => i.text)
+        expect(texts).toEqual(expect.arrayContaining([
+            'Festival tickets or wristband',
+            'Bum bag or small crossbody bag',
+            'Cash in small notes',
+            'Ear plugs',
+            'Tent flag or marker',
+            'Dry shampoo',
+            'Toilet roll',
+        ]))
+    })
+
+    // Wellies, a head torch and camp chairs are already in the camping option;
+    // repeating them here is what makes the list right for someone at a
+    // festival who booked a hotel, and `deduplicateItems` collapses the pair
+    // for everyone else.
+    it('repeats the outdoor kit that a festival needs whether or not you camp', () => {
+        const texts = festivalItems(createExampleData(family)).map(i => i.text)
+        expect(texts).toEqual(expect.arrayContaining(['Wellies', 'Head torch', 'Camp chairs']))
+    })
+
+    it('gives children ear defenders and adults ear plugs', () => {
+        const items = festivalItems(createExampleData(family))
+        const defenders = items.find(i => i.text === 'Ear defenders')!
+        expect(defenders.personSelections.find(ps => ps.personId === 'c1')?.selected).toBe(true)
+        expect(defenders.personSelections.find(ps => ps.personId === 'a1')?.selected).toBe(false)
+
+        const plugs = items.find(i => i.text === 'Ear plugs')!
+        expect(plugs.personSelections.find(ps => ps.personId === 'a1')?.selected).toBe(true)
+    })
+
+    it('puts the wristband and the cash where you can reach them', () => {
+        const items = festivalItems(createExampleData(family))
+        expect(items.find(i => i.text === 'Festival tickets or wristband')!.category)
+            .toBe(CATEGORIES.dayBag)
+        expect(items.find(i => i.text === 'Cash in small notes')!.category)
+            .toBe(CATEGORIES.dayBag)
     })
 })
 

--- a/src/edit-questions/example-data.ts
+++ b/src/edit-questions/example-data.ts
@@ -13,6 +13,7 @@ export const ACTIVITY_OPTION_IDS = {
     skiing: 'activity-option-skiing',
     themePark: 'activity-option-theme-park',
     formalOccasions: 'activity-option-formal-occasions',
+    festival: 'activity-option-festival',
 } as const
 
 // Stable IDs for the options of the other multiple-choice questions. Like the
@@ -66,7 +67,7 @@ export const TEMPLATE_QUESTION_IDS = {
 // existing item (a corrected age filter, a new quantity rate, flipping an item
 // to communal) reach new users only; `buildTemplateUpdateSuggestions` matches
 // on item text and never rewrites what the user already has.
-export const WIZARD_TEMPLATE_VERSION = 2
+export const WIZARD_TEMPLATE_VERSION = 3
 import {
     getBabies,
     getToddlers,
@@ -191,7 +192,6 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             order: 1,
             items: items(
                 section(C.toiletries,
-                    item("Beach towel", people),
                     communalItem("After-sun", people),
                 ),
                 section(C.clothes,
@@ -201,6 +201,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                     communalItem("Cool bag", people),
                 ),
                 section(C.kit,
+                    item("Beach towel", people),
                     communalItem("Bucket and spade", people, getUnderTeenagers),
                     communalItem("Beach shade or windbreak", people),
                     communalItem("Beach bag", people),
@@ -245,7 +246,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             text: "Running",
             order: 4,
             items: items(
-                section(C.tech,
+                section(C.kit,
                     item("Sports watch", people, getTeenagersAndAdults),
                 ),
                 section(C.clothes,
@@ -296,7 +297,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             text: "Sightseeing and city walking",
             order: 7,
             items: items(
-                section(C.tech,
+                section(C.dayBag,
                     item("Power bank", people, getTeenagersAndAdults),
                     communalItem("Offline maps downloaded", people, getTeenagersAndAdults),
                 ),
@@ -312,7 +313,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             text: "Skiing or snowboarding",
             order: 8,
             items: items(
-                section(C.toiletries,
+                section(C.dayBag,
                     communalItem("Sunscreen", people),
                     item("Lip balm with SPF", people, getChildrenAndOlder),
                 ),
@@ -334,18 +335,16 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
             text: "Theme park or days out",
             order: 9,
             items: items(
-                section(C.tech,
+                section(C.dayBag,
                     item("Power bank", people, getTeenagersAndAdults),
+                    item("Poncho", people),
+                    item("Ear defenders", people, getUnderTeenagers),
                 ),
                 section(C.clothes,
                     item("Comfortable walking shoes", people, getToddlersAndOlder),
-                    item("Poncho", people),
                 ),
                 section(C.food,
                     communalItem("Cool bag", people),
-                ),
-                section(C.kit,
-                    item("Ear defenders", people, getUnderTeenagers),
                 ),
             )
         },
@@ -362,6 +361,61 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                     item("Evening bag/Clutch", people, getTeenagersAndAdults),
                 ),
             )
+        },
+        {
+            id: ACTIVITY_OPTION_IDS.festival,
+            text: "Festival or live music",
+            order: 11,
+            items: items(
+                // A festival is an activity rather than a place to stay, so it
+                // combines with whichever accommodation you actually booked —
+                // a tent, a campervan, or a hotel down the road.
+                section(C.dayBag,
+                    item("Festival tickets or wristband", people),
+                    item("Bum bag or small crossbody bag", people, getChildrenAndOlder),
+                    // Card readers need signal, and the signal is the first
+                    // thing a field full of people takes away.
+                    communalItem("Cash in small notes", people, getTeenagersAndAdults),
+                    item("Power bank", people, getTeenagersAndAdults),
+                    communalItem("Waterproof phone pouch", people, getTeenagersAndAdults),
+                    item("Water bottle", people, getToddlersAndOlder),
+                    item("Snacks", people, getToddlersAndOlder),
+                    communalItem("Sunscreen", people),
+                    item("Poncho", people),
+                    item("Ear plugs", people, getChildrenAndOlder),
+                    item("Ear defenders", people, getUnderTeenagers),
+                    item("Reusable cup", people, getChildrenAndOlder),
+                ),
+                section(C.documents,
+                    item("Photo ID", people, getTeenagersAndAdults),
+                ),
+                section(C.medical,
+                    communalItem("Blister plasters", people),
+                ),
+                section(C.toiletries,
+                    // Showers are a queue and the taps are cold, so this is the
+                    // washbag a field needs rather than the one a bathroom does.
+                    communalItem("Toilet roll", people),
+                    communalItem("Wet wipes", people),
+                    item("Dry shampoo", people, getTeenagersAndAdults),
+                ),
+                section(C.clothes,
+                    item("Wellies", people, getToddlersAndOlder),
+                    item("Warm layers for the evening", people),
+                    item("Sunglasses", people, getChildrenAndOlder),
+                    item("Fancy dress or costume", people, getChildrenAndOlder),
+                ),
+                section(C.food,
+                    communalItem("Bin bags", people),
+                ),
+                section(C.kit,
+                    // Tents in rows all look alike in the dark, and by then
+                    // your phone is flat.
+                    communalItem("Tent flag or marker", people),
+                    item("Head torch", people, getChildrenAndOlder),
+                    communalItem("Camp chairs", people),
+                ),
+            )
         }
     ]
 
@@ -373,11 +427,30 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
         _id: "1",
         people,
         alwaysNeededItems: items(
-            // Keys and cards lead because this section leads the list: it is the
-            // "check before the door shuts" pile, not strictly paperwork.
-            section(C.documents,
+            // The bag that stays with you. Keys and cards lead the whole list
+            // because this is the "check before the door shuts" pile — and it
+            // is where the phone, the snacks and the wipes belong too, however
+            // little they have in common otherwise.
+            section(C.dayBag,
                 item("Wallet and bank cards", people, getTeenagersAndAdults),
                 communalItem("House keys", people),
+                item("Phone", people, getTeenagersAndAdults),
+                item("Phone charger", people, getTeenagersAndAdults),
+                item("Power bank", people, getTeenagersAndAdults),
+                item("Headphones", people, getChildrenAndOlder),
+                item("Tablet and charger", people, getChildrenAndOlder),
+                communalItem("Hand sanitiser", people),
+                communalItem("Tissues", people),
+                item("Snacks", people, getToddlersAndOlder),
+                item("Water bottle", people, getToddlersAndOlder),
+                item("Colouring book and pens", people, getChildren),
+                communalItem("Playing cards/Travel games", people, getChildrenAndOlder),
+                item("Ear defenders", people, getUnderTeenagers),
+                // The bag itself, so nobody packs a day bag's worth of things
+                // and then leaves the bag at home.
+                item("Day bag / Backpack", people, getChildrenAndOlder),
+            ),
+            section(C.documents,
                 // A pet's papers are wanted at a border, so they sit with the
                 // other documents rather than in Pet Care.
                 item("Vaccination/health records", people, getPets),
@@ -394,22 +467,14 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                 communalItem("Thermometer", people),
                 item("Teething gel", people, getBabies),
             ),
-            section(C.tech,
-                item("Phone", people, getTeenagersAndAdults),
-                item("Phone charger", people, getTeenagersAndAdults),
-                item("Power bank", people, getTeenagersAndAdults),
-                item("Headphones", people, getChildrenAndOlder),
-                item("Tablet and charger", people, getChildrenAndOlder),
-            ),
-            section(C.toiletries,
-                communalItem("Hand sanitiser", people),
-                communalItem("Tissues", people),
-            ),
             section(C.clothes,
                 item("Spare clothes", people, getBabies, { perNight: 1, perNights: 2, maxQuantity: 6 }),
                 item("Spare clothes", people, getToddlers, { perNight: 1, perNights: 3, maxQuantity: 4 }),
             ),
             section(C.sleep,
+                // A dummy is wanted on the journey as much as at bedtime, but
+                // it is the comfort item that decides whether anyone sleeps, so
+                // the pair stays together rather than being split by bag.
                 item("Dummy (if used)", people, getBabies),
                 item("Comfort item (teddy/blanket)", people, getToddlers),
             ),
@@ -423,13 +488,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                 item("Pull-ups/Toddler nappies", people, getToddlers, { perNight: 4 }),
                 communalItem("Potty (travel potty)", people, getToddlers),
             ),
-            section(C.toys,
-                item("Colouring book and pens", people, getChildren),
-                communalItem("Playing cards/Travel games", people, getChildrenAndOlder),
-            ),
             section(C.food,
-                item("Snacks", people, getToddlersAndOlder),
-                item("Water bottle", people, getToddlersAndOlder),
                 item("Bibs", people, getBabies),
                 item("Bottles (if bottle feeding)", people, getBabies),
                 communalItem("Bottle brush and steriliser bags", people, getBabies),
@@ -437,12 +496,10 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                 item("Sippy cup/Toddler cup", people, getToddlers),
             ),
             section(C.kit,
-                item("Day bag / Backpack", people, getChildrenAndOlder),
                 communalItem("Reusable bags", people),
                 communalItem("Pram/Buggy", people, getBabiesAndToddlers),
                 communalItem("Pram rain cover", people, getBabiesAndToddlers),
                 communalItem("Baby carrier/Sling", people, getBabies),
-                item("Ear defenders", people, getUnderTeenagers),
             ),
             // Pet items — only appear when a matching pet is in the group
             section(C.pet,
@@ -500,9 +557,13 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                                 communalItem("Laundry bag", people),
                                 communalItem("Travel detergent", people),
                             ),
+                            section(C.dayBag,
+                                // Wanted on the way, not on arrival — the same
+                                // reason the flying option carries it.
+                                item("Travel pillow", people, getTeenagersAndAdults),
+                            ),
                             section(C.sleep,
                                 item("Pyjamas", people, undefined, { perNight: 1, perNights: 3, maxQuantity: 3 }),
-                                item("Travel pillow", people, getTeenagersAndAdults),
                                 item("Earplugs and eye mask", people, getTeenagersAndAdults),
                                 communalItem("Baby monitor", people, getBabies),
                                 item("Nightlight", people, getUnderTeenagers),
@@ -551,7 +612,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                                 communalItem("Copies of important documents", people, getAdults),
                                 item("Pet passport/Animal health certificate", people, getPets),
                             ),
-                            section(C.tech,
+                            section(C.dayBag,
                                 item("Travel adapter", people, getTeenagersAndAdults),
                             ),
                         )
@@ -576,12 +637,18 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         text: "Hot",
                         order: 0,
                         items: items(
-                            section(C.toiletries,
+                            // Sun cream is applied where you are, not where you
+                            // are staying, so it travels in the day bag; the
+                            // after-sun is an evening job and stays in the wash
+                            // bag.
+                            section(C.dayBag,
                                 communalItem("Sunscreen", people),
-                                communalItem("After-sun", people),
                                 communalItem("Baby sunscreen (SPF 50+)", people, getBabies),
                                 communalItem("Toddler sunscreen", people, getToddlers),
                                 communalItem("Kids sunscreen", people, getChildren),
+                            ),
+                            section(C.toiletries,
+                                communalItem("After-sun", people),
                             ),
                             section(C.medical,
                                 communalItem("Insect repellent", people),
@@ -604,7 +671,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         text: "Strong sun",
                         order: 1,
                         items: items(
-                            section(C.toiletries,
+                            section(C.dayBag,
                                 communalItem("Sunscreen", people),
                                 item("Lip balm with SPF", people, getChildrenAndOlder),
                             ),
@@ -635,7 +702,7 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                                 item("Raincoat", people),
                                 item("Waterproof shoes/boots", people),
                             ),
-                            section(C.kit,
+                            section(C.dayBag,
                                 communalItem("Umbrella", people),
                                 communalItem("Waterproof rucksack cover", people, getChildrenAndOlder),
                             ),
@@ -693,26 +760,16 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         text: "Flying",
                         order: 0,
                         items: items(
-                            section(C.documents,
+                            // Everything a flight adds is by definition
+                            // something you need before you reach the hold.
+                            section(C.dayBag,
                                 communalItem("Boarding passes", people),
-                            ),
-                            section(C.medical,
                                 item("Medication in hand luggage", people),
-                            ),
-                            section(C.tech,
-                                communalItem("Downloaded films and music", people),
-                            ),
-                            section(C.clothes,
-                                item("Spare clothes in cabin bag", people, getBabiesAndToddlers),
-                            ),
-                            section(C.sleep,
-                                item("Travel pillow", people, getTeenagersAndAdults),
-                            ),
-                            section(C.food,
-                                item("Milk or dummy for take-off and landing", people, getBabies),
-                            ),
-                            section(C.kit,
                                 item("Hand luggage liquids bag", people, getTeenagersAndAdults),
+                                communalItem("Downloaded films and music", people),
+                                item("Travel pillow", people, getTeenagersAndAdults),
+                                item("Spare clothes in cabin bag", people, getBabiesAndToddlers),
+                                item("Milk or dummy for take-off and landing", people, getBabies),
                             ),
                         )
                     },
@@ -721,20 +778,18 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         text: "Driving",
                         order: 1,
                         items: items(
-                            section(C.documents,
-                                item("Driving licence", people, getAdults),
+                            // Sick bags and snacks are no use in the boot, and
+                            // the keys are no use anywhere else.
+                            section(C.dayBag,
                                 communalItem("Car keys", people),
-                                communalItem("Breakdown cover documents", people, getAdults),
-                            ),
-                            section(C.medical,
                                 communalItem("Travel sickness tablets", people),
                                 communalItem("Sick bags", people),
-                            ),
-                            section(C.tech,
                                 communalItem("Car charger", people),
-                            ),
-                            section(C.food,
                                 communalItem("Snacks for the journey", people),
+                            ),
+                            section(C.documents,
+                                item("Driving licence", people, getAdults),
+                                communalItem("Breakdown cover documents", people, getAdults),
                             ),
                             section(C.kit,
                                 item("Car seat", people, getUnderTeenagers),
@@ -747,13 +802,9 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         text: "Train or coach",
                         order: 2,
                         items: items(
-                            section(C.documents,
+                            section(C.dayBag,
                                 communalItem("Tickets", people),
-                            ),
-                            section(C.tech,
                                 communalItem("Downloaded films and music", people),
-                            ),
-                            section(C.food,
                                 communalItem("Snacks for the journey", people),
                             ),
                         )
@@ -763,10 +814,11 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         text: "Ferry",
                         order: 3,
                         items: items(
-                            section(C.documents,
+                            // A seasickness remedy in the car deck is a remedy
+                            // you can't get to, which is also why the cruise
+                            // option files it here.
+                            section(C.dayBag,
                                 communalItem("Tickets", people),
-                            ),
-                            section(C.medical,
                                 communalItem("Seasickness remedies", people),
                             ),
                             section(C.kit,
@@ -908,18 +960,16 @@ export function createExampleData(people: Person[], selectedActivityIds: string[
                         text: "Cruise ship",
                         order: 5,
                         items: items(
+                            section(C.dayBag,
+                                communalItem("Seasickness remedies", people),
+                                item("Lanyard for key card", people, getChildrenAndOlder),
+                                communalItem("Port daypack", people),
+                            ),
                             section(C.documents,
                                 communalItem("Booking confirmations", people),
                             ),
-                            section(C.medical,
-                                communalItem("Seasickness remedies", people),
-                            ),
                             section(C.clothes,
                                 item("Formal outfit", people),
-                            ),
-                            section(C.kit,
-                                item("Lanyard for key card", people, getChildrenAndOlder),
-                                communalItem("Port daypack", people),
                             ),
                         )
                     }

--- a/src/edit-questions/item-sections.test.ts
+++ b/src/edit-questions/item-sections.test.ts
@@ -448,6 +448,22 @@ describe('CATEGORY_ORDER', () => {
         expect(at(CATEGORIES.kit)).toBe(CATEGORY_ORDER.length - 2)
         expect(at(CATEGORIES.pet)).toBe(CATEGORY_ORDER.length - 1)
     })
+
+    // The day bag is the one that has to be right before the door shuts, and
+    // it is the shortest section, so it is the first thing you read.
+    it('leads with the day bag, ahead of even the documents', () => {
+        const at = (name: string) => CATEGORY_ORDER.indexOf(name)
+        expect(at(CATEGORIES.dayBag)).toBe(1)
+        expect(at(CATEGORIES.dayBag)).toBeLessThan(at(CATEGORIES.documents))
+    })
+
+    // Ten sections is already a long walk through the house; the two that were
+    // dropped were both really "things I want to hand", which is the day bag.
+    it('keeps the section list short enough to hold in your head', () => {
+        expect(Object.values(CATEGORIES).length).toBeLessThanOrEqual(10)
+        expect(Object.values(CATEGORIES)).not.toContain('Tech & Chargers')
+        expect(Object.values(CATEGORIES)).not.toContain('Toys & Games')
+    })
 })
 
 describe('empty sections', () => {

--- a/src/edit-questions/item-sections.ts
+++ b/src/edit-questions/item-sections.ts
@@ -17,25 +17,38 @@ import type { Item, Option, PackingListQuestionSet, Question } from './types'
 export const ALWAYS_NEEDED_CATEGORY = 'Essentials'
 
 /**
- * The sections the built-in template sorts its items into. Functional rather
- * than by-person or by-bag: a functional name is stable across every trip type,
- * derivable from the item alone, and maps onto a place in the house — so the
- * family walks from bathroom to bedroom to kitchen once. By-person is already
- * the list's other axis, and by-bag would depend on how you're travelling.
+ * The sections the built-in template sorts its items into. Mostly functional:
+ * a functional name is stable across every trip type, derivable from the item
+ * alone, and maps onto a place in the house — so the family walks from bathroom
+ * to bedroom to kitchen once. By-person is already the list's other axis.
+ *
+ * `dayBag` is the one deliberate exception, and it earns it. Packing is really
+ * the job of filling two things: the case, which can be anything, and the bag
+ * that stays with you, which cannot — a phone charger in the hold is a phone
+ * charger you don't have. Spreading those items over Tech, Toiletries, Food and
+ * Toys meant assembling the day bag by reading the whole list and remembering
+ * which rows counted. One card for it is the single biggest practical win here,
+ * and unlike "hand luggage" or "boot of the car" the name holds whether you're
+ * flying, driving or walking to the station.
+ *
+ * It also absorbed two whole sections. Tech & Chargers was phone, charger,
+ * power bank, headphones, tablet, adapter — day bag, all of it. Toys & Games
+ * was colouring books and travel card games, which are there for the journey;
+ * the bedtime teddy was always filed under Sleep & Comfort anyway. Neither
+ * section had a life of its own once its day-bag half left.
  *
  * These are plain labels, not an enum: a user can rename or delete any of them,
  * and items they add carry no category at all. Nothing here is load-bearing for
  * correctness — it only decides headings and their order.
  */
 export const CATEGORIES = {
+    dayBag: 'Day Bag',
     documents: 'Documents & Money',
     medical: 'Medicines & First Aid',
-    tech: 'Tech & Chargers',
     toiletries: 'Toiletries',
     clothes: 'Clothes',
     sleep: 'Sleep & Comfort',
     nappies: 'Nappies & Changing',
-    toys: 'Toys & Games',
     food: 'Food & Kitchen',
     kit: 'Kit & Gear',
     pet: 'Pet Care',
@@ -45,6 +58,11 @@ export const CATEGORIES = {
  * Display order for the sections above: irreplaceability descending, bulk
  * ascending. A forgotten passport ends the trip and there are only a handful of
  * them, so documents lead and the tent is loaded last.
+ *
+ * The day bag goes ahead of even the documents. Everything else on the list can
+ * be packed the night before and checked at leisure; the day bag is the one you
+ * are still filling as you leave, so it wants to be the first thing on screen —
+ * and it is short enough to read in the doorway.
  *
  * Without this, a section's position came from the lowest `order` among its
  * items (see `groupItemsByCategory`), which was coherent while a section *was*
@@ -60,14 +78,13 @@ export const CATEGORIES = {
  */
 export const CATEGORY_ORDER: readonly string[] = [
     ALWAYS_NEEDED_CATEGORY,
+    CATEGORIES.dayBag,
     CATEGORIES.documents,
     CATEGORIES.medical,
-    CATEGORIES.tech,
     CATEGORIES.toiletries,
     CATEGORIES.clothes,
     CATEGORIES.sleep,
     CATEGORIES.nappies,
-    CATEGORIES.toys,
     CATEGORIES.food,
     CATEGORIES.kit,
     CATEGORIES.pet,

--- a/src/edit-questions/template-updates.test.ts
+++ b/src/edit-questions/template-updates.test.ts
@@ -222,7 +222,7 @@ describe('buildTemplateUpdateSuggestions - filing an uncategorised set into sect
         const updated = applyTemplateUpdates(set, buildTemplateUpdateSuggestions(set))
 
         const charger = updated.alwaysNeededItems.find(i => i.text === 'Phone charger')!
-        expect(charger.category).toBe('Tech & Chargers')
+        expect(charger.category).toBe('Day Bag')
         expect(charger.lastModified).toBeTruthy()
 
         const overnightYes = updated.questions

--- a/src/edit-questions/template-updates.ts
+++ b/src/edit-questions/template-updates.ts
@@ -123,7 +123,7 @@ function buildSetCategoriesSuggestion(
     return {
         kind: 'setCategories',
         key: 'setCategories',
-        label: `Sort ${itemCount} item${itemCount === 1 ? '' : 's'} into ${sections.size} sections (Clothes, Toiletries, Documents & Money…)`,
+        label: `Sort ${itemCount} item${itemCount === 1 ? '' : 's'} into ${sections.size} sections (Day Bag, Clothes, Toiletries…)`,
         contextLabel: 'Organise your list',
         categories,
         itemCount,


### PR DESCRIPTION
Two things came out of using the generated list to actually pack.

The first: there was nowhere for the day bag. Its contents were spread over
Tech, Toiletries, Food and Toys, so assembling it meant reading the whole list
and remembering which rows counted — and the one bag you cannot re-buy on
arrival is exactly the one the list didn't help with. `Day Bag` is now a section
of its own, and the first one on the list: everything else can be packed the
night before, but the day bag is still being filled as you leave.

The by-bag axis was rejected when the sections were designed, for a good reason
that turns out to be narrower than it looked. Hold-vs-boot is transport-specific
and can't be named on a question set; the bag that stays with you exists on
every trip under the same name, whether you're flying, driving or walking to the
station.

It absorbed two whole sections, which is the second thing. Tech & Chargers was
phone, charger, power bank, headphones, tablet, adapter — day bag, all of it.
Toys & Games was a colouring book and travel cards, there for the journey; the
bedtime teddy was filed under Sleep & Comfort already. Neither section had a
life of its own once its day-bag half left, so ten sections now, not eleven.
Transport options in particular collapse to a single card each: everything a
flight adds is by definition something you need before you reach the hold.

And a festival is now an activity you can pick. It's an activity rather than a
place to stay so it combines with whatever you actually booked — a tent, a
campervan, or a hotel down the road — which is also why it repeats the wellies
and the head torch that camping already carries. Wristband and cash in the day
bag, because the card readers stop working the moment the field fills up.

Existing users are offered the festival option and its items through the usual
review card. The re-filed sections reach new lists only: matching is by item
text, so an item you already have is never revisited — except for a set that
never used sections at all, which is offered the whole filing in one go.