### PR TITLE
Fix oversized mobile header

### DIFF
--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -31,6 +31,17 @@ describe('Footer', () => {
         expect(screen.getByRole('link', { name: 'Feedback' }).getAttribute('href')).toBe(`mailto:${FEEDBACK_EMAIL}`)
     })
 
+    // Same story as the nav's top inset: a browser tab has its own chrome below
+    // the page, so only the native shell and installed PWAs should reserve room
+    // for the gesture bar. CSS decides that, not an inline style.
+    it('leaves the gesture-bar inset to CSS rather than an inline style', () => {
+        const { container } = renderFooter()
+
+        const footer = container.querySelector('footer')!
+        expect(footer.style.paddingBottom).toBe('')
+        expect(footer.className).toContain('safe-area-bottom')
+    })
+
     it('avoids reusing "Your data", which the pod switcher already uses for something else', () => {
         renderFooter()
 

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -31,6 +31,18 @@ describe('Footer', () => {
         expect(screen.getByRole('link', { name: 'Feedback' }).getAttribute('href')).toBe(`mailto:${FEEDBACK_EMAIL}`)
     })
 
+    // Sentry's feedback widget is a fixed circle in the bottom-right corner, and
+    // on a narrow screen it sat right on top of the "Feedback" link once you
+    // scrolled to the end of the page. The links need to clear it; on desktop the
+    // row is centred well clear of the widget, so the extra space comes off again.
+    it('keeps the links clear of the floating feedback widget on mobile', () => {
+        const { container } = renderFooter()
+
+        const nav = container.querySelector('footer nav')!
+        expect(nav.className).toContain('pb-24')
+        expect(nav.className).toContain('md:pb-5')
+    })
+
     // Same story as the nav's top inset: a browser tab has its own chrome below
     // the page, so only the native shell and installed PWAs should reserve room
     // for the gesture bar. CSS decides that, not an inline style.

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,9 +16,15 @@ const linkStyles = 'text-gray-500 hover:text-primary-700 hover:underline transit
 export function Footer() {
     return (
         <footer className="border-t border-primary-100 bg-white/40 safe-area-bottom">
+            {/*
+              * pb-24 on mobile keeps the last row above Sentry's fixed feedback
+              * widget, which otherwise sits on top of the "Feedback" link once you
+              * scroll to the end of the page. Desktop centres the row well clear of
+              * the widget, so the extra space comes off again at md.
+              */}
             <nav
                 aria-label="Site information"
-                className="container mx-auto px-4 py-5 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm"
+                className="container mx-auto px-4 py-5 pb-24 md:pb-5 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm"
             >
                 <Link to="/privacy-policy" className={linkStyles}>
                     Privacy policy

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,10 +15,7 @@ const linkStyles = 'text-gray-500 hover:text-primary-700 hover:underline transit
  */
 export function Footer() {
     return (
-        <footer
-            className="border-t border-primary-100 bg-white/40"
-            style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
-        >
+        <footer className="border-t border-primary-100 bg-white/40 safe-area-bottom">
             <nav
                 aria-label="Site information"
                 className="container mx-auto px-4 py-5 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm"

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -74,6 +74,34 @@ describe('Navigation', () => {
         expect(screen.queryByRole('link', { name: /delete my data/i })).toBeNull()
     })
 
+    // In a normal browser tab the browser's own chrome sits above the page, but
+    // Chrome on Android still reports a non-zero safe-area-inset-top, which left
+    // a tall empty band above the logo. The inset is applied through a class so
+    // CSS can limit it to the cases that actually draw under the status bar.
+    it('leaves the status-bar inset to CSS rather than an inline style', () => {
+        const { container } = render(
+            <MemoryRouter>
+                <Navigation />
+            </MemoryRouter>
+        )
+
+        const nav = container.querySelector('nav')!
+        expect(nav.style.paddingTop).toBe('')
+        expect(nav.className).toContain('safe-area-top')
+    })
+
+    it('uses a shorter header row on mobile than on desktop', () => {
+        const { container } = render(
+            <MemoryRouter>
+                <Navigation />
+            </MemoryRouter>
+        )
+
+        const row = container.querySelector('nav .flex.items-center.justify-between')!
+        expect(row.className).toContain('h-14')
+        expect(row.className).toContain('md:h-16')
+    })
+
     it('shows Backups link when logged in', () => {
         mockUseSolidPod.mockReturnValue({
             session: null,

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -43,13 +43,13 @@ export const Navigation = () => {
 
     return (
         <>
-            <nav className="bg-primary-950 text-white shadow-soft" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
+            <nav className="bg-primary-950 text-white shadow-soft safe-area-top">
                 <div className="max-w-7xl mx-auto px-4">
-                    <div className="flex items-center justify-between h-16">
+                    <div className="flex items-center justify-between h-14 md:h-16">
                         <div className="flex items-center">
                             <div className="flex-shrink-0">
-                                <Link to="/home" className="flex items-center gap-2 text-2xl font-bold hover:scale-105 transition-transform duration-200 drop-shadow-md">
-                                    <img src="/favicon.svg" alt="" className="h-8 w-8" />
+                                <Link to="/home" className="flex items-center gap-2 text-xl md:text-2xl font-bold hover:scale-105 transition-transform duration-200 drop-shadow-md">
+                                    <img src="/favicon.svg" alt="" className="h-7 w-7 md:h-8 md:w-8" />
                                     Pack Me Up
                                 </Link>
                             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1029,24 +1029,36 @@ body {
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
 }
 /*
- * Status-bar inset for the top of the app.
+ * Device insets for the top (status bar) and bottom (gesture bar) of the app.
  *
- * The nav only needs to reserve room for the device status bar when the app
- * actually paints underneath it — the native shell, or an installed PWA. In an
- * ordinary browser tab the browser's own chrome already sits above the page,
- * yet Chrome on Android still reports a non-zero safe-area-inset-top with
- * viewport-fit=cover, which left a tall empty band above the logo on mobile.
+ * The nav and footer only need to reserve that room when the app actually
+ * paints underneath those bars — the native shell, or an installed PWA. In an
+ * ordinary browser tab the browser's own chrome already sits outside the page,
+ * yet Chrome on Android still reports non-zero insets with viewport-fit=cover,
+ * which left a tall empty band above the logo on mobile.
  */
 .safe-area-top {
   padding-top: 0;
+}
+
+.safe-area-bottom {
+  padding-bottom: 0;
 }
 
 @media (display-mode: standalone), (display-mode: fullscreen), (display-mode: minimal-ui) {
   .safe-area-top {
     padding-top: env(safe-area-inset-top);
   }
+
+  .safe-area-bottom {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
 }
 
 .native-app .safe-area-top {
   padding-top: env(safe-area-inset-top);
+}
+
+.native-app .safe-area-bottom {
+  padding-bottom: env(safe-area-inset-bottom);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1028,3 +1028,25 @@ body {
   margin-top: 0.25rem;
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
 }
+/*
+ * Status-bar inset for the top of the app.
+ *
+ * The nav only needs to reserve room for the device status bar when the app
+ * actually paints underneath it — the native shell, or an installed PWA. In an
+ * ordinary browser tab the browser's own chrome already sits above the page,
+ * yet Chrome on Android still reports a non-zero safe-area-inset-top with
+ * viewport-fit=cover, which left a tall empty band above the logo on mobile.
+ */
+.safe-area-top {
+  padding-top: 0;
+}
+
+@media (display-mode: standalone), (display-mode: fullscreen), (display-mode: minimal-ui) {
+  .safe-area-top {
+    padding-top: env(safe-area-inset-top);
+  }
+}
+
+.native-app .safe-area-top {
+  padding-top: env(safe-area-inset-top);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,9 +10,9 @@ import { initSentry } from './sentry.ts'
 
 initSentry()
 
-// The native shell draws under the status bar, so the safe-area insets in
-// index.css apply there. A browser tab renders below the browser's own chrome
-// and must not add them — see the .safe-area-top rules.
+// The native shell draws under the status and gesture bars, so the safe-area
+// insets in index.css apply there. A browser tab renders inside the browser's
+// own chrome and must not add them — see the .safe-area-* rules.
 if (Capacitor.isNativePlatform()) {
     document.documentElement.classList.add('native-app')
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,20 @@ import './polyfills'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ErrorBoundary } from '@sentry/react'
+import { Capacitor } from '@capacitor/core'
 import './index.css'
 import App from './App.tsx'
 import { ErrorFallback } from './components/ErrorFallback.tsx'
 import { initSentry } from './sentry.ts'
 
 initSentry()
+
+// The native shell draws under the status bar, so the safe-area insets in
+// index.css apply there. A browser tab renders below the browser's own chrome
+// and must not add them — see the .safe-area-top rules.
+if (Capacitor.isNativePlatform()) {
+    document.documentElement.classList.add('native-app')
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
The nav reserved space for the device status bar unconditionally via an
inline `env(safe-area-inset-top)`. In an ordinary browser tab the browser's
own chrome already sits above the page, but Chrome on Android still reports
a non-zero inset with `viewport-fit=cover`, so mobile got a tall empty band
of dark teal above the logo.

Move the inset into a `.safe-area-top` class that only applies where the app
really does paint under the status bar — the Capacitor shell (flagged with a
`native-app` class on <html>) and installed PWA display modes. Also make the
header row itself compact on mobile: 56px tall with a smaller logo and title,
back to 64px from `md` up.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LEdmJnKHeA7i6dTb5c7Yj4