### PR TITLE
Ask for sign-in where it pays off, not during onboarding

### DIFF
--- a/.claude/skills/pickup-issue/SKILL.md
+++ b/.claude/skills/pickup-issue/SKILL.md
@@ -3,8 +3,10 @@ name: pickup-issue
 version: 1.0.0
 description: |
   Find the first open GitHub issue without a "taken" label, claim it by adding
-  the label, then produce an implementation plan. Use when the user wants to
-  pick up the next available issue or asks /pickup-issue.
+  the label, produce an implementation plan, and — once built — manually test it
+  in the running app and push a dated screenshot report to the agent-testing
+  branch. Use when the user wants to pick up the next available issue or asks
+  /pickup-issue.
 allowed-tools:
   - Bash
   - Read
@@ -20,13 +22,18 @@ allowed-tools:
 
 You are running the `/pickup-issue` workflow. Find the next unclaimed issue,
 label it as taken, understand what it requires, then enter plan mode to produce
-an actionable implementation plan.
+an actionable implementation plan. Once the work is built, manually test it in
+the running app and publish the report (Step 6) — the issue is not done until
+that report is pushed.
 
 **Hard rules:**
 - Never claim more than one issue per invocation.
 - Never skip the codebase exploration — the plan must reference real files.
 - Always follow TDD: the plan must include a red → green → refactor cycle.
 - Never enter plan mode without first reading the full issue body and comments.
+- **Always manually test the finished change in the running app** (Step 6), and
+  push a dated manual test report with screenshots to the `agent-testing`
+  branch. Passing unit tests are never the whole story.
 
 ---
 
@@ -113,6 +120,83 @@ Call EnterPlanMode, then write a plan file with these sections:
   1. **Red** — write a failing test (`.test.tsx` / `.test.ts`) that captures the expected behaviour.
   2. **Green** — make the minimal change to pass the test.
   3. **Refactor** — clean up without breaking tests.
-- **Verification** — `npm test` to confirm everything passes.
+- **Verification** — `npm test` to confirm everything passes, plus the manual
+  test pass described in Step 6 (include it as a plan step, not an afterthought).
 
 Call ExitPlanMode to present the plan for user approval before writing any code.
+
+---
+
+## Step 6: Always manually test, and publish the report
+
+Automated tests are not enough on their own. Once the implementation is done,
+**drive the real app yourself** and see the change working, then write up what
+you saw. Never report an issue as finished without this.
+
+### 6a. Run the app and exercise the change
+
+Use the `/run` skill, or the project's own tooling:
+
+- `/solid-dev` starts a local Community Solid Server when the change touches
+  sign-in, sync, or sharing — use it so sign-in paths are tested for real
+  rather than mocked.
+- Otherwise `npm run build && npm run preview` and drive the built app
+  (Playwright is available with a pre-installed Chromium; a throwaway spec under
+  `e2e/tests/` is a fine way to script the walkthrough and capture screenshots —
+  delete it afterwards so it never lands in the committed suite).
+
+Cover, at minimum:
+- Every success criterion listed on the issue, one by one.
+- **Desktop and mobile viewports** (e.g. 1280×900 and 390×844) for anything with UI.
+- The unhappy paths a user will actually hit — dismiss, cancel, reload, back.
+
+**Take a screenshot of each step.** Note anything surprising, including
+pre-existing behaviour that shapes the flow.
+
+### 6b. Write the report
+
+A single markdown file, named `README.md`, containing:
+
+- A header table: date, issue link, PR link, branch + commit under test, result.
+- **How it was tested** — build, server, viewports, accounts used.
+- One section per success criterion, with the embedded screenshots
+  (`![…](images/NN-name.png)`) and what they show.
+- A success-criteria table with a pass/fail per row.
+- The automated-check results alongside (`npm test`, e2e).
+- A **Bugs found** section — say "None" explicitly if there were none.
+
+### 6c. Push it to the `agent-testing` branch
+
+Reports live on a dedicated `agent-testing` branch, which is **branched off the
+repository's first commit** so it never carries the codebase's history and never
+merges into `main`. Each report gets its own dated folder.
+
+```bash
+# Create the branch off the first commit if it does not exist yet
+git fetch origin agent-testing || \
+  git branch agent-testing $(git rev-list --max-parents=0 origin/main | tail -1)
+
+# Work in a separate worktree so the feature branch is left alone
+git worktree add /tmp/agent-testing-wt agent-testing   # add -b agent-testing if new
+
+FOLDER=/tmp/agent-testing-wt/$(date +%F)-issue-<number>-<short-slug>
+mkdir -p "$FOLDER/images"
+# write README.md into $FOLDER, screenshots into $FOLDER/images/
+
+git -C /tmp/agent-testing-wt add -A
+git -C /tmp/agent-testing-wt commit -m "Manual test report: issue #<number> (<date>)"
+git -C /tmp/agent-testing-wt push -u origin agent-testing
+git worktree remove /tmp/agent-testing-wt
+```
+
+Folder name: `YYYY-MM-DD-issue-<number>-<short-slug>`, e.g.
+`2026-07-31-issue-202-contextual-sign-in`.
+
+### 6d. Link the report from the PR
+
+Update the PR description with a link to the report on the `agent-testing`
+branch, so a reviewer can see the evidence without running anything:
+
+```
+📋 **[Manual test report — YYYY-MM-DD, with screenshots](https://github.com/timgent/pack-me-up/blob/agent-testing/YYYY-MM-DD-issue-<number>-<slug>/README.md)** (on the `agent-testing` branch)
+```

--- a/e2e/tests/a-onboarding.spec.ts
+++ b/e2e/tests/a-onboarding.spec.ts
@@ -15,7 +15,7 @@ test.describe('A – Onboarding & Wizard', () => {
     await expect(page.getByRole('link', { name: /View Packing Lists/i })).not.toBeVisible()
   })
 
-  test('A2: wizard with one person redirects to create-packing-list after dismissing pod prompt', async ({ freshPage: page }) => {
+  test('A2: wizard with one person goes straight to create-packing-list, with no sign-in ask', async ({ freshPage: page }) => {
     await page.goto('/#/wizard')
     // name field is pre-filled with "Me"
     await fillPersonRequiredFields(page)
@@ -26,11 +26,9 @@ test.describe('A – Onboarding & Wizard', () => {
     await expect(page.getByText(/Thinking about Me/i)).toBeVisible()
     await expect(page.getByText(/\d+ questions and \d+ items across 1 person/i)).toBeVisible({ timeout: 5_000 })
     await page.getByRole('button', { name: /Create My First Packing List/i }).click()
-    // Pod prompt appears for non-logged-in users
-    await expect(page.getByText("Great! Your Questions Are Ready")).toBeVisible({ timeout: 5_000 })
-    await page.getByRole('button', { name: 'Maybe Later' }).click()
-    // Should be on create-packing-list page
+    // Straight to the list builder — onboarding never asks a logged-out user to sign in
     await expect(page).toHaveURL(/#\/create-packing-list/, { timeout: 5_000 })
+    await expect(page.getByRole('button', { name: 'Maybe Later' })).toHaveCount(0)
     // Landing page now shows "View Packing Lists"
     await page.goto('/')
     await expect(page.getByRole('link', { name: /View Packing Lists/i })).toBeVisible()
@@ -49,9 +47,7 @@ test.describe('A – Onboarding & Wizard', () => {
     // Generate
     await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
     await waitForWizardSuccess(page)
-    // Dismiss pod prompt path
     await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
-    await page.getByRole('button', { name: 'Maybe Later' }).click()
     // On manage-questions page, expand People section and verify both names
     await expect(page).toHaveURL(/#\/manage-questions/, { timeout: 5_000 })
     // Open People modal via pencil icon in the legend
@@ -70,7 +66,6 @@ test.describe('A – Onboarding & Wizard', () => {
     await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
     await waitForWizardSuccess(page)
     await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
-    await page.getByRole('button', { name: 'Maybe Later' }).click()
     // Wait for client-side navigation to manage-questions and let the page settle
     await page.waitForURL(/#\/manage-questions/, { timeout: 8_000 })
     await page.waitForLoadState('networkidle')
@@ -98,7 +93,6 @@ test.describe('A – Onboarding & Wizard', () => {
     await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
     await waitForWizardSuccess(page)
     await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
-    await page.getByRole('button', { name: 'Maybe Later' }).click()
     await page.waitForURL(/#\/manage-questions/, { timeout: 8_000 })
     await page.waitForLoadState('networkidle')
 

--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -8,10 +8,6 @@ async function setupWizardAndGoToQuestions(page: import('@playwright/test').Page
   // Use role heading to distinguish modal title from toast notification
   await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 10_000 })
   await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
-  // handle pod prompt
-  try {
-    await page.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 })
-  } catch { /* already dismissed or logged in */ }
   await page.waitForURL(/#\/manage-questions/, { timeout: 8_000 })
 }
 
@@ -85,7 +81,6 @@ test.describe('B – Editing Questions', () => {
     await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
     await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 10_000 })
     await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
-    try { await page.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 }) } catch { /* ok */ }
     await page.waitForURL(/#\/manage-questions/, { timeout: 8_000 })
     // Open People modal
     await openPeopleModal(page)

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -7,7 +7,6 @@ async function runWizard(page: import('@playwright/test').Page) {
   await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
   await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 10_000 })
   await page.getByRole('button', { name: /Create My First Packing List/i }).click()
-  try { await page.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 }) } catch { /* ok */ }
   await page.waitForURL(/#\/create-packing-list/, { timeout: 5_000 })
 }
 
@@ -198,5 +197,69 @@ test.describe('C – Packing Lists', () => {
     const card = page.locator('[data-testid="list-section"]').filter({ hasText: "Me's Items" })
     await expect(card.getByTestId('person-avatar')).toHaveClass(/bg-fuchsia-500/)
     await expect(card).toHaveClass(/border-fuchsia-300/)
+  })
+})
+
+test.describe('C – Contextual sign-in prompts (logged out)', () => {
+  test('C10: the lists index nudges a logged-out user to sync, and stays dismissed for the session', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'Sync Nudge Trip')
+
+    await page.goto('/#/view-lists')
+    const prompt = page.getByTestId('sync-across-devices-prompt')
+    await expect(prompt).toBeVisible({ timeout: 8_000 })
+    await expect(prompt).toContainText(/sync across devices/i)
+
+    await prompt.getByRole('button', { name: 'Dismiss sync prompt' }).click()
+    await expect(prompt).toHaveCount(0)
+
+    // A reload is the same session, so the nudge stays gone
+    await page.reload()
+    await expect(page.getByText('Sync Nudge Trip')).toBeVisible({ timeout: 8_000 })
+    await expect(page.getByTestId('sync-across-devices-prompt')).toHaveCount(0)
+  })
+
+  test('C11: the nudge waits until there is a list worth syncing', async ({ freshPage: page }) => {
+    await page.goto('/#/view-lists')
+    await expect(page.getByText(/No packing lists found/i)).toBeVisible({ timeout: 8_000 })
+    await expect(page.getByTestId('sync-across-devices-prompt')).toHaveCount(0)
+  })
+
+  test('C12: sharing while logged out asks to sign in, framed around sharing', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'Share Prompt Trip')
+
+    await page.getByRole('button', { name: 'Share', exact: true }).click()
+    await expect(page.getByRole('heading', { name: /Sign in to share this list/i })).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(/Send a friend a link/i)).toBeVisible()
+
+    // Backing out leaves the list exactly as it was
+    await page.getByRole('button', { name: 'Not now' }).click()
+    await expect(page.getByRole('heading', { name: /Sign in to share this list/i })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Share', exact: true })).toBeVisible()
+  })
+
+  test('C13: both contextual prompts work on a phone-sized screen', async ({ freshPage: page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await runWizard(page)
+    await createList(page, 'Mobile Prompt Trip')
+
+    // Share prompt: the modal and both of its buttons fit the viewport
+    await page.getByRole('button', { name: 'Share', exact: true }).click()
+    const signInButton = page.getByRole('button', { name: /Sign in to share/i })
+    await expect(signInButton).toBeVisible({ timeout: 5_000 })
+    const signInBox = await signInButton.boundingBox()
+    expect(signInBox!.x).toBeGreaterThanOrEqual(0)
+    expect(signInBox!.x + signInBox!.width).toBeLessThanOrEqual(390)
+    await page.getByRole('button', { name: 'Not now' }).click()
+
+    // Sync nudge: fits the width, and the dismiss control is reachable
+    await page.goto('/#/view-lists')
+    const prompt = page.getByTestId('sync-across-devices-prompt')
+    await expect(prompt).toBeVisible({ timeout: 8_000 })
+    const promptBox = await prompt.boundingBox()
+    expect(promptBox!.x + promptBox!.width).toBeLessThanOrEqual(390)
+    await prompt.getByRole('button', { name: 'Dismiss sync prompt' }).click()
+    await expect(prompt).toHaveCount(0)
   })
 })

--- a/e2e/tests/f-sync.spec.ts
+++ b/e2e/tests/f-sync.spec.ts
@@ -26,7 +26,6 @@ test.describe('F – Solid Pod Sync', () => {
     try { await page.getByRole('button', { name: 'Yes, Override' }).click({ timeout: 3_000 }) } catch { /* ok */ }
     await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('button', { name: /Create My First Packing List/i }).click()
-    try { await page.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 }) } catch { /* ok */ }
     await page.waitForURL(/#\/create-packing-list/, { timeout: 10_000 })
   })
 

--- a/e2e/tests/g-cross-context.spec.ts
+++ b/e2e/tests/g-cross-context.spec.ts
@@ -22,7 +22,6 @@ test.describe('G – Cross-context Pod Sync', () => {
     try { await page.getByRole('button', { name: 'Yes, Override' }).click({ timeout: 3_000 }) } catch { /* ok */ }
     await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('button', { name: /Create My First Packing List/i }).click()
-    try { await page.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 }) } catch { /* ok */ }
     await page.waitForURL(/#\/create-packing-list/, { timeout: 10_000 })
   })
 

--- a/e2e/tests/h-backups.spec.ts
+++ b/e2e/tests/h-backups.spec.ts
@@ -24,7 +24,6 @@ test.describe('H – Backups', () => {
     try { await page.getByRole('button', { name: 'Yes, Override' }).click({ timeout: 3_000 }) } catch { /* ok */ }
     await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('button', { name: /Create My First Packing List/i }).click()
-    try { await page.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 }) } catch { /* ok */ }
     await page.waitForURL(/#\/create-packing-list/, { timeout: 10_000 })
     await page.getByPlaceholder('Enter a name for your packing list').waitFor({ timeout: 15_000 })
     await page.getByPlaceholder('Enter a name for your packing list').fill('Backup Test List')

--- a/e2e/tests/i-migration.spec.ts
+++ b/e2e/tests/i-migration.spec.ts
@@ -28,8 +28,6 @@ test.describe('I – Data Migration', () => {
     await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 10_000 })
     // The Success Modal's backdrop blocks the nav; dismiss it by clicking an action button
     await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
-    // For unauthenticated users, a SolidPodPrompt may appear — dismiss it
-    try { await page.getByRole('button', { name: /Maybe Later/i }).click({ timeout: 3_000 }) } catch { /* ok */ }
     await page.waitForURL(/#\/manage-questions/, { timeout: 5_000 })
     await page.waitForLoadState('networkidle')
   }

--- a/e2e/tests/l-sharing.spec.ts
+++ b/e2e/tests/l-sharing.spec.ts
@@ -25,7 +25,6 @@ test.describe('L – Sharing a packing list', () => {
         try { await pageA.getByRole('button', { name: 'Yes, Override' }).click({ timeout: 3_000 }) } catch { /* ok */ }
         await expect(pageA.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 15_000 })
         await pageA.getByRole('button', { name: /Create My First Packing List/i }).click()
-        try { await pageA.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 }) } catch { /* ok */ }
         await pageA.waitForURL(/#\/create-packing-list/, { timeout: 10_000 })
 
         // Create list

--- a/e2e/tests/m-collaboration.spec.ts
+++ b/e2e/tests/m-collaboration.spec.ts
@@ -44,7 +44,6 @@ test.describe('M – Full pod collaboration', () => {
             try { await pageA.getByRole('button', { name: 'Yes, Override' }).click({ timeout: 3_000 }) } catch { /* ok */ }
             await expect(pageA.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 15_000 })
             await pageA.getByRole('button', { name: /Create My First Packing List/i }).click()
-            try { await pageA.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 }) } catch { /* ok */ }
             await pageA.waitForURL(/#\/create-packing-list/, { timeout: 10_000 })
         }
 

--- a/e2e/tests/z-verify-offline-share.spec.ts
+++ b/e2e/tests/z-verify-offline-share.spec.ts
@@ -21,7 +21,6 @@ test.describe('Z – Offline list → login → share (regression for 404 fix)',
         try { await page.getByRole('button', { name: 'Yes, Override' }).click({ timeout: 3_000 }) } catch { /* ok */ }
         await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 15_000 })
         await page.getByRole('button', { name: /Create My First Packing List/i }).click()
-        try { await page.getByRole('button', { name: 'Maybe Later' }).click({ timeout: 3_000 }) } catch { /* ok */ }
         await page.waitForURL(/#\/create-packing-list/, { timeout: 10_000 })
 
         await page.getByPlaceholder('Enter a name for your packing list').fill('Offline Verification List')

--- a/src/components/SolidPodPrompt.tsx
+++ b/src/components/SolidPodPrompt.tsx
@@ -4,12 +4,34 @@ import { Button } from './Button'
 import { SolidProviderSelector } from './SolidProviderSelector'
 import { useSolidPod } from './SolidPodContext'
 
+export interface PodBenefit {
+  label: string
+  text: string
+}
+
+const DEFAULT_BENEFITS: PodBenefit[] = [
+  { label: 'Free', text: 'All major Pod providers are free to sign up' },
+  { label: 'Multi-device access', text: 'Access your packing lists from any device' },
+  { label: 'You own your data', text: 'Your lists stay in your personal storage' },
+  { label: 'Never lose your work', text: 'Safe even if you clear browser data' },
+  { label: 'Privacy-focused', text: 'You control who can access your data' },
+]
+
 interface SolidPodPromptProps {
   isOpen: boolean
   onClose: () => void
   title: string
   message: string
-  dismissalKey?: string
+  /** Heading above the benefits list */
+  benefitsTitle?: string
+  /** Override the benefits when the prompt is framed around a specific payoff */
+  benefits?: PodBenefit[]
+  /** Label of the button that starts the sign-in flow */
+  confirmLabel?: string
+  /** Label of the dismiss button */
+  dismissLabel?: string
+  /** Runs just before the redirect to the provider — record what to resume here */
+  onBeforeLogin?: () => void
 }
 
 /**
@@ -21,7 +43,11 @@ export function SolidPodPrompt({
   onClose,
   title,
   message,
-  dismissalKey
+  benefitsTitle = 'Benefits of using a Solid Pod:',
+  benefits = DEFAULT_BENEFITS,
+  confirmLabel = '🔒 Set Up Solid Pod',
+  dismissLabel = 'Maybe Later',
+  onBeforeLogin,
 }: SolidPodPromptProps) {
   const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
   const { login } = useSolidPod()
@@ -31,18 +57,12 @@ export function SolidPodPrompt({
   }
 
   const handleProviderSelect = (issuer: string) => {
-    // Mark as dismissed since they're taking action
-    if (dismissalKey) {
-      localStorage.setItem(dismissalKey, 'true')
-    }
+    onBeforeLogin?.()
     onClose()
     return login(issuer)
   }
 
   const handleMaybeLater = () => {
-    if (dismissalKey) {
-      localStorage.setItem(dismissalKey, 'true')
-    }
     onClose()
   }
 
@@ -57,23 +77,13 @@ export function SolidPodPrompt({
           <p className="text-gray-700 leading-relaxed">{message}</p>
 
           <div className="bg-gradient-to-br from-primary-50 to-accent-50 border-2 border-primary-200 rounded-xl p-4 space-y-2">
-            <h4 className="font-bold text-primary-900 text-sm">Benefits of using a Solid Pod:</h4>
+            <h4 className="font-bold text-primary-900 text-sm">{benefitsTitle}</h4>
             <ul className="text-sm text-gray-700 space-y-1.5 ml-4 list-disc">
-              <li>
-                <strong>Free</strong> - All major Pod providers are free to sign up
-              </li>
-              <li>
-                <strong>Multi-device access</strong> - Access your packing lists from any device
-              </li>
-              <li>
-                <strong>You own your data</strong> - Your lists stay in your personal storage
-              </li>
-              <li>
-                <strong>Never lose your work</strong> - Safe even if you clear browser data
-              </li>
-              <li>
-                <strong>Privacy-focused</strong> - You control who can access your data
-              </li>
+              {benefits.map(benefit => (
+                <li key={benefit.label}>
+                  <strong>{benefit.label}</strong> - {benefit.text}
+                </li>
+              ))}
             </ul>
           </div>
 
@@ -84,7 +94,7 @@ export function SolidPodPrompt({
               variant="primary"
               className="flex-1"
             >
-              🔒 Set Up Solid Pod
+              {confirmLabel}
             </Button>
             <Button
               type="button"
@@ -92,7 +102,7 @@ export function SolidPodPrompt({
               variant="ghost"
               className="flex-1"
             >
-              Maybe Later
+              {dismissLabel}
             </Button>
           </div>
 

--- a/src/components/SyncAcrossDevicesPrompt.test.tsx
+++ b/src/components/SyncAcrossDevicesPrompt.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { SyncAcrossDevicesPrompt, SYNC_PROMPT_DISMISSED_KEY } from './SyncAcrossDevicesPrompt'
+
+vi.mock('./SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+import { useSolidPod } from './SolidPodContext'
+
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockLogin = vi.fn()
+
+function mockPod(isLoggedIn: boolean) {
+    mockUseSolidPod.mockReturnValue({
+        isLoggedIn,
+        session: null,
+        sessionExpired: false,
+        clearSessionExpired: vi.fn(),
+        webId: undefined,
+        isLoading: false,
+        login: mockLogin,
+        logout: vi.fn(),
+    })
+}
+
+describe('SyncAcrossDevicesPrompt', () => {
+    beforeEach(() => {
+        sessionStorage.clear()
+        localStorage.clear()
+        vi.clearAllMocks()
+    })
+
+    it('nudges logged-out users to sync across devices', () => {
+        mockPod(false)
+
+        render(<SyncAcrossDevicesPrompt />)
+
+        expect(screen.getByText(/sync across devices/i)).toBeTruthy()
+        expect(screen.getByRole('button', { name: /^sign in$/i })).toBeTruthy()
+    })
+
+    it('renders nothing when the user is already logged in', () => {
+        mockPod(true)
+
+        const { container } = render(<SyncAcrossDevicesPrompt />)
+
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('opens the provider selector from the sign-in link', () => {
+        mockPod(false)
+
+        render(<SyncAcrossDevicesPrompt />)
+        fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
+
+        expect(screen.getByText(/login with your solid pod/i)).toBeTruthy()
+    })
+
+    it('logs in with the chosen provider', () => {
+        mockPod(false)
+
+        render(<SyncAcrossDevicesPrompt />)
+        fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
+        fireEvent.click(screen.getByLabelText('Inrupt PodSpaces'))
+
+        expect(mockLogin).toHaveBeenCalledWith('https://login.inrupt.com')
+    })
+
+    it('stays dismissed for the rest of the session', () => {
+        mockPod(false)
+
+        const { unmount } = render(<SyncAcrossDevicesPrompt />)
+        fireEvent.click(screen.getByLabelText('Dismiss sync prompt'))
+
+        expect(screen.queryByText(/sync across devices/i)).toBeNull()
+        expect(sessionStorage.getItem(SYNC_PROMPT_DISMISSED_KEY)).toBe('true')
+
+        unmount()
+        const { container } = render(<SyncAcrossDevicesPrompt />)
+        expect(container.firstChild).toBeNull()
+    })
+})

--- a/src/components/SyncAcrossDevicesPrompt.tsx
+++ b/src/components/SyncAcrossDevicesPrompt.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import { useSolidPod } from './SolidPodContext'
+import { SolidProviderSelector } from './SolidProviderSelector'
+
+/**
+ * Dismissal lives in sessionStorage on purpose: a "not now" should hold for the
+ * rest of the visit without silencing the prompt forever.
+ */
+export const SYNC_PROMPT_DISMISSED_KEY = 'sync-prompt-dismissed'
+
+function wasDismissed(): boolean {
+    try {
+        return sessionStorage.getItem(SYNC_PROMPT_DISMISSED_KEY) === 'true'
+    } catch {
+        return false
+    }
+}
+
+/**
+ * A subtle, dismissible nudge shown to logged-out users who already have
+ * something worth keeping. Renders nothing once the user is logged in or has
+ * dismissed it this session.
+ */
+export function SyncAcrossDevicesPrompt() {
+    const { isLoggedIn, login } = useSolidPod()
+    const [isDismissed, setIsDismissed] = useState(wasDismissed)
+    const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
+
+    if (isLoggedIn || isDismissed) return null
+
+    const handleDismiss = () => {
+        try {
+            sessionStorage.setItem(SYNC_PROMPT_DISMISSED_KEY, 'true')
+        } catch {
+            // Storage unavailable — the prompt just comes back on the next visit
+        }
+        setIsDismissed(true)
+    }
+
+    return (
+        <>
+            <div
+                data-testid="sync-across-devices-prompt"
+                className="mb-6 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-primary-200 bg-primary-50/70 px-4 py-3"
+            >
+                <p className="flex-1 min-w-50 text-sm text-gray-700">
+                    <span className="font-bold text-primary-900">📱 Sync across devices</span>
+                    {' — '}
+                    sign in to pick these lists up on your phone or laptop, and keep them safe if you clear your browser.
+                </p>
+                <div className="flex items-center gap-1 ml-auto">
+                    <button
+                        type="button"
+                        onClick={() => setIsProviderSelectorOpen(true)}
+                        className="text-sm font-bold text-primary-700 underline hover:no-underline px-2 py-1"
+                    >
+                        Sign in
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleDismiss}
+                        aria-label="Dismiss sync prompt"
+                        className="p-2 rounded-lg hover:bg-primary-100 transition-colors"
+                    >
+                        <XMarkIcon className="h-4 w-4 text-primary-700" />
+                    </button>
+                </div>
+            </div>
+
+            <SolidProviderSelector
+                isOpen={isProviderSelectorOpen}
+                onClose={() => setIsProviderSelectorOpen(false)}
+                onSelect={issuer => login(issuer)}
+            />
+        </>
+    )
+}

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -547,6 +547,9 @@ describe('CreatePackingList – suggestion card', () => {
 
         fireEvent.click(screen.getAllByRole('button', { name: /^add$/i })[0])
         await waitFor(() => expect(saveQuestionSet).toHaveBeenCalledTimes(1))
+        // The save resolving is not the row going away — wait for the first
+        // suggestion to leave before reaching for the remaining Add button
+        await waitFor(() => expect(screen.getAllByRole('button', { name: /^add$/i })).toHaveLength(1))
         fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
         await waitFor(() => expect(saveQuestionSet).toHaveBeenCalledTimes(2))
 
@@ -572,7 +575,9 @@ describe('CreatePackingList – suggestion card', () => {
         // Skip both
         const skipButtons = screen.getAllByRole('button', { name: /skip/i })
         fireEvent.click(skipButtons[0])
-        await waitFor(() => screen.getAllByRole('button', { name: /skip/i }).length < 2)
+        // A returned boolean never fails a waitFor — assert, so this really does
+        // wait for the first suggestion to go
+        await waitFor(() => expect(screen.getAllByRole('button', { name: /skip/i })).toHaveLength(1))
         const remainingSkip = screen.getByRole('button', { name: /skip/i })
         fireEvent.click(remainingSkip)
 

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -650,3 +650,72 @@ describe('PackingLists trip destination and dates', () => {
         expect(screen.queryByText(/📍/)).toBeNull()
     })
 })
+
+describe('PackingLists sync-across-devices prompt', () => {
+    beforeEach(() => {
+        sessionStorage.clear()
+        localStorage.clear()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        } as unknown as ReturnType<typeof useSolidPod>)
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function renderWithLists(lists: Record<string, unknown>[]) {
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn().mockResolvedValue(lists),
+                deletePackingList: vi.fn(),
+                savePackingList: vi.fn(),
+                getSharedListsWithMe: vi.fn().mockResolvedValue({ lists: [], lastModified: '' }),
+            } as unknown as PackingAppDatabase,
+        })
+        return renderComponent()
+    }
+
+    it('nudges a logged-out user with a list to sync across devices', async () => {
+        renderWithLists([testPackingList])
+
+        expect(await screen.findByTestId('sync-across-devices-prompt')).toBeTruthy()
+    })
+
+    it('does not nudge before there is anything to sync', async () => {
+        renderWithLists([])
+
+        await waitFor(() => expect(screen.getByText(/No packing lists found/i)).toBeTruthy())
+        expect(screen.queryByTestId('sync-across-devices-prompt')).toBeNull()
+    })
+
+    it('does not nudge a user who is already logged in', async () => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: { fetch: vi.fn(), info: { isLoggedIn: true, webId: 'https://me.example/profile#me' } },
+            webId: 'https://me.example/profile#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        } as unknown as ReturnType<typeof useSolidPod>)
+        mockGetPrimaryPodUrl.mockResolvedValue('https://pod.example/')
+
+        renderWithLists([testPackingList])
+
+        await waitFor(() => expect(screen.getByText(/Beach Trip/)).toBeTruthy())
+        expect(screen.queryByTestId('sync-across-devices-prompt')).toBeNull()
+    })
+
+    it('stays dismissed for the rest of the session', async () => {
+        renderWithLists([testPackingList])
+
+        fireEvent.click(await screen.findByLabelText('Dismiss sync prompt'))
+
+        expect(screen.queryByTestId('sync-across-devices-prompt')).toBeNull()
+    })
+})

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -7,6 +7,7 @@ import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { LoadingState } from '../components/LoadingState'
 import { Modal } from '../components/Modal'
+import { SyncAcrossDevicesPrompt } from '../components/SyncAcrossDevicesPrompt'
 import { getPrimaryPodUrl, saveRdfToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES, getCollaborators, isPubliclyAccessible, resolveOwnerDisplayName, buildSharedListPath } from '../services/solidPod'
 import { useOwnerDisplayNames } from '../hooks/useOwnerDisplayName'
 import { packingListToDataset } from '../services/rdfSerialization'
@@ -181,6 +182,9 @@ export function PackingLists() {
                 </div>
                 <Button variant="primary" onClick={() => navigate('/create-packing-list')}>➕ New List</Button>
             </div>
+
+            {/* Only worth asking once there is something to sync */}
+            {packingLists.length > 0 && <SyncAcrossDevicesPrompt />}
 
             {packingLists.length === 0 ? (
                 <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -51,6 +51,9 @@ vi.mock('../components/SharePackingListModal', () => ({
     SharePackingListModal: vi.fn(() => null),
 }))
 
+import { SharePackingListModal } from '../components/SharePackingListModal'
+import { getPendingSignInAction, setPendingSignInAction } from '../utils/pendingSignInAction'
+
 vi.mock('../hooks/useSharedListsSync', () => ({
     useSharedListsSync: vi.fn(() => ({
         sharedListsWithMe: { lists: [], lastModified: '' },
@@ -2747,5 +2750,113 @@ describe('ViewPackingList opening a long list for the first time', () => {
         expect(screen.queryByText('Alice item 0')).toBeNull()
         // Second time around it is their arrangement, not something to explain
         expect(screen.queryByTestId('folded-on-open-note')).toBeNull()
+    })
+})
+
+describe('ViewPackingList contextual sign-in to share', () => {
+    beforeEach(() => {
+        sessionStorage.clear()
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+        vi.mocked(SharePackingListModal).mockClear()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function mockLoggedOut() {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: mockLogin,
+            logout: vi.fn(),
+        } as unknown as ReturnType<typeof useSolidPod>)
+    }
+
+    function mockLoggedIn() {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: { fetch: vi.fn(), info: { isLoggedIn: true, webId: 'https://me.example/profile#me' } },
+            webId: 'https://me.example/profile#me',
+            isLoading: false,
+            login: mockLogin,
+            logout: vi.fn(),
+        } as unknown as ReturnType<typeof useSolidPod>)
+    }
+
+    const mockLogin = vi.fn()
+
+    it('offers Share to a logged-out user rather than hiding it', async () => {
+        mockLoggedOut()
+        renderComponent()
+
+        const shareButton = await screen.findByRole('button', { name: 'Share' })
+        expect((shareButton as HTMLButtonElement).disabled).toBe(false)
+    })
+
+    it('frames the sign-in ask around sharing when a logged-out user shares', async () => {
+        mockLoggedOut()
+        renderComponent()
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Share' }))
+
+        expect(screen.getByText(/sign in to share this list/i)).toBeTruthy()
+        expect(screen.getByRole('button', { name: /sign in to share/i })).toBeTruthy()
+    })
+
+    it('remembers the share the user was attempting when they sign in', async () => {
+        mockLoggedOut()
+        renderComponent()
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Share' }))
+        fireEvent.click(screen.getByRole('button', { name: /sign in to share/i }))
+        fireEvent.click(screen.getByLabelText('Inrupt PodSpaces'))
+
+        expect(mockLogin).toHaveBeenCalledWith('https://login.inrupt.com')
+        expect(getPendingSignInAction()).toEqual({ type: 'share', listId: 'test-list-1' })
+    })
+
+    it('drops the prompt without remembering anything when the user backs out', async () => {
+        mockLoggedOut()
+        renderComponent()
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Share' }))
+        fireEvent.click(screen.getByRole('button', { name: /not now/i }))
+
+        await waitFor(() => expect(screen.queryByText(/sign in to share this list/i)).toBeNull())
+        expect(getPendingSignInAction()).toBeNull()
+    })
+
+    it('resumes the share once the user comes back signed in', async () => {
+        setPendingSignInAction({ type: 'share', listId: 'test-list-1' })
+        mockLoggedIn()
+
+        renderComponent()
+
+        await waitFor(() =>
+            expect(vi.mocked(SharePackingListModal).mock.calls.some(([props]) => props.isOpen)).toBe(true)
+        )
+        // Consumed, so a later visit does not pop the dialog again
+        expect(getPendingSignInAction()).toBeNull()
+    })
+
+    it('leaves a share intended for another list alone', async () => {
+        setPendingSignInAction({ type: 'share', listId: 'some-other-list' })
+        mockLoggedIn()
+
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+        expect(vi.mocked(SharePackingListModal).mock.calls.every(([props]) => !props.isOpen)).toBe(true)
+        expect(getPendingSignInAction()).toEqual({ type: 'share', listId: 'some-other-list' })
     })
 })

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -16,6 +16,7 @@ import { POD_CONTAINERS, getPrimaryPodUrl, saveRdfToPod, resolveOwnerDisplayName
 import { useOwnerDisplayName } from '../hooks/useOwnerDisplayName'
 import { packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { SharePackingListModal } from '../components/SharePackingListModal'
+import { SolidPodPrompt } from '../components/SolidPodPrompt'
 import { UpdateFromQuestionsModal } from '../components/UpdateFromQuestionsModal'
 import { useForeignPod } from '../components/ForeignPodContext'
 import { useSharedListsSync } from '../hooks/useSharedListsSync'
@@ -28,6 +29,7 @@ import { prefersReducedMotion } from '../utils/prefersReducedMotion'
 import { groupItemsByCategory, sortByOrder, type CategoryAccessors } from '../utils/groupByCategory'
 import { CATEGORY_ORDER } from '../edit-questions/item-sections'
 import { useSectionOrder } from '../hooks/useSectionOrder'
+import { clearPendingSignInAction, getPendingSignInAction, setPendingSignInAction } from '../utils/pendingSignInAction'
 import { usePersonColors } from '../hooks/usePersonColors'
 import { PersonAvatar } from '../components/PersonAvatar'
 import { AddItemComposer, UNCATEGORISED_LABEL, type AddItemTarget, type PersonOption } from '../components/AddItemComposer'
@@ -172,6 +174,9 @@ export function ViewPackingList() {
     const [packingList, setPackingList] = useState<PackingList | null>(null)
     const [isLoading, setIsLoading] = useState(true)
     const [shareModalOpen, setShareModalOpen] = useState(false)
+    // Sharing needs a pod, so a logged-out sharer gets the ask framed around
+    // sharing rather than a generic "set up a pod" pitch.
+    const [signInToSharePromptOpen, setSignInToSharePromptOpen] = useState(false)
     // Additions computed from the question set; non-null opens the preview modal.
     const [questionUpdateAdditions, setQuestionUpdateAdditions] = useState<PackingListItem[] | null>(null)
     // Whether the question set exists locally (gates the "Update from questions" button).
@@ -309,6 +314,18 @@ export function ViewPackingList() {
             getPrimaryPodUrl(session).then(url => setOwnPodUrl(url ?? null))
         }
     }, [isLoggedIn, session])
+
+    // Someone who signed in from the "share this list" prompt came back here to
+    // share — pick the action up where they left it rather than making them
+    // find the button again.
+    useEffect(() => {
+        if (!isLoggedIn || !id) return
+        const pending = getPendingSignInAction()
+        if (pending?.type === 'share' && pending.listId === id) {
+            clearPendingSignInAction()
+            setShareModalOpen(true)
+        }
+    }, [isLoggedIn, id])
 
     // The "Update from questions" action only applies to the user's own lists,
     // regenerating them from their local question set. Foreign lists belong to
@@ -1258,12 +1275,12 @@ export function ViewPackingList() {
                                 Update from questions
                             </Button>
                         )}
-                        {isLoggedIn && !foreignPodUrl && (
+                        {!foreignPodUrl && (
                             <Button
                                 type="button"
                                 variant="secondary"
-                                onClick={() => setShareModalOpen(true)}
-                                disabled={!ownPodUrl}
+                                onClick={() => isLoggedIn ? setShareModalOpen(true) : setSignInToSharePromptOpen(true)}
+                                disabled={isLoggedIn && !ownPodUrl}
                             >
                                 Share
                             </Button>
@@ -1863,6 +1880,22 @@ export function ViewPackingList() {
             message="Remove this guest and all their items from this list?"
             confirmText="Remove"
             confirmVariant="danger"
+        />
+        <SolidPodPrompt
+            isOpen={signInToSharePromptOpen}
+            onClose={() => setSignInToSharePromptOpen(false)}
+            title="Sign in to share this list"
+            message="Sharing sends your friend a link to this list, so it needs somewhere online to live. Sign in with a Solid Pod and we'll bring you straight back here to share."
+            benefitsTitle="What signing in unlocks:"
+            benefits={[
+                { label: 'Share this list', text: 'Send a friend a link, or invite them by WebID' },
+                { label: 'Pack together', text: 'You both tick items off the same list' },
+                { label: 'Free', text: 'All major Pod providers are free to sign up' },
+                { label: 'You own your data', text: 'Your lists stay in your personal storage' },
+            ]}
+            confirmLabel="🔗 Sign in to share"
+            dismissLabel="Not now"
+            onBeforeLogin={() => { if (id) setPendingSignInAction({ type: 'share', listId: id }) }}
         />
         {session && ownPodUrl && id && (
             <SharePackingListModal

--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -9,10 +9,6 @@ vi.mock('../components/DatabaseContext', () => ({
     useDatabase: vi.fn(),
 }))
 
-vi.mock('../components/SolidPodContext', () => ({
-    useSolidPod: vi.fn(),
-}))
-
 vi.mock('./useWizardGeneration', () => ({
     useWizardGeneration: vi.fn(),
 }))
@@ -22,12 +18,10 @@ vi.mock('../components/ToastContext', () => ({
 }))
 
 import { useDatabase } from '../components/DatabaseContext'
-import { useSolidPod } from '../components/SolidPodContext'
 import { useWizardGeneration } from './useWizardGeneration'
 import { createExampleData } from '../edit-questions/example-data'
 
 const mockUseDatabase = vi.mocked(useDatabase)
-const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockUseWizardGeneration = vi.mocked(useWizardGeneration)
 
 function makeDb(overrides: { getQuestionSet?: ReturnType<typeof vi.fn> } = {}) {
@@ -47,15 +41,6 @@ function makeGeneratedSet() {
 describe('Wizard', () => {
     beforeEach(() => {
         vi.spyOn(console, 'error').mockImplementation(() => {})
-
-        mockUseSolidPod.mockReturnValue({
-            session: null,
-            isLoggedIn: false,
-            webId: undefined,
-            isLoading: false,
-            login: vi.fn(),
-            logout: vi.fn(),
-        })
 
         mockUseWizardGeneration.mockReturnValue({
             isLoading: false,
@@ -176,7 +161,7 @@ describe('Wizard', () => {
         })
     })
 
-    it('shows success modal but not pod prompt immediately after generation succeeds', async () => {
+    it('shows the success modal, and never a sign-in ask, when generation succeeds', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
         mockUseWizardGeneration.mockReturnValue({
@@ -195,7 +180,7 @@ describe('Wizard', () => {
         await waitFor(() =>
             expect(screen.getByText(/questions generated successfully/i)).toBeTruthy()
         )
-        expect(screen.queryByText(/great! your questions are ready/i)).toBeNull()
+        expect(screen.queryByText(/set up solid pod/i)).toBeNull()
     })
 
     it('closes the success modal when the X button is clicked', async () => {
@@ -226,7 +211,7 @@ describe('Wizard', () => {
         )
     })
 
-    it('shows pod prompt only after a success modal CTA is clicked', async () => {
+    it('acts on a success modal CTA without asking a logged-out user to sign in', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
         mockUseWizardGeneration.mockReturnValue({
@@ -235,37 +220,6 @@ describe('Wizard', () => {
             generatedSet: null,
             generateAndSave: vi.fn(),
         })
-        localStorage.removeItem('solid-pod-upsell-shown')
-
-        const { getByRole } = render(
-            <MemoryRouter>
-                <Wizard />
-            </MemoryRouter>
-        )
-
-        await waitFor(() =>
-            expect(screen.getByText(/questions generated successfully/i)).toBeTruthy()
-        )
-        expect(screen.queryByText(/great! your questions are ready/i)).toBeNull()
-
-        const createListBtn = getByRole('button', { name: /create my first packing list/i })
-        createListBtn.click()
-
-        await waitFor(() =>
-            expect(screen.getByText(/great! your questions are ready/i)).toBeTruthy()
-        )
-    })
-
-    it('sets solid-pod-upsell-shown global key when pod prompt is dismissed', async () => {
-        const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
-        mockUseWizardGeneration.mockReturnValue({
-            isLoading: false,
-            isSuccess: true,
-            generatedSet: null,
-            generateAndSave: vi.fn(),
-        })
-        localStorage.removeItem('solid-pod-upsell-shown')
 
         const { getByRole } = render(
             <MemoryRouter>
@@ -279,13 +233,12 @@ describe('Wizard', () => {
 
         getByRole('button', { name: /create my first packing list/i }).click()
 
+        // The modal closes straight into the chosen route — no pod upsell in between
         await waitFor(() =>
-            expect(screen.getByText(/great! your questions are ready/i)).toBeTruthy()
+            expect(screen.queryByText(/questions generated successfully/i)).toBeNull()
         )
-
-        getByRole('button', { name: /maybe later/i }).click()
-
-        expect(localStorage.getItem('solid-pod-upsell-shown')).toBe('true')
+        expect(screen.queryByText(/set up solid pod/i)).toBeNull()
+        expect(screen.queryByRole('button', { name: /maybe later/i })).toBeNull()
     })
 
     it('shows the create packing questions heading', async () => {
@@ -470,7 +423,6 @@ describe('Wizard', () => {
                 generatedSet: makeGeneratedSet(),
                 generateAndSave: vi.fn(),
             })
-            localStorage.setItem('solid-pod-upsell-shown', 'true')
             return render(
                 <MemoryRouter>
                     <Wizard />
@@ -551,33 +503,5 @@ describe('Wizard', () => {
             expect(screen.queryByRole('button', { name: /skip/i })).toBeNull()
             expect(screen.getByText(/\d+ questions and \d+ items across 2 people and 1 pet/i)).toBeTruthy()
         })
-    })
-
-    it('does not show pod prompt when solid-pod-upsell-shown is already set', async () => {
-        const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
-        mockUseWizardGeneration.mockReturnValue({
-            isLoading: false,
-            isSuccess: true,
-            generatedSet: null,
-            generateAndSave: vi.fn(),
-        })
-        localStorage.setItem('solid-pod-upsell-shown', 'true')
-
-        const { getByRole } = render(
-            <MemoryRouter>
-                <Wizard />
-            </MemoryRouter>
-        )
-
-        await waitFor(() =>
-            expect(screen.getByText(/questions generated successfully/i)).toBeTruthy()
-        )
-
-        getByRole('button', { name: /create my first packing list/i }).click()
-
-        // Give React a chance to update - pod prompt should NOT appear
-        await new Promise(r => setTimeout(r, 50))
-        expect(screen.queryByText(/great! your questions are ready/i)).toBeNull()
     })
 })

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -5,8 +5,6 @@ import { useNavigate, Link } from 'react-router-dom'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { Modal } from '../components/Modal'
-import { SolidPodPrompt } from '../components/SolidPodPrompt'
-import { useSolidPod } from '../components/SolidPodContext'
 import { useDatabase } from '../components/DatabaseContext'
 import { wizardSchema, WizardFormData, WizardEntry } from './wizard-types'
 import { useWizardGeneration } from './useWizardGeneration'
@@ -16,19 +14,14 @@ import { buildRevealSteps, buildGenerationSummary, REVEAL_STEP_MS } from './wiza
 import { peopleToWizardEntries } from './wizard-prefill'
 import { prefersReducedMotion } from '../utils/prefersReducedMotion'
 
-const SOLID_POD_UPSELL_SHOWN_KEY = 'solid-pod-upsell-shown'
-
 export const Wizard = () => {
     const navigate = useNavigate()
     const [showConfirmDialog, setShowConfirmDialog] = useState(false)
-    const [showPodPrompt, setShowPodPrompt] = useState(false)
     const [showSuccessModal, setShowSuccessModal] = useState(false)
-    const [pendingNavRoute, setPendingNavRoute] = useState<string | null>(null)
     const [hasExistingData, setHasExistingData] = useState(false)
     const [isPrefilled, setIsPrefilled] = useState(false)
     const [revealedCount, setRevealedCount] = useState(0)
     const [isRevealComplete, setIsRevealComplete] = useState(false)
-    const { isLoggedIn } = useSolidPod()
     const { db } = useDatabase()
     const { isLoading, isSuccess, generatedSet, generateAndSave } = useWizardGeneration()
 
@@ -107,25 +100,12 @@ export const Wizard = () => {
         setIsRevealComplete(true)
     }
 
+    // Onboarding never asks for a sign-in: the ask belongs where it pays off
+    // (sharing a list, syncing across devices), not before there is anything
+    // worth saving.
     const handleSuccessAction = (route: string) => {
         setShowSuccessModal(false)
-        if (!isLoggedIn) {
-            const dismissed = localStorage.getItem(SOLID_POD_UPSELL_SHOWN_KEY) === 'true'
-            if (!dismissed) {
-                setPendingNavRoute(route)
-                setShowPodPrompt(true)
-                return
-            }
-        }
         navigate(route)
-    }
-
-    const handlePodPromptClose = () => {
-        setShowPodPrompt(false)
-        if (pendingNavRoute) {
-            navigate(pendingNavRoute)
-            setPendingNavRoute(null)
-        }
     }
 
     const onSubmit = async (data: WizardFormData) => {
@@ -438,15 +418,6 @@ Are you sure you want to continue?"
                     )}
                 </div>
             </Modal>
-
-            {/* Solid Pod Onboarding Prompt */}
-            <SolidPodPrompt
-                isOpen={showPodPrompt}
-                onClose={handlePodPromptClose}
-                title="🎉 Great! Your Questions Are Ready"
-                message="Want to keep your personalized packing questions safe and accessible from any device? Set up a Solid Pod to store your data securely in personal storage that you control."
-                dismissalKey={SOLID_POD_UPSELL_SHOWN_KEY}
-            />
         </div>
     )
 }

--- a/src/utils/pendingSignInAction.test.ts
+++ b/src/utils/pendingSignInAction.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+    setPendingSignInAction,
+    getPendingSignInAction,
+    clearPendingSignInAction,
+    PENDING_SIGN_IN_ACTION_KEY,
+} from './pendingSignInAction'
+
+describe('pendingSignInAction', () => {
+    beforeEach(() => {
+        sessionStorage.clear()
+    })
+
+    it('returns null when nothing is pending', () => {
+        expect(getPendingSignInAction()).toBeNull()
+    })
+
+    it('round-trips a share action so it survives the login redirect', () => {
+        setPendingSignInAction({ type: 'share', listId: 'list-1' })
+
+        expect(getPendingSignInAction()).toEqual({ type: 'share', listId: 'list-1' })
+    })
+
+    it('clears the pending action', () => {
+        setPendingSignInAction({ type: 'share', listId: 'list-1' })
+
+        clearPendingSignInAction()
+
+        expect(getPendingSignInAction()).toBeNull()
+    })
+
+    it('ignores stored values it does not recognise', () => {
+        sessionStorage.setItem(PENDING_SIGN_IN_ACTION_KEY, 'not json')
+        expect(getPendingSignInAction()).toBeNull()
+
+        sessionStorage.setItem(PENDING_SIGN_IN_ACTION_KEY, JSON.stringify({ type: 'something-else' }))
+        expect(getPendingSignInAction()).toBeNull()
+
+        sessionStorage.setItem(PENDING_SIGN_IN_ACTION_KEY, JSON.stringify({ type: 'share' }))
+        expect(getPendingSignInAction()).toBeNull()
+    })
+})

--- a/src/utils/pendingSignInAction.ts
+++ b/src/utils/pendingSignInAction.ts
@@ -1,0 +1,44 @@
+/**
+ * Remembers the action a logged-out user was attempting when they were offered
+ * a contextual sign-in, so it can be resumed once they come back from the
+ * provider's login page. sessionStorage (not localStorage) because the intent
+ * belongs to this tab and this visit — a stale "open the share dialog" a week
+ * later would be a surprise.
+ */
+export const PENDING_SIGN_IN_ACTION_KEY = 'pending-sign-in-action'
+
+export type PendingSignInAction = { type: 'share'; listId: string }
+
+function isPendingSignInAction(value: unknown): value is PendingSignInAction {
+    if (typeof value !== 'object' || value === null) return false
+    const candidate = value as Record<string, unknown>
+    return candidate.type === 'share' && typeof candidate.listId === 'string'
+}
+
+export function setPendingSignInAction(action: PendingSignInAction): void {
+    try {
+        sessionStorage.setItem(PENDING_SIGN_IN_ACTION_KEY, JSON.stringify(action))
+    } catch {
+        // Storage unavailable (private mode, quota) — the user just lands back
+        // on the page without the action resuming.
+    }
+}
+
+export function getPendingSignInAction(): PendingSignInAction | null {
+    try {
+        const raw = sessionStorage.getItem(PENDING_SIGN_IN_ACTION_KEY)
+        if (!raw) return null
+        const parsed: unknown = JSON.parse(raw)
+        return isPendingSignInAction(parsed) ? parsed : null
+    } catch {
+        return null
+    }
+}
+
+export function clearPendingSignInAction(): void {
+    try {
+        sessionStorage.removeItem(PENDING_SIGN_IN_ACTION_KEY)
+    } catch {
+        // Nothing to do — see setPendingSignInAction.
+    }
+}


### PR DESCRIPTION
The wizard used to interrupt a brand-new user with a "set up a Solid Pod"
modal before they had a single list worth saving. Move the ask to the two
moments where signing in is the thing the user wants:

- Sharing a list. The Share button now shows for logged-out users too and
  opens a prompt framed around sharing. The list being shared is recorded
  in sessionStorage, so coming back from the provider reopens the share
  dialog on that list instead of dropping the user on the page.
- The lists index, once there is at least one list, carries a subtle
  "Sync across devices" banner. Dismissing it holds for the session.

SolidPodPrompt grows optional copy overrides (benefits, button labels) so
the sharing ask can name its own payoff, and loses the now-unused
localStorage dismissal key along with the wizard prompt.

## Manual test report

Walked through every path in a real browser against a production build and a live
Community Solid Server, on desktop and phone viewports — including a real OIDC
sign-in from the share prompt and the resumed share afterwards.

📋 **[Manual test report — 2026-07-31, with screenshots](https://github.com/timgent/pack-me-up/blob/agent-testing/2026-07-31-issue-202-contextual-sign-in/README.md)** (on the `agent-testing` branch)

All six success criteria from #202 verified; no bugs found.

Closes #202

Co-Authored-By: Claude Opus 5
Claude-Session: https://claude.ai/code/session_01CMuDgj9HVqRKkmneL8KVgt