### PR TITLE
Disable Sentry error reporting in local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 # Set to the hosted Client ID Document URL for static OIDC registration (production only).
 # Leave unset for local dev and preview deploys — they fall back to dynamic client registration.
 # VITE_CLIENT_ID_URL=https://packmeup.tim-gent.com/client-id.json
+
+# Sentry error reporting is off in local dev (errors go to the console instead).
+# Set this to true to send local dev errors to Sentry, e.g. when verifying a Sentry change.
+# VITE_SENTRY_ENABLED=true

--- a/src/sentry.test.ts
+++ b/src/sentry.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const init = vi.fn()
+vi.mock('@sentry/capacitor', () => ({ init: (...args: unknown[]) => init(...args) }))
+vi.mock('@sentry/react', () => ({ init: vi.fn(), feedbackIntegration: () => ({ name: 'Feedback' }) }))
+
+import { initSentry } from './sentry'
+
+describe('initSentry', () => {
+    beforeEach(() => {
+        init.mockClear()
+    })
+
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    it('does not initialise Sentry in local dev', () => {
+        vi.stubEnv('MODE', 'development')
+
+        initSentry()
+
+        expect(init).not.toHaveBeenCalled()
+    })
+
+    it('does not initialise Sentry under test', () => {
+        vi.stubEnv('MODE', 'test')
+
+        initSentry()
+
+        expect(init).not.toHaveBeenCalled()
+    })
+
+    it('initialises Sentry in production builds', () => {
+        vi.stubEnv('MODE', 'production')
+
+        initSentry()
+
+        expect(init).toHaveBeenCalledOnce()
+        expect(init.mock.calls[0][0]).toMatchObject({ environment: 'production' })
+    })
+
+    it('initialises Sentry in local dev when explicitly opted in', () => {
+        vi.stubEnv('MODE', 'development')
+        vi.stubEnv('VITE_SENTRY_ENABLED', 'true')
+
+        initSentry()
+
+        expect(init).toHaveBeenCalledOnce()
+    })
+})

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -4,8 +4,17 @@ import * as SentryReact from '@sentry/react'
 // Sentry DSNs are public identifiers, safe to ship in client-side code.
 const SENTRY_DSN = 'https://a331ffe142776c6dd8d5fcecfb2a4a97@o4511757730578432.ingest.de.sentry.io/4511757737525328'
 
+// Local dev and test runs report to the console instead of Sentry, so day-to-day
+// development doesn't fill the project's error quota with noise from work in progress.
+// Set VITE_SENTRY_ENABLED=true to opt a local dev build back in (e.g. to verify a
+// Sentry change end to end).
+function isSentryEnabled() {
+  if (import.meta.env.VITE_SENTRY_ENABLED === 'true') return true
+  return import.meta.env.MODE !== 'development' && import.meta.env.MODE !== 'test'
+}
+
 export function initSentry() {
-  if (import.meta.env.MODE === 'test') return
+  if (!isSentryEnabled()) return
 
   Sentry.init(
     {


### PR DESCRIPTION
Sentry only initialises for non-development builds now, so errors raised while
working locally go to the console instead of the project's Sentry quota. Test
mode was already skipped; development joins it.

Set VITE_SENTRY_ENABLED=true to opt a local dev build back in when verifying a
Sentry change end to end.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012V4jj6DFzYyCuaHBqYNyLZ