### PR TITLE
Carry each person's colour onto their packing list, and let them pick it

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -2,6 +2,7 @@
 
 - Generate packing lists based on trip answers (travelers, duration, climate, activities)
 - Manage packing questions and the items each answer triggers
+- Give each traveller a colour of their own, carried onto every packing list
 - Local-first storage via PouchDB — works offline, no account needed
 - Sync to a Solid Pod for backup and cross-device access
 - Share lists with other users via their Solid Pod; grant/revoke access

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -175,4 +175,28 @@ test.describe('C – Packing Lists', () => {
     await expect(page.getByText('This list already matches your questions')).toBeVisible({ timeout: 5_000 })
     await expect(page.getByRole('button', { name: /Add \d+ item/i })).not.toBeVisible()
   })
+
+  test('C9: a person’s chosen colour follows them onto a packing list', async ({ freshPage: page }) => {
+    await runWizard(page)
+
+    // Give the one person in the set a colour of their own
+    await page.goto('/#/manage-questions')
+    await expect(page.getByRole('heading', { name: 'My Questions & Items' })).toBeVisible({ timeout: 8_000 })
+    await page.locator('button[title="Edit people"]').click()
+    await expect(page.getByRole('heading', { name: 'Edit People' })).toBeVisible({ timeout: 3_000 })
+    await page.getByRole('button', { name: 'Change colour for Me' }).click()
+    await page.getByRole('group', { name: 'Colour for Me' }).getByRole('button', { name: 'Fuchsia' }).click()
+    // The avatar shows the choice before the modal is even saved
+    await expect(page.getByRole('button', { name: 'Change colour for Me' })).toHaveClass(/bg-fuchsia-500/)
+    await page.getByRole('button', { name: 'Save' }).click()
+    // Give the async IndexedDB write time to commit
+    await page.waitForTimeout(800)
+
+    // A list made afterwards shows that colour on their card
+    await page.goto('/#/create-packing-list')
+    await createList(page, 'Colourful Trip')
+    const card = page.locator('[data-testid="list-section"]').filter({ hasText: "Me's Items" })
+    await expect(card.getByTestId('person-avatar')).toHaveClass(/bg-fuchsia-500/)
+    await expect(card).toHaveClass(/border-fuchsia-300/)
+  })
 })

--- a/src/components/ItemEditorControls.tsx
+++ b/src/components/ItemEditorControls.tsx
@@ -8,18 +8,7 @@
  */
 import { memo } from 'react'
 import type { Item, Person } from '../edit-questions/types'
-
-// One distinct colour per person slot (by index). Tailwind classes must be
-// literal strings, so this is a lookup rather than an interpolation.
-export const AVATAR_ON = [
-    'bg-blue-500 text-white',
-    'bg-violet-500 text-white',
-    'bg-emerald-500 text-white',
-    'bg-amber-500 text-white',
-    'bg-rose-500 text-white',
-    'bg-cyan-500 text-white',
-]
-export const AVATAR_OFF = 'bg-gray-100 text-gray-300'
+import { PERSON_COLOR_OFF, personColorFor } from '../edit-questions/person-colors'
 
 /** "2 per night" / "1 per 4 nights" — the human phrasing of an item's rate. */
 export function rateLabel(item: Item): string {
@@ -78,7 +67,7 @@ export const PersonToggles = memo(function PersonToggles({ item, people, layout,
                     title={communalTitle}
                     aria-label={`Toggle shared for ${item.text || 'item'}`}
                     aria-pressed={isCommunal}
-                    className={`inline-flex items-center justify-center h-5 rounded-full px-1 text-[10px] transition-colors mr-1 ${isCommunal ? 'bg-blue-600 text-white' : AVATAR_OFF}`}
+                    className={`inline-flex items-center justify-center h-5 rounded-full px-1 text-[10px] transition-colors mr-1 ${isCommunal ? 'bg-blue-600 text-white' : PERSON_COLOR_OFF}`}
                 >
                     👥
                 </button>
@@ -91,7 +80,7 @@ export const PersonToggles = memo(function PersonToggles({ item, people, layout,
                             onClick={() => onTogglePerson(personIdx)}
                             title={personTitle(person.name)}
                             aria-pressed={selected}
-                            className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold transition-colors ${selected ? AVATAR_ON[personIdx % AVATAR_ON.length] : AVATAR_OFF} ${isCommunal && selected ? 'ring-2 ring-blue-300 ring-offset-1' : ''}`}
+                            className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold transition-colors ${selected ? personColorFor(person, personIdx).avatar : PERSON_COLOR_OFF} ${isCommunal && selected ? 'ring-2 ring-blue-300 ring-offset-1' : ''}`}
                         >
                             {person.name.charAt(0).toUpperCase()}
                         </button>
@@ -125,7 +114,7 @@ export const PersonToggles = memo(function PersonToggles({ item, people, layout,
                         onClick={() => onTogglePerson(personIdx)}
                         title={personTitle(person.name)}
                         aria-pressed={selected}
-                        className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${selected ? `${AVATAR_ON[personIdx % AVATAR_ON.length]} border-transparent` : 'bg-white border-gray-200 text-gray-400'}`}
+                        className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${selected ? `${personColorFor(person, personIdx).avatar} border-transparent` : 'bg-white border-gray-200 text-gray-400'}`}
                     >
                         <span className="text-lg font-bold leading-none">
                             {person.name.charAt(0).toUpperCase()}

--- a/src/components/PersonAvatar.tsx
+++ b/src/components/PersonAvatar.tsx
@@ -1,0 +1,28 @@
+import type { PersonColor } from '../edit-questions/person-colors'
+
+/**
+ * A person's coloured initial — the same mark the questions page puts beside
+ * every item, so a packing list can be read the same way: find your colour,
+ * that's your pile.
+ *
+ * Decorative, always: everywhere it appears the person's name is written
+ * beside it, so announcing the initial as well would only make a screen
+ * reader say "A, Alice's Items".
+ */
+export function PersonAvatar({ name, color, size = 'md' }: {
+    name: string
+    color: PersonColor
+    size?: 'sm' | 'md'
+}) {
+    const dimensions = size === 'sm' ? 'w-5 h-5 text-[10px]' : 'w-7 h-7 text-xs'
+    return (
+        <span
+            data-testid="person-avatar"
+            title={name}
+            aria-hidden="true"
+            className={`inline-flex items-center justify-center rounded-full font-bold select-none shrink-0 ${dimensions} ${color.avatar}`}
+        >
+            {name.charAt(0).toUpperCase() || '?'}
+        </span>
+    )
+}

--- a/src/components/PersonColorPicker.tsx
+++ b/src/components/PersonColorPicker.tsx
@@ -1,0 +1,41 @@
+import { PERSON_COLORS, type PersonColor, type PersonColorId } from '../edit-questions/person-colors'
+
+/**
+ * The palette behind a person's avatar in the People editor.
+ *
+ * Colour is the only thing on that page carrying a person's identity, so the
+ * place to change it is the avatar itself rather than a field somewhere below
+ * it. The grid opens under the person it belongs to and shows the whole palette
+ * at once — twelve swatches are quicker to scan than a dropdown of colour names,
+ * and the names are only there for screen readers.
+ */
+export function PersonColorSwatches({ personName, selected, onSelect }: {
+    personName: string
+    selected: PersonColor
+    onSelect: (id: PersonColorId) => void
+}) {
+    return (
+        <div
+            role="group"
+            aria-label={`Colour for ${personName}`}
+            className="mt-2 ml-9 grid grid-cols-6 gap-1.5"
+        >
+            {PERSON_COLORS.map(color => {
+                const isSelected = color.id === selected.id
+                return (
+                    <button
+                        key={color.id}
+                        type="button"
+                        onClick={() => onSelect(color.id)}
+                        aria-label={color.label}
+                        aria-pressed={isSelected}
+                        title={color.label}
+                        className={`h-7 w-7 rounded-full flex items-center justify-center text-xs font-bold transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-gray-400 ${color.avatar} ${isSelected ? `ring-2 ring-offset-1 ${color.ring}` : ''}`}
+                    >
+                        {isSelected ? '✓' : ''}
+                    </button>
+                )
+            })}
+        </div>
+    )
+}

--- a/src/edit-questions/person-colors.test.ts
+++ b/src/edit-questions/person-colors.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import type { Person } from './types'
+import {
+    PERSON_COLORS,
+    LEGACY_AVATAR_ROTATION,
+    personColorAt,
+    personColorFor,
+    personColorForName,
+    buildPersonColorLookup,
+} from './person-colors'
+
+const person = (over: Partial<Person> = {}): Person => ({ id: 'p1', name: 'Alice', ...over })
+
+describe('person-colors palette', () => {
+    it('gives every colour a unique id and a distinct avatar class', () => {
+        const ids = PERSON_COLORS.map(c => c.id)
+        expect(new Set(ids).size).toBe(ids.length)
+        const avatars = PERSON_COLORS.map(c => c.avatar)
+        expect(new Set(avatars).size).toBe(avatars.length)
+    })
+
+    it('keeps the first six positions on the colours people already have', () => {
+        // Anyone who has never picked a colour keeps the one they have been
+        // looking at, so adding the picker doesn't repaint their question set.
+        expect(PERSON_COLORS.slice(0, LEGACY_AVATAR_ROTATION.length).map(c => c.avatar))
+            .toEqual([...LEGACY_AVATAR_ROTATION])
+    })
+
+    it('rotates the default colour by position, wrapping past the end', () => {
+        expect(personColorAt(0)).toBe(PERSON_COLORS[0])
+        expect(personColorAt(PERSON_COLORS.length)).toBe(PERSON_COLORS[0])
+        expect(personColorAt(PERSON_COLORS.length + 2)).toBe(PERSON_COLORS[2])
+    })
+})
+
+describe('personColorFor', () => {
+    it('falls back to the position when the person has not chosen', () => {
+        expect(personColorFor(person(), 3)).toBe(personColorAt(3))
+    })
+
+    it('uses the person’s own colour when they have chosen one', () => {
+        const chosen = PERSON_COLORS[5]
+        expect(personColorFor(person({ color: chosen.id }), 0)).toBe(chosen)
+    })
+
+    it('falls back to the position for a colour it does not know', () => {
+        // A colour added by a newer client, arriving over the pod. Better a
+        // sensible default than a person with no avatar at all.
+        const unknown = { ...person(), color: 'ultraviolet' } as Person
+        expect(personColorFor(unknown, 1)).toBe(personColorAt(1))
+    })
+})
+
+describe('personColorForName', () => {
+    it('is stable for the same name', () => {
+        expect(personColorForName('Bob')).toBe(personColorForName('Bob'))
+    })
+
+    it('is a real palette colour for any name, including an empty one', () => {
+        for (const name of ['', 'Bob', 'Zoë', '👻', 'a very long name indeed']) {
+            expect(PERSON_COLORS).toContain(personColorForName(name))
+        }
+    })
+})
+
+describe('buildPersonColorLookup', () => {
+    const people: Person[] = [
+        { id: 'p1', name: 'Alice' },
+        { id: 'p2', name: 'Bob', color: PERSON_COLORS[7].id },
+        { id: 'p3', name: 'Cara' },
+    ]
+
+    it('resolves a known person by id', () => {
+        const lookup = buildPersonColorLookup(people)
+        expect(lookup({ id: 'p1', name: 'Alice' })).toBe(personColorAt(0))
+        expect(lookup({ id: 'p2', name: 'Bob' })).toBe(PERSON_COLORS[7])
+        expect(lookup({ id: 'p3', name: 'Cara' })).toBe(personColorAt(2))
+    })
+
+    it('resolves by name when the id is missing', () => {
+        // A packing list item carries the name it was generated with; its
+        // personId is empty on custom items added straight to the list.
+        const lookup = buildPersonColorLookup(people)
+        expect(lookup({ id: '', name: 'Bob' })).toBe(PERSON_COLORS[7])
+    })
+
+    it('gives someone the question set has never heard of a stable colour', () => {
+        const lookup = buildPersonColorLookup(people)
+        expect(lookup({ id: 'guest-1', name: 'Zoe' })).toBe(personColorForName('Zoe'))
+    })
+
+    it('hands a listed stranger a colour nobody on the list is using', () => {
+        // Alice and Cara hold positions 0 and 2; Bob chose position 7's colour.
+        const lookup = buildPersonColorLookup(people, [{ id: 'guest-1', name: 'Zoe' }])
+        const zoe = lookup({ id: 'guest-1', name: 'Zoe' })
+        expect(zoe).toBe(personColorAt(1))
+        expect([personColorAt(0), personColorAt(2), PERSON_COLORS[7]]).not.toContain(zoe)
+    })
+
+    it('gives two strangers different colours', () => {
+        const lookup = buildPersonColorLookup(people, [
+            { id: 'guest-1', name: 'Zoe' },
+            { id: 'guest-2', name: 'Yan' },
+        ])
+        expect(lookup({ id: 'guest-1', name: 'Zoe' }))
+            .not.toBe(lookup({ id: 'guest-2', name: 'Yan' }))
+    })
+
+    it('does not re-colour someone the question set already places', () => {
+        const lookup = buildPersonColorLookup(people, [
+            { id: 'p2', name: 'Bob' },
+            { id: 'guest-1', name: 'Zoe' },
+        ])
+        expect(lookup({ id: 'p2', name: 'Bob' })).toBe(PERSON_COLORS[7])
+    })
+
+    it('falls back to the hash once every colour is spoken for', () => {
+        const crowd = PERSON_COLORS.map((color, i) => ({ id: `p${i}`, name: `P${i}`, color: color.id }))
+        const lookup = buildPersonColorLookup(crowd, [{ id: 'guest-1', name: 'Zoe' }])
+        expect(lookup({ id: 'guest-1', name: 'Zoe' })).toBe(personColorForName('Zoe'))
+    })
+
+    it('skips deleted people when numbering the defaults', () => {
+        // Deleted people are gone from every list of people on screen, so
+        // leaving a gap in the rotation for one would shift everyone after it.
+        const lookup = buildPersonColorLookup([
+            { id: 'p0', name: 'Ghost', deletedAt: '2025-01-01T00:00:00.000Z' },
+            ...people,
+        ])
+        expect(lookup({ id: 'p1', name: 'Alice' })).toBe(personColorAt(0))
+    })
+})

--- a/src/edit-questions/person-colors.ts
+++ b/src/edit-questions/person-colors.ts
@@ -1,0 +1,179 @@
+/**
+ * The colours people are shown in — the coloured initial beside every item on
+ * the questions page, and the same person's section on a packing list.
+ *
+ * The colour is the fastest way to answer "whose is this?", so it has to mean
+ * the same thing everywhere it appears. That is the whole reason this palette
+ * is one shared table rather than a couple of class lists next to the two
+ * components that happened to need them.
+ *
+ * How a person's colour is decided, in order:
+ *
+ *   1. `person.color`, if they picked one.
+ *   2. Their position in the question set's people — the rotation the app has
+ *      always used, so nobody who never opens the picker sees anything change.
+ *   3. A hash of their name, where there is no position to count: guests added
+ *      straight to a list, and lists shared from someone else's pod, whose
+ *      people aren't in your question set at all.
+ *
+ * Every class is written out in full. Tailwind scans source text, so a class
+ * assembled from a colour variable would simply not exist at runtime.
+ */
+
+import { z } from 'zod'
+
+export const PersonColorSchema = z.enum([
+    'blue',
+    'violet',
+    'emerald',
+    'amber',
+    'rose',
+    'cyan',
+    'orange',
+    'indigo',
+    'teal',
+    'fuchsia',
+    'lime',
+    'pink',
+])
+
+export type PersonColorId = z.infer<typeof PersonColorSchema>
+
+export interface PersonColor {
+    /** Stored on the person; the palette is keyed by it. */
+    id: PersonColorId
+    /** Shown in the picker, and read out to screen readers there. */
+    label: string
+    /** The filled disc carrying the person's initial. */
+    avatar: string
+    /** Outline of that person's card on a packing list. */
+    border: string
+    /** Tinted fill, for a heading strip that belongs to one person. */
+    soft: string
+    /** Text on that tinted fill. */
+    text: string
+    /** Ring around the swatch currently chosen in the picker. */
+    ring: string
+}
+
+export const PERSON_COLORS: readonly PersonColor[] = [
+    { id: 'blue', label: 'Blue', avatar: 'bg-blue-500 text-white', border: 'border-blue-300', soft: 'bg-blue-50', text: 'text-blue-900', ring: 'ring-blue-400' },
+    { id: 'violet', label: 'Violet', avatar: 'bg-violet-500 text-white', border: 'border-violet-300', soft: 'bg-violet-50', text: 'text-violet-900', ring: 'ring-violet-400' },
+    { id: 'emerald', label: 'Emerald', avatar: 'bg-emerald-500 text-white', border: 'border-emerald-300', soft: 'bg-emerald-50', text: 'text-emerald-900', ring: 'ring-emerald-400' },
+    { id: 'amber', label: 'Amber', avatar: 'bg-amber-500 text-white', border: 'border-amber-300', soft: 'bg-amber-50', text: 'text-amber-900', ring: 'ring-amber-400' },
+    { id: 'rose', label: 'Rose', avatar: 'bg-rose-500 text-white', border: 'border-rose-300', soft: 'bg-rose-50', text: 'text-rose-900', ring: 'ring-rose-400' },
+    { id: 'cyan', label: 'Cyan', avatar: 'bg-cyan-500 text-white', border: 'border-cyan-300', soft: 'bg-cyan-50', text: 'text-cyan-900', ring: 'ring-cyan-400' },
+    { id: 'orange', label: 'Orange', avatar: 'bg-orange-500 text-white', border: 'border-orange-300', soft: 'bg-orange-50', text: 'text-orange-900', ring: 'ring-orange-400' },
+    { id: 'indigo', label: 'Indigo', avatar: 'bg-indigo-500 text-white', border: 'border-indigo-300', soft: 'bg-indigo-50', text: 'text-indigo-900', ring: 'ring-indigo-400' },
+    { id: 'teal', label: 'Teal', avatar: 'bg-teal-500 text-white', border: 'border-teal-300', soft: 'bg-teal-50', text: 'text-teal-900', ring: 'ring-teal-400' },
+    { id: 'fuchsia', label: 'Fuchsia', avatar: 'bg-fuchsia-500 text-white', border: 'border-fuchsia-300', soft: 'bg-fuchsia-50', text: 'text-fuchsia-900', ring: 'ring-fuchsia-400' },
+    // The one initial not written in white: lime is too bright to carry it.
+    { id: 'lime', label: 'Lime', avatar: 'bg-lime-400 text-lime-950', border: 'border-lime-300', soft: 'bg-lime-50', text: 'text-lime-900', ring: 'ring-lime-500' },
+    { id: 'pink', label: 'Pink', avatar: 'bg-pink-500 text-white', border: 'border-pink-300', soft: 'bg-pink-50', text: 'text-pink-900', ring: 'ring-pink-400' },
+]
+
+/**
+ * The avatar classes the app rotated through before colours could be chosen,
+ * in their original order. The palette starts with exactly these, so the
+ * position fallback hands every existing person the colour they already had —
+ * asserted in the tests rather than left to whoever next edits the table.
+ */
+export const LEGACY_AVATAR_ROTATION: readonly string[] = [
+    'bg-blue-500 text-white',
+    'bg-violet-500 text-white',
+    'bg-emerald-500 text-white',
+    'bg-amber-500 text-white',
+    'bg-rose-500 text-white',
+    'bg-cyan-500 text-white',
+]
+
+/** An avatar for someone this item isn't for: present, but plainly off. */
+export const PERSON_COLOR_OFF = 'bg-gray-100 text-gray-300'
+
+const BY_ID = new Map<string, PersonColor>(PERSON_COLORS.map(color => [color.id, color]))
+
+/** The default colour for the nth person in a list of people. */
+export function personColorAt(index: number): PersonColor {
+    return PERSON_COLORS[((index % PERSON_COLORS.length) + PERSON_COLORS.length) % PERSON_COLORS.length]
+}
+
+/** Plain string hash — stable across reloads, machines and stored data. */
+function hashName(name: string): number {
+    let hash = 0
+    for (let i = 0; i < name.length; i++) {
+        hash = (hash * 31 + name.charCodeAt(i)) | 0
+    }
+    return Math.abs(hash)
+}
+
+/**
+ * A colour for someone with no position to count from. Two names can land on
+ * the same colour; that costs nothing, because the name is written next to it.
+ */
+export function personColorForName(name: string): PersonColor {
+    return PERSON_COLORS[hashName(name) % PERSON_COLORS.length]
+}
+
+/**
+ * The colour of the person at `index` in a set of people. An unrecognised
+ * stored colour — one a newer version of the app knows and this one doesn't —
+ * falls back to the position rather than leaving the avatar unpainted.
+ */
+export function personColorFor(person: { color?: string }, index: number): PersonColor {
+    return (person.color !== undefined ? BY_ID.get(person.color) : undefined) ?? personColorAt(index)
+}
+
+/** Someone a packing list knows about: an item's person, or a guest. */
+export interface ColorablePerson {
+    id?: string
+    name: string
+}
+
+/**
+ * A colour for anyone a packing list mentions, resolved against the people in
+ * the question set.
+ *
+ * Lists carry a person's id and name, not their colour, so the colours are read
+ * from the question set when the list is shown rather than copied onto it. Same
+ * reasoning as the section order: how you want your people coloured is one
+ * setting, not a decision frozen into each trip on the day you made it.
+ *
+ * `others` are the people a list mentions that the question set has never heard
+ * of — guests added straight to a list, and everyone on a list shared from
+ * someone else's pod. They can't have a position in the question set to count
+ * from, so they take the first colour nobody on this list is already using.
+ * That is what keeps a guest from turning up in the same colour as the person
+ * sitting next to them, which the position rotation alone cannot promise.
+ */
+export function buildPersonColorLookup(
+    people: readonly { id: string; name: string; color?: string; deletedAt?: string }[],
+    others: readonly ColorablePerson[] = []
+): (person: ColorablePerson) => PersonColor {
+    const byId = new Map<string, PersonColor>()
+    const byName = new Map<string, PersonColor>()
+    const taken = new Set<PersonColorId>()
+
+    const assign = (id: string | undefined, name: string, color: PersonColor) => {
+        if (id) byId.set(id, color)
+        // First one wins: two people sharing a name is already ambiguous
+        // everywhere else in the app, and an id will usually settle it.
+        if (!byName.has(name)) byName.set(name, color)
+        taken.add(color.id)
+    }
+
+    people
+        .filter(person => !person.deletedAt)
+        .forEach((person, index) => assign(person.id, person.name, personColorFor(person, index)))
+
+    for (const other of others) {
+        if (other.id && byId.has(other.id)) continue
+        if (!other.id && byName.has(other.name)) continue
+        // Once every colour is spoken for there is nothing left to hand out, so
+        // fall back to the hash rather than always reaching for the same one.
+        const free = PERSON_COLORS.find(color => !taken.has(color.id))
+        assign(other.id, other.name, free ?? personColorForName(other.name))
+    }
+
+    return ({ id, name }) =>
+        (id ? byId.get(id) : undefined) ?? byName.get(name) ?? personColorForName(name)
+}

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { PersonColorSchema } from './person-colors'
 
 // Age Range Type
 export const AgeRangeSchema = z.enum(['Baby', 'Toddler', 'Child', 'Teenager', 'Adult'])
@@ -41,6 +42,9 @@ export const PET_SPECIES_OPTIONS = [
 // `dateOfBirth` (ISO date, YYYY-MM-DD) is optional and additive: when present
 // the person's bracket is derived from it and `ageRange` acts as the last
 // bracket the user acknowledged, which is how age-up transitions are detected.
+// `color` is optional and additive: absent means "whatever this person's
+// position gives them", which is the colour they had before the picker
+// existed. See `person-colors.ts`.
 export const PersonSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -48,6 +52,7 @@ export const PersonSchema = z.object({
   dateOfBirth: z.string().optional(),
   gender: GenderSchema.optional(),
   species: PetSpeciesSchema.optional(),
+  color: PersonColorSchema.optional(),
   lastModified: z.string().optional(),
   deletedAt: z.string().optional(),
 })

--- a/src/hooks/usePersonColors.ts
+++ b/src/hooks/usePersonColors.ts
@@ -1,0 +1,48 @@
+import { useEffect, useMemo, useState } from 'react'
+import { buildPersonColorLookup, type ColorablePerson, type PersonColor } from '../edit-questions/person-colors'
+import type { Person } from '../edit-questions/types'
+import type { PackingAppDatabase } from '../services/database'
+
+export type PersonColorLookup = (person: ColorablePerson) => PersonColor
+
+const NO_ONE: readonly ColorablePerson[] = []
+
+/**
+ * How to colour the people a packing list mentions: the colours set on the
+ * questions page, read live.
+ *
+ * Live rather than copied onto each list at generation, for the same reason the
+ * section order is (see `useSectionOrder`) — a person's colour is a statement
+ * about that person, not about one trip. Recolouring someone should reach the
+ * list already open in front of you, not just the next one you make.
+ *
+ * `alsoOnThisList` is everyone the list names who isn't in the question set:
+ * guests, and the whole cast of a list shared from someone else's pod. They get
+ * whatever colours are left over, so no two people on one list collide.
+ */
+export function usePersonColors(
+    db: PackingAppDatabase | undefined,
+    alsoOnThisList: readonly ColorablePerson[] = NO_ONE,
+): PersonColorLookup {
+    const [people, setPeople] = useState<Person[]>([])
+
+    useEffect(() => {
+        if (!db) return
+        let cancelled = false
+        Promise.resolve()
+            .then(() => db.getQuestionSet())
+            .then(questionSet => {
+                if (cancelled) return
+                setPeople(questionSet?.people ?? [])
+            })
+            .catch(() => { /* nobody known: everyone is coloured as a stranger */ })
+        return () => { cancelled = true }
+    }, [db])
+
+    // Who is on the list, not the identity of the array holding them — the
+    // callers build it fresh whenever an item changes.
+    const rosterKey = alsoOnThisList.map(p => `${p.id ?? ''}${p.name}`).join('')
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rosterKey stands in for alsoOnThisList
+    return useMemo(() => buildPersonColorLookup(people, alsoOnThisList), [people, rosterKey])
+}

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -19,6 +19,8 @@ import { AgePromotionCard } from '../components/AgePromotionCard'
 import { LoadingState } from '../components/LoadingState'
 import { tripDatesOutOfOrder } from '../create-packing-list/tripDetails'
 import { deduplicateItems } from '../create-packing-list/deduplicate'
+import { PersonAvatar } from '../components/PersonAvatar'
+import { personColorFor } from '../edit-questions/person-colors'
 
 export function getUnreviewedDeletedItems(
     packingLists: PackingList[],
@@ -843,7 +845,7 @@ export function CreatePackingList() {
                             </button>
                         </div>
                         <div className="space-y-2">
-                            {questionSet.people.map((person) => (
+                            {questionSet.people.map((person, personIndex) => (
                                 <label key={person.id} className="flex items-center space-x-3">
                                     <input
                                         type="checkbox"
@@ -856,6 +858,12 @@ export function CreatePackingList() {
                                             }
                                         }}
                                         className="h-4 w-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+                                    />
+                                    {/* The same mark they'll carry on the list this makes */}
+                                    <PersonAvatar
+                                        name={person.name}
+                                        color={personColorFor(person, personIndex)}
+                                        size="sm"
                                     />
                                     <span className="text-gray-700">
                                         {person.name}

--- a/src/pages/questions-page.person-colors.test.tsx
+++ b/src/pages/questions-page.person-colors.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import React from 'react'
+import { PeopleModal } from './questions-page'
+import type { Person } from '../edit-questions/types'
+import { PERSON_COLORS, personColorAt } from '../edit-questions/person-colors'
+
+vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
+vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn() }))
+vi.mock('../components/ForeignPodContext', () => ({ useForeignPod: vi.fn() }))
+
+const people: Person[] = [
+    { id: 'p1', name: 'Alice' },
+    { id: 'p2', name: 'Bob' },
+]
+
+function renderModal(initial: Person[] = people) {
+    const onSave = vi.fn()
+    render(<PeopleModal people={initial} onSave={onSave} onClose={vi.fn()} />)
+    return { onSave }
+}
+
+const avatarFor = (name: string) => screen.getByRole('button', { name: `Change colour for ${name}` })
+
+describe('PeopleModal colour picker', () => {
+    it('paints each avatar with the colour for that person’s position', () => {
+        renderModal()
+        expect(avatarFor('Alice').className).toContain(personColorAt(0).avatar)
+        expect(avatarFor('Bob').className).toContain(personColorAt(1).avatar)
+    })
+
+    it('paints an avatar with the colour the person chose earlier', () => {
+        renderModal([{ id: 'p1', name: 'Alice', color: 'lime' }])
+        const lime = PERSON_COLORS.find(c => c.id === 'lime')!
+        expect(avatarFor('Alice').className).toContain(lime.avatar)
+    })
+
+    it('keeps the palette shut until the avatar is tapped', () => {
+        renderModal()
+        expect(screen.queryByRole('group', { name: /Colour for Alice/ })).toBeNull()
+        fireEvent.click(avatarFor('Alice'))
+        expect(screen.getByRole('group', { name: 'Colour for Alice' })).toBeTruthy()
+    })
+
+    it('opens one palette at a time', () => {
+        renderModal()
+        fireEvent.click(avatarFor('Alice'))
+        fireEvent.click(avatarFor('Bob'))
+        expect(screen.queryByRole('group', { name: 'Colour for Alice' })).toBeNull()
+        expect(screen.getByRole('group', { name: 'Colour for Bob' })).toBeTruthy()
+    })
+
+    it('marks the person’s current colour as the chosen swatch', () => {
+        renderModal()
+        fireEvent.click(avatarFor('Alice'))
+        const group = screen.getByRole('group', { name: 'Colour for Alice' })
+        const chosen = within(group).getByRole('button', { name: personColorAt(0).label })
+        expect(chosen.getAttribute('aria-pressed')).toBe('true')
+    })
+
+    it('repaints the avatar and closes the palette when a colour is picked', () => {
+        renderModal()
+        fireEvent.click(avatarFor('Alice'))
+        fireEvent.click(screen.getByRole('button', { name: 'Pink' }))
+        const pink = PERSON_COLORS.find(c => c.id === 'pink')!
+        expect(avatarFor('Alice').className).toContain(pink.avatar)
+        expect(screen.queryByRole('group', { name: 'Colour for Alice' })).toBeNull()
+    })
+
+    it('saves the chosen colour on the person', () => {
+        const { onSave } = renderModal()
+        fireEvent.click(avatarFor('Bob'))
+        fireEvent.click(screen.getByRole('button', { name: 'Teal' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+        expect(onSave).toHaveBeenCalledWith([
+            { id: 'p1', name: 'Alice' },
+            { id: 'p2', name: 'Bob', color: 'teal' },
+        ])
+    })
+
+    it('names an unnamed person by position so the picker is still findable', () => {
+        renderModal([{ id: 'p1', name: '' }])
+        expect(screen.getByRole('button', { name: 'Change colour for Person 1' })).toBeTruthy()
+    })
+})

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -27,11 +27,11 @@ import { AddQuestionItem } from '../components/AddQuestionItem'
 import { ALWAYS_LIST_KEY, buildQuestionSetSuggestions, listKeyFor } from '../edit-questions/item-suggestions'
 import { buildIndexOf, type SuggestionIndex } from '../utils/itemSuggestions'
 import {
-    AVATAR_ON,
-    AVATAR_OFF,
     rateLabel,
     quantityTitle,
 } from '../components/ItemEditorControls'
+import { PERSON_COLOR_OFF, personColorFor, type PersonColorId } from '../edit-questions/person-colors'
+import { PersonColorSwatches } from '../components/PersonColorPicker'
 
 // Stable empty default for the optional inline-editing props, so a section that
 // isn't editable doesn't hand its memoized children a new array every render.
@@ -41,7 +41,7 @@ function PersonDot({ person, index, selected }: { person: Person; index: number;
     return (
         <span
             title={person.name}
-            className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold select-none shrink-0 ${selected ? AVATAR_ON[index % AVATAR_ON.length] : AVATAR_OFF}`}
+            className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold select-none shrink-0 ${selected ? personColorFor(person, index).avatar : PERSON_COLOR_OFF}`}
         >
             {person.name.charAt(0).toUpperCase()}
         </span>
@@ -57,7 +57,7 @@ const PersonLegend = memo(function PersonLegend({ people, onEdit }: { people: Pe
             )}
             {people.map((person, i) => (
                 <span key={person.id} className="flex items-center gap-1 text-xs text-gray-500">
-                    <span className={`inline-flex items-center justify-center w-4 h-4 rounded-full text-[9px] font-bold ${AVATAR_ON[i % AVATAR_ON.length]}`}>
+                    <span className={`inline-flex items-center justify-center w-4 h-4 rounded-full text-[9px] font-bold ${personColorFor(person, i).avatar}`}>
                         {person.name.charAt(0).toUpperCase()}
                     </span>
                     {person.name}
@@ -1268,7 +1268,7 @@ function OptionEditModal({ option, onSave, onClose }: {
     )
 }
 
-function PeopleModal({ people, onSave, onClose }: {
+export function PeopleModal({ people, onSave, onClose }: {
     people: Person[]
     onSave: (newPeople: Person[]) => void
     onClose: () => void
@@ -1276,6 +1276,9 @@ function PeopleModal({ people, onSave, onClose }: {
     const [localPeople, setLocalPeople] = useState<Person[]>(
         people.length > 0 ? people : [{ id: crypto.randomUUID(), name: '' }]
     )
+    // Which person's palette is open. One at a time: twelve swatches under
+    // every row would bury the names this modal exists to edit.
+    const [colorPickerFor, setColorPickerFor] = useState<string | null>(null)
 
     const addPerson = () => setLocalPeople(prev => [...prev, { id: crypto.randomUUID(), name: '' }])
     const removePerson = (idx: number) => {
@@ -1292,6 +1295,12 @@ function PeopleModal({ people, onSave, onClose }: {
         setLocalPeople(prev => prev.map((p, i) => i === idx
             ? { ...p, ageRange: value === '' ? undefined : value as Person['ageRange'] }
             : p))
+    // Picking closes the palette: the choice shows immediately on the avatar
+    // above it, so leaving the grid open would only hide the confirmation.
+    const updateColor = (idx: number, color: PersonColorId) => {
+        setLocalPeople(prev => prev.map((p, i) => i === idx ? { ...p, color } : p))
+        setColorPickerFor(null)
+    }
 
     return (
         <div
@@ -1303,12 +1312,23 @@ function PeopleModal({ people, onSave, onClose }: {
                 <div className="p-5">
                     <h2 className="text-lg font-semibold text-gray-900 mb-4">Edit People</h2>
                     <div className="space-y-2 mb-3">
-                        {localPeople.map((person, i) => (
+                        {localPeople.map((person, i) => {
+                            const color = personColorFor(person, i)
+                            const pickerOpen = colorPickerFor === person.id
+                            const personLabel = person.name || `Person ${i + 1}`
+                            return (
                             <div key={person.id}>
                                 <div className="flex items-center gap-2">
-                                    <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold shrink-0 ${AVATAR_ON[i % AVATAR_ON.length]}`}>
+                                    <button
+                                        type="button"
+                                        onClick={() => setColorPickerFor(pickerOpen ? null : person.id)}
+                                        aria-label={`Change colour for ${personLabel}`}
+                                        aria-expanded={pickerOpen}
+                                        title="Change colour"
+                                        className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold shrink-0 transition-shadow hover:ring-2 hover:ring-offset-1 focus:outline-none focus:ring-2 focus:ring-offset-1 ${color.avatar} ${color.ring} ${pickerOpen ? 'ring-2 ring-offset-1' : ''}`}
+                                    >
                                         {person.name.charAt(0).toUpperCase() || '?'}
-                                    </span>
+                                    </button>
                                     <input
                                         autoFocus={i === 0}
                                         type="text"
@@ -1353,10 +1373,18 @@ function PeopleModal({ people, onSave, onClose }: {
                                         </select>
                                     </div>
                                 )}
+                                {pickerOpen && (
+                                    <PersonColorSwatches
+                                        personName={personLabel}
+                                        selected={color}
+                                        onSelect={id => updateColor(i, id)}
+                                    />
+                                )}
                             </div>
-                        ))}
+                            )
+                        })}
                     </div>
-                    <p className="text-xs text-gray-400 mb-3">Birthdays are optional — add one and we'll suggest packing-item updates as they grow. You can also bump the age group early if they're ready for it.</p>
+                    <p className="text-xs text-gray-400 mb-3">Tap someone's circle to change their colour — it follows them onto every packing list. Birthdays are optional: add one and we'll suggest packing-item updates as they grow, or bump the age group early if they're ready for it.</p>
                     <button
                         type="button"
                         onClick={addPerson}

--- a/src/pages/view-packing-list.person-colors.test.tsx
+++ b/src/pages/view-packing-list.person-colors.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { ViewPackingList } from './view-packing-list'
+import type { PackingAppDatabase } from '../services/database'
+import { PERSON_COLORS, personColorAt } from '../edit-questions/person-colors'
+
+vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
+vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn() }))
+vi.mock('../components/ToastContext', () => ({ useToast: vi.fn(() => ({ showToast: vi.fn() })) }))
+vi.mock('../hooks/usePodSync', () => ({ usePodSync: vi.fn() }))
+vi.mock('../hooks/useSyncCoordinator', () => ({ useSyncCoordinator: vi.fn() }))
+vi.mock('../components/SharePackingListModal', () => ({ SharePackingListModal: vi.fn(() => null) }))
+vi.mock('../hooks/useSharedListsSync', () => ({
+    useSharedListsSync: vi.fn(() => ({
+        sharedListsWithMe: { lists: [], lastModified: '' },
+        saveSharedListsWithMe: vi.fn().mockResolvedValue(null),
+    })),
+}))
+vi.mock('../services/solidPod', () => ({
+    POD_CONTAINERS: { PACKING_LISTS: 'pack-me-up/packing-lists/', SHARED_LISTS_WITH_ME: 'pack-me-up/shared-lists-with-me.ttl' },
+    getPrimaryPodUrl: vi.fn().mockResolvedValue('https://own.solidcommunity.net/'),
+    saveRdfToPod: vi.fn().mockResolvedValue(undefined),
+    resolveOwnerDisplayName: vi.fn(() => 'owner'),
+    deriveWebIdFromPodUrl: vi.fn((url: string) => `${url}profile/card#me`),
+}))
+
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+import { usePodSync } from '../hooks/usePodSync'
+import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
+
+const packingList = {
+    id: 'colour-list',
+    name: 'Colour Trip',
+    createdAt: '2026-01-01T00:00:00Z',
+    guests: [{ id: 'g1', name: 'Zoe' }],
+    items: [
+        { id: 'i1', itemText: 'Toothbrush', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', packed: false, category: 'Essentials' },
+        { id: 'i2', itemText: 'Nappies', personName: 'Bob', personId: 'p2', questionId: 'q1', optionId: 'o1', packed: false, category: 'Essentials' },
+        { id: 'i3', itemText: 'Sun hat', personName: 'Zoe', personId: 'g1', questionId: 'q2', optionId: 'o2', packed: false, category: 'Beach' },
+    ],
+}
+
+// Bob has picked a colour; Alice never has, so she keeps the one her position
+// gives her. Zoe is a guest — the question set has never heard of her.
+const questionSet = {
+    people: [
+        { id: 'p1', name: 'Alice' },
+        { id: 'p2', name: 'Bob', color: 'pink' as const },
+    ],
+    alwaysNeededItems: [],
+    questions: [],
+}
+
+function makeDb() {
+    return {
+        getPackingList: vi.fn().mockResolvedValue(packingList),
+        savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+        getQuestionSet: vi.fn().mockResolvedValue(questionSet),
+        getSharedListsWithMe: vi.fn().mockResolvedValue({ lists: [], lastModified: '' }),
+        saveSharedListsWithMe: vi.fn().mockResolvedValue({ rev: '1' }),
+    }
+}
+
+function renderList() {
+    return render(
+        <MemoryRouter initialEntries={['/view-list/colour-list']}>
+            <Routes>
+                <Route path="/view-list/:id" element={<ViewPackingList />} />
+            </Routes>
+        </MemoryRouter>
+    )
+}
+
+/** The card whose heading names this person. */
+function cardFor(name: string): HTMLElement {
+    const heading = screen.getByRole('button', { name: new RegExp(`Collapse ${name}'s list`) })
+    return heading.closest('[data-testid="list-section"]') as HTMLElement
+}
+
+const pink = PERSON_COLORS.find(c => c.id === 'pink')!
+
+beforeEach(() => {
+    localStorage.clear()
+    vi.mocked(useSolidPod).mockReturnValue({
+        isLoggedIn: false, session: null, webId: undefined, isLoading: false, login: vi.fn(), logout: vi.fn(),
+    })
+    vi.mocked(usePodSync).mockReturnValue({ saveToPod: vi.fn() })
+    vi.mocked(useSyncCoordinator).mockReturnValue({
+        syncingFromPod: false,
+        handleSyncSuccess: vi.fn(),
+        handleSyncError: vi.fn(),
+        saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...packingList, _rev: '2' }),
+    })
+    vi.mocked(useDatabase).mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+})
+
+describe('ViewPackingList person colours', () => {
+    it('marks each person’s card with their coloured initial', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+        await waitFor(() =>
+            expect(within(cardFor('Bob')).getByTestId('person-avatar').className).toContain(pink.avatar))
+        expect(within(cardFor('Alice')).getByTestId('person-avatar').className)
+            .toContain(personColorAt(0).avatar)
+    })
+
+    it('outlines the card in the same colour', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Nappies')).toBeTruthy())
+
+        await waitFor(() => expect(cardFor('Bob').className).toContain(pink.border))
+        expect(cardFor('Alice').className).toContain(personColorAt(0).border)
+    })
+
+    it('gives a guest a colour nobody else on the list is wearing', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Sun hat')).toBeTruthy())
+
+        // Alice holds position 0 and Bob chose pink, so the first colour going
+        // spare is position 1's.
+        await waitFor(() =>
+            expect(within(cardFor('Zoe')).getByTestId('person-avatar').className)
+                .toContain(personColorAt(1).avatar))
+        expect(within(cardFor('Zoe')).getByTestId('person-avatar').className)
+            .not.toContain(pink.avatar)
+    })
+
+    it('carries the colours into the section-grouped view', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: 'Question View' }))
+
+        // Each person's group inside a section card is marked the same way
+        const bobGroup = await screen.findByRole('button', { name: /Collapse Bob/ })
+        await waitFor(() => expect(within(bobGroup).getByTestId('person-avatar').className).toContain(pink.avatar))
+        const aliceGroup = screen.getByRole('button', { name: /Collapse Alice/ })
+        expect(within(aliceGroup).getByTestId('person-avatar').className).toContain(personColorAt(0).avatar)
+    })
+
+    it('leaves the shared card unmarked — it belongs to nobody in particular', async () => {
+        renderList()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /Add Shared Items/i }))
+        const sharedHeading = await screen.findByRole('button', { name: /Collapse the shared items list/ })
+        const sharedCard = sharedHeading.closest('[data-testid="list-section"]') as HTMLElement
+        expect(within(sharedCard).queryByTestId('person-avatar')).toBeNull()
+    })
+})

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -28,6 +28,8 @@ import { prefersReducedMotion } from '../utils/prefersReducedMotion'
 import { groupItemsByCategory, sortByOrder, type CategoryAccessors } from '../utils/groupByCategory'
 import { CATEGORY_ORDER } from '../edit-questions/item-sections'
 import { useSectionOrder } from '../hooks/useSectionOrder'
+import { usePersonColors } from '../hooks/usePersonColors'
+import { PersonAvatar } from '../components/PersonAvatar'
 import { AddItemComposer, UNCATEGORISED_LABEL, type AddItemTarget, type PersonOption } from '../components/AddItemComposer'
 import { buildSuggestionIndex } from '../utils/itemSuggestions'
 import { useIsDesktop } from '../hooks/useIsDesktop'
@@ -137,10 +139,13 @@ function isSectionComplete(stats?: SectionStats): boolean {
     return stats !== undefined && stats.total > 0 && stats.packed === stats.total
 }
 
+/** Where a custom item was added without saying whose it is. */
+export const UNASSIGNED_LABEL = 'Unassigned'
+
 export function groupByPerson(items: PackingListItem[]) {
     const map = new Map<string, PackingListItem[]>()
     for (const item of items) {
-        const person = item.personName || 'Unassigned'
+        const person = item.personName || UNASSIGNED_LABEL
         if (!map.has(person)) map.set(person, [])
         map.get(person)!.push(item)
     }
@@ -384,6 +389,11 @@ export function ViewPackingList() {
             .sort(([a], [b]) => a.localeCompare(b))
             .map(([name, id]) => ({ name, id }))
     }, [packingList?.items, packingList?.guests])
+
+    // Everyone this list names, so the ones the question set doesn't know —
+    // guests, or the whole cast of a shared list — still come out in colours
+    // nobody else here is wearing.
+    const personColor = usePersonColors(db, peopleOptions)
 
 
     const { register, setValue, getValues, control, reset } = useForm<FormData>({
@@ -1492,8 +1502,16 @@ export function ViewPackingList() {
                                 ? groupByCategory(items, sectionOrder)
                                 : groupByPerson(items)
                             const isSectionCollapsed = collapsedSections.has(sectionKey)
+                            // Only a card that belongs to one person can wear
+                            // their colour: a category card holds everybody's.
+                            const sectionPersonColor = (isShared || isCategorySection)
+                                ? undefined
+                                : personColor({ id: guestId ?? personIdByName.get(section.name) ?? '', name: section.name })
+                            const sectionBorder = isComplete
+                                ? 'border-emerald-300 bg-emerald-50'
+                                : `bg-white ${sectionPersonColor?.border ?? (isShared ? 'border-blue-200' : 'border-gray-200')}`
                             return (
-                            <div key={sectionKey} className={`border rounded-lg p-4 shadow-sm mb-4 transition-colors duration-300 ${isComplete ? 'border-emerald-300 bg-emerald-50' : `bg-white ${isGuest ? 'border-amber-200' : isShared ? 'border-blue-200' : 'border-gray-200'}`}`} style={{ breakInside: 'avoid' }}>
+                            <div key={sectionKey} data-testid="list-section" className={`border rounded-lg p-4 shadow-sm mb-4 transition-colors duration-300 ${sectionBorder}`} style={{ breakInside: 'avoid' }}>
                                 {/* The rule under the heading separates it from the items
                                     below; a folded card has none, so it would just be a
                                     line ruling off empty space. */}
@@ -1523,6 +1541,9 @@ export function ViewPackingList() {
                                                 className="flex items-center gap-2 flex-1 min-w-0 text-left"
                                             >
                                                 <span className="shrink-0 text-sm text-gray-400">{isSectionCollapsed ? '▶' : '▼'}</span>
+                                                {sectionPersonColor && (
+                                                    <PersonAvatar name={section.name} color={sectionPersonColor} />
+                                                )}
                                                 <span className="text-xl font-semibold text-gray-800">{title}</span>
                                                 {/* Never let a count break across lines — "9 /" above "9" is
                                                     a fraction the eye has to reassemble. */}
@@ -1627,6 +1648,16 @@ export function ViewPackingList() {
                                                         className="flex items-center gap-1 text-left text-sm font-semibold text-gray-600 hover:text-gray-900"
                                                     >
                                                         <span>{isCollapsed ? '▶' : '▼'}</span>
+                                                        {/* A category card's groups are people, so each one
+                                                            gets the same mark its owner's card would have.
+                                                            The catch-all group is nobody's. */}
+                                                        {isCategorySection && label !== UNASSIGNED_LABEL && (
+                                                            <PersonAvatar
+                                                                name={label}
+                                                                color={personColor({ id: personIdByName.get(label) ?? '', name: label })}
+                                                                size="sm"
+                                                            />
+                                                        )}
                                                         <span>{label}</span>
                                                         <span className="ml-1 shrink-0 whitespace-nowrap text-xs font-normal text-gray-400">{groupStat.packed} / {groupStat.total}</span>
                                                     </button>

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -364,6 +364,7 @@ function personToThing(person: Person, personUrl: string): Thing {
     if (person.gender) t = t.addStringNoLocale(PMU.gender, person.gender)
     if (person.species) t = t.addStringNoLocale(PMU.species, person.species)
     if (person.dateOfBirth) t = t.addStringNoLocale(PMU.dateOfBirth, person.dateOfBirth)
+    if (person.color) t = t.addStringNoLocale(PMU.personColor, person.color)
     if (person.lastModified) t = t.addDatetime(PMU.personLastModified, new Date(person.lastModified))
     if (person.deletedAt) t = t.addDatetime(PMU.personDeletedAt, new Date(person.deletedAt))
 
@@ -378,6 +379,7 @@ function thingToPerson(thing: Thing | null, url: string): Person | null {
     const gender = getStringNoLocale(thing, PMU.gender) ?? undefined
     const species = getStringNoLocale(thing, PMU.species) ?? undefined
     const dateOfBirth = getStringNoLocale(thing, PMU.dateOfBirth) ?? undefined
+    const color = getStringNoLocale(thing, PMU.personColor) ?? undefined
     const lastModified = getDatetime(thing, PMU.personLastModified)?.toISOString()
     const deletedAt = getDatetime(thing, PMU.personDeletedAt)?.toISOString()
     return {
@@ -387,6 +389,7 @@ function thingToPerson(thing: Thing | null, url: string): Person | null {
         ...(gender !== undefined ? { gender: gender as Person['gender'] } : {}),
         ...(species !== undefined ? { species: species as Person['species'] } : {}),
         ...(dateOfBirth !== undefined ? { dateOfBirth } : {}),
+        ...(color !== undefined ? { color: color as Person['color'] } : {}),
         ...(lastModified !== undefined ? { lastModified } : {}),
         ...(deletedAt !== undefined ? { deletedAt } : {}),
     }

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -66,6 +66,10 @@ export const PMU = {
     species: `${PMU_NS}species`,
     // Stored as a plain YYYY-MM-DD string (not a datetime) to avoid timezone drift
     dateOfBirth: 'https://schema.org/birthDate',
+    // Palette id (see person-colors.ts), not a CSS colour — the app owns what
+    // 'rose' looks like, and an older client that doesn't know an id just falls
+    // back to the person's position.
+    personColor: `${PMU_NS}personColor`,
     personLastModified: `${PMU_NS}personLastModified`,
     personDeletedAt: `${PMU_NS}personDeletedAt`,
 

--- a/src/test-utils/fullyPopulatedFixtures.ts
+++ b/src/test-utils/fullyPopulatedFixtures.ts
@@ -95,6 +95,7 @@ const fullyPopulatedPerson: Required<Person> = {
     dateOfBirth: '1990-05-04',
     gender: 'female',
     species: 'dog',
+    color: 'fuchsia',
     lastModified: '2025-01-02T00:00:00.000Z',
     deletedAt: '2025-01-03T00:00:00.000Z',
 }


### PR DESCRIPTION
The coloured initial beside every item on My Questions & Items was the fastest way to answer "whose is this?" — and it stopped at the door of the thing it describes. A packing list was four identically grey cards.

Two changes: the colour now follows the person onto their lists, and it can be chosen.

## Picking a colour

The picker **is** the avatar. Tapping someone's circle in Edit People opens twelve swatches under their row — colour is the only thing on that page carrying their identity, so a field somewhere below it would be the wrong place to change it. Picking closes the palette, because the confirmation is the avatar right above it.

## On a packing list

- Person view: their coloured initial in the card heading, and the card outlined in the same colour.
- Question view: the same mark on each person's group inside a section card.
- Create a list: the same mark beside each person in "Who is going on this trip?".

## How a colour is decided

1. `person.color`, if they picked one.
2. Their position in the question set's people — the rotation the app has always used, so **nobody who never opens the picker sees anything change**. The first six palette entries are the old `AVATAR_ON` list in its original order, and a test asserts it.
3. First colour nobody else on the list is using, for people the question set has never heard of: guests, and everyone on a list shared from another pod. This is what stops a guest turning up in the same colour as the person sitting next to them.

## Reading the colour, not copying it

Lists carry a person's id and name, not their colour, so `usePersonColors` reads colours from the question set when the list is shown rather than stamping them on at generation — the same reasoning as `useSectionOrder`. A person's colour is a statement about that person, not a decision frozen into each trip on the day it was made, so recolouring someone reaches the list already open in front of you.

## Persistence

`Person.color` is optional and additive: a palette id (`'rose'`), not a CSS colour, so the app owns what it looks like and an older client that doesn't know an id simply falls back to the position. Added to `fullyPopulatedFixtures`, so the existing PouchDB and RDF round-trip guards cover it; new `pmu:personColor` predicate for the pod.

## Accessibility

Colour is never the only signal — the name is written beside every avatar, and the avatar itself is `aria-hidden`, so a screen reader says "Alice's Items" rather than "A, Alice's Items". Swatches are labelled by colour name with `aria-pressed`.

## Testing

- `npm test`: 1371 passing, including new unit tests for the palette/resolution rules, the People modal picker, and the list view.
- `npm run lint`: no new problems.
- New e2e `C9` covers the whole path: choose a colour → create a list → the card wears it. `b-questions` and `c-packing-lists` both green.
- Driven by hand in a real browser at 1280px and at 390px: wizard → recolour two people → create list → add a guest → both list views. Two rounds — the first showed a guest landing on a colour another person had chosen (fixed by rule 3 above) and a muddy `lime-600` swatch (now a bright `lime-400`).

## Not included

Addresses #248, which also asks for a per-person **emoji**. This PR is the colour half only, so the issue stays open for the emoji work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7vYfNTgFgiDWHzNeDyW23

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7vYfNTgFgiDWHzNeDyW23)_