### PR TITLE
Person profile photos, past-trip folding, navigation & wizard improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ android/local.properties
 *.njsproj
 *.sln
 *.sw?
+.vercel
+.env*

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -38,9 +38,9 @@ export const test = base.extend<MyFixtures>({
     // The context already has a valid session from authedContext's fresh login.
     // The app will try to restore the session (prompt=none), but since the same
     // CSS process is running and consent was just given, this should succeed quickly.
-    // Wait up to 30 seconds for "Logout" to appear.
+    // Wait up to 30 seconds for the account menu to appear.
     await page.goto('/')
-    await page.getByRole('button', { name: 'Logout' }).first().waitFor({ state: 'visible', timeout: 30_000 })
+    await page.getByRole('button', { name: 'Account menu' }).first().waitFor({ state: 'visible', timeout: 30_000 })
     await use(page)
   },
 

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -74,6 +74,6 @@ export async function loginToCss(
   await page.waitForURL(/localhost:4173/, { timeout: 20_000 })
   // Wait for logged-in state (skip if the caller expects a migration prompt to block the nav)
   if (options?.waitForLoggedIn !== false) {
-    await page.getByRole('button', { name: 'Logout' }).first().waitFor({ timeout: 20_000 })
+    await page.getByRole('button', { name: 'Account menu' }).first().waitFor({ timeout: 20_000 })
   }
 }

--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -57,7 +57,7 @@ test.describe('B – Editing Questions', () => {
     const personInputs = page.locator('input[placeholder^="Person "]')
     const initialCount = await personInputs.count()
     // Click Add Person
-    await page.getByRole('button', { name: '+ Add Person' }).click()
+    await page.getByRole('button', { name: 'Add Person', exact: true }).click()
     await expect(personInputs).toHaveCount(initialCount + 1)
     // Fill in the new person's name
     await personInputs.last().fill('Charlie')
@@ -116,7 +116,7 @@ test.describe('B – Editing Questions', () => {
 
     // One field at the foot of the list, rather than a modal, a blank row and a
     // Save button.
-    await page.getByRole('button', { name: '+ Add item' }).first().click()
+    await page.getByRole('button', { name: 'Add item', exact: true }).first().click()
     const field = page.getByLabel(/^New item in /)
     await expect(field).toBeVisible({ timeout: 3_000 })
     await field.fill('WaterBottleTest')
@@ -334,7 +334,7 @@ test.describe('B – Editing Questions', () => {
 
     // The composer at the foot of the list is the one that asks where the item
     // goes, so it is the one a suggestion can answer for.
-    await page.getByRole('button', { name: '+ Add item' }).first().click()
+    await page.getByRole('button', { name: 'Add item', exact: true }).first().click()
     const field = page.getByLabel(/^New item in /)
     await expect(field).toBeVisible({ timeout: 3_000 })
 
@@ -382,7 +382,7 @@ test.describe('B – Editing Questions', () => {
     await setupWizardAndGoToQuestions(page)
     await openAlwaysNeeded(page)
 
-    await page.getByRole('button', { name: '+ Add section' }).first().click()
+    await page.getByRole('button', { name: 'Add section', exact: true }).first().click()
     const nameField = page.getByLabel('New section name')
     await expect(nameField).toBeVisible({ timeout: 3_000 })
     await nameField.fill('Paperwork')
@@ -413,7 +413,7 @@ test.describe('B – Editing Questions', () => {
     await page.getByTitle('Edit option').first().click()
     await expect(page.getByRole('heading', { name: 'Edit Option' })).toBeVisible({ timeout: 3_000 })
     await expect(page.getByLabel('Answer text')).toBeVisible()
-    await expect(page.getByRole('button', { name: '+ Add Item' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Add item', exact: true })).toHaveCount(0)
     await expect(page.getByRole('button', { name: 'Organise items' })).toHaveCount(0)
   })
 
@@ -434,7 +434,7 @@ test.describe('B – Editing Questions', () => {
     const emptyOption = options.nth(emptyIndex)
     await emptyOption.getByTestId('option-expand-chevron').click()
 
-    await emptyOption.getByRole('button', { name: '+ Add item' }).click()
+    await emptyOption.getByRole('button', { name: 'Add item', exact: true }).click()
     const field = emptyOption.locator('input[role="combobox"]')
     await field.fill('FirstItemTest')
     await field.press('Enter')

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -130,7 +130,7 @@ test.describe('C – Packing Lists', () => {
     await expect(page.getByRole('heading', { name: 'My Questions & Items' })).toBeVisible({ timeout: 8_000 })
     await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
     await expect(page.getByTestId('item-row').first()).toBeVisible({ timeout: 5_000 })
-    await page.getByRole('button', { name: '+ Add item' }).first().click()
+    await page.getByRole('button', { name: 'Add item', exact: true }).first().click()
     const field = page.getByLabel(/^New item in /)
     await expect(field).toBeVisible({ timeout: 3_000 })
     await field.fill(itemName)
@@ -170,9 +170,9 @@ test.describe('C – Packing Lists', () => {
     await page.getByRole('button', { name: /^Remove$/ }).click()
     await expect(page.getByText('GadgetTest')).not.toBeVisible({ timeout: 5_000 })
 
-    await page.getByRole('button', { name: /Update from questions/i }).click()
-    // No preview — the list already matches (the deleted item is not resurrected)
-    await expect(page.getByText('This list already matches your questions')).toBeVisible({ timeout: 5_000 })
+    // The update button disappears — the list already matches, and the
+    // deleted item is not resurrected as a pending update
+    await expect(page.getByRole('button', { name: /Update from questions/i })).not.toBeVisible({ timeout: 5_000 })
     await expect(page.getByRole('button', { name: /Add \d+ item/i })).not.toBeVisible()
   })
 

--- a/e2e/tests/d-navigation.spec.ts
+++ b/e2e/tests/d-navigation.spec.ts
@@ -6,11 +6,12 @@ test.describe('D – Navigation & UI', () => {
     await page.getByRole('link', { name: /My Questions & Items/i }).click()
     await expect(page).toHaveURL(/#\/manage-questions/)
 
-    await page.getByRole('link', { name: /Create List/i }).click()
-    await expect(page).toHaveURL(/#\/create-packing-list/)
-
-    await page.getByRole('link', { name: /View Lists/i }).click()
+    await page.getByRole('link', { name: 'Lists', exact: true }).click()
     await expect(page).toHaveURL(/#\/view-lists/)
+
+    // Creating a list happens from the Lists page now, not a nav link
+    await page.getByRole('button', { name: 'New List' }).first().click()
+    await expect(page).toHaveURL(/#\/create-packing-list/)
   })
 
   test('D2: Backups nav link is hidden when not logged in', async ({ freshPage: page }) => {

--- a/e2e/tests/e-auth.spec.ts
+++ b/e2e/tests/e-auth.spec.ts
@@ -10,30 +10,32 @@ test.describe('E – Solid Pod Authentication', () => {
     await page.goto('/')
     await expect(page.getByRole('button', { name: 'Login with Solid Pod' })).toBeVisible()
     await loginToCss(page, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD)
-    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
-    // webId should be displayed (use .first() to avoid strict mode violations when multiple elements match)
-    await expect(page.getByText(/testuser.*profile|profile.*testuser/i).or(
-      page.locator('span:has-text("localhost:4001/testuser")')
-    ).first()).toBeVisible()
+    const accountMenu = page.getByRole('button', { name: 'Account menu' })
+    await expect(accountMenu).toBeVisible()
+    // the full webId lives in the dropdown
+    await accountMenu.click()
+    await expect(page.getByRole('menu').getByText(/localhost:4001\/testuser/)).toBeVisible()
   })
 
   test('E2: logout returns to unauthenticated state', async ({ authedPage: page }) => {
-    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
-    await page.getByRole('button', { name: 'Logout' }).click()
+    await page.getByRole('button', { name: 'Account menu' }).click()
+    await page.getByRole('menuitem', { name: 'Logout' }).click()
     await expect(page.getByRole('button', { name: 'Login with Solid Pod' })).toBeVisible({ timeout: 8_000 })
-    await expect(page.getByRole('button', { name: 'Logout' })).not.toBeVisible()
+    await expect(page.getByRole('button', { name: 'Account menu' })).not.toBeVisible()
   })
 
-  test('E3: Backups nav link appears only when logged in', async ({ authedPage: page }) => {
-    await expect(page.getByRole('link', { name: 'Backups' })).toBeVisible()
-    await page.getByRole('button', { name: 'Logout' }).click()
-    await expect(page.getByRole('link', { name: 'Backups' })).not.toBeVisible({ timeout: 8_000 })
+  test('E3: Backups link appears in the account menu only when logged in', async ({ authedPage: page }) => {
+    await page.getByRole('button', { name: 'Account menu' }).click()
+    await expect(page.getByRole('menuitem', { name: 'Backups' })).toBeVisible()
+    await page.getByRole('menuitem', { name: 'Logout' }).click()
+    await expect(page.getByRole('button', { name: 'Account menu' })).not.toBeVisible({ timeout: 8_000 })
+    await expect(page.getByRole('link', { name: 'Backups' })).not.toBeVisible()
   })
 
   test('E4: session restored on page reload', async ({ authedPage: page }) => {
-    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Account menu' })).toBeVisible()
     await page.reload()
     // Session should be restored from storage
-    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('button', { name: 'Account menu' })).toBeVisible({ timeout: 15_000 })
   })
 })

--- a/e2e/tests/f-sync.spec.ts
+++ b/e2e/tests/f-sync.spec.ts
@@ -78,7 +78,7 @@ test.describe('F – Solid Pod Sync', () => {
     // Open People modal via pencil icon
     await page.locator('button[title="Edit people"]').click()
     await expect(page.getByRole('heading', { name: 'Edit People' })).toBeVisible({ timeout: 5_000 })
-    await page.getByRole('button', { name: '+ Add Person' }).click()
+    await page.getByRole('button', { name: 'Add Person', exact: true }).click()
     await page.locator('input[placeholder^="Person "]').last().fill('Sync Test Person')
     // Wait for the pod PUT to complete — set up the promise before clicking Save
     const putDone = page.waitForResponse(

--- a/e2e/tests/k-schema-compat.spec.ts
+++ b/e2e/tests/k-schema-compat.spec.ts
@@ -83,7 +83,7 @@ test.describe('K – JSON Schema Compatibility', () => {
     await page.goto('/#/view-lists')
     await page.waitForLoadState('networkidle')
 
-    await page.getByRole('link', { name: 'Create List' }).first().click()
+    await page.getByRole('button', { name: 'New List' }).first().click()
     await page.waitForURL(/#\/create-packing-list/, { timeout: 10_000 })
 
     // The question from the fixture should appear (local DB already has it from beforeAll sync)

--- a/e2e/tests/z-verify-offline-share.spec.ts
+++ b/e2e/tests/z-verify-offline-share.spec.ts
@@ -36,7 +36,7 @@ test.describe('Z – Offline list → login → share (regression for 404 fix)',
         try {
             await page.getByRole('button', { name: /use.*local/i }).click({ timeout: 3_000 })
         } catch { /* no modal */ }
-        await page.getByRole('button', { name: 'Logout' }).waitFor({ timeout: 15_000 })
+        await page.getByRole('button', { name: 'Account menu' }).waitFor({ timeout: 15_000 })
         console.log('Logged in')
 
         // ── 3. Navigate to the list ──────────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -6,6 +6,15 @@
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Pack Me Up</title>
+  <script>
+    // Applied before first paint so there's no flash of the wrong theme.
+    // Mirrors ThemeContext's own resolution: an explicit choice wins, else the OS setting.
+    (function () {
+      var stored = localStorage.getItem('theme-preference');
+      var dark = stored ? stored === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.classList.toggle('dark', dark);
+    })();
+  </script>
 </head>
 
 <body>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,85 @@
+// Vercel Edge Middleware: content negotiation at "/". A real browser (or
+// anything asking for text/html) keeps getting the SPA; a client that asks
+// for application/ld+json or text/turtle at least as strongly as text/html
+// gets the app's Application Capability description instead
+// (https://dokieli.github.io/application-capability/). See
+// src/capability/document.ts for the description itself and the reasoning
+// behind it.
+import { next } from '@vercel/functions'
+import { APP_ORIGIN, CAPABILITY_JSONLD, CAPABILITY_TURTLE } from './src/capability/document'
+
+export const config = { matcher: '/' }
+
+const JSONLD_TYPE = 'application/ld+json'
+const TURTLE_TYPE = 'text/turtle'
+const HTML_TYPE = 'text/html'
+
+interface AcceptEntry {
+    type: string
+    q: number
+}
+
+function parseAccept(header: string | null): AcceptEntry[] {
+    if (!header) return [{ type: '*/*', q: 1 }]
+    return header.split(',').map(part => {
+        const [type, ...params] = part.trim().split(';').map(s => s.trim())
+        const qParam = params.find(p => p.startsWith('q='))
+        const q = qParam ? parseFloat(qParam.slice(2)) : 1
+        return { type: type.toLowerCase(), q: Number.isFinite(q) ? q : 1 }
+    })
+}
+
+function qualityFor(entries: AcceptEntry[], mediaType: string): number {
+    const [maintype] = mediaType.split('/')
+    let best = 0
+    for (const entry of entries) {
+        if (entry.type === mediaType || entry.type === `${maintype}/*` || entry.type === '*/*') {
+            if (entry.q > best) best = entry.q
+        }
+    }
+    return best
+}
+
+// Only an exact, explicit entry counts as "asking for" this RDF type - a bare
+// `*/*` (or a missing Accept header, which we treat as `*/*`) must not be
+// enough on its own, or every plain `curl /` and every ordinary page load
+// with no Accept header at all would get the capability doc instead of the app.
+function explicitQualityFor(entries: AcceptEntry[], mediaType: string): number {
+    let best = 0
+    for (const entry of entries) {
+        if (entry.type === mediaType && entry.q > best) best = entry.q
+    }
+    return best
+}
+
+export default function middleware(request: Request) {
+    const entries = parseAccept(request.headers.get('accept'))
+    const jsonldQ = explicitQualityFor(entries, JSONLD_TYPE)
+    const turtleQ = explicitQualityFor(entries, TURTLE_TYPE)
+    const htmlQ = qualityFor(entries, HTML_TYPE)
+
+    // Between the two RDF formats, honour whichever the client actually
+    // weighted higher rather than always preferring one - only a tie falls
+    // back to JSON-LD, which the ac spec calls out as the preferred format.
+    if (jsonldQ > 0 && jsonldQ >= htmlQ && jsonldQ >= turtleQ) {
+        return new Response(JSON.stringify(CAPABILITY_JSONLD, null, 2), {
+            headers: {
+                'content-type': `${JSONLD_TYPE}; charset=utf-8`,
+                'content-location': `${APP_ORIGIN}/`,
+                vary: 'accept',
+            },
+        })
+    }
+
+    if (turtleQ > 0 && turtleQ >= htmlQ) {
+        return new Response(CAPABILITY_TURTLE, {
+            headers: {
+                'content-type': `${TURTLE_TYPE}; charset=utf-8`,
+                'content-location': `${APP_ORIGIN}/`,
+                vary: 'accept',
+            },
+        })
+    }
+
+    return next()
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react-select": "^5.0.1",
         "@uvdsl/solid-oidc-client-browser": "^0.2.2",
         "@vercel/analytics": "^1.5.0",
+        "@vercel/functions": "^3.7.6",
         "events": "^3.3.0",
         "lucide-react": "^1.28.0",
         "pouchdb": "^9.0.0",
@@ -7582,6 +7583,75 @@
         }
       }
     },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.1.tgz",
+      "integrity": "sha512-RhfyXmRLHdbnry8RJqHDc+5rGxMZ0bu+fpysZjtv3bE+BubpuwxTancHOKiH5zKQREsdwFVr3mOI2kOvxlOyxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+      "integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.7.6.tgz",
+      "integrity": "sha512-QKlSfrgvo4pGEnzHw8Dha9GRTb5hhLBbImKi4rL4CmxClaVs+36hxgjW0MOqez57wWShstpKOWZY/mU8KuYoUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.8.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*",
+        "ws": ">=8"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.1.tgz",
+      "integrity": "sha512-ufdalm2MWOYksyj8KVpWjoOFPJO6zoYpuyvIggIQ2bB0CFCjTCiTkGXHqAKwG77GVRjOaN3/8S5ITlZpXWmqOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.1",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -9497,6 +9567,29 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -9939,7 +10032,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10442,6 +10534,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -10738,7 +10839,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11924,6 +12024,12 @@
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -12016,6 +12122,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mimic-response": {
@@ -12284,6 +12399,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12403,6 +12530,21 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/only": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
@@ -12442,6 +12584,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/p-cancelable": {
@@ -14506,6 +14657,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -15485,7 +15645,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -15501,6 +15661,31 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/xml2js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@uvdsl/solid-oidc-client-browser": "^0.2.2",
         "@vercel/analytics": "^1.5.0",
         "events": "^3.3.0",
+        "lucide-react": "^1.28.0",
         "pouchdb": "^9.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -11827,6 +11828,15 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
       "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
       "license": "MIT"
+    },
+    "node_modules/lucide-react": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
+      "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@uvdsl/solid-oidc-client-browser": "^0.2.2",
     "@vercel/analytics": "^1.5.0",
     "events": "^3.3.0",
+    "lucide-react": "^1.28.0",
     "pouchdb": "^9.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/react-select": "^5.0.1",
     "@uvdsl/solid-oidc-client-browser": "^0.2.2",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/functions": "^3.7.6",
     "events": "^3.3.0",
     "lucide-react": "^1.28.0",
     "pouchdb": "^9.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Navigation } from './components/Navigation'
 import { Footer } from './components/Footer'
 import { SessionExpiredBanner } from './components/SessionExpiredBanner'
 import { ToastProvider } from './components/ToastContext'
+import { ThemeProvider } from './components/ThemeContext'
 import { LandingPage } from './pages/landing-page'
 import { CreatePackingList } from './pages/create-packing-list'
 import { PackingLists } from './pages/packing-lists'
@@ -32,6 +33,7 @@ function DefaultRedirect() {
 
 function App() {
   return (
+    <ThemeProvider>
     <ToastProvider>
       <SolidPodProvider>
         <DatabaseProvider>
@@ -39,7 +41,7 @@ function App() {
             <Analytics />
           {/* Column layout keeps the footer at the bottom of short pages rather
               than floating it under the content. */}
-          <div className="min-h-screen flex flex-col bg-gradient-to-br from-primary-50 via-white to-accent-50">
+          <div className="min-h-screen flex flex-col bg-gradient-to-br from-primary-50 via-white to-accent-50 dark:from-gray-900 dark:via-gray-950 dark:to-gray-900">
             <Navigation />
             <SessionExpiredBanner />
             <div className="flex-1 container mx-auto px-4 py-8">
@@ -71,6 +73,7 @@ function App() {
         </DatabaseProvider>
       </SolidPodProvider>
     </ToastProvider>
+    </ThemeProvider>
   )
 }
 

--- a/src/capability/document.ts
+++ b/src/capability/document.ts
@@ -229,6 +229,61 @@ const questionSetShape = {
     ],
 }
 
+// ---------------------------------------------------------------------------
+// Exports for the RDFa restatement in the footer
+// (src/components/ApplicationCapabilityRdfa.tsx). These re-export the exact
+// same objects that feed CAPABILITY_JSONLD's @graph below, so the RDFa
+// markup can't drift out of sync with it the way two independently
+// hand-typed documents could - see the module doc comment.
+// ---------------------------------------------------------------------------
+
+interface Capability {
+    id: string
+    type: string
+    action: string
+    output: string
+    resourceType: string
+    shape?: string
+    invocation: string
+}
+
+interface Invocation {
+    id: string
+    type: string
+    template: string
+    mapping: { variable: string; property: string }[]
+}
+
+interface Requirement {
+    id: string
+    type: string
+    cspDirective?: string
+    browserPermission?: string
+    hasPurpose: string
+}
+
+export const APPLICATION = application
+
+export const CAPABILITIES: Capability[] = [
+    capabilityViewPackingList,
+    capabilityViewQuestionSet,
+    capabilityCreatePackingList,
+    capabilitySetupWizard,
+]
+
+export const INVOCATIONS: Invocation[] = [
+    invokeViewPackingList,
+    invokeViewQuestionSet,
+    invokeCreatePackingList,
+    invokeSetupWizard,
+]
+
+export const REQUIREMENTS: Requirement[] = [
+    requirementScripts,
+    requirementConnect,
+    requirementClipboard,
+]
+
 export const CAPABILITY_JSONLD = {
     '@context': CONTEXT,
     '@graph': [

--- a/src/capability/document.ts
+++ b/src/capability/document.ts
@@ -1,0 +1,360 @@
+/**
+ * The app's Application Capability description (https://dokieli.github.io/application-capability/),
+ * served at "/" via content negotiation instead of the SPA when a client asks
+ * for `application/ld+json` or `text/turtle` (see /middleware.ts).
+ *
+ * This describes Pack Me Up as a Solid-aware web app: what it can do
+ * (Capabilities), how another agent invokes those actions (Invocations, as
+ * RFC 6570 URI Templates resolved against the app's own origin), and what it
+ * needs from its environment (Requirements: CSP directives, browser
+ * permissions). Two representations are hand-maintained here - JSON-LD (the
+ * spec's preferred format) and Turtle - and MUST describe the same triples.
+ * If you change one, change the other.
+ *
+ * Grounded in the app's real shape, not aspirational: the vocabulary
+ * (`pmu:`) and predicates match src/services/rdfVocab.ts and
+ * src/services/rdfSerialization.ts exactly, the invocation templates match
+ * routes in src/App.tsx, and the Requirements match actual browser API and
+ * network usage (src/components/SharePackingListModal.tsx,
+ * src/components/Toast.tsx, src/sentry.ts, Solid pod fetches).
+ *
+ * Some terms couldn't be verified against a live spec while this was written
+ * (network access to w3.org and the ODRL/DPV vocabularies was blocked) -
+ * flagged inline below with "unverified:". Worth a spec-in-hand review
+ * before this is treated as normative.
+ */
+
+export const APP_ORIGIN = 'https://packmeup.tim-gent.com'
+
+/**
+ * Local context extension on top of https://www.w3.org/ns/ac.jsonld.
+ * `resourceType`, `shape`, `action`, `hasPurpose`, `capability`,
+ * `requirement`, `invocation`, `mapping.property` etc. are already defined
+ * (and @protected) there - only the terms this document adds are declared
+ * here. SHACL terms are added as their own compact-IRI keys (e.g.
+ * "sh:targetClass") rather than bare aliases like "targetClass", so nothing
+ * here can collide with an ac.jsonld term.
+ */
+const CONTEXT = [
+    'https://www.w3.org/ns/ac.jsonld',
+    {
+        pmu: 'https://pack-me-up.app/vocab#',
+        schema: 'https://schema.org/',
+        dcterms: 'http://purl.org/dc/terms/',
+        xsd: 'http://www.w3.org/2001/XMLSchema#',
+        sh: 'http://www.w3.org/ns/shacl#',
+        'sh:targetClass': { '@type': '@id' },
+        'sh:path': { '@type': '@id' },
+        'sh:class': { '@type': '@id' },
+        'sh:datatype': { '@type': '@id' },
+        'sh:nodeKind': { '@type': '@id' },
+    },
+]
+
+// ---------------------------------------------------------------------------
+// Capabilities + Invocations
+// ---------------------------------------------------------------------------
+
+const application = {
+    id: `${APP_ORIGIN}/#i`,
+    type: 'ac:Application',
+    'as:name': 'Pack Me Up',
+    capability: [
+        `${APP_ORIGIN}/#capability-view-packing-list`,
+        `${APP_ORIGIN}/#capability-view-question-set`,
+        `${APP_ORIGIN}/#capability-create-packing-list`,
+        `${APP_ORIGIN}/#capability-setup-wizard`,
+    ],
+    requirement: [
+        `${APP_ORIGIN}/#requirement-scripts`,
+        `${APP_ORIGIN}/#requirement-connect`,
+        `${APP_ORIGIN}/#requirement-clipboard`,
+    ],
+}
+
+// View a packing list - your own, or one shared into a foreign pod. The
+// invocation is the spec's own "#open={open}" idiom: a single variable
+// carrying the full resource IRI. The app doesn't parse that form yet - see
+// the "future invocations" notes in the PR description; today's share links
+// (buildSharedListUrl in src/services/solidPod.ts) instead spell podUrl and
+// owner out as separate query parameters on a legacy-shaped path.
+const capabilityViewPackingList = {
+    id: `${APP_ORIGIN}/#capability-view-packing-list`,
+    type: 'Capability',
+    // unverified: odrl:use is a well-attested ODRL Vocabulary action, but
+    // the exact ODRL 2.2 action list couldn't be re-checked against the spec.
+    action: 'odrl:use',
+    output: 'text/html',
+    resourceType: 'pmu:PackingList',
+    shape: `${APP_ORIGIN}/#PackingListShape`,
+    invocation: `${APP_ORIGIN}/#invoke-view-packing-list`,
+}
+
+const invokeViewPackingList = {
+    id: `${APP_ORIGIN}/#invoke-view-packing-list`,
+    type: 'UriTemplateInvocation',
+    template: '#open-packing-list={open}',
+    mapping: [{ variable: 'open', property: 'ac:open' }],
+}
+
+// View a question/items set - today, own data only (see suggestion 2 below
+// for extending this to shared question sets the way lists already are).
+const capabilityViewQuestionSet = {
+    id: `${APP_ORIGIN}/#capability-view-question-set`,
+    type: 'Capability',
+    action: 'odrl:use',
+    output: 'text/html',
+    resourceType: 'pmu:QuestionSet',
+    shape: `${APP_ORIGIN}/#QuestionSetShape`,
+    invocation: `${APP_ORIGIN}/#invoke-view-question-set`,
+}
+
+const invokeViewQuestionSet = {
+    id: `${APP_ORIGIN}/#invoke-view-question-set`,
+    type: 'UriTemplateInvocation',
+    template: '#/manage-questions',
+    mapping: [],
+}
+
+// Start the "create a new packing list" flow. No target resource exists yet,
+// so there's no resourceType/shape to match against - just an action.
+const capabilityCreatePackingList = {
+    id: `${APP_ORIGIN}/#capability-create-packing-list`,
+    type: 'Capability',
+    action: 'as:Create',
+    output: 'text/html',
+    resourceType: 'pmu:PackingList',
+    invocation: `${APP_ORIGIN}/#invoke-create-packing-list`,
+}
+
+const invokeCreatePackingList = {
+    id: `${APP_ORIGIN}/#invoke-create-packing-list`,
+    type: 'UriTemplateInvocation',
+    template: '#/create-packing-list',
+    mapping: [],
+}
+
+// Run the guided setup wizard, which generates a starter QuestionSet.
+const capabilitySetupWizard = {
+    id: `${APP_ORIGIN}/#capability-setup-wizard`,
+    type: 'Capability',
+    action: 'as:Create',
+    output: 'text/html',
+    resourceType: 'pmu:QuestionSet',
+    invocation: `${APP_ORIGIN}/#invoke-setup-wizard`,
+}
+
+const invokeSetupWizard = {
+    id: `${APP_ORIGIN}/#invoke-setup-wizard`,
+    type: 'UriTemplateInvocation',
+    template: '#/wizard',
+    mapping: [],
+}
+
+// ---------------------------------------------------------------------------
+// Requirements
+// ---------------------------------------------------------------------------
+
+const requirementScripts = {
+    id: `${APP_ORIGIN}/#requirement-scripts`,
+    type: 'Requirement',
+    cspDirective: "script-src 'self'",
+    // unverified: dpv:ServiceProvision is a commonly-cited DPV purpose term;
+    // couldn't re-check it against the current DPV taxonomy.
+    hasPurpose: 'dpv:ServiceProvision',
+}
+
+// Solid pods are arbitrary, user-chosen HTTPS origins (any Community Solid
+// Server, Inrupt PodSpaces, or self-hosted pod a person points the app at),
+// so this can't be a fixed allowlist the way requirement-scripts' script-src
+// can. Sentry error reporting (src/sentry.ts) also needs an origin here, but
+// it's covered by the same https: wildcard so isn't called out separately.
+const requirementConnect = {
+    id: `${APP_ORIGIN}/#requirement-connect`,
+    type: 'Requirement',
+    cspDirective: "connect-src 'self' https:",
+    hasPurpose: 'dpv:ServiceProvision',
+}
+
+// navigator.clipboard.writeText - copying a share link
+// (SharePackingListModal.tsx) and copying error details (Toast.tsx).
+const requirementClipboard = {
+    id: `${APP_ORIGIN}/#requirement-clipboard`,
+    type: 'Requirement',
+    browserPermission: 'clipboard-write',
+    hasPurpose: 'dpv:ServiceProvision',
+}
+
+// ---------------------------------------------------------------------------
+// SHACL shapes
+//
+// Not exhaustive - each covers the predicates that define the type (present
+// on every instance, or structurally load-bearing), not every optional field
+// PMU_NS carries. Cross-checked against packingListToDataset/
+// questionSetToDataset in src/services/rdfSerialization.ts.
+// ---------------------------------------------------------------------------
+
+const packingListShape = {
+    id: `${APP_ORIGIN}/#PackingListShape`,
+    type: 'sh:NodeShape',
+    'sh:targetClass': 'pmu:PackingList',
+    'sh:property': [
+        { 'sh:path': 'schema:name', 'sh:datatype': 'xsd:string', 'sh:minCount': 1, 'sh:maxCount': 1 },
+        { 'sh:path': 'dcterms:created', 'sh:datatype': 'xsd:dateTime', 'sh:minCount': 1, 'sh:maxCount': 1 },
+        { 'sh:path': 'dcterms:modified', 'sh:datatype': 'xsd:dateTime', 'sh:maxCount': 1 },
+        { 'sh:path': 'pmu:destination', 'sh:datatype': 'xsd:string', 'sh:maxCount': 1 },
+        // Stored as plain YYYY-MM-DD strings, not xsd:date, to avoid timezone drift.
+        { 'sh:path': 'pmu:tripStartDate', 'sh:datatype': 'xsd:string', 'sh:maxCount': 1 },
+        { 'sh:path': 'pmu:tripEndDate', 'sh:datatype': 'xsd:string', 'sh:maxCount': 1 },
+        { 'sh:path': 'pmu:hasItem', 'sh:nodeKind': 'sh:IRI', 'sh:class': 'pmu:PackingListItem' },
+        { 'sh:path': 'pmu:hasDeletedItem', 'sh:nodeKind': 'sh:IRI', 'sh:class': 'pmu:PackingListItem' },
+        { 'sh:path': 'pmu:hasGuest', 'sh:nodeKind': 'sh:IRI' },
+        { 'sh:path': 'pmu:selectedPersonId', 'sh:datatype': 'xsd:string' },
+        { 'sh:path': 'pmu:hasAnswer', 'sh:nodeKind': 'sh:IRI' },
+    ],
+}
+
+const questionSetShape = {
+    id: `${APP_ORIGIN}/#QuestionSetShape`,
+    type: 'sh:NodeShape',
+    'sh:targetClass': 'pmu:QuestionSet',
+    'sh:property': [
+        { 'sh:path': 'dcterms:modified', 'sh:datatype': 'xsd:dateTime', 'sh:maxCount': 1 },
+        { 'sh:path': 'pmu:hasPerson', 'sh:nodeKind': 'sh:IRI', 'sh:class': 'pmu:Person' },
+        { 'sh:path': 'pmu:hasQuestion', 'sh:nodeKind': 'sh:IRI', 'sh:class': 'pmu:Question' },
+        { 'sh:path': 'pmu:hasAlwaysNeededItem', 'sh:nodeKind': 'sh:IRI', 'sh:class': 'pmu:QuestionItem' },
+        { 'sh:path': 'pmu:alwaysNeededEmptySection', 'sh:datatype': 'xsd:string' },
+        { 'sh:path': 'pmu:hasSectionOrderEntry', 'sh:nodeKind': 'sh:IRI', 'sh:class': 'pmu:SectionOrderEntry' },
+        { 'sh:path': 'pmu:templateVersion', 'sh:datatype': 'xsd:integer', 'sh:maxCount': 1 },
+    ],
+}
+
+export const CAPABILITY_JSONLD = {
+    '@context': CONTEXT,
+    '@graph': [
+        application,
+        capabilityViewPackingList,
+        invokeViewPackingList,
+        capabilityViewQuestionSet,
+        invokeViewQuestionSet,
+        capabilityCreatePackingList,
+        invokeCreatePackingList,
+        capabilitySetupWizard,
+        invokeSetupWizard,
+        requirementScripts,
+        requirementConnect,
+        requirementClipboard,
+        packingListShape,
+        questionSetShape,
+    ],
+}
+
+// Hand-maintained Turtle representation of the exact same triples as
+// CAPABILITY_JSONLD above - see the module doc comment.
+export const CAPABILITY_TURTLE = `@prefix ac: <https://www.w3.org/ns/ac#> .
+@prefix as: <https://www.w3.org/ns/activitystreams#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix dpv: <https://w3id.org/dpv#> .
+@prefix pmu: <https://pack-me-up.app/vocab#> .
+@prefix schema: <https://schema.org/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+<${APP_ORIGIN}/#i> a ac:Application ;
+    as:name "Pack Me Up" ;
+    ac:capability
+        <${APP_ORIGIN}/#capability-view-packing-list>,
+        <${APP_ORIGIN}/#capability-view-question-set>,
+        <${APP_ORIGIN}/#capability-create-packing-list>,
+        <${APP_ORIGIN}/#capability-setup-wizard> ;
+    ac:requirement
+        <${APP_ORIGIN}/#requirement-scripts>,
+        <${APP_ORIGIN}/#requirement-connect>,
+        <${APP_ORIGIN}/#requirement-clipboard> .
+
+# View a packing list - your own, or one shared into a foreign pod.
+<${APP_ORIGIN}/#capability-view-packing-list> a ac:Capability ;
+    ac:action odrl:use ;
+    ac:output "text/html" ;
+    ac:resourceType pmu:PackingList ;
+    ac:shape <${APP_ORIGIN}/#PackingListShape> ;
+    ac:invocation <${APP_ORIGIN}/#invoke-view-packing-list> .
+
+<${APP_ORIGIN}/#invoke-view-packing-list> a ac:UriTemplateInvocation ;
+    hydra:template "#open-packing-list={open}" ;
+    hydra:mapping [ hydra:variable "open" ; hydra:property ac:open ] .
+
+# View a question/items set - today, own data only.
+<${APP_ORIGIN}/#capability-view-question-set> a ac:Capability ;
+    ac:action odrl:use ;
+    ac:output "text/html" ;
+    ac:resourceType pmu:QuestionSet ;
+    ac:shape <${APP_ORIGIN}/#QuestionSetShape> ;
+    ac:invocation <${APP_ORIGIN}/#invoke-view-question-set> .
+
+<${APP_ORIGIN}/#invoke-view-question-set> a ac:UriTemplateInvocation ;
+    hydra:template "#/manage-questions" .
+
+# Start the "create a new packing list" flow.
+<${APP_ORIGIN}/#capability-create-packing-list> a ac:Capability ;
+    ac:action as:Create ;
+    ac:output "text/html" ;
+    ac:resourceType pmu:PackingList ;
+    ac:invocation <${APP_ORIGIN}/#invoke-create-packing-list> .
+
+<${APP_ORIGIN}/#invoke-create-packing-list> a ac:UriTemplateInvocation ;
+    hydra:template "#/create-packing-list" .
+
+# Run the guided setup wizard, which generates a starter QuestionSet.
+<${APP_ORIGIN}/#capability-setup-wizard> a ac:Capability ;
+    ac:action as:Create ;
+    ac:output "text/html" ;
+    ac:resourceType pmu:QuestionSet ;
+    ac:invocation <${APP_ORIGIN}/#invoke-setup-wizard> .
+
+<${APP_ORIGIN}/#invoke-setup-wizard> a ac:UriTemplateInvocation ;
+    hydra:template "#/wizard" .
+
+<${APP_ORIGIN}/#requirement-scripts> a ac:Requirement ;
+    ac:cspDirective "script-src 'self'" ;
+    dpv:hasPurpose dpv:ServiceProvision .
+
+# Solid pods are arbitrary, user-chosen HTTPS origins, so this can't be a
+# fixed allowlist. Sentry error reporting is covered by the same https: wildcard.
+<${APP_ORIGIN}/#requirement-connect> a ac:Requirement ;
+    ac:cspDirective "connect-src 'self' https:" ;
+    dpv:hasPurpose dpv:ServiceProvision .
+
+# navigator.clipboard.writeText - copying a share link and copying error details.
+<${APP_ORIGIN}/#requirement-clipboard> a ac:Requirement ;
+    ac:browserPermission "clipboard-write" ;
+    dpv:hasPurpose dpv:ServiceProvision .
+
+<${APP_ORIGIN}/#PackingListShape> a sh:NodeShape ;
+    sh:targetClass pmu:PackingList ;
+    sh:property
+        [ sh:path schema:name ; sh:datatype xsd:string ; sh:minCount 1 ; sh:maxCount 1 ],
+        [ sh:path dcterms:created ; sh:datatype xsd:dateTime ; sh:minCount 1 ; sh:maxCount 1 ],
+        [ sh:path dcterms:modified ; sh:datatype xsd:dateTime ; sh:maxCount 1 ],
+        [ sh:path pmu:destination ; sh:datatype xsd:string ; sh:maxCount 1 ],
+        [ sh:path pmu:tripStartDate ; sh:datatype xsd:string ; sh:maxCount 1 ],
+        [ sh:path pmu:tripEndDate ; sh:datatype xsd:string ; sh:maxCount 1 ],
+        [ sh:path pmu:hasItem ; sh:nodeKind sh:IRI ; sh:class pmu:PackingListItem ],
+        [ sh:path pmu:hasDeletedItem ; sh:nodeKind sh:IRI ; sh:class pmu:PackingListItem ],
+        [ sh:path pmu:hasGuest ; sh:nodeKind sh:IRI ],
+        [ sh:path pmu:selectedPersonId ; sh:datatype xsd:string ],
+        [ sh:path pmu:hasAnswer ; sh:nodeKind sh:IRI ] .
+
+<${APP_ORIGIN}/#QuestionSetShape> a sh:NodeShape ;
+    sh:targetClass pmu:QuestionSet ;
+    sh:property
+        [ sh:path dcterms:modified ; sh:datatype xsd:dateTime ; sh:maxCount 1 ],
+        [ sh:path pmu:hasPerson ; sh:nodeKind sh:IRI ; sh:class pmu:Person ],
+        [ sh:path pmu:hasQuestion ; sh:nodeKind sh:IRI ; sh:class pmu:Question ],
+        [ sh:path pmu:hasAlwaysNeededItem ; sh:nodeKind sh:IRI ; sh:class pmu:QuestionItem ],
+        [ sh:path pmu:alwaysNeededEmptySection ; sh:datatype xsd:string ],
+        [ sh:path pmu:hasSectionOrderEntry ; sh:nodeKind sh:IRI ; sh:class pmu:SectionOrderEntry ],
+        [ sh:path pmu:templateVersion ; sh:datatype xsd:integer ; sh:maxCount 1 ] .
+`

--- a/src/components/AgePromotionCard.tsx
+++ b/src/components/AgePromotionCard.tsx
@@ -116,7 +116,7 @@ export function AgePromotionCard({ questionSet, onApply, manualTransitions, onMa
         .join(', ')
 
     const renderSuggestion = (s: PromotionSuggestion) => (
-        <label key={s.key} className="flex items-start gap-2 text-sm text-gray-700 bg-white rounded border border-violet-200 px-3 py-2">
+        <label key={s.key} className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 rounded border border-violet-200 px-3 py-2">
             <input
                 type="checkbox"
                 checked={!unchecked.has(s.key)}
@@ -124,8 +124,8 @@ export function AgePromotionCard({ questionSet, onApply, manualTransitions, onMa
                 className="mt-0.5 h-4 w-4 text-violet-600 rounded focus:ring-2 focus:ring-violet-500"
             />
             <span>
-                <span className="font-medium text-gray-900">{s.itemText}</span>
-                <span className="ml-2 text-xs text-gray-500">{s.contextLabel}</span>
+                <span className="font-medium text-gray-900 dark:text-gray-100">{s.itemText}</span>
+                <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">{s.contextLabel}</span>
             </span>
         </label>
     )
@@ -180,7 +180,7 @@ export function AgePromotionCard({ questionSet, onApply, manualTransitions, onMa
                         <button
                             type="button"
                             onClick={() => setIsExpanded(false)}
-                            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-violet-100"
+                            className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 rounded-lg hover:bg-violet-100"
                         >
                             Not now
                         </button>

--- a/src/components/ApplicationCapabilityRdfa.test.tsx
+++ b/src/components/ApplicationCapabilityRdfa.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import React from 'react'
+import { ApplicationCapabilityRdfa } from './ApplicationCapabilityRdfa'
+import { APPLICATION, CAPABILITIES, REQUIREMENTS } from '../capability/document'
+
+describe('ApplicationCapabilityRdfa', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('declares the vocabulary prefixes the markup below relies on', () => {
+        const { container } = render(<ApplicationCapabilityRdfa />)
+
+        const root = container.querySelector('[typeof="ac:Application"]')!
+        expect(root.getAttribute('prefix')).toContain('ac: https://www.w3.org/ns/ac#')
+        expect(root.getAttribute('prefix')).toContain('pmu: https://pack-me-up.app/vocab#')
+    })
+
+    it('identifies the application by its own IRI and name', () => {
+        const { container } = render(<ApplicationCapabilityRdfa />)
+
+        const root = container.querySelector('[typeof="ac:Application"]')!
+        expect(root.getAttribute('resource')).toBe(APPLICATION.id)
+        expect(container.querySelector('[property="as:name"]')?.getAttribute('content')).toBe('Pack Me Up')
+    })
+
+    it('restates every capability from the negotiated document as ac:Capability', () => {
+        const { container } = render(<ApplicationCapabilityRdfa />)
+
+        const capabilities = container.querySelectorAll('[property="ac:capability"]')
+        expect(capabilities.length).toBe(CAPABILITIES.length)
+
+        for (const capability of CAPABILITIES) {
+            const node = container.querySelector(`[typeof="ac:Capability"][resource="${capability.id}"]`)
+            expect(node).not.toBeNull()
+            expect(node!.querySelector('[property="ac:action"]')?.getAttribute('resource')).toBe(capability.action)
+            expect(node!.querySelector('[property="ac:output"]')?.getAttribute('content')).toBe(capability.output)
+            expect(node!.querySelector('link[property="ac:resourceType"]')?.getAttribute('resource')).toBe(capability.resourceType)
+        }
+    })
+
+    it('nests each capability\'s invocation as an ac:UriTemplateInvocation with its hydra:template', () => {
+        const { container } = render(<ApplicationCapabilityRdfa />)
+
+        const capability = CAPABILITIES.find(c => c.id.endsWith('capability-view-packing-list'))!
+        const capabilityNode = container.querySelector(`[resource="${capability.id}"]`)!
+        const invocationNode = capabilityNode.querySelector('[typeof="ac:UriTemplateInvocation"]')!
+
+        expect(invocationNode.getAttribute('resource')).toBe(capability.invocation)
+        expect(invocationNode.querySelector('[property="hydra:template"]')?.getAttribute('content')).toBe('#open-packing-list={open}')
+    })
+
+    it('only points ac:shape at capabilities that actually declare a shape', () => {
+        const { container } = render(<ApplicationCapabilityRdfa />)
+
+        const withShape = CAPABILITIES.find(c => c.shape)!
+        const withoutShape = CAPABILITIES.find(c => !c.shape)!
+
+        expect(container.querySelector(`[resource="${withShape.id}"] link[property="ac:shape"]`)).not.toBeNull()
+        expect(container.querySelector(`[resource="${withoutShape.id}"] link[property="ac:shape"]`)).toBeNull()
+    })
+
+    it('restates every requirement as an ac:Requirement with its purpose', () => {
+        const { container } = render(<ApplicationCapabilityRdfa />)
+
+        for (const requirement of REQUIREMENTS) {
+            const node = container.querySelector(`[typeof="ac:Requirement"][resource="${requirement.id}"]`)
+            expect(node).not.toBeNull()
+            expect(node!.querySelector('[property="dpv:hasPurpose"]')?.getAttribute('resource')).toBe(requirement.hasPurpose)
+        }
+    })
+
+    it('renders nothing visible, since every element is empty or a <meta>/<link>', () => {
+        const { container } = render(<ApplicationCapabilityRdfa />)
+
+        expect(container.textContent).toBe('')
+    })
+})

--- a/src/components/ApplicationCapabilityRdfa.tsx
+++ b/src/components/ApplicationCapabilityRdfa.tsx
@@ -1,0 +1,66 @@
+import { APPLICATION, CAPABILITIES, INVOCATIONS, REQUIREMENTS } from '../capability/document'
+
+const PREFIX = [
+    'ac: https://www.w3.org/ns/ac#',
+    'as: https://www.w3.org/ns/activitystreams#',
+    'odrl: http://www.w3.org/ns/odrl/2/',
+    'hydra: http://www.w3.org/ns/hydra/core#',
+    'dpv: https://w3id.org/dpv#',
+    'pmu: https://pack-me-up.app/vocab#',
+].join(' ')
+
+/**
+ * The same Application Capability description served via content
+ * negotiation at "/" (src/capability/document.ts, /middleware.ts), restated
+ * as RDFa attributes in the footer so a plain browser GET of the SPA's HTML
+ * carries the triples too, with no Accept header gymnastics required
+ * (https://dokieli.github.io/application-capability/).
+ *
+ * Literal values use `<span property=… content=…/>` rather than `<meta>`:
+ * React 19 auto-hoists `<meta>` into `<head>` wherever it's rendered, which
+ * would pull it out from under its `typeof` ancestor and break the subject
+ * it's meant to describe. `content` is a general RDFa attribute, not
+ * `<meta>`-specific, so the empty `<span>` carries the same triple without
+ * being hoisted. Every element here is otherwise empty, so this adds no
+ * visible footprint to the footer. SHACL shapes aren't restated: ac:shape
+ * just points at their fragment on the negotiated JSON-LD/Turtle document,
+ * which stays the one place they're defined.
+ */
+export function ApplicationCapabilityRdfa() {
+    const invocationById = new Map(INVOCATIONS.map(invocation => [invocation.id, invocation]))
+
+    return (
+        <div prefix={PREFIX} typeof="ac:Application" resource={APPLICATION.id}>
+            <span property="as:name" content={APPLICATION['as:name']} />
+
+            {CAPABILITIES.map(capability => {
+                const invocation = invocationById.get(capability.invocation)
+                return (
+                    <div key={capability.id} property="ac:capability" typeof="ac:Capability" resource={capability.id}>
+                        <span property="ac:action" resource={capability.action} />
+                        <span property="ac:output" content={capability.output} />
+                        <link property="ac:resourceType" resource={capability.resourceType} />
+                        {capability.shape && <link property="ac:shape" resource={capability.shape} />}
+                        {invocation && (
+                            <div property="ac:invocation" typeof="ac:UriTemplateInvocation" resource={invocation.id}>
+                                <span property="hydra:template" content={invocation.template} />
+                            </div>
+                        )}
+                    </div>
+                )
+            })}
+
+            {REQUIREMENTS.map(requirement => (
+                <div key={requirement.id} property="ac:requirement" typeof="ac:Requirement" resource={requirement.id}>
+                    {requirement.cspDirective && (
+                        <span property="ac:cspDirective" content={requirement.cspDirective} />
+                    )}
+                    {requirement.browserPermission && (
+                        <span property="ac:browserPermission" content={requirement.browserPermission} />
+                    )}
+                    <span property="dpv:hasPurpose" resource={requirement.hasPurpose} />
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -11,7 +11,7 @@ export function Button({ variant = 'primary', ...props }: ButtonProps) {
         primary: 'bg-gradient-primary text-white shadow-soft hover:shadow-glow-primary focus:ring-primary-500',
         secondary: 'bg-gradient-secondary text-white shadow-soft hover:shadow-glow-secondary focus:ring-secondary-500',
         danger: 'bg-gradient-to-r from-danger-500 to-danger-600 text-white shadow-soft hover:shadow-lg focus:ring-danger-500',
-        ghost: 'text-primary-700 hover:bg-primary-50 border-2 border-primary-200 hover:border-primary-400 focus:ring-primary-500'
+        ghost: 'text-primary-700 dark:text-primary-300 hover:bg-primary-50 dark:hover:bg-primary-950/40 border-2 border-primary-200 dark:border-primary-800 hover:border-primary-400 focus:ring-primary-500'
     }[variant]
 
     return (

--- a/src/components/Callout.tsx
+++ b/src/components/Callout.tsx
@@ -11,11 +11,11 @@ interface CalloutProps {
 
 export function Callout({ title, description, action }: CalloutProps) {
     return (
-        <div className="rounded-2xl bg-gradient-to-br from-primary-50 to-accent-50 p-6 border-2 border-primary-200 shadow-soft hover:shadow-glow-primary transition-all duration-300">
+        <div className="rounded-2xl bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 p-6 border-2 border-primary-200 dark:border-primary-800 shadow-soft hover:shadow-glow-primary transition-all duration-300">
             <div className="flex">
                 <div className="flex-1">
-                    <h3 className="text-lg font-bold text-primary-900">{title}</h3>
-                    <div className="mt-3 text-sm text-gray-700 leading-relaxed">
+                    <h3 className="text-lg font-bold text-primary-900 dark:text-primary-200">{title}</h3>
+                    <div className="mt-3 text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
                         <p>{description}</p>
                     </div>
                     {action && (

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -13,8 +13,8 @@ export function CloseButton({ label, className, ...props }: CloseButtonProps) {
                 inline-flex items-center justify-center
                 w-8 h-8
                 rounded-full
-                text-gray-400 hover:text-gray-600
-                hover:bg-gray-100
+                text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300
+                hover:bg-gray-100 dark:hover:bg-gray-700
                 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2
                 transition-colors duration-200
                 ${className || ''}

--- a/src/components/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog.tsx
@@ -25,7 +25,7 @@ export function ConfirmationDialog({
     return (
         <Modal isOpen={isOpen} onClose={onClose} title={title}>
             <div className="space-y-4">
-                <p className="text-gray-700 whitespace-pre-line">{message}</p>
+                <p className="text-gray-700 dark:text-gray-300 whitespace-pre-line">{message}</p>
                 <div className="flex gap-3 justify-end mt-6">
                     <Button variant="ghost" onClick={onClose}>
                         {cancelText}

--- a/src/components/CreatableSelect.tsx
+++ b/src/components/CreatableSelect.tsx
@@ -101,9 +101,9 @@ export function CustomCreatableSelect({ value, onChange, options, placeholder = 
                 tabIndex={0}
                 onClick={() => setIsActive(true)}
                 onFocus={() => setIsActive(true)}
-                className="flex items-center min-h-[42px] border border-gray-200 hover:border-gray-400 rounded px-3 cursor-text"
+                className="flex items-center min-h-[42px] border border-gray-200 dark:border-gray-700 hover:border-gray-400 rounded px-3 cursor-text"
             >
-                <span className={`flex-1 text-sm ${value ? 'text-gray-700' : 'text-gray-400'}`}>
+                <span className={`flex-1 text-sm ${value ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'}`}>
                     {value || placeholder}
                 </span>
                 {value && (
@@ -112,7 +112,7 @@ export function CustomCreatableSelect({ value, onChange, options, placeholder = 
                         tabIndex={-1}
                         onMouseDown={(e) => e.preventDefault()}
                         onClick={(e) => { e.stopPropagation(); onChange(''); }}
-                        className="text-gray-300 hover:text-gray-500 text-lg leading-none ml-1"
+                        className="text-gray-300 hover:text-gray-500 dark:hover:text-gray-300 text-lg leading-none ml-1"
                         aria-label="Clear"
                     >
                         ×

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -6,10 +6,10 @@ interface ErrorFallbackProps {
 
 export function ErrorFallback({ resetError }: ErrorFallbackProps) {
     return (
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-50 via-white to-accent-50 px-4">
-            <div className="max-w-md w-full text-center bg-white rounded-2xl shadow-soft p-8">
-                <h1 className="text-xl font-bold text-gray-900 mb-2">Something went wrong</h1>
-                <p className="text-gray-600 mb-6">
+        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-50 dark:from-primary-950/40 via-white to-accent-50 dark:to-accent-950/40 px-4">
+            <div className="max-w-md w-full text-center bg-white dark:bg-gray-800 rounded-2xl shadow-soft p-8">
+                <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">Something went wrong</h1>
+                <p className="text-gray-600 dark:text-gray-400 mb-6">
                     We've been notified about this error. A report dialog should appear where you can add details
                     about what happened — that helps us fix it faster.
                 </p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 
 export const FEEDBACK_EMAIL = 'tim.packmeup@gmail.com'
 
-const linkStyles = 'text-gray-500 hover:text-primary-700 hover:underline transition-colors duration-200'
+const linkStyles = 'text-gray-500 dark:text-gray-400 hover:text-primary-700 dark:hover:text-primary-400 hover:underline transition-colors duration-200'
 
 /**
  * Where the things you need once belong — the policy, the data-deletion page, a
@@ -15,7 +15,7 @@ const linkStyles = 'text-gray-500 hover:text-primary-700 hover:underline transit
  */
 export function Footer() {
     return (
-        <footer className="border-t border-primary-100 bg-white/40 safe-area-bottom">
+        <footer className="border-t border-primary-100 dark:border-gray-800 bg-white/40 dark:bg-gray-900/60 safe-area-bottom">
             {/*
               * pb-24 on mobile keeps the last row above Sentry's fixed feedback
               * widget, which otherwise sits on top of the "Feedback" link once you

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { ApplicationCapabilityRdfa } from './ApplicationCapabilityRdfa'
 
 export const FEEDBACK_EMAIL = 'tim.packmeup@gmail.com'
 
@@ -16,6 +17,7 @@ const linkStyles = 'text-gray-500 dark:text-gray-400 hover:text-primary-700 dark
 export function Footer() {
     return (
         <footer className="border-t border-primary-100 dark:border-gray-800 bg-white/40 dark:bg-gray-900/60 safe-area-bottom">
+            <ApplicationCapabilityRdfa />
             {/*
               * pb-24 on mobile keeps the last row above Sentry's fixed feedback
               * widget, which otherwise sits on top of the "Feedback" link once you

--- a/src/components/ForeignPodLayout.tsx
+++ b/src/components/ForeignPodLayout.tsx
@@ -98,7 +98,7 @@ export function ForeignPodLayout() {
     if (!isLoggedIn) {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
-                <p className="text-gray-700">Please log in to view shared content.</p>
+                <p className="text-gray-700 dark:text-gray-300">Please log in to view shared content.</p>
             </div>
         )
     }
@@ -114,7 +114,7 @@ export function ForeignPodLayout() {
     if (accessState === 'pending') {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
-                <p className="text-gray-500">Verifying access…</p>
+                <p className="text-gray-500 dark:text-gray-400">Verifying access…</p>
             </div>
         )
     }

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -8,7 +8,7 @@ export function Input({ label, ...props }: InputProps) {
     return (
         <div className="flex-1">
             {label && (
-                <label className="block text-sm font-semibold text-gray-800 mb-2">
+                <label className="block text-sm font-semibold text-gray-800 dark:text-gray-200 mb-2">
                     {label}
                 </label>
             )}
@@ -22,7 +22,7 @@ export function Input({ label, ...props }: InputProps) {
                     border-primary-200
                     rounded-xl
                     shadow-soft
-                    text-gray-900
+                    text-gray-900 dark:text-gray-100
                     placeholder-gray-400
                     focus:outline-none
                     focus:ring-2

--- a/src/components/ItemEditorControls.tsx
+++ b/src/components/ItemEditorControls.tsx
@@ -98,7 +98,7 @@ export const PersonToggles = memo(function PersonToggles({ item, people, layout,
                 title={communalTitle}
                 aria-label={`Toggle shared for ${item.text || 'item'}`}
                 aria-pressed={isCommunal}
-                className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${isCommunal ? 'bg-blue-600 text-white border-transparent' : 'bg-white border-gray-200 text-gray-400'}`}
+                className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${isCommunal ? 'bg-blue-600 text-white border-transparent' : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500'}`}
             >
                 <span className="text-lg font-bold leading-none">👥</span>
                 <span className="text-[10px] font-medium leading-none truncate w-full text-center px-1">
@@ -114,7 +114,7 @@ export const PersonToggles = memo(function PersonToggles({ item, people, layout,
                         onClick={() => onTogglePerson(personIdx)}
                         title={personTitle(person.name)}
                         aria-pressed={selected}
-                        className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${selected ? `${personColorFor(person, personIdx).avatar} border-transparent` : 'bg-white border-gray-200 text-gray-400'}`}
+                        className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${selected ? `${personColorFor(person, personIdx).avatar} border-transparent` : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500'}`}
                     >
                         <span className="text-lg font-bold leading-none">
                             {person.name.charAt(0).toUpperCase()}
@@ -142,7 +142,7 @@ export const QuantityPanel = memo(function QuantityPanel({ item, onPerNight, onP
 }) {
     const hasRate = item.perNight !== undefined
     return (
-        <div className="w-full flex items-center gap-3 flex-wrap text-xs text-gray-600 bg-emerald-50 border border-emerald-100 rounded-lg px-2.5 py-1.5">
+        <div className="w-full flex items-center gap-3 flex-wrap text-xs text-gray-600 dark:text-gray-400 bg-emerald-50 border border-emerald-100 rounded-lg px-2.5 py-1.5">
             <span className="flex items-center gap-1.5">
                 Pack
                 <input
@@ -151,7 +151,7 @@ export const QuantityPanel = memo(function QuantityPanel({ item, onPerNight, onP
                     value={item.perNight ?? ''}
                     onChange={e => onPerNight(parseQty(e.target.value))}
                     aria-label={`Quantity to pack for ${item.text || 'item'}`}
-                    className="w-12 border border-gray-300 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                    className="w-12 border border-gray-300 dark:border-gray-600 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400"
                 />
                 per
                 <input
@@ -162,7 +162,7 @@ export const QuantityPanel = memo(function QuantityPanel({ item, onPerNight, onP
                     onChange={e => onPerNights(parseQty(e.target.value))}
                     disabled={!hasRate}
                     aria-label={`Number of nights per ${item.text || 'item'}`}
-                    className="w-12 border border-gray-300 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400 disabled:opacity-40"
+                    className="w-12 border border-gray-300 dark:border-gray-600 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400 disabled:opacity-40"
                 />
                 night{(item.perNights ?? 1) > 1 ? 's' : ''}
             </span>
@@ -175,10 +175,10 @@ export const QuantityPanel = memo(function QuantityPanel({ item, onPerNight, onP
                     onChange={e => onMaxQuantity(parseQty(e.target.value))}
                     disabled={!hasRate}
                     aria-label={`Maximum quantity for ${item.text || 'item'}`}
-                    className="w-12 border border-gray-300 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                    className="w-12 border border-gray-300 dark:border-gray-600 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400"
                 />
             </label>
-            <span className="text-gray-400">
+            <span className="text-gray-400 dark:text-gray-500">
                 e.g. socks: 1 per night; a jumper: 1 per 4 nights. Suggests a
                 quantity when a list has nights away — leave blank to skip
             </span>

--- a/src/components/ItemInlineEditor.tsx
+++ b/src/components/ItemInlineEditor.tsx
@@ -18,7 +18,7 @@ import { CustomCreatableSelect } from './CreatableSelect'
 import { PersonToggles, QuantityPanel } from './ItemEditorControls'
 import type { Item, Person } from '../edit-questions/types'
 
-const FIELD_LABEL = 'block text-[11px] font-semibold text-gray-400 uppercase tracking-wide mb-1'
+const FIELD_LABEL = 'block text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1'
 
 export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, allItemNames, sectionNames, sectionDefaultLabel, onChange, onDelete, onClose }: {
     item: Item
@@ -78,7 +78,7 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
         <div
             data-testid="item-inline-editor"
             onKeyDown={e => { if (e.key === 'Escape') onClose() }}
-            className="mt-1 mb-2 rounded-lg border border-primary-200 bg-white p-3 space-y-3 shadow-sm"
+            className="mt-1 mb-2 rounded-lg border border-primary-200 dark:border-primary-800 bg-white dark:bg-gray-800 p-3 space-y-3 shadow-sm"
         >
             <div data-testid="item-name-field">
                 <span className={FIELD_LABEL}>Item</span>
@@ -129,7 +129,7 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
                     aria-label="Section"
                     value={item.category ?? sectionDefaultLabel}
                     onChange={e => setSection(e.target.value)}
-                    className="w-full border border-gray-200 rounded px-3 py-2.5 text-sm text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    className="w-full border border-gray-200 dark:border-gray-700 rounded px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-primary-500"
                 >
                     {sectionOptions.map(label => (
                         <option key={label} value={label}>{label}</option>
@@ -146,7 +146,7 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
                         type="button"
                         onClick={onDelete}
                         aria-label={item.text ? `Delete ${item.text}` : 'Delete item'}
-                        className="px-2 py-1.5 text-sm font-medium text-gray-400 rounded-lg hover:text-red-600 hover:bg-red-50"
+                        className="px-2 py-1.5 text-sm font-medium text-gray-400 dark:text-gray-500 rounded-lg hover:text-red-600 hover:bg-red-50"
                     >
                         Delete
                     </button>
@@ -154,7 +154,7 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
                 <button
                     type="button"
                     onClick={onClose}
-                    className="px-4 py-1.5 text-sm font-medium text-primary-700 bg-primary-50 rounded-lg hover:bg-primary-100"
+                    className="px-4 py-1.5 text-sm font-medium text-primary-700 dark:text-primary-300 bg-primary-50 dark:bg-primary-950/40 rounded-lg hover:bg-primary-100"
                 >
                     Done
                 </button>

--- a/src/components/ItemNameField.tsx
+++ b/src/components/ItemNameField.tsx
@@ -17,7 +17,7 @@ import { useMemo, useState } from 'react'
 import { suggestFor, type ItemSuggestion, type SuggestionIndex } from '../utils/itemSuggestions'
 
 /** A composer field, bar the focus ring — each page brings its own accent. */
-export const FIELD_BASE = 'px-3 py-2 border border-gray-300 rounded-md bg-white text-sm text-gray-700 focus:outline-none focus:ring-2'
+export const FIELD_BASE = 'px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2'
 export const FIELD = `${FIELD_BASE} focus:ring-blue-500`
 
 interface ItemNameFieldProps {
@@ -144,7 +144,7 @@ export function ItemNameField({
                 <ul
                     id={listboxId}
                     role="listbox"
-                    className="absolute left-0 right-0 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+                    className="absolute left-0 right-0 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 py-1 shadow-lg"
                 >
                     {matches.map((suggestion, i) => (
                         <li key={suggestion.text}>
@@ -155,11 +155,11 @@ export function ItemNameField({
                                 // Blur would close the list before the click landed.
                                 onMouseDown={e => e.preventDefault()}
                                 onClick={() => applySuggestion(suggestion)}
-                                className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm ${i === highlighted ? 'bg-blue-50 text-blue-900' : 'text-gray-700 hover:bg-gray-50'}`}
+                                className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm ${i === highlighted ? 'bg-blue-50 text-blue-900' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'}`}
                             >
                                 <span className="truncate">{suggestion.text}</span>
                                 {suggestion.category && (
-                                    <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[11px] text-gray-500">
+                                    <span className="shrink-0 rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-[11px] text-gray-500 dark:text-gray-400">
                                         {suggestion.category}
                                     </span>
                                 )}

--- a/src/components/LoadingState.tsx
+++ b/src/components/LoadingState.tsx
@@ -15,7 +15,7 @@ export function LoadingState({ message, rows = 3 }: LoadingStateProps) {
         <div role="status" aria-live="polite">
             <div className="flex flex-col items-center gap-3 py-6">
                 <span aria-hidden="true" className="loading-suitcase text-5xl leading-none">🧳</span>
-                <p className="text-lg font-semibold text-gray-700">{message}</p>
+                <p className="text-lg font-semibold text-gray-700 dark:text-gray-300">{message}</p>
             </div>
 
             <div data-testid="loading-skeleton" aria-hidden="true" className="space-y-4">
@@ -23,7 +23,7 @@ export function LoadingState({ message, rows = 3 }: LoadingStateProps) {
                     <div
                         key={index}
                         data-testid="loading-skeleton-card"
-                        className="rounded-2xl border-2 border-primary-100 bg-white p-5 shadow-soft"
+                        className="rounded-2xl border-2 border-primary-100 bg-white dark:bg-gray-800 p-5 shadow-soft"
                     >
                         <div className="loading-skeleton-bar h-5 w-1/2 rounded-full" />
                         <div className="loading-skeleton-bar mt-3 h-4 w-1/3 rounded-full" />

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -17,11 +17,11 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
                     colour itself, and /40 matches every other overlay in the app */}
                 <div className="fixed inset-0 bg-black/40 transition-opacity" onClick={onClose} />
 
-                <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all w-full sm:my-8 sm:max-w-lg sm:p-6">
+                <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 pb-4 pt-5 text-left shadow-xl transition-all w-full sm:my-8 sm:max-w-lg sm:p-6">
                     <div className="absolute right-0 top-0 pr-4 pt-4">
                         <button
                             type="button"
-                            className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
+                            className="rounded-md bg-white dark:bg-gray-800 text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none"
                             onClick={onClose}
                         >
                             <span className="sr-only">Close</span>
@@ -32,7 +32,7 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
                     </div>
                     <div className="sm:flex sm:items-start">
                         <div className="mt-3 text-center sm:mt-0 sm:text-left w-full">
-                            <h3 className="text-lg font-semibold leading-6 text-gray-900 mb-4">
+                            <h3 className="text-lg font-semibold leading-6 text-gray-900 dark:text-gray-100 mb-4">
                                 {title}
                             </h3>
                             <div className="mt-2">

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -17,7 +17,7 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
                     colour itself, and /40 matches every other overlay in the app */}
                 <div className="fixed inset-0 bg-black/40 transition-opacity" onClick={onClose} />
 
-                <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+                <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all w-full sm:my-8 sm:max-w-lg sm:p-6">
                     <div className="absolute right-0 top-0 pr-4 pt-4">
                         <button
                             type="button"

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -13,7 +13,9 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
     return (
         <div className="fixed inset-0 z-50 overflow-y-auto">
             <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
-                <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={onClose} />
+                {/* bg-opacity-* is gone in Tailwind v4 — opacity must live in the
+                    colour itself, and /40 matches every other overlay in the app */}
+                <div className="fixed inset-0 bg-black/40 transition-opacity" onClick={onClose} />
 
                 <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                     <div className="absolute right-0 top-0 pr-4 pt-4">

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within, fireEvent } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { Navigation } from './Navigation'
@@ -12,6 +12,10 @@ vi.mock('./SolidProviderSelector', () => ({
     SolidProviderSelector: () => null,
 }))
 
+vi.mock('../services/solidPod', () => ({
+    getPodOwnerProfile: vi.fn().mockResolvedValue({ name: null, photo: null }),
+}))
+
 vi.mock('./DatabaseContext', () => ({
     useDatabase: vi.fn().mockReturnValue({
         db: { getSharedWithMe: vi.fn().mockResolvedValue({ contexts: [], lastModified: '' }) },
@@ -21,8 +25,10 @@ vi.mock('./DatabaseContext', () => ({
 }))
 
 import { useSolidPod } from './SolidPodContext'
+import { getPodOwnerProfile } from '../services/solidPod'
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockGetPodOwnerProfile = vi.mocked(getPodOwnerProfile)
 
 describe('Navigation', () => {
     beforeEach(() => {
@@ -121,5 +127,122 @@ describe('Navigation', () => {
         )
 
         expect(screen.getAllByText('Backups').length).toBeGreaterThan(0)
+    })
+
+    describe('profile dropdown', () => {
+        const loggedIn = () => {
+            mockUseSolidPod.mockReturnValue({
+                session: null,
+                isLoggedIn: true,
+                sessionExpired: false,
+                clearSessionExpired: vi.fn(),
+                webId: 'https://user.solidpod.example/profile/card#me',
+                isLoading: false,
+                login: vi.fn(),
+                logout: vi.fn(),
+            })
+        }
+
+        it('shows a profile button with a friendly name instead of the raw address and logout button', () => {
+            loggedIn()
+            render(<MemoryRouter><Navigation /></MemoryRouter>)
+
+            const profile = screen.getByRole('button', { name: /account menu/i })
+            expect(within(profile).getByText('user')).toBeTruthy()
+            // The raw WebID and a Logout button only appear once the menu opens
+            // (the mobile menu still carries its own copies, so scope to the bar)
+            expect(profile.textContent).not.toContain('profile/card#me')
+            expect(screen.queryByRole('menu')).toBeNull()
+        })
+
+        it('reflects the WebID username as-is, without lowercasing', () => {
+            mockUseSolidPod.mockReturnValue({
+                session: null,
+                isLoggedIn: true,
+                sessionExpired: false,
+                clearSessionExpired: vi.fn(),
+                webId: 'https://pods.example.org/TestUser/profile/card#me',
+                isLoading: false,
+                login: vi.fn(),
+                logout: vi.fn(),
+            })
+            render(<MemoryRouter><Navigation /></MemoryRouter>)
+
+            const profile = screen.getByRole('button', { name: /account menu/i })
+            expect(within(profile).getByText('TestUser')).toBeTruthy()
+        })
+
+        it("shows the profile's name and photo when the profile provides them", async () => {
+            mockGetPodOwnerProfile.mockResolvedValueOnce({ name: 'Alice Smith', photo: 'https://pod.example/photo.jpg' })
+            mockUseSolidPod.mockReturnValue({
+                session: {} as never,
+                isLoggedIn: true,
+                sessionExpired: false,
+                clearSessionExpired: vi.fn(),
+                webId: 'https://user.solidpod.example/profile/card#me',
+                isLoading: false,
+                login: vi.fn(),
+                logout: vi.fn(),
+            })
+            render(<MemoryRouter><Navigation /></MemoryRouter>)
+
+            const profile = screen.getByRole('button', { name: /account menu/i })
+            expect(await within(profile).findByText('Alice Smith')).toBeTruthy()
+            const avatar = profile.querySelector('img')
+            expect(avatar?.getAttribute('src')).toBe('https://pod.example/photo.jpg')
+        })
+
+        it('opens a dropdown with the full address, Backups, Sharing and Logout', () => {
+            loggedIn()
+            render(<MemoryRouter><Navigation /></MemoryRouter>)
+
+            fireEvent.click(screen.getByRole('button', { name: /account menu/i }))
+
+            const menu = screen.getByRole('menu')
+            expect(within(menu).getByText('https://user.solidpod.example/profile/card#me')).toBeTruthy()
+            expect(within(menu).getByRole('menuitem', { name: 'Backups' })).toBeTruthy()
+            expect(within(menu).getByRole('menuitem', { name: 'Sharing' })).toBeTruthy()
+            expect(within(menu).getByRole('menuitem', { name: 'Logout' })).toBeTruthy()
+        })
+
+        it('keeps Backups and Sharing out of the desktop link row', () => {
+            loggedIn()
+            render(<MemoryRouter><Navigation /></MemoryRouter>)
+
+            // Only the mobile menu copies remain outside the dropdown
+            expect(screen.getAllByText('Backups')).toHaveLength(1)
+            expect(screen.getAllByText('Sharing')).toHaveLength(1)
+        })
+
+        it('logs out from the dropdown', () => {
+            const logout = vi.fn().mockResolvedValue(undefined)
+            mockUseSolidPod.mockReturnValue({
+                session: null,
+                isLoggedIn: true,
+                sessionExpired: false,
+                clearSessionExpired: vi.fn(),
+                webId: 'https://user.solidpod.example/profile/card#me',
+                isLoading: false,
+                login: vi.fn(),
+                logout,
+            })
+            render(<MemoryRouter><Navigation /></MemoryRouter>)
+
+            fireEvent.click(screen.getByRole('button', { name: /account menu/i }))
+            fireEvent.click(screen.getByRole('menuitem', { name: 'Logout' }))
+
+            expect(logout).toHaveBeenCalled()
+        })
+
+        it('closes when clicking outside', () => {
+            loggedIn()
+            render(<MemoryRouter><Navigation /></MemoryRouter>)
+
+            fireEvent.click(screen.getByRole('button', { name: /account menu/i }))
+            expect(screen.getByRole('menu')).toBeTruthy()
+
+            fireEvent.mouseDown(document.body)
+            expect(screen.queryByRole('menu')).toBeNull()
+        })
     })
 })

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -205,6 +205,27 @@ describe('Navigation', () => {
             expect(within(menu).getByRole('menuitem', { name: 'Logout' })).toBeTruthy()
         })
 
+        it('shows the profile name and photo instead of the raw address in the mobile menu', async () => {
+            mockGetPodOwnerProfile.mockResolvedValueOnce({ name: 'Alice Smith', photo: 'https://pod.example/photo.jpg' })
+            mockUseSolidPod.mockReturnValue({
+                session: {} as never,
+                isLoggedIn: true,
+                sessionExpired: false,
+                clearSessionExpired: vi.fn(),
+                webId: 'https://user.solidpod.example/profile/card#me',
+                isLoading: false,
+                login: vi.fn(),
+                logout: vi.fn(),
+            })
+            render(<MemoryRouter><Navigation /></MemoryRouter>)
+
+            const mobileIdentity = await screen.findByTitle('https://user.solidpod.example/profile/card#me')
+            expect(within(mobileIdentity).getByText('Alice Smith')).toBeTruthy()
+            const avatar = mobileIdentity.querySelector('img')
+            expect(avatar?.getAttribute('src')).toBe('https://pod.example/photo.jpg')
+            expect(mobileIdentity.textContent).not.toContain('profile/card#me')
+        })
+
         it('keeps Backups and Sharing out of the desktop link row', () => {
             loggedIn()
             render(<MemoryRouter><Navigation /></MemoryRouter>)

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -24,6 +24,10 @@ vi.mock('./DatabaseContext', () => ({
     }),
 }))
 
+vi.mock('./ThemeContext', () => ({
+    useTheme: vi.fn().mockReturnValue({ theme: 'light', setTheme: vi.fn(), toggleTheme: vi.fn() }),
+}))
+
 import { useSolidPod } from './SolidPodContext'
 import { getPodOwnerProfile } from '../services/solidPod'
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -315,8 +315,19 @@ export const Navigation = () => {
                         <div className="border-t border-white/20 pt-2 mt-2">
                             {isLoggedIn ? (
                                 <>
-                                    <div className="px-3 py-2 text-sm font-medium truncate" title={webId}>
-                                        {webId}
+                                    <div className="px-3 py-2 flex items-center gap-2" title={webId}>
+                                        {profilePhoto ? (
+                                            <img
+                                                src={profilePhoto}
+                                                alt=""
+                                                className="w-8 h-8 shrink-0 rounded-full object-cover ring-2 ring-white"
+                                                // The photo may live behind pod auth; fall back to the icon
+                                                onError={() => setProfilePhoto(null)}
+                                            />
+                                        ) : (
+                                            <CircleUserRound className="w-8 h-8 shrink-0" aria-hidden="true" />
+                                        )}
+                                        <span className="text-sm font-medium truncate">{displayName}</span>
                                     </div>
                                     <button
                                         onClick={() => {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,24 +1,85 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { CircleUserRound, ChevronDown } from 'lucide-react'
 import { useSolidPod } from './SolidPodContext'
 import { useDatabase } from './DatabaseContext'
 import { SolidProviderSelector } from './SolidProviderSelector'
+import { getPodOwnerProfile } from '../services/solidPod'
 import type { SharedContext } from '../services/rdfSerialization'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// The username as it appears in the WebID itself — no provider suffix, no case
+// changes beyond what the URL already carries. Used only when the profile has
+// no foaf:name to show.
+const webIdShortName = (webId: string): string => {
+    try {
+        const url = new URL(webId)
+        const path = url.pathname
+            .replace(/\/profile\/card\/?$/, '/')
+            .replace(/\/profile\/?$/, '/')
+        const firstSegment = path.split('/').find(s => s.length > 0)
+        if (firstSegment && !UUID_RE.test(firstSegment)) return decodeURIComponent(firstSegment)
+        const parts = url.hostname.split('.')
+        return parts.length >= 3 ? parts[0] : url.hostname
+    } catch {
+        return webId
+    }
+}
 
 export const Navigation = () => {
     const [isOpen, setIsOpen] = useState(false)
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
-    const { login, logout, isLoggedIn, webId } = useSolidPod()
+    const { login, logout, isLoggedIn, webId, session } = useSolidPod()
     const { db, loginSyncVersion } = useDatabase()
     const location = useLocation()
     const navigate = useNavigate()
     const [sharedContexts, setSharedContexts] = useState<SharedContext[]>([])
+    const [isProfileOpen, setIsProfileOpen] = useState(false)
+    const [profileName, setProfileName] = useState<string | null>(null)
+    const [profilePhoto, setProfilePhoto] = useState<string | null>(null)
+    const profileRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
         db.getSharedWithMe()
             .then(swm => setSharedContexts(swm.contexts))
             .catch(() => {})
     }, [db, loginSyncVersion])
+
+    // The bar shows a person, not an address: prefer the profile's foaf:name
+    // and photo, fall back to the WebID's username and a generic icon.
+    useEffect(() => {
+        setProfileName(null)
+        setProfilePhoto(null)
+        if (!session || !webId) return
+        let cancelled = false
+        getPodOwnerProfile(session, '', webId)
+            .then(({ name, photo }) => {
+                if (cancelled) return
+                if (name) setProfileName(name)
+                if (photo) setProfilePhoto(photo)
+            })
+            .catch(() => {})
+        return () => { cancelled = true }
+    }, [session, webId])
+
+    useEffect(() => {
+        if (!isProfileOpen) return
+        const onOutside = (e: MouseEvent) => {
+            if (profileRef.current && !profileRef.current.contains(e.target as Node)) setIsProfileOpen(false)
+        }
+        const onEscape = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setIsProfileOpen(false)
+        }
+        document.addEventListener('mousedown', onOutside)
+        document.addEventListener('keydown', onEscape)
+        return () => {
+            document.removeEventListener('mousedown', onOutside)
+            document.removeEventListener('keydown', onEscape)
+        }
+    }, [isProfileOpen])
+
+    const displayName = profileName ?? (webId ? webIdShortName(webId) : '')
 
     const podMatch = /^\/pod\/([^/]+)/.exec(location.pathname)
     const currentForeignEncoded = podMatch?.[1] ?? null
@@ -27,7 +88,6 @@ export const Navigation = () => {
     // When viewing a foreign pod, contextual links stay inside that pod's routes
     const viewListsPath = inForeignContext ? `/pod/${currentForeignEncoded}/view-lists` : '/view-lists'
     const manageQuestionsPath = inForeignContext ? `/pod/${currentForeignEncoded}/manage-questions` : '/manage-questions'
-    const createListPath = inForeignContext ? `/pod/${currentForeignEncoded}/create-packing-list` : '/create-packing-list'
 
     const handleSolidLogin = () => {
         setIsProviderSelectorOpen(true)
@@ -62,40 +122,20 @@ export const Navigation = () => {
                                         {inForeignContext ? 'Questions & Items' : 'My Questions & Items'}
                                     </Link>
                                     <Link
-                                        to={createListPath}
-                                        className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
-                                    >
-                                        Create List
-                                    </Link>
-                                    <Link
                                         to={viewListsPath}
                                         className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
                                     >
-                                        View Lists
+                                        Lists
                                     </Link>
-                                    {isLoggedIn && (
-                                        <Link
-                                            to="/backups"
-                                            className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
-                                        >
-                                            Backups
-                                        </Link>
-                                    )}
-                                    {isLoggedIn && (
-                                        <Link
-                                            to="/sharing"
-                                            className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
-                                        >
-                                            Sharing
-                                        </Link>
-                                    )}
                                 </div>
                             </div>
                         </div>
                         {/* Solid Login/Logout section */}
                         <div className="hidden md:flex items-center gap-4">
                             {isLoggedIn ? (
-                                <div className="flex items-center gap-3 bg-white/10 backdrop-blur-sm px-4 py-2 rounded-xl">
+                                /* relative z-[70]: keeps the dropdown above the packing list's
+                                   sticky progress strip (z-50) */
+                                <div className="relative z-[70] flex items-center gap-3">
                                     {sharedContexts.length > 0 && (
                                         <select
                                             value={currentForeignEncoded ?? '__own__'}
@@ -119,15 +159,76 @@ export const Navigation = () => {
                                             ))}
                                         </select>
                                     )}
-                                    <span className="text-sm font-medium truncate max-w-xs" title={webId}>
-                                        {webId}
-                                    </span>
-                                    <button
-                                        onClick={handleLogout}
-                                        className="px-3 py-1.5 rounded-lg text-sm font-semibold bg-white/20 hover:bg-white/30 transition-all duration-200 hover:scale-105"
-                                    >
-                                        Logout
-                                    </button>
+                                    <div ref={profileRef} className="relative">
+                                        <button
+                                            onClick={() => setIsProfileOpen(v => !v)}
+                                            aria-haspopup="menu"
+                                            aria-expanded={isProfileOpen}
+                                            aria-label="Account menu"
+                                            className="flex items-center gap-2 px-2 py-1.5 rounded-lg text-sm font-medium hover:bg-white/20 transition-all duration-200"
+                                        >
+                                            {profilePhoto ? (
+                                                <img
+                                                    src={profilePhoto}
+                                                    alt=""
+                                                    className="w-6 h-6 shrink-0 rounded-full object-cover ring-2 ring-white"
+                                                    // The photo may live behind pod auth; fall back to the icon
+                                                    onError={() => setProfilePhoto(null)}
+                                                />
+                                            ) : (
+                                                <CircleUserRound className="w-6 h-6 shrink-0" aria-hidden="true" />
+                                            )}
+                                            <span className="truncate max-w-[12rem]">{displayName}</span>
+                                            <ChevronDown className={`w-4 h-4 shrink-0 transition-transform ${isProfileOpen ? 'rotate-180' : ''}`} aria-hidden="true" />
+                                        </button>
+                                        {isProfileOpen && (
+                                            <div
+                                                role="menu"
+                                                // z-[70]: above the sticky progress strip (z-50) and the
+                                                // confetti overlay (z-60) on the packing-list page
+                                                className="absolute right-0 top-full mt-2 w-72 rounded-xl bg-white text-gray-900 shadow-lg ring-1 ring-black/10 py-2 z-[70]"
+                                            >
+                                                <div className="px-4 py-2 border-b border-gray-100">
+                                                    <p className="text-xs text-gray-500">Signed in as</p>
+                                                    <a
+                                                        href={webId}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        className="block text-sm font-medium break-all text-primary-700 hover:underline"
+                                                        title="Open your profile in a new tab"
+                                                    >
+                                                        {webId}
+                                                    </a>
+                                                </div>
+                                                <Link
+                                                    to="/backups"
+                                                    role="menuitem"
+                                                    onClick={() => setIsProfileOpen(false)}
+                                                    className="block px-4 py-2 text-sm font-medium hover:bg-primary-50"
+                                                >
+                                                    Backups
+                                                </Link>
+                                                <Link
+                                                    to="/sharing"
+                                                    role="menuitem"
+                                                    onClick={() => setIsProfileOpen(false)}
+                                                    className="block px-4 py-2 text-sm font-medium hover:bg-primary-50"
+                                                >
+                                                    Sharing
+                                                </Link>
+                                                <button
+                                                    role="menuitem"
+                                                    onClick={() => {
+                                                        setIsProfileOpen(false)
+                                                        handleLogout()
+                                                    }}
+                                                    className="w-full text-left px-4 py-2 text-sm font-medium text-danger-600 hover:bg-danger-50 border-t border-gray-100 mt-1 pt-2.5"
+                                                >
+                                                    Logout
+                                                </button>
+                                            </div>
+                                        )}
+                                    </div>
                                 </div>
                             ) : (
                                 <div className="flex flex-col items-end">
@@ -186,18 +287,11 @@ export const Navigation = () => {
                             {inForeignContext ? 'Questions & Items' : 'My Questions & Items'}
                         </Link>
                         <Link
-                            to={createListPath}
-                            className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
-                            onClick={() => setIsOpen(false)}
-                        >
-                            Create List
-                        </Link>
-                        <Link
                             to={viewListsPath}
                             className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                             onClick={() => setIsOpen(false)}
                         >
-                            View Lists
+                            Lists
                         </Link>
                         {isLoggedIn && (
                             <Link

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,8 +1,9 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useState, useEffect, useRef } from 'react'
-import { CircleUserRound, ChevronDown } from 'lucide-react'
+import { CircleUserRound, ChevronDown, Sun, Moon } from 'lucide-react'
 import { useSolidPod } from './SolidPodContext'
 import { useDatabase } from './DatabaseContext'
+import { useTheme } from './ThemeContext'
 import { SolidProviderSelector } from './SolidProviderSelector'
 import { getPodOwnerProfile } from '../services/solidPod'
 import type { SharedContext } from '../services/rdfSerialization'
@@ -32,6 +33,7 @@ export const Navigation = () => {
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
     const { login, logout, isLoggedIn, webId, session } = useSolidPod()
     const { db, loginSyncVersion } = useDatabase()
+    const { theme, toggleTheme } = useTheme()
     const location = useLocation()
     const navigate = useNavigate()
     const [sharedContexts, setSharedContexts] = useState<SharedContext[]>([])
@@ -132,6 +134,15 @@ export const Navigation = () => {
                         </div>
                         {/* Solid Login/Logout section */}
                         <div className="hidden md:flex items-center gap-4">
+                            <button
+                                type="button"
+                                onClick={toggleTheme}
+                                aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                                title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                                className="p-2 rounded-lg hover:bg-white/20 transition-all duration-200"
+                            >
+                                {theme === 'dark' ? <Sun className="w-5 h-5" aria-hidden="true" /> : <Moon className="w-5 h-5" aria-hidden="true" />}
+                            </button>
                             {isLoggedIn ? (
                                 /* relative z-[70]: keeps the dropdown above the packing list's
                                    sticky progress strip (z-50) */
@@ -147,12 +158,12 @@ export const Navigation = () => {
                                             className="text-sm font-medium bg-white/20 text-white rounded-lg px-2 py-1 border-0 focus:ring-0 cursor-pointer"
                                             aria-label="Switch context"
                                         >
-                                            <option value="__own__" className="text-gray-900">Your data</option>
+                                            <option value="__own__" className="text-gray-900 dark:text-gray-100">Your data</option>
                                             {sharedContexts.map(ctx => (
                                                 <option
                                                     key={ctx.podUrl}
                                                     value={encodeURIComponent(ctx.podUrl)}
-                                                    className="text-gray-900"
+                                                    className="text-gray-900 dark:text-gray-100"
                                                 >
                                                     {ctx.label ?? ctx.podUrl}
                                                 </option>
@@ -186,15 +197,15 @@ export const Navigation = () => {
                                                 role="menu"
                                                 // z-[70]: above the sticky progress strip (z-50) and the
                                                 // confetti overlay (z-60) on the packing-list page
-                                                className="absolute right-0 top-full mt-2 w-72 rounded-xl bg-white text-gray-900 shadow-lg ring-1 ring-black/10 py-2 z-[70]"
+                                                className="absolute right-0 top-full mt-2 w-72 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-lg ring-1 ring-black/10 py-2 z-[70]"
                                             >
-                                                <div className="px-4 py-2 border-b border-gray-100">
-                                                    <p className="text-xs text-gray-500">Signed in as</p>
+                                                <div className="px-4 py-2 border-b border-gray-100 dark:border-gray-800">
+                                                    <p className="text-xs text-gray-500 dark:text-gray-400">Signed in as</p>
                                                     <a
                                                         href={webId}
                                                         target="_blank"
                                                         rel="noopener noreferrer"
-                                                        className="block text-sm font-medium break-all text-primary-700 hover:underline"
+                                                        className="block text-sm font-medium break-all text-primary-700 dark:text-primary-300 hover:underline"
                                                         title="Open your profile in a new tab"
                                                     >
                                                         {webId}
@@ -204,7 +215,7 @@ export const Navigation = () => {
                                                     to="/backups"
                                                     role="menuitem"
                                                     onClick={() => setIsProfileOpen(false)}
-                                                    className="block px-4 py-2 text-sm font-medium hover:bg-primary-50"
+                                                    className="block px-4 py-2 text-sm font-medium hover:bg-primary-50 dark:hover:bg-gray-700"
                                                 >
                                                     Backups
                                                 </Link>
@@ -212,7 +223,7 @@ export const Navigation = () => {
                                                     to="/sharing"
                                                     role="menuitem"
                                                     onClick={() => setIsProfileOpen(false)}
-                                                    className="block px-4 py-2 text-sm font-medium hover:bg-primary-50"
+                                                    className="block px-4 py-2 text-sm font-medium hover:bg-primary-50 dark:hover:bg-gray-700"
                                                 >
                                                     Sharing
                                                 </Link>
@@ -222,7 +233,7 @@ export const Navigation = () => {
                                                         setIsProfileOpen(false)
                                                         handleLogout()
                                                     }}
-                                                    className="w-full text-left px-4 py-2 text-sm font-medium text-danger-600 hover:bg-danger-50 border-t border-gray-100 mt-1 pt-2.5"
+                                                    className="w-full text-left px-4 py-2 text-sm font-medium text-danger-600 dark:text-danger-400 hover:bg-danger-50 dark:hover:bg-red-950/40 border-t border-gray-100 dark:border-gray-800 mt-1 pt-2.5"
                                                 >
                                                     Logout
                                                 </button>
@@ -311,6 +322,14 @@ export const Navigation = () => {
                                 Sharing
                             </Link>
                         )}
+                        <button
+                            type="button"
+                            onClick={toggleTheme}
+                            className="w-full flex items-center gap-2 px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
+                        >
+                            {theme === 'dark' ? <Sun className="w-5 h-5 shrink-0" aria-hidden="true" /> : <Moon className="w-5 h-5 shrink-0" aria-hidden="true" />}
+                            {theme === 'dark' ? 'Light mode' : 'Dark mode'}
+                        </button>
                         {/* Mobile Solid Login/Logout */}
                         <div className="border-t border-white/20 pt-2 mt-2">
                             {isLoggedIn ? (

--- a/src/components/PersonAvatar.test.tsx
+++ b/src/components/PersonAvatar.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import React from 'react'
+import { PersonAvatar } from './PersonAvatar'
+import { PERSON_COLORS } from '../edit-questions/person-colors'
+
+const color = PERSON_COLORS[0]
+
+describe('PersonAvatar', () => {
+    afterEach(cleanup)
+
+    it('renders the coloured initial when there is no photo', () => {
+        render(<PersonAvatar name="Alice" color={color} />)
+        const avatar = screen.getByTestId('person-avatar')
+        expect(avatar.textContent).toBe('A')
+    })
+
+    it('renders the profile photo when one is provided', () => {
+        render(<PersonAvatar name="Mel" color={color} photoUrl="https://pod.example/avatar.jpg" />)
+        const avatar = screen.getByTestId('person-avatar')
+        expect(avatar.tagName).toBe('IMG')
+        expect(avatar.getAttribute('src')).toBe('https://pod.example/avatar.jpg')
+        expect(avatar.getAttribute('title')).toBe('Mel')
+    })
+
+    it('falls back to the initial when the photo fails to load', () => {
+        render(<PersonAvatar name="Mel" color={color} photoUrl="https://pod.example/broken.jpg" />)
+        fireEvent.error(screen.getByTestId('person-avatar'))
+        const avatar = screen.getByTestId('person-avatar')
+        expect(avatar.tagName).toBe('SPAN')
+        expect(avatar.textContent).toBe('M')
+    })
+})

--- a/src/components/PersonAvatar.tsx
+++ b/src/components/PersonAvatar.tsx
@@ -1,20 +1,38 @@
+import { useState } from 'react'
 import type { PersonColor } from '../edit-questions/person-colors'
 
 /**
  * A person's coloured initial — the same mark the questions page puts beside
  * every item, so a packing list can be read the same way: find your colour,
- * that's your pile.
+ * that's your pile. When the person has a WebID with a profile photo, the
+ * photo takes the initial's place (still ringed in their colour).
  *
  * Decorative, always: everywhere it appears the person's name is written
  * beside it, so announcing the initial as well would only make a screen
  * reader say "A, Alice's Items".
  */
-export function PersonAvatar({ name, color, size = 'md' }: {
+export function PersonAvatar({ name, color, size = 'md', photoUrl }: {
     name: string
     color: PersonColor
     size?: 'sm' | 'md'
+    photoUrl?: string | null
 }) {
+    // The photo may live behind pod auth or 404; fall back to the initial
+    const [photoFailed, setPhotoFailed] = useState(false)
     const dimensions = size === 'sm' ? 'w-5 h-5 text-[10px]' : 'w-7 h-7 text-xs'
+    if (photoUrl && !photoFailed) {
+        return (
+            <img
+                data-testid="person-avatar"
+                src={photoUrl}
+                title={name}
+                alt=""
+                aria-hidden="true"
+                onError={() => setPhotoFailed(true)}
+                className={`rounded-full object-cover select-none shrink-0 ${dimensions}`}
+            />
+        )
+    }
     return (
         <span
             data-testid="person-avatar"

--- a/src/components/SectionOrderEditor.test.tsx
+++ b/src/components/SectionOrderEditor.test.tsx
@@ -26,11 +26,12 @@ describe('SectionOrderLegend', () => {
         expect(screen.getByText('+7 more')).toBeTruthy()
     })
 
-    // The narrow-screen line replaces the chips rather than joining them, so
-    // the order is still there in full when there is no room to draw it.
-    it('carries the whole order as one compact line', () => {
+    // The chips already carry the order on wider screens; on a phone they're
+    // hidden, and joining the names into one line to fill the gap just made
+    // the row longer than the "Reorder" button it sits beside needs.
+    it('does not spell out the section names on a phone', () => {
         render(<SectionOrderLegend labels={['Documents', 'Toiletries', 'Clothes']} onEdit={vi.fn()} />)
-        expect(screen.getByText('Documents · Toiletries · Clothes')).toBeTruthy()
+        expect(screen.queryByText('Documents · Toiletries · Clothes')).toBeNull()
     })
 
     it('numbers the sections for a screen reader', () => {

--- a/src/components/SectionOrderEditor.tsx
+++ b/src/components/SectionOrderEditor.tsx
@@ -67,7 +67,7 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
             {/* On a phone the caption costs a third of the row it introduces,
                 and the names beside a "Reorder" button say what it would have
                 said. Still read out, just not drawn. */}
-            <span className="sr-only sm:not-sr-only sm:text-xs sm:text-gray-600 sm:shrink-0">List order</span>
+            <span className="sr-only sm:not-sr-only sm:text-xs sm:text-gray-600 dark:sm:text-gray-400 sm:shrink-0">List order</span>
             <div className="hidden sm:flex sm:flex-wrap sm:items-center sm:gap-1.5 sm:min-w-0">
                 {shown.map((label, i) => {
                     const accent = sectionAccent(label, false)
@@ -82,9 +82,9 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
                         </span>
                     )
                 })}
-                {hidden > 0 && <span className="text-[11px] text-gray-600">+{hidden} more</span>}
+                {hidden > 0 && <span className="text-[11px] text-gray-600 dark:text-gray-400">+{hidden} more</span>}
             </div>
-            <span className="sm:hidden flex-1 min-w-0 truncate text-[11px] text-gray-600">
+            <span className="sm:hidden flex-1 min-w-0 truncate text-[11px] text-gray-600 dark:text-gray-400">
                 {labels.join(' · ')}
             </span>
             {onEdit && (
@@ -95,7 +95,7 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
                     // A full-size touch target, like every other control the
                     // page expects a thumb to find. At the strip's own scale it
                     // was 24px tall, and missing it looked like a dead button.
-                    className="inline-flex items-center justify-center gap-1 shrink-0 h-11 px-3 text-[11px] font-medium rounded-lg text-primary-600 hover:bg-primary-50 active:bg-primary-100 transition-colors"
+                    className="inline-flex items-center justify-center gap-1 shrink-0 h-11 px-3 text-[11px] font-medium rounded-lg text-primary-600 dark:text-primary-400 hover:bg-primary-50 dark:bg-primary-950/40 active:bg-primary-100 transition-colors"
                 >
                     <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
@@ -119,14 +119,14 @@ function SortableSectionRow({ label, position, total, onMove }: {
         <div
             ref={setNodeRef}
             style={{ transform: CSS.Transform.toString(transform), transition }}
-            className={`flex items-center gap-1 rounded-lg border bg-white p-2 ${isDragging ? 'relative z-10 border-primary-400 shadow-md opacity-95' : accent.border}`}
+            className={`flex items-center gap-1 rounded-lg border bg-white dark:bg-gray-800 p-2 ${isDragging ? 'relative z-10 border-primary-400 shadow-md opacity-95' : accent.border}`}
         >
             <button
                 type="button"
                 ref={setActivatorNodeRef}
                 {...attributes}
                 {...listeners}
-                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-50 cursor-grab active:cursor-grabbing touch-none"
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-grab active:cursor-grabbing touch-none"
                 title="Drag to reorder"
                 aria-label={`Drag ${label} to reorder`}
             >
@@ -135,7 +135,7 @@ function SortableSectionRow({ label, position, total, onMove }: {
                 </svg>
             </button>
             <span className={`w-1.5 h-5 rounded-full shrink-0 ${accent.rail}`} aria-hidden="true" />
-            <span className="flex-1 min-w-0 truncate text-sm text-gray-800 px-1">{label}</span>
+            <span className="flex-1 min-w-0 truncate text-sm text-gray-800 dark:text-gray-200 px-1">{label}</span>
             {/* Named destinations rather than bare arrows: this is the path that
                 works from the keyboard, and "move up" alone doesn't say where. */}
             <button
@@ -143,7 +143,7 @@ function SortableSectionRow({ label, position, total, onMove }: {
                 disabled={position === 0}
                 onClick={() => onMove(position - 1)}
                 aria-label={`Move ${label} up`}
-                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:text-gray-200 disabled:border-gray-100 disabled:hover:bg-transparent transition-colors"
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:text-gray-200 disabled:border-gray-100 dark:disabled:border-gray-700 disabled:hover:bg-transparent transition-colors"
             >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
@@ -154,7 +154,7 @@ function SortableSectionRow({ label, position, total, onMove }: {
                 disabled={position === total - 1}
                 onClick={() => onMove(position + 1)}
                 aria-label={`Move ${label} down`}
-                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:text-gray-200 disabled:border-gray-100 disabled:hover:bg-transparent transition-colors"
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:text-gray-200 disabled:border-gray-100 dark:disabled:border-gray-700 disabled:hover:bg-transparent transition-colors"
             >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
@@ -199,17 +199,17 @@ export function SectionOrderModal({ labels, onChange, onClose }: {
             <div
                 role="dialog"
                 aria-label="Reorder list sections"
-                className="bg-white rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
+                className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
                 onClick={e => e.stopPropagation()}
             >
-                <div className="p-5 border-b border-gray-100 flex-shrink-0">
-                    <h2 className="text-lg font-semibold text-gray-900">Reorder sections</h2>
-                    <p className="mt-0.5 text-sm text-gray-500">
+                <div className="p-5 border-b border-gray-100 dark:border-gray-800 flex-shrink-0">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Reorder sections</h2>
+                    <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
                         The order your packing lists are grouped in — every list, including the ones you already have.
                     </p>
                 </div>
                 <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
-                    <div className="text-[11px] text-gray-600 mb-2 px-0.5">
+                    <div className="text-[11px] text-gray-600 dark:text-gray-400 mb-2 px-0.5">
                         Drag the handle (press and hold on touch) to reorder, or use the arrows.
                     </div>
                     <DndContext
@@ -254,7 +254,7 @@ export function SectionOrderModal({ labels, onChange, onClose }: {
                         </SortableContext>
                     </DndContext>
                 </div>
-                <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex justify-end">
+                <div className="px-5 py-4 border-t border-gray-100 dark:border-gray-800 flex-shrink-0 flex justify-end">
                     <button
                         type="button"
                         onClick={onClose}

--- a/src/components/SectionOrderEditor.tsx
+++ b/src/components/SectionOrderEditor.tsx
@@ -64,9 +64,10 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
     const hidden = labels.length - shown.length
     return (
         <div className="flex items-center gap-2 mb-4">
-            {/* On a phone the caption costs a third of the row it introduces,
-                and the names beside a "Reorder" button say what it would have
-                said. Still read out, just not drawn. */}
+            {/* On a phone the caption costs a third of the row it introduces, and
+                the section names aren't worth the space next to a "Reorder"
+                button that already says what the row is about. Still read out,
+                just not drawn. */}
             <span className="sr-only sm:not-sr-only sm:text-xs sm:text-gray-600 dark:sm:text-gray-400 sm:shrink-0">List order</span>
             <div className="hidden sm:flex sm:flex-wrap sm:items-center sm:gap-1.5 sm:min-w-0">
                 {shown.map((label, i) => {
@@ -84,9 +85,6 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
                 })}
                 {hidden > 0 && <span className="text-[11px] text-gray-600 dark:text-gray-400">+{hidden} more</span>}
             </div>
-            <span className="sm:hidden flex-1 min-w-0 truncate text-[11px] text-gray-600 dark:text-gray-400">
-                {labels.join(' · ')}
-            </span>
             {onEdit && (
                 <button
                     type="button"
@@ -95,7 +93,7 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
                     // A full-size touch target, like every other control the
                     // page expects a thumb to find. At the strip's own scale it
                     // was 24px tall, and missing it looked like a dead button.
-                    className="inline-flex items-center justify-center gap-1 shrink-0 h-11 px-3 text-[11px] font-medium rounded-lg text-primary-600 dark:text-primary-400 hover:bg-primary-50 dark:bg-primary-950/40 active:bg-primary-100 transition-colors"
+                    className="ml-auto sm:ml-0 inline-flex items-center justify-center gap-1 shrink-0 h-11 px-3 text-[11px] font-medium rounded-lg text-primary-600 dark:text-primary-400 hover:bg-primary-50 dark:bg-primary-950/40 active:bg-primary-100 transition-colors"
                 >
                     <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />

--- a/src/components/SectionOrderEditor.tsx
+++ b/src/components/SectionOrderEditor.tsx
@@ -67,7 +67,7 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
             {/* On a phone the caption costs a third of the row it introduces,
                 and the names beside a "Reorder" button say what it would have
                 said. Still read out, just not drawn. */}
-            <span className="sr-only sm:not-sr-only sm:text-xs sm:text-gray-400 sm:shrink-0">List order</span>
+            <span className="sr-only sm:not-sr-only sm:text-xs sm:text-gray-600 sm:shrink-0">List order</span>
             <div className="hidden sm:flex sm:flex-wrap sm:items-center sm:gap-1.5 sm:min-w-0">
                 {shown.map((label, i) => {
                     const accent = sectionAccent(label, false)
@@ -82,9 +82,9 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
                         </span>
                     )
                 })}
-                {hidden > 0 && <span className="text-[11px] text-gray-400">+{hidden} more</span>}
+                {hidden > 0 && <span className="text-[11px] text-gray-600">+{hidden} more</span>}
             </div>
-            <span className="sm:hidden flex-1 min-w-0 truncate text-[11px] text-gray-400">
+            <span className="sm:hidden flex-1 min-w-0 truncate text-[11px] text-gray-600">
                 {labels.join(' · ')}
             </span>
             {onEdit && (
@@ -209,7 +209,7 @@ export function SectionOrderModal({ labels, onChange, onClose }: {
                     </p>
                 </div>
                 <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
-                    <div className="text-[11px] text-gray-400 mb-2 px-0.5">
+                    <div className="text-[11px] text-gray-600 mb-2 px-0.5">
                         Drag the handle (press and hold on touch) to reorder, or use the arrows.
                     </div>
                     <DndContext

--- a/src/components/SectionedItemReorder.test.tsx
+++ b/src/components/SectionedItemReorder.test.tsx
@@ -158,6 +158,6 @@ describe('SectionedItemReorder move menu', () => {
 
     it('no longer creates sections of its own', () => {
         renderReorder(unsectioned())
-        expect(screen.queryByRole('button', { name: '+ Add section' })).toBeNull()
+        expect(screen.queryByRole('button', { name: 'Add section' })).toBeNull()
     })
 })

--- a/src/components/SectionedItemReorder.tsx
+++ b/src/components/SectionedItemReorder.tsx
@@ -100,7 +100,7 @@ function SectionHeaderRow({ id, label, isDefault, onRename, onRemove }: {
                                 type="button"
                                 onClick={() => { setDraft(label); setEditing(true) }}
                                 aria-label={`Rename section ${label}`}
-                                className={`ml-auto text-[11px] px-1 ${accent.muted} hover:text-primary-700`}
+                                className={`ml-auto text-[11px] px-1 ${accent.muted} hover:text-primary-700 dark:hover:text-primary-400`}
                             >
                                 Rename
                             </button>
@@ -143,7 +143,7 @@ function MoveMenu({ label, canMoveToTop, canMoveToBottom, otherSections, onMoveW
                     disabled={!hasMoves}
                     title="Move item"
                     aria-label={`Move ${label}`}
-                    className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 active:bg-gray-100 disabled:text-gray-200 disabled:border-gray-100 disabled:hover:bg-transparent transition-colors"
+                    className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 active:bg-gray-100 dark:active:bg-gray-700 disabled:text-gray-200 disabled:border-gray-100 dark:disabled:border-gray-700 disabled:hover:bg-transparent transition-colors"
                 >
                     <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                         <circle cx="12" cy="5" r="1.5" />
@@ -156,12 +156,12 @@ function MoveMenu({ label, canMoveToTop, canMoveToBottom, otherSections, onMoveW
                 <DropdownMenu.Content
                     align="end"
                     sideOffset={4}
-                    className="min-w-52 max-w-72 bg-white rounded-lg shadow-lg border border-gray-100 py-1 z-50"
+                    className="min-w-52 max-w-72 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-100 dark:border-gray-800 py-1 z-50"
                 >
                     {canMoveToTop && (
                         <DropdownMenu.Item
                             onSelect={() => onMoveWithinSection('top')}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 cursor-default outline-none"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 focus:bg-gray-50 dark:focus:bg-gray-800 cursor-default outline-none"
                         >
                             Move to top of section
                         </DropdownMenu.Item>
@@ -169,19 +169,19 @@ function MoveMenu({ label, canMoveToTop, canMoveToBottom, otherSections, onMoveW
                     {canMoveToBottom && (
                         <DropdownMenu.Item
                             onSelect={() => onMoveWithinSection('bottom')}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 cursor-default outline-none"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 focus:bg-gray-50 dark:focus:bg-gray-800 cursor-default outline-none"
                         >
                             Move to bottom of section
                         </DropdownMenu.Item>
                     )}
                     {otherSections.length > 0 && (canMoveToTop || canMoveToBottom) && (
-                        <DropdownMenu.Separator className="my-1 h-px bg-gray-100" />
+                        <DropdownMenu.Separator className="my-1 h-px bg-gray-100 dark:bg-gray-800" />
                     )}
                     {otherSections.map(section => (
                         <DropdownMenu.Item
                             key={section}
                             onSelect={() => onMoveToSection(section)}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 cursor-default outline-none truncate"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 focus:bg-gray-50 dark:focus:bg-gray-800 cursor-default outline-none truncate"
                         >
                             Move to {section}
                         </DropdownMenu.Item>
@@ -207,14 +207,14 @@ function SortableSectionItem({ id, item, canMoveToTop, canMoveToBottom, otherSec
             ref={setNodeRef}
             style={{ transform: CSS.Transform.toString(transform), transition }}
             data-reorder-row
-            className={`flex items-center gap-1 rounded-lg border bg-white p-2 ${isDragging ? 'relative z-10 border-primary-400 shadow-md opacity-95' : 'border-gray-200'}`}
+            className={`flex items-center gap-1 rounded-lg border bg-white dark:bg-gray-800 p-2 ${isDragging ? 'relative z-10 border-primary-400 shadow-md opacity-95' : 'border-gray-200 dark:border-gray-700'}`}
         >
             <button
                 type="button"
                 ref={setActivatorNodeRef}
                 {...attributes}
                 {...listeners}
-                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-50 cursor-grab active:cursor-grabbing touch-none"
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-grab active:cursor-grabbing touch-none"
                 title="Drag to reorder or move between sections"
                 aria-label={`Drag ${item.text || 'item'} to reorder`}
             >
@@ -222,8 +222,8 @@ function SortableSectionItem({ id, item, canMoveToTop, canMoveToBottom, otherSec
                     <path d="M7 4a1 1 0 100 2 1 1 0 000-2zM7 9a1 1 0 100 2 1 1 0 000-2zM7 14a1 1 0 100 2 1 1 0 000-2zM13 4a1 1 0 100 2 1 1 0 000-2zM13 9a1 1 0 100 2 1 1 0 000-2zM13 14a1 1 0 100 2 1 1 0 000-2z" />
                 </svg>
             </button>
-            <span className="flex-1 min-w-0 truncate text-sm text-gray-800 px-1">
-                {item.text || <span className="text-gray-400 italic">Unnamed item</span>}
+            <span className="flex-1 min-w-0 truncate text-sm text-gray-800 dark:text-gray-200 px-1">
+                {item.text || <span className="text-gray-400 dark:text-gray-500 italic">Unnamed item</span>}
             </span>
             <MoveMenu
                 label={item.text || 'item'}
@@ -336,7 +336,7 @@ export function SectionedItemReorder({ items, defaultLabel, emptySections, scrol
 
     return (
         <>
-            <div className="text-[11px] text-gray-400 mb-2 px-0.5">
+            <div className="text-[11px] text-gray-400 dark:text-gray-500 mb-2 px-0.5">
                 Drag the handle (press and hold on touch) to reorder, or focus it and press
                 space, then the arrow keys. Each item's move menu jumps it to the top or
                 bottom of its section, or into another section.

--- a/src/components/SharePackingListModal.tsx
+++ b/src/components/SharePackingListModal.tsx
@@ -147,16 +147,16 @@ export function SharePackingListModal({
             <div className="space-y-5">
                 {/* Current access section */}
                 <div>
-                    <h3 className="text-sm font-semibold text-gray-700 mb-2">Current access</h3>
+                    <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Current access</h3>
                     {isLoadingAccess ? (
-                        <p className="text-sm text-gray-500">Loading…</p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
                     ) : !hasAnyAccess ? (
-                        <p className="text-sm text-gray-500">No one else has access yet.</p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">No one else has access yet.</p>
                     ) : (
                         <ul className="space-y-2">
                             {isPublic && (
-                                <li className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
-                                    <span className="text-sm text-gray-800">🌐 Anyone with the link</span>
+                                <li className="flex items-center justify-between bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
+                                    <span className="text-sm text-gray-800 dark:text-gray-200">🌐 Anyone with the link</span>
                                     <button
                                         type="button"
                                         onClick={handleRevokePublic}
@@ -169,8 +169,8 @@ export function SharePackingListModal({
                                 </li>
                             )}
                             {currentCollaborators.map(webId => (
-                                <li key={webId} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
-                                    <span className="text-sm text-gray-800 truncate flex-1" title={webId}>{webId}</span>
+                                <li key={webId} className="flex items-center justify-between bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
+                                    <span className="text-sm text-gray-800 dark:text-gray-200 truncate flex-1" title={webId}>{webId}</span>
                                     <button
                                         type="button"
                                         onClick={() => handleRevokeCollaborator(webId)}
@@ -186,21 +186,21 @@ export function SharePackingListModal({
                     )}
                 </div>
 
-                <hr className="border-gray-200" />
+                <hr className="border-gray-200 dark:border-gray-700" />
 
                 {/* Add access section */}
                 <div>
-                    <h3 className="text-sm font-semibold text-gray-700 mb-3">Add access</h3>
+                    <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Add access</h3>
 
                     {/* Mode tabs */}
-                    <div className="flex rounded-lg border border-gray-200 overflow-hidden mb-4">
+                    <div className="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden mb-4">
                         <button
                             type="button"
                             onClick={() => handleModeChange('person')}
                             className={`flex-1 py-2 px-3 text-sm font-medium transition-colors ${
                                 shareMode === 'person'
                                     ? 'bg-blue-600 text-white'
-                                    : 'bg-white text-gray-600 hover:bg-gray-50'
+                                    : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
                             }`}
                         >
                             With a person
@@ -211,7 +211,7 @@ export function SharePackingListModal({
                             className={`flex-1 py-2 px-3 text-sm font-medium transition-colors ${
                                 shareMode === 'public'
                                     ? 'bg-blue-600 text-white'
-                                    : 'bg-white text-gray-600 hover:bg-gray-50'
+                                    : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
                             }`}
                         >
                             Anyone with the link
@@ -234,7 +234,7 @@ export function SharePackingListModal({
                     )}
 
                     {shareMode === 'public' && !generatedLink && (
-                        <p className="text-sm text-gray-600">
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
                             Anyone who follows this link can view and edit this list — no sign-in required to view.
                         </p>
                     )}
@@ -267,14 +267,14 @@ export function SharePackingListModal({
 
                     {generatedLink && (
                         <div className="space-y-2 mt-3">
-                            <label className="block text-sm font-medium text-gray-700">
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                                 Shareable link
                                 <input
                                     aria-label="Shareable link"
                                     type="text"
                                     readOnly
                                     value={generatedLink}
-                                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 bg-gray-50"
+                                    className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-900"
                                 />
                             </label>
                             <Button type="button" variant="secondary" onClick={handleCopy}>

--- a/src/components/SolidPodPrompt.tsx
+++ b/src/components/SolidPodPrompt.tsx
@@ -54,11 +54,11 @@ export function SolidPodPrompt({
     <>
       <Modal isOpen={isOpen} onClose={handleMaybeLater} title={title}>
         <div className="space-y-4">
-          <p className="text-gray-700 leading-relaxed">{message}</p>
+          <p className="text-gray-700 dark:text-gray-300 leading-relaxed">{message}</p>
 
-          <div className="bg-gradient-to-br from-primary-50 to-accent-50 border-2 border-primary-200 rounded-xl p-4 space-y-2">
-            <h4 className="font-bold text-primary-900 text-sm">Benefits of using a Solid Pod:</h4>
-            <ul className="text-sm text-gray-700 space-y-1.5 ml-4 list-disc">
+          <div className="bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 border-2 border-primary-200 dark:border-primary-800 rounded-xl p-4 space-y-2">
+            <h4 className="font-bold text-primary-900 dark:text-primary-200 text-sm">Benefits of using a Solid Pod:</h4>
+            <ul className="text-sm text-gray-700 dark:text-gray-300 space-y-1.5 ml-4 list-disc">
               <li>
                 <strong>Free</strong> - All major Pod providers are free to sign up
               </li>
@@ -96,7 +96,7 @@ export function SolidPodPrompt({
             </Button>
           </div>
 
-          <p className="text-xs text-gray-500 text-center">
+          <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
             You can always set this up later from the navigation menu
           </p>
         </div>

--- a/src/components/SolidProviderSelector.test.tsx
+++ b/src/components/SolidProviderSelector.test.tsx
@@ -137,4 +137,30 @@ describe('SolidProviderSelector', () => {
       expect(onSelect).toHaveBeenCalledWith('https://login.inrupt.com')
     })
   })
+
+  describe('connecting state', () => {
+    it('shows a spinner instead of closing while the redirect is in flight', () => {
+      let resolveLogin: () => void = () => {}
+      const onSelect = vi.fn(() => new Promise<void>(resolve => { resolveLogin = resolve }))
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+
+      clickProvider('Inrupt PodSpaces')
+
+      expect(screen.getByText(/connecting to inrupt podspaces/i)).toBeTruthy()
+      expect(screen.queryByPlaceholderText(/search providers/i)).toBeNull()
+
+      resolveLogin()
+    })
+
+    it('shows an error and lets the user try again when the connection fails', async () => {
+      const onSelect = vi.fn().mockRejectedValue(new Error('nope'))
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+
+      clickProvider('Inrupt PodSpaces')
+
+      expect(await screen.findByText(/couldn't connect to that provider/i)).toBeTruthy()
+      // Back to the search UI, not stuck showing the spinner
+      expect(getSearchInput()).toBeTruthy()
+    })
+  })
 })

--- a/src/components/SolidProviderSelector.test.tsx
+++ b/src/components/SolidProviderSelector.test.tsx
@@ -30,6 +30,10 @@ function isProviderVisible(name: string): boolean {
   return all.some(b => b.querySelector('div.font-medium')?.textContent === name)
 }
 
+function getSearchInput(): HTMLInputElement {
+  return screen.getByPlaceholderText(/search providers/i) as HTMLInputElement
+}
+
 describe('SolidProviderSelector', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -46,17 +50,25 @@ describe('SolidProviderSelector', () => {
       expect(getPrimaryProviderName()).toBe('Inrupt PodSpaces')
     })
 
-    it('hides other providers by default', () => {
+    it('shows all providers below the search box by default', () => {
       render(<SolidProviderSelector {...defaultProps} />)
-      expect(isProviderVisible('solidcommunity.net')).toBe(false)
+      expect(isProviderVisible('solidcommunity.net')).toBe(true)
+      expect(isProviderVisible('Private Data Pod')).toBe(true)
+    })
+
+    it('filters the results as the user types', () => {
+      render(<SolidProviderSelector {...defaultProps} />)
+      fireEvent.change(getSearchInput(), { target: { value: 'solidcommunity' } })
+      expect(isProviderVisible('solidcommunity.net')).toBe(true)
+      expect(isProviderVisible('Inrupt PodSpaces')).toBe(false)
       expect(isProviderVisible('Private Data Pod')).toBe(false)
     })
 
-    it('shows other providers when "Other providers" is clicked', () => {
+    it('offers a custom-provider option built from the typed text', () => {
       render(<SolidProviderSelector {...defaultProps} />)
-      fireEvent.click(screen.getByRole('button', { name: /other providers/i }))
-      expect(isProviderVisible('solidcommunity.net')).toBe(true)
-      expect(isProviderVisible('Private Data Pod')).toBe(true)
+      fireEvent.change(getSearchInput(), { target: { value: 'https://my-pod.example.com' } })
+      expect(screen.getByText('Connect to custom provider')).toBeTruthy()
+      expect(screen.getByText('https://my-pod.example.com')).toBeTruthy()
     })
   })
 
@@ -65,13 +77,6 @@ describe('SolidProviderSelector', () => {
       localStorage.setItem(LAST_PROVIDER_KEY, 'https://solidcommunity.net')
       render(<SolidProviderSelector {...defaultProps} />)
       expect(getPrimaryProviderName()).toBe('solidcommunity.net')
-    })
-
-    it('does not show other providers by default', () => {
-      localStorage.setItem(LAST_PROVIDER_KEY, 'https://solidcommunity.net')
-      render(<SolidProviderSelector {...defaultProps} />)
-      expect(isProviderVisible('Inrupt PodSpaces')).toBe(false)
-      expect(isProviderVisible('Private Data Pod')).toBe(false)
     })
 
     it('falls back to Inrupt PodSpaces for an unrecognised issuer', () => {
@@ -88,11 +93,26 @@ describe('SolidProviderSelector', () => {
       expect(localStorage.getItem(LAST_PROVIDER_KEY)).toBe('https://login.inrupt.com')
     })
 
-    it('saves a different provider when selected from the expanded list', () => {
+    it('saves a different provider when selected from the results list', () => {
       render(<SolidProviderSelector {...defaultProps} />)
-      fireEvent.click(screen.getByRole('button', { name: /other providers/i }))
       clickProvider('solidcommunity.net')
       expect(localStorage.getItem(LAST_PROVIDER_KEY)).toBe('https://solidcommunity.net')
+    })
+
+    it('saves a custom provider URL typed into the search box', () => {
+      render(<SolidProviderSelector {...defaultProps} />)
+      fireEvent.change(getSearchInput(), { target: { value: 'https://my-pod.example.com' } })
+      fireEvent.click(screen.getByText('Connect to custom provider'))
+      expect(localStorage.getItem(LAST_PROVIDER_KEY)).toBe('https://my-pod.example.com')
+    })
+
+    it('connects to the custom provider on Enter when nothing matches', () => {
+      const onSelect = vi.fn()
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+      const input = getSearchInput()
+      fireEvent.change(input, { target: { value: 'https://my-pod.example.com' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(onSelect).toHaveBeenCalledWith('https://my-pod.example.com')
     })
 
     it('calls onSelect with the issuer', () => {

--- a/src/components/SolidProviderSelector.test.tsx
+++ b/src/components/SolidProviderSelector.test.tsx
@@ -70,6 +70,12 @@ describe('SolidProviderSelector', () => {
       expect(screen.getByText('Connect to custom provider')).toBeTruthy()
       expect(screen.getByText('https://my-pod.example.com')).toBeTruthy()
     })
+
+    it('defaults the custom-provider option to https:// when no scheme is typed', () => {
+      render(<SolidProviderSelector {...defaultProps} />)
+      fireEvent.change(getSearchInput(), { target: { value: 'my-pod.example.com' } })
+      expect(screen.getByText('https://my-pod.example.com')).toBeTruthy()
+    })
   })
 
   describe('with last-used provider stored', () => {
@@ -113,6 +119,15 @@ describe('SolidProviderSelector', () => {
       fireEvent.change(input, { target: { value: 'https://my-pod.example.com' } })
       fireEvent.keyDown(input, { key: 'Enter' })
       expect(onSelect).toHaveBeenCalledWith('https://my-pod.example.com')
+    })
+
+    it('prepends https:// to a custom provider URL typed without a scheme', () => {
+      const onSelect = vi.fn()
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+      fireEvent.change(getSearchInput(), { target: { value: 'my-pod.example.com' } })
+      fireEvent.click(screen.getByText('Connect to custom provider'))
+      expect(onSelect).toHaveBeenCalledWith('https://my-pod.example.com')
+      expect(localStorage.getItem(LAST_PROVIDER_KEY)).toBe('https://my-pod.example.com')
     })
 
     it('calls onSelect with the issuer', () => {

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -75,76 +75,61 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose} title="Login with Your Solid Pod">
-      <div className="space-y-4">
-        {/* Explanation section */}
-        <div className="bg-blue-50 border border-blue-200 rounded-md p-4 space-y-2">
-          <h3 className="font-semibold text-gray-900 text-sm">What is a Solid Pod?</h3>
-          <p className="text-sm text-gray-700">
-            A Solid Pod is your personal data storage that <strong>you control</strong>. Instead of storing your packing lists on our servers, they're stored in your own secure space.
-          </p>
-          <ul className="text-sm text-gray-700 space-y-1 ml-4 list-disc">
-            <li><strong>You own your data</strong> - it stays in your Pod</li>
-            <li><strong>Privacy-focused</strong> - you choose who can access it</li>
-            <li><strong>Portable</strong> - use your Pod with any Solid app</li>
-          </ul>
-        </div>
+      <div className="space-y-3">
+        <label className="block">
+          <span className="text-sm text-gray-600">
+            {isLastUsed && !query ? 'Continue with your last-used provider, search for another, or paste a Pod URL:' : 'Search providers or paste a Pod URL:'}
+          </span>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key !== 'Enter') return;
+              e.preventDefault();
+              if (matchingProviders.length > 0) handleProviderSelect(matchingProviders[0].issuer);
+              else handleCustomSubmit();
+            }}
+            placeholder="Search providers or paste a Pod URL…"
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            autoFocus
+          />
+        </label>
 
-        <div className="border-t border-gray-200 pt-4 space-y-3">
-          <label className="block">
-            <span className="text-sm text-gray-600">
-              {isLastUsed && !query ? 'Continue with your last-used provider, search for another, or paste a Pod URL:' : 'Search providers or paste a Pod URL:'}
-            </span>
-            <input
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key !== 'Enter') return;
-                e.preventDefault();
-                if (matchingProviders.length > 0) handleProviderSelect(matchingProviders[0].issuer);
-                else handleCustomSubmit();
-              }}
-              placeholder="Search providers or paste a Pod URL…"
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-              autoFocus
-            />
-          </label>
+        <div className="space-y-2">
+          {matchingProviders.map((provider) => (
+            <button
+              key={provider.issuer}
+              aria-label={provider.name}
+              onClick={() => handleProviderSelect(provider.issuer)}
+              className={`w-full text-left px-4 py-3 rounded-md transition-colors ${
+                provider.issuer === primaryProvider.issuer
+                  ? 'border-2 border-blue-400 bg-blue-50 hover:bg-blue-100 hover:border-blue-500'
+                  : 'border border-gray-300 hover:bg-gray-50 hover:border-gray-400'
+              }`}
+            >
+              <div className="font-medium text-gray-900">{provider.name}</div>
+              {provider.description && (
+                <div className="text-xs text-green-700 font-medium">{provider.description}</div>
+              )}
+              <div className="text-xs text-gray-400">{provider.issuer}</div>
+            </button>
+          ))}
 
-          <div className="space-y-2">
-            {matchingProviders.map((provider) => (
-              <button
-                key={provider.issuer}
-                aria-label={provider.name}
-                onClick={() => handleProviderSelect(provider.issuer)}
-                className={`w-full text-left px-4 py-3 rounded-md transition-colors ${
-                  provider.issuer === primaryProvider.issuer
-                    ? 'border-2 border-blue-400 bg-blue-50 hover:bg-blue-100 hover:border-blue-500'
-                    : 'border border-gray-300 hover:bg-gray-50 hover:border-gray-400'
-                }`}
-              >
-                <div className="font-medium text-gray-900">{provider.name}</div>
-                {provider.description && (
-                  <div className="text-xs text-green-700 font-medium">{provider.description}</div>
-                )}
-                <div className="text-xs text-gray-400">{provider.issuer}</div>
-              </button>
-            ))}
+          {query.trim() && matchingProviders.length === 0 && (
+            <p className="text-sm text-gray-500 px-1">No matching providers.</p>
+          )}
 
-            {query.trim() && matchingProviders.length === 0 && (
-              <p className="text-sm text-gray-500 px-1">No matching providers.</p>
-            )}
-
-            {query.trim() && (
-              <button
-                type="button"
-                onClick={handleCustomSubmit}
-                className="w-full text-left px-4 py-3 border border-dashed border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
-              >
-                <div className="font-medium text-gray-900">Connect to custom provider</div>
-                <div className="text-xs text-gray-400 truncate">{query.trim()}</div>
-              </button>
-            )}
-          </div>
+          {query.trim() && (
+            <button
+              type="button"
+              onClick={handleCustomSubmit}
+              className="w-full text-left px-4 py-3 border border-dashed border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
+            >
+              <div className="font-medium text-gray-900">Connect to custom provider</div>
+              <div className="text-xs text-gray-400 truncate">{query.trim()}</div>
+            </button>
+          )}
         </div>
       </div>
     </Modal>

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { Modal } from './Modal';
-import { Button } from './Button';
 
 export interface SolidProvider {
   name: string;
@@ -45,32 +44,31 @@ interface SolidProviderSelectorProps {
 
 export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProviderSelectorProps) {
   const primaryProvider = getLastUsedProvider() ?? DEFAULT_PROVIDER;
-  const otherProviders = COMMON_PROVIDERS.filter(p => p.issuer !== primaryProvider.issuer);
+  const sortedProviders = [primaryProvider, ...COMMON_PROVIDERS.filter(p => p.issuer !== primaryProvider.issuer)];
 
-  const [showOthers, setShowOthers] = useState(false);
-  const [showCustomInput, setShowCustomInput] = useState(false);
-  const [customIssuer, setCustomIssuer] = useState('');
+  const [query, setQuery] = useState('');
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const matchingProviders = normalizedQuery
+    ? sortedProviders.filter(p => p.name.toLowerCase().includes(normalizedQuery) || p.issuer.toLowerCase().includes(normalizedQuery))
+    : sortedProviders;
 
   const handleProviderSelect = (issuer: string) => {
     localStorage.setItem(LAST_PROVIDER_KEY, issuer);
     onSelect(issuer);
     onClose();
-    setShowOthers(false);
-    setShowCustomInput(false);
-    setCustomIssuer('');
+    setQuery('');
   };
 
   const handleCustomSubmit = () => {
-    if (customIssuer.trim()) {
-      handleProviderSelect(customIssuer.trim());
+    if (query.trim()) {
+      handleProviderSelect(query.trim());
     }
   };
 
   const handleClose = () => {
     onClose();
-    setShowOthers(false);
-    setShowCustomInput(false);
-    setCustomIssuer('');
+    setQuery('');
   };
 
   const isLastUsed = localStorage.getItem(LAST_PROVIDER_KEY) === primaryProvider.issuer;
@@ -91,104 +89,63 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
           </ul>
         </div>
 
-        <div className="border-t border-gray-200 pt-4">
-          <p className="text-sm text-gray-600 mb-3">
-            {isLastUsed ? 'Continue with your last-used provider:' : 'Get started with a free provider:'}
-          </p>
+        <div className="border-t border-gray-200 pt-4 space-y-3">
+          <label className="block">
+            <span className="text-sm text-gray-600">
+              {isLastUsed && !query ? 'Continue with your last-used provider, search for another, or paste a Pod URL:' : 'Search providers or paste a Pod URL:'}
+            </span>
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key !== 'Enter') return;
+                e.preventDefault();
+                if (matchingProviders.length > 0) handleProviderSelect(matchingProviders[0].issuer);
+                else handleCustomSubmit();
+              }}
+              placeholder="Search providers or paste a Pod URL…"
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+              autoFocus
+            />
+          </label>
 
-          {/* Primary provider */}
-          <button
-            aria-label={primaryProvider.name}
-            onClick={() => handleProviderSelect(primaryProvider.issuer)}
-            className="w-full text-left px-4 py-3 border-2 border-blue-400 bg-blue-50 hover:bg-blue-100 hover:border-blue-500 rounded-md transition-colors"
-          >
-            <div className="font-medium text-gray-900">{primaryProvider.name}</div>
-            {primaryProvider.description && (
-              <div className="text-xs text-green-700 font-medium">{primaryProvider.description}</div>
+          <div className="space-y-2">
+            {matchingProviders.map((provider) => (
+              <button
+                key={provider.issuer}
+                aria-label={provider.name}
+                onClick={() => handleProviderSelect(provider.issuer)}
+                className={`w-full text-left px-4 py-3 rounded-md transition-colors ${
+                  provider.issuer === primaryProvider.issuer
+                    ? 'border-2 border-blue-400 bg-blue-50 hover:bg-blue-100 hover:border-blue-500'
+                    : 'border border-gray-300 hover:bg-gray-50 hover:border-gray-400'
+                }`}
+              >
+                <div className="font-medium text-gray-900">{provider.name}</div>
+                {provider.description && (
+                  <div className="text-xs text-green-700 font-medium">{provider.description}</div>
+                )}
+                <div className="text-xs text-gray-400">{provider.issuer}</div>
+              </button>
+            ))}
+
+            {query.trim() && matchingProviders.length === 0 && (
+              <p className="text-sm text-gray-500 px-1">No matching providers.</p>
             )}
-            <div className="text-xs text-gray-400">{primaryProvider.issuer}</div>
-          </button>
+
+            {query.trim() && (
+              <button
+                type="button"
+                onClick={handleCustomSubmit}
+                className="w-full text-left px-4 py-3 border border-dashed border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
+              >
+                <div className="font-medium text-gray-900">Connect to custom provider</div>
+                <div className="text-xs text-gray-400 truncate">{query.trim()}</div>
+              </button>
+            )}
+          </div>
         </div>
-
-        {/* Other providers toggle */}
-        <div className="space-y-2">
-          <button
-            type="button"
-            onClick={() => setShowOthers(v => !v)}
-            className="w-full text-sm text-gray-500 hover:text-gray-700 transition-colors text-center"
-          >
-            {showOthers ? 'Hide other providers ▲' : 'Other providers ▼'}
-          </button>
-
-          {showOthers && (
-            <div className="space-y-2">
-              {otherProviders.map((provider) => (
-                <button
-                  key={provider.issuer}
-                  aria-label={provider.name}
-                  onClick={() => handleProviderSelect(provider.issuer)}
-                  className="w-full text-left px-4 py-3 border border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
-                >
-                  <div className="font-medium text-gray-900">{provider.name}</div>
-                  {provider.description && (
-                    <div className="text-xs text-green-700 font-medium">{provider.description}</div>
-                  )}
-                  <div className="text-xs text-gray-400">{provider.issuer}</div>
-                </button>
-              ))}
-
-              {!showCustomInput ? (
-                <Button
-                  type="button"
-                  onClick={() => setShowCustomInput(true)}
-                  variant="secondary"
-                  className="w-full"
-                >
-                  Use Custom Provider
-                </Button>
-              ) : (
-                <div className="space-y-3 pt-2 border-t border-gray-200">
-                  <label className="block">
-                    <span className="text-sm font-medium text-gray-700">Custom Provider URL</span>
-                    <input
-                      type="url"
-                      value={customIssuer}
-                      onChange={(e) => setCustomIssuer(e.target.value)}
-                      placeholder="https://your-provider.com"
-                      className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-                      autoFocus
-                    />
-                  </label>
-                  <div className="flex gap-2">
-                    <Button
-                      type="button"
-                      onClick={handleCustomSubmit}
-                      disabled={!customIssuer.trim()}
-                      className="flex-1"
-                    >
-                      Connect
-                    </Button>
-                    <Button
-                      type="button"
-                      onClick={() => {
-                        setShowCustomInput(false);
-                        setCustomIssuer('');
-                      }}
-                      variant="secondary"
-                      className="flex-1"
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-
-        <p className="text-xs text-gray-500 text-center">
-          No Pod? No problem — your data saves locally in your browser automatically.
-        </p>
       </div>
     </Modal>
   );

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
 import { Modal } from './Modal';
 
 export interface SolidProvider {
@@ -46,7 +47,7 @@ function getLastUsedProvider(): SolidProvider | null {
 interface SolidProviderSelectorProps {
   isOpen: boolean;
   onClose: () => void;
-  onSelect: (issuer: string) => void;
+  onSelect: (issuer: string) => void | Promise<void>;
 }
 
 export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProviderSelectorProps) {
@@ -54,17 +55,29 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
   const sortedProviders = [primaryProvider, ...COMMON_PROVIDERS.filter(p => p.issuer !== primaryProvider.issuer)];
 
   const [query, setQuery] = useState('');
+  // Set while we're waiting on OIDC discovery/registration and the browser
+  // redirect they lead to - that round trip can take a few seconds, so the
+  // modal stays open with a spinner instead of vanishing immediately.
+  const [connectingIssuer, setConnectingIssuer] = useState<string | null>(null);
+  const [connectError, setConnectError] = useState<string | null>(null);
 
   const normalizedQuery = query.trim().toLowerCase();
   const matchingProviders = normalizedQuery
     ? sortedProviders.filter(p => p.name.toLowerCase().includes(normalizedQuery) || p.issuer.toLowerCase().includes(normalizedQuery))
     : sortedProviders;
 
-  const handleProviderSelect = (issuer: string) => {
+  const handleProviderSelect = async (issuer: string) => {
+    setConnectError(null);
+    setConnectingIssuer(issuer);
     localStorage.setItem(LAST_PROVIDER_KEY, issuer);
-    onSelect(issuer);
-    onClose();
-    setQuery('');
+    try {
+      await onSelect(issuer);
+      // On success the browser is navigating away to the identity provider,
+      // so there's nothing left to reset here.
+    } catch {
+      setConnectingIssuer(null);
+      setConnectError("Couldn't connect to that provider. Check the URL and try again.");
+    }
   };
 
   const handleCustomSubmit = () => {
@@ -76,69 +89,89 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
   const handleClose = () => {
     onClose();
     setQuery('');
+    setConnectingIssuer(null);
+    setConnectError(null);
   };
 
   const isLastUsed = localStorage.getItem(LAST_PROVIDER_KEY) === primaryProvider.issuer;
+  const connectingProviderName = COMMON_PROVIDERS.find(p => p.issuer === connectingIssuer)?.name ?? connectingIssuer;
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose} title="Login with Your Solid Pod">
-      <div className="space-y-3">
-        <label className="block">
-          <span className="text-sm text-gray-600">
-            {isLastUsed && !query ? 'Continue with your last-used provider, search for another, or paste a Pod URL:' : 'Search providers or paste a Pod URL:'}
-          </span>
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key !== 'Enter') return;
-              e.preventDefault();
-              if (matchingProviders.length > 0) handleProviderSelect(matchingProviders[0].issuer);
-              else handleCustomSubmit();
-            }}
-            placeholder="Search providers or paste a Pod URL…"
-            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-            autoFocus
-          />
-        </label>
-
-        <div className="space-y-2">
-          {matchingProviders.map((provider) => (
-            <button
-              key={provider.issuer}
-              aria-label={provider.name}
-              onClick={() => handleProviderSelect(provider.issuer)}
-              className={`w-full text-left px-4 py-3 rounded-md transition-colors ${
-                provider.issuer === primaryProvider.issuer
-                  ? 'border-2 border-blue-400 bg-blue-50 hover:bg-blue-100 hover:border-blue-500'
-                  : 'border border-gray-300 hover:bg-gray-50 hover:border-gray-400'
-              }`}
-            >
-              <div className="font-medium text-gray-900">{provider.name}</div>
-              {provider.description && (
-                <div className="text-xs text-green-700 font-medium">{provider.description}</div>
-              )}
-              <div className="text-xs text-gray-400">{provider.issuer}</div>
-            </button>
-          ))}
-
-          {query.trim() && matchingProviders.length === 0 && (
-            <p className="text-sm text-gray-500 px-1">No matching providers.</p>
-          )}
-
-          {query.trim() && (
-            <button
-              type="button"
-              onClick={handleCustomSubmit}
-              className="w-full text-left px-4 py-3 border border-dashed border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
-            >
-              <div className="font-medium text-gray-900">Connect to custom provider</div>
-              <div className="text-xs text-gray-400 truncate">{normalizeIssuerUrl(query)}</div>
-            </button>
-          )}
+      {connectingIssuer ? (
+        <div className="flex flex-col items-center gap-3 py-8 text-center">
+          <Loader2 className="w-8 h-8 text-primary-600 animate-spin" aria-hidden="true" />
+          <div>
+            <p className="font-medium text-gray-900">Connecting to {connectingProviderName}…</p>
+            <p className="mt-1 text-sm text-gray-500">You'll be redirected to sign in. This can take a few seconds.</p>
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="space-y-3">
+          <label className="block">
+            <span className="text-sm text-gray-600">
+              {isLastUsed && !query ? 'Continue with your last-used provider, search for another, or paste a Pod URL:' : 'Search providers or paste a Pod URL:'}
+            </span>
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setConnectError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key !== 'Enter') return;
+                e.preventDefault();
+                if (matchingProviders.length > 0) handleProviderSelect(matchingProviders[0].issuer);
+                else handleCustomSubmit();
+              }}
+              placeholder="Search providers or paste a Pod URL…"
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+              autoFocus
+            />
+          </label>
+
+          {connectError && (
+            <p className="text-sm text-danger-600">{connectError}</p>
+          )}
+
+          <div className="space-y-2">
+            {matchingProviders.map((provider) => (
+              <button
+                key={provider.issuer}
+                aria-label={provider.name}
+                onClick={() => handleProviderSelect(provider.issuer)}
+                className={`w-full text-left px-4 py-3 rounded-md transition-colors ${
+                  provider.issuer === primaryProvider.issuer
+                    ? 'border-2 border-blue-400 bg-blue-50 hover:bg-blue-100 hover:border-blue-500'
+                    : 'border border-gray-300 hover:bg-gray-50 hover:border-gray-400'
+                }`}
+              >
+                <div className="font-medium text-gray-900">{provider.name}</div>
+                {provider.description && (
+                  <div className="text-xs text-green-700 font-medium">{provider.description}</div>
+                )}
+                <div className="text-xs text-gray-400">{provider.issuer}</div>
+              </button>
+            ))}
+
+            {query.trim() && matchingProviders.length === 0 && (
+              <p className="text-sm text-gray-500 px-1">No matching providers.</p>
+            )}
+
+            {query.trim() && (
+              <button
+                type="button"
+                onClick={handleCustomSubmit}
+                className="w-full text-left px-4 py-3 border border-dashed border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
+              >
+                <div className="font-medium text-gray-900">Connect to custom provider</div>
+                <div className="text-xs text-gray-400 truncate">{normalizeIssuerUrl(query)}</div>
+              </button>
+            )}
+          </div>
+        </div>
+      )}
     </Modal>
   );
 }

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -100,16 +100,16 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
     <Modal isOpen={isOpen} onClose={handleClose} title="Login with Your Solid Pod">
       {connectingIssuer ? (
         <div className="flex flex-col items-center gap-3 py-8 text-center">
-          <Loader2 className="w-8 h-8 text-primary-600 animate-spin" aria-hidden="true" />
+          <Loader2 className="w-8 h-8 text-primary-600 dark:text-primary-400 animate-spin" aria-hidden="true" />
           <div>
-            <p className="font-medium text-gray-900">Connecting to {connectingProviderName}…</p>
-            <p className="mt-1 text-sm text-gray-500">You'll be redirected to sign in. This can take a few seconds.</p>
+            <p className="font-medium text-gray-900 dark:text-gray-100">Connecting to {connectingProviderName}…</p>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">You'll be redirected to sign in. This can take a few seconds.</p>
           </div>
         </div>
       ) : (
         <div className="space-y-3">
           <label className="block">
-            <span className="text-sm text-gray-600">
+            <span className="text-sm text-gray-600 dark:text-gray-400">
               {isLastUsed && !query ? 'Continue with your last-used provider, search for another, or paste a Pod URL:' : 'Search providers or paste a Pod URL:'}
             </span>
             <input
@@ -126,13 +126,13 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
                 else handleCustomSubmit();
               }}
               placeholder="Search providers or paste a Pod URL…"
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
               autoFocus
             />
           </label>
 
           {connectError && (
-            <p className="text-sm text-danger-600">{connectError}</p>
+            <p className="text-sm text-danger-600 dark:text-danger-400">{connectError}</p>
           )}
 
           <div className="space-y-2">
@@ -144,29 +144,29 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
                 className={`w-full text-left px-4 py-3 rounded-md transition-colors ${
                   provider.issuer === primaryProvider.issuer
                     ? 'border-2 border-blue-400 bg-blue-50 hover:bg-blue-100 hover:border-blue-500'
-                    : 'border border-gray-300 hover:bg-gray-50 hover:border-gray-400'
+                    : 'border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-400'
                 }`}
               >
-                <div className="font-medium text-gray-900">{provider.name}</div>
+                <div className="font-medium text-gray-900 dark:text-gray-100">{provider.name}</div>
                 {provider.description && (
                   <div className="text-xs text-green-700 font-medium">{provider.description}</div>
                 )}
-                <div className="text-xs text-gray-400">{provider.issuer}</div>
+                <div className="text-xs text-gray-400 dark:text-gray-500">{provider.issuer}</div>
               </button>
             ))}
 
             {query.trim() && matchingProviders.length === 0 && (
-              <p className="text-sm text-gray-500 px-1">No matching providers.</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400 px-1">No matching providers.</p>
             )}
 
             {query.trim() && (
               <button
                 type="button"
                 onClick={handleCustomSubmit}
-                className="w-full text-left px-4 py-3 border border-dashed border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
+                className="w-full text-left px-4 py-3 border border-dashed border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-400 rounded-md transition-colors"
               >
-                <div className="font-medium text-gray-900">Connect to custom provider</div>
-                <div className="text-xs text-gray-400 truncate">{normalizeIssuerUrl(query)}</div>
+                <div className="font-medium text-gray-900 dark:text-gray-100">Connect to custom provider</div>
+                <div className="text-xs text-gray-400 dark:text-gray-500 truncate">{normalizeIssuerUrl(query)}</div>
               </button>
             )}
           </div>

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -28,6 +28,13 @@ export const COMMON_PROVIDERS: SolidProvider[] = [
 
 export const LAST_PROVIDER_KEY = 'solid-last-provider-issuer';
 
+// Users shouldn't have to type the scheme themselves - default to https:// for
+// anything that doesn't already specify http:// or https://.
+const normalizeIssuerUrl = (value: string): string => {
+  const trimmed = value.trim();
+  return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+};
+
 const DEFAULT_PROVIDER = COMMON_PROVIDERS.find(p => p.issuer === 'https://login.inrupt.com')!;
 
 function getLastUsedProvider(): SolidProvider | null {
@@ -62,7 +69,7 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
 
   const handleCustomSubmit = () => {
     if (query.trim()) {
-      handleProviderSelect(query.trim());
+      handleProviderSelect(normalizeIssuerUrl(query));
     }
   };
 
@@ -127,7 +134,7 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
               className="w-full text-left px-4 py-3 border border-dashed border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
             >
               <div className="font-medium text-gray-900">Connect to custom provider</div>
-              <div className="text-xs text-gray-400 truncate">{query.trim()}</div>
+              <div className="text-xs text-gray-400 truncate">{normalizeIssuerUrl(query)}</div>
             </button>
           )}
         </div>

--- a/src/components/TemplateUpdatesCard.tsx
+++ b/src/components/TemplateUpdatesCard.tsx
@@ -111,7 +111,7 @@ export function TemplateUpdatesCard({ questionSet, onApply }: TemplateUpdatesCar
                                 {group.items.map(s => (
                                     <label
                                         key={s.key}
-                                        className="flex items-start gap-2 text-sm text-gray-700 bg-white rounded border border-emerald-200 px-3 py-2"
+                                        className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 rounded border border-emerald-200 px-3 py-2"
                                     >
                                         <input
                                             type="checkbox"
@@ -120,7 +120,7 @@ export function TemplateUpdatesCard({ questionSet, onApply }: TemplateUpdatesCar
                                             className="mt-0.5 h-4 w-4 text-emerald-600 rounded focus:ring-2 focus:ring-emerald-500"
                                         />
                                         <span>
-                                            <span className="font-medium text-gray-900">{s.label}</span>
+                                            <span className="font-medium text-gray-900 dark:text-gray-100">{s.label}</span>
                                             {KIND_HINT[s.kind] && (
                                                 <span className="ml-2 text-xs text-emerald-600">{KIND_HINT[s.kind]}</span>
                                             )}
@@ -134,7 +134,7 @@ export function TemplateUpdatesCard({ questionSet, onApply }: TemplateUpdatesCar
                         <button
                             type="button"
                             onClick={() => setIsExpanded(false)}
-                            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-emerald-100"
+                            className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 rounded-lg hover:bg-emerald-100"
                         >
                             Not now
                         </button>

--- a/src/components/ThemeContext.tsx
+++ b/src/components/ThemeContext.tsx
@@ -1,0 +1,63 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const THEME_KEY = 'theme-preference';
+
+interface ThemeContextType {
+    theme: Theme;
+    setTheme: (theme: Theme) => void;
+    toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+function getSystemTheme(): Theme {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function getInitialTheme(): Theme {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored === 'light' || stored === 'dark') return stored;
+    return getSystemTheme();
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+    const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+    useEffect(() => {
+        document.documentElement.classList.toggle('dark', theme === 'dark');
+    }, [theme]);
+
+    // Follow the OS setting live as long as the user hasn't picked a theme
+    // of their own - once they do, their choice sticks regardless of OS changes.
+    useEffect(() => {
+        if (localStorage.getItem(THEME_KEY)) return;
+        const media = window.matchMedia('(prefers-color-scheme: dark)');
+        const onChange = () => setThemeState(getSystemTheme());
+        media.addEventListener('change', onChange);
+        return () => media.removeEventListener('change', onChange);
+    }, []);
+
+    const setTheme = (next: Theme) => {
+        localStorage.setItem(THEME_KEY, next);
+        setThemeState(next);
+    };
+
+    const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+
+    return (
+        <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useTheme() {
+    const context = useContext(ThemeContext);
+    if (context === undefined) {
+        throw new Error('useTheme must be used within a ThemeProvider');
+    }
+    return context;
+}

--- a/src/components/UpdateFromQuestionsModal.tsx
+++ b/src/components/UpdateFromQuestionsModal.tsx
@@ -1,85 +1,144 @@
 import { useMemo, useState } from 'react'
 import { Modal } from './Modal'
 import { Button } from './Button'
+import type { QuestionSetChange } from '../create-packing-list/updateFromQuestions'
 import { PackingListItem } from '../create-packing-list/types'
 
 interface UpdateFromQuestionsModalProps {
     isOpen: boolean
     onClose: () => void
-    additions: PackingListItem[]
-    onConfirm: (selected: PackingListItem[]) => void
+    changes: QuestionSetChange[]
+    onConfirm: (selected: QuestionSetChange[]) => void
 }
 
-// Groups additions by traveller for the preview, communal ("Shared items")
-// first, then people alphabetically.
-function groupAdditions(additions: PackingListItem[]): Array<{ label: string; items: PackingListItem[] }> {
-    const shared: PackingListItem[] = []
-    const byPerson = new Map<string, PackingListItem[]>()
-    for (const item of additions) {
-        if (item.communal || item.personId === '') {
-            shared.push(item)
-        } else {
-            const key = item.personName || 'Unassigned'
-            if (!byPerson.has(key)) byPerson.set(key, [])
-            byPerson.get(key)!.push(item)
+const forWhom = (item: PackingListItem) =>
+    item.communal || item.personId === '' ? 'Shared' : item.personName || 'Unassigned'
+
+// One human-readable line per change; the checkbox's accessible name.
+function describeChange(change: QuestionSetChange): string {
+    switch (change.type) {
+        case 'add': {
+            const { item } = change
+            return `Add ${item.itemText}${item.personName ? ` for ${item.personName}` : ''}`
+        }
+        case 'remove':
+            return `Remove ${change.item.itemText}${change.item.personName ? ` for ${change.item.personName}` : ''}`
+        case 'sharing':
+            return change.direction === 'shared'
+                ? `Make ${change.itemText} a shared item`
+                : `Give everyone their own ${change.itemText}`
+        case 'update': {
+            const parts: string[] = []
+            if (change.kinds.includes('renamed')) parts.push(`rename ${change.before.itemText} to ${change.after.itemText}`)
+            if (change.kinds.includes('moved')) parts.push(`move ${change.before.itemText} to ${change.after.category}`)
+            if (change.kinds.includes('quantity')) parts.push(`change ${change.before.itemText} quantity to ${change.after.quantity ?? 1}`)
+            const [first, ...rest] = parts
+            const joined = [first.charAt(0).toUpperCase() + first.slice(1), ...rest].join(', ')
+            return `${joined}${change.before.personName ? ` for ${change.before.personName}` : ''}`
         }
     }
-    const groups: Array<{ label: string; items: PackingListItem[] }> = []
-    if (shared.length > 0) groups.push({ label: 'Shared items', items: shared })
-    for (const label of [...byPerson.keys()].sort((a, b) => a.localeCompare(b))) {
-        groups.push({ label, items: byPerson.get(label)! })
-    }
-    return groups
 }
+
+function sectionOf(change: QuestionSetChange): 'add' | 'change' | 'remove' {
+    if (change.type === 'add') return 'add'
+    if (change.type === 'remove') return 'remove'
+    return 'change'
+}
+
+const SECTIONS = [
+    { key: 'add' as const, title: 'New items' },
+    { key: 'change' as const, title: 'Changed items' },
+    { key: 'remove' as const, title: 'No longer in your questions' },
+]
 
 export function UpdateFromQuestionsModal({
     isOpen,
     onClose,
-    additions,
+    changes,
     onConfirm,
 }: UpdateFromQuestionsModalProps) {
-    // All additions start selected; the user unchecks any they don't want.
-    const [excludedIds, setExcludedIds] = useState<Set<string>>(new Set())
+    // Everything starts selected; the user unchecks what they don't want.
+    // Changes are keyed by their index — the array is stable for the modal's life.
+    const [excluded, setExcluded] = useState<Set<number>>(new Set())
 
-    const groups = useMemo(() => groupAdditions(additions), [additions])
-    const selectedCount = additions.length - excludedIds.size
+    const sections = useMemo(() => SECTIONS
+        .map(section => ({
+            ...section,
+            entries: changes
+                .map((change, index) => ({ change, index }))
+                .filter(({ change }) => sectionOf(change) === section.key),
+        }))
+        .filter(section => section.entries.length > 0),
+    [changes])
 
-    const toggle = (id: string) => {
-        setExcludedIds(prev => {
+    const selected = changes.filter((_, i) => !excluded.has(i))
+    const onlyAdditions = selected.every(c => c.type === 'add')
+
+    const toggle = (index: number) => {
+        setExcluded(prev => {
             const next = new Set(prev)
-            if (next.has(id)) next.delete(id)
-            else next.add(id)
+            if (next.has(index)) next.delete(index)
+            else next.add(index)
             return next
         })
-    }
-
-    const handleConfirm = () => {
-        onConfirm(additions.filter(item => !excludedIds.has(item.id)))
     }
 
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Update from questions">
             <p className="text-sm text-gray-600 mb-4">
-                Your questions have new items that match this trip. Choose which to add.
+                Your questions have changed since this list was made. Choose which updates to apply.
             </p>
             <div className="max-h-96 overflow-y-auto space-y-4">
-                {groups.map(group => (
-                    <div key={group.label}>
-                        <p className="text-sm font-semibold text-gray-700 mb-2">{group.label}</p>
+                {sections.map(section => (
+                    <div key={section.key}>
+                        <p className="text-sm font-semibold text-gray-700 mb-2">{section.title}</p>
                         <div className="space-y-1">
-                            {group.items.map(item => (
-                                <label key={item.id} className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer">
+                            {section.entries.map(({ change, index }) => (
+                                <label key={index} className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer">
                                     <input
                                         type="checkbox"
-                                        aria-label={`Add ${item.itemText}${item.personName ? ` for ${item.personName}` : ''}`}
-                                        checked={!excludedIds.has(item.id)}
-                                        onChange={() => toggle(item.id)}
+                                        aria-label={describeChange(change)}
+                                        checked={!excluded.has(index)}
+                                        onChange={() => toggle(index)}
                                         className="h-4 w-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
                                     />
-                                    <span className="text-gray-900">
-                                        {item.itemText}
-                                        {item.quantity !== undefined && (
-                                            <span className="ml-1.5 text-sm text-gray-500">×{item.quantity}</span>
+                                    <span className={change.type === 'remove' ? 'text-gray-500 line-through' : 'text-gray-900'}>
+                                        {change.type === 'add' && (
+                                            <>
+                                                {change.item.itemText}
+                                                {change.item.quantity !== undefined && (
+                                                    <span className="ml-1.5 text-sm text-gray-500 no-underline">×{change.item.quantity}</span>
+                                                )}
+                                                <span className="ml-1.5 text-sm text-gray-500">{forWhom(change.item)}</span>
+                                            </>
+                                        )}
+                                        {change.type === 'remove' && (
+                                            <>
+                                                {change.item.itemText}
+                                                <span className="ml-1.5 text-sm text-gray-500">{forWhom(change.item)}</span>
+                                            </>
+                                        )}
+                                        {change.type === 'update' && (
+                                            <>
+                                                {change.kinds.includes('renamed')
+                                                    ? <>{change.before.itemText} <span aria-hidden="true">→</span> {change.after.itemText}</>
+                                                    : change.before.itemText}
+                                                {change.kinds.includes('moved') && (
+                                                    <span className="ml-1.5 text-sm text-gray-500">now in {change.after.category}</span>
+                                                )}
+                                                {change.kinds.includes('quantity') && (
+                                                    <span className="ml-1.5 text-sm text-gray-500">×{change.before.quantity ?? 1} <span aria-hidden="true">→</span> ×{change.after.quantity ?? 1}</span>
+                                                )}
+                                                <span className="ml-1.5 text-sm text-gray-500">{forWhom(change.before)}</span>
+                                            </>
+                                        )}
+                                        {change.type === 'sharing' && (
+                                            <>
+                                                {change.itemText}
+                                                <span className="ml-1.5 text-sm text-gray-500">
+                                                    {change.direction === 'shared' ? 'now packed once for everyone' : 'now one per person'}
+                                                </span>
+                                            </>
                                         )}
                                     </span>
                                 </label>
@@ -95,10 +154,14 @@ export function UpdateFromQuestionsModal({
                 <Button
                     type="button"
                     variant="primary"
-                    onClick={handleConfirm}
-                    disabled={selectedCount === 0}
+                    onClick={() => onConfirm(selected)}
+                    disabled={selected.length === 0}
                 >
-                    {selectedCount > 0 ? `Add ${selectedCount} item${selectedCount === 1 ? '' : 's'}` : 'Add items'}
+                    {selected.length === 0
+                        ? 'Apply changes'
+                        : onlyAdditions
+                            ? `Add ${selected.length} item${selected.length === 1 ? '' : 's'}`
+                            : `Apply ${selected.length} change${selected.length === 1 ? '' : 's'}`}
                 </Button>
             </div>
         </Modal>

--- a/src/components/UpdateFromQuestionsModal.tsx
+++ b/src/components/UpdateFromQuestionsModal.tsx
@@ -59,16 +59,16 @@ export function UpdateFromQuestionsModal({
 
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Update from questions">
-            <p className="text-sm text-gray-600 mb-4">
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                 Your questions have new items that match this trip. Choose which to add.
             </p>
             <div className="max-h-96 overflow-y-auto space-y-4">
                 {groups.map(group => (
                     <div key={group.label}>
-                        <p className="text-sm font-semibold text-gray-700 mb-2">{group.label}</p>
+                        <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{group.label}</p>
                         <div className="space-y-1">
                             {group.items.map(item => (
-                                <label key={item.id} className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer">
+                                <label key={item.id} className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer">
                                     <input
                                         type="checkbox"
                                         aria-label={`Add ${item.itemText}${item.personName ? ` for ${item.personName}` : ''}`}
@@ -76,10 +76,10 @@ export function UpdateFromQuestionsModal({
                                         onChange={() => toggle(item.id)}
                                         className="h-4 w-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
                                     />
-                                    <span className="text-gray-900">
+                                    <span className="text-gray-900 dark:text-gray-100">
                                         {item.itemText}
                                         {item.quantity !== undefined && (
-                                            <span className="ml-1.5 text-sm text-gray-500">×{item.quantity}</span>
+                                            <span className="ml-1.5 text-sm text-gray-500 dark:text-gray-400">×{item.quantity}</span>
                                         )}
                                     </span>
                                 </label>

--- a/src/create-packing-list/tripDetails.test.ts
+++ b/src/create-packing-list/tripDetails.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { formatTripDate, formatTripDates, tripDatesOutOfOrder } from './tripDetails'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { formatTripDate, formatTripDates, tripDatesOutOfOrder, tripIsPast } from './tripDetails'
 
 describe('formatTripDate', () => {
     it('formats a YYYY-MM-DD string as a local calendar date', () => {
@@ -60,5 +60,35 @@ describe('tripDatesOutOfOrder', () => {
 
     it('is true when the end date is before the start date', () => {
         expect(tripDatesOutOfOrder('2026-07-19', '2026-07-12')).toBe(true)
+    })
+})
+
+describe('tripIsPast', () => {
+    afterEach(() => vi.useRealTimers())
+
+    it('is true when the trip ended before today', () => {
+        vi.useFakeTimers({ now: new Date(2026, 6, 31) })
+        expect(tripIsPast('2026-07-12', '2026-07-19')).toBe(true)
+    })
+
+    it('is false while the trip is still running or upcoming', () => {
+        vi.useFakeTimers({ now: new Date(2026, 6, 31) })
+        expect(tripIsPast('2026-07-28', '2026-08-08')).toBe(false)
+        expect(tripIsPast('2026-08-02', '2026-08-08')).toBe(false)
+    })
+
+    it('is false on the end date itself', () => {
+        vi.useFakeTimers({ now: new Date(2026, 6, 31) })
+        expect(tripIsPast('2026-07-28', '2026-07-31')).toBe(false)
+    })
+
+    it('falls back to the start date when there is no end date', () => {
+        vi.useFakeTimers({ now: new Date(2026, 6, 31) })
+        expect(tripIsPast('2026-07-12', undefined)).toBe(true)
+        expect(tripIsPast('2026-08-02', undefined)).toBe(false)
+    })
+
+    it('is false when the list has no trip dates', () => {
+        expect(tripIsPast(undefined, undefined)).toBe(false)
     })
 })

--- a/src/create-packing-list/tripDetails.ts
+++ b/src/create-packing-list/tripDetails.ts
@@ -45,3 +45,16 @@ export function tripDatesOutOfOrder(startDate: string | undefined, endDate: stri
     if (!start || !end) return false
     return end.getTime() < start.getTime()
 }
+
+/**
+ * Whether the trip is over: its last known date (end, or start when there is
+ * no end) is before today. A list without trip dates is never "past" — there
+ * is nothing to age it by.
+ */
+export function tripIsPast(startDate: string | undefined, endDate: string | undefined): boolean {
+    const last = parseTripDate(endDate) ?? parseTripDate(startDate)
+    if (!last) return false
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    return last < today
+}

--- a/src/create-packing-list/updateFromQuestions.test.ts
+++ b/src/create-packing-list/updateFromQuestions.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import PouchDB from 'pouchdb'
 import PouchDBMemoryAdapter from 'pouchdb-adapter-memory'
 import { PackingAppDatabase } from '../services/database'
-import { computeQuestionSetAdditions, reconstructGenerationInputs } from './updateFromQuestions'
+import { computeQuestionSetAdditions, computeQuestionSetChanges, reconstructGenerationInputs } from './updateFromQuestions'
 import { PackingList, PackingListItem } from './types'
 import { PackingListQuestionSet, Question, Person, Item } from '../edit-questions/types'
 
@@ -406,5 +406,165 @@ describe('an item reaching one person from two answers', () => {
     it('offers the larger of the two suggested quantities', () => {
         const [towels] = computeQuestionSetAdditions(list, questionSet)
         expect(towels.quantity).toBe(3)
+    })
+})
+
+describe('computeQuestionSetChanges', () => {
+    // A question set whose one option holds the given items
+    const setWith = (...items: Item[]) => makeQuestionSet({
+        questions: [makeQuestion({
+            options: [{ id: 'opt-swimming', text: 'Swimming', order: 0, items }],
+        })],
+    })
+    const answered = { questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }] }
+
+    it('reports an item removed from the questions as a removal', () => {
+        const questionSet = setWith(makeItem('Goggles', ['p1']))
+        const towel = listItem({ itemText: 'Towel', personId: 'p1', personName: 'Alice' })
+        const goggles = listItem({ itemText: 'Goggles', personId: 'p1', personName: 'Alice' })
+        const list = makeList({ ...answered, items: [towel, goggles] })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes).toEqual([{ type: 'remove', item: towel }])
+    })
+
+    it('never flags hand-added custom items as removals', () => {
+        const questionSet = setWith(makeItem('Goggles', ['p1']))
+        const custom = listItem({ itemText: 'Souvenir money', questionId: '', optionId: '' })
+        const goggles = listItem({ itemText: 'Goggles' })
+        const list = makeList({ ...answered, items: [custom, goggles] })
+
+        expect(computeQuestionSetChanges(list, questionSet)).toEqual([])
+    })
+
+    it('reports a renamed item as an update that keeps the packed state and id', () => {
+        const questionSet = setWith(makeItem('Swimming goggles', ['p1']))
+        const goggles = listItem({ itemText: 'Goggles', packed: true })
+        const list = makeList({ ...answered, items: [goggles] })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes).toHaveLength(1)
+        const change = changes[0]
+        if (change.type !== 'update') throw new Error('expected update')
+        expect(change.kinds).toEqual(['renamed'])
+        expect(change.before.itemText).toBe('Goggles')
+        expect(change.after.itemText).toBe('Swimming goggles')
+        expect(change.after.id).toBe(goggles.id)
+        expect(change.after.packed).toBe(true)
+    })
+
+    it('does not guess a rename when several items changed in the same option', () => {
+        const questionSet = setWith(makeItem('Snorkel', ['p1']), makeItem('Fins', ['p1']))
+        const list = makeList({
+            ...answered,
+            items: [
+                listItem({ itemText: 'Goggles' }),
+                listItem({ itemText: 'Towel' }),
+            ],
+        })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        const types = changes.map(c => c.type).sort()
+        expect(types).toEqual(['add', 'add', 'remove', 'remove'])
+    })
+
+    it('reports a moved item (new category) as an update', () => {
+        const questionSet = setWith(makeItem('Goggles', ['p1'], { category: 'Beach' }))
+        const goggles = listItem({ itemText: 'Goggles', category: 'Essentials' })
+        const list = makeList({ ...answered, items: [goggles] })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes).toHaveLength(1)
+        const change = changes[0]
+        if (change.type !== 'update') throw new Error('expected update')
+        expect(change.kinds).toEqual(['moved'])
+        expect(change.after.category).toBe('Beach')
+    })
+
+    it('reports a quantity change as an update', () => {
+        const questionSet = setWith(makeItem('Socks', ['p1'], { perNight: 1, perNights: 1, maxQuantity: 3 }))
+        const socks = listItem({ itemText: 'Socks', quantity: 1 })
+        const list = makeList({ ...answered, items: [socks], nights: 5 })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes).toHaveLength(1)
+        const change = changes[0]
+        if (change.type !== 'update') throw new Error('expected update')
+        expect(change.kinds).toEqual(['quantity'])
+        expect(change.after.quantity).toBe(3)
+    })
+
+    it('reports an item that became communal as one sharing change', () => {
+        const questionSet = setWith(makeItem('Tent', ['p1', 'p2'], { communal: true }))
+        const aliceTent = listItem({ itemText: 'Tent', personId: 'p1', personName: 'Alice', packed: true })
+        const bobTent = listItem({ itemText: 'Tent', personId: 'p2', personName: 'Bob', packed: true })
+        const list = makeList({ ...answered, items: [aliceTent, bobTent] })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes).toHaveLength(1)
+        const change = changes[0]
+        if (change.type !== 'sharing') throw new Error('expected sharing')
+        expect(change.direction).toBe('shared')
+        expect(change.remove.map(i => i.id).sort()).toEqual([aliceTent.id, bobTent.id].sort())
+        expect(change.add).toHaveLength(1)
+        expect(change.add[0].communal).toBe(true)
+        // Every copy was packed, so the shared one arrives packed
+        expect(change.add[0].packed).toBe(true)
+    })
+
+    it('reports a communal item that became per-person as one sharing change', () => {
+        const questionSet = setWith(makeItem('Sunscreen', ['p1', 'p2']))
+        const shared = listItem({ itemText: 'Sunscreen', personId: '', personName: '', communal: true, packed: false })
+        const list = makeList({ ...answered, items: [shared] })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes).toHaveLength(1)
+        const change = changes[0]
+        if (change.type !== 'sharing') throw new Error('expected sharing')
+        expect(change.direction).toBe('personal')
+        expect(change.remove.map(i => i.id)).toEqual([shared.id])
+        expect(change.add.map(i => i.personName).sort()).toEqual(['Alice', 'Bob'])
+    })
+
+    it('still reports plain additions, skipping deleted items', () => {
+        const questionSet = setWith(makeItem('Goggles', ['p1']), makeItem('Towel', ['p1']))
+        const list = makeList({
+            ...answered,
+            items: [listItem({ itemText: 'Goggles' })],
+            deletedItems: [listItem({ itemText: 'Towel' })],
+        })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes).toEqual([])
+    })
+
+    it('does not flag removals for a question the list never answered', () => {
+        // The list has items from q-activities but no stored answer for it
+        // (the pre-fix empty-inputs shape) — nothing should look removed.
+        const questionSet = setWith(makeItem('Goggles', ['p1']))
+        const list = makeList({ questionAnswers: [], items: [listItem({ itemText: 'Goggles' })] })
+
+        expect(computeQuestionSetChanges(list, questionSet)).toEqual([])
+    })
+
+    it('leaves items of a person no longer in the question set alone', () => {
+        const questionSet = makeQuestionSet({
+            people: [alice],
+            questions: [makeQuestion({
+                options: [{ id: 'opt-swimming', text: 'Swimming', order: 0, items: [makeItem('Goggles', ['p1'])] }],
+            })],
+        })
+        const bobItem = listItem({ itemText: 'Goggles', personId: 'p2', personName: 'Bob' })
+        const list = makeList({ ...answered, items: [listItem({ itemText: 'Goggles' }), bobItem] })
+
+        expect(computeQuestionSetChanges(list, questionSet)).toEqual([])
     })
 })

--- a/src/create-packing-list/updateFromQuestions.ts
+++ b/src/create-packing-list/updateFromQuestions.ts
@@ -63,6 +63,36 @@ export function computeQuestionSetAdditions(
     list: PackingList,
     questionSet: PackingListQuestionSet,
 ): PackingListItem[] {
+    return computeQuestionSetChanges(list, questionSet)
+        .filter((c): c is Extract<QuestionSetChange, { type: 'add' }> => c.type === 'add')
+        .map(c => c.item)
+}
+
+export type UpdateKind = 'renamed' | 'moved' | 'quantity'
+
+/**
+ * The full diff between a list and what its questions would generate today.
+ *
+ *  - `add`     — a genuinely new item (fresh id, unpacked).
+ *  - `remove`  — a question-generated item on the list the questions no longer
+ *                produce (deleted, or its option/question removed).
+ *  - `update`  — the same item, changed in place: renamed, moved to another
+ *                section, or given a different suggested quantity. `after`
+ *                keeps the id and packed state of `before`.
+ *  - `sharing` — the item crossed the communal boundary: `remove` the old
+ *                copies, `add` the replacements. Packed state carries over
+ *                (a shared item is packed once every copy was).
+ */
+export type QuestionSetChange =
+    | { type: 'add'; item: PackingListItem }
+    | { type: 'remove'; item: PackingListItem }
+    | { type: 'update'; before: PackingListItem; after: PackingListItem; kinds: UpdateKind[] }
+    | { type: 'sharing'; direction: 'shared' | 'personal'; itemText: string; remove: PackingListItem[]; add: PackingListItem[] }
+
+export function computeQuestionSetChanges(
+    list: PackingList,
+    questionSet: PackingListQuestionSet,
+): QuestionSetChange[] {
     const { questionAnswers, selectedPeopleIds } = resolveGenerationInputs(list)
 
     // A person removed from the question set must not be regenerated; this also
@@ -70,7 +100,7 @@ export function computeQuestionSetAdditions(
     const currentPeopleIds = new Set(questionSet.people.map(p => p.id))
     const validPeopleIds = selectedPeopleIds.filter(id => currentPeopleIds.has(id))
 
-    const regenerated = [
+    const regenerated = deduplicateItems([
         ...generateQuestionBasedItems(
             questionSet.questions,
             questionAnswers,
@@ -84,19 +114,159 @@ export function computeQuestionSetAdditions(
             validPeopleIds,
             list.nights,
         ),
-    ]
+    ])
 
-    // Anything already present (incl. custom items the user added by hand with
-    // the same text) or previously deleted is not an addition.
-    const existingKeys = new Set<string>()
-    for (const item of list.items) existingKeys.add(itemKey(item.personId, item.itemText))
-    for (const item of (list.deletedItems ?? [])) existingKeys.add(itemKey(item.personId, item.itemText))
-
-    const additions: PackingListItem[] = []
     const now = new Date().toISOString()
-    for (const item of deduplicateItems(regenerated)) {
-        if (existingKeys.has(itemKey(item.personId, item.itemText))) continue
-        additions.push({ ...item, id: crypto.randomUUID(), packed: false, lastModified: now })
+    const deletedKeys = new Set(
+        (list.deletedItems ?? []).map(item => itemKey(item.personId, item.itemText))
+    )
+    const listByKey = new Map<string, PackingListItem>()
+    for (const item of list.items) listByKey.set(itemKey(item.personId, item.itemText), item)
+
+    const changes: QuestionSetChange[] = []
+    const matchedListIds = new Set<string>()
+    const unmatchedRegen: PackingListItem[] = []
+
+    // Pass 1 — exact identity (person + text): the item is still generated;
+    // anything that differs about it is an in-place update.
+    for (const item of regenerated) {
+        const key = itemKey(item.personId, item.itemText)
+        const existing = listByKey.get(key)
+        if (existing) {
+            matchedListIds.add(existing.id)
+            const update = buildUpdate(existing, item, now)
+            if (update) changes.push(update)
+            continue
+        }
+        // Deleted by the user: never resurrected, in any form.
+        if (deletedKeys.has(key)) continue
+        unmatchedRegen.push(item)
     }
-    return additions
+
+    // Which list items may be judged against the regeneration at all: only
+    // question-generated ones (custom items are the user's, not the questions'),
+    // only from questions this list actually answered (a list whose generation
+    // inputs are missing must not see everything flagged as removed), and only
+    // for people the question set still knows.
+    const answeredQuestionIds = new Set(questionAnswers.map(a => a.questionId))
+    const unmatchedList = list.items.filter(item => {
+        if (matchedListIds.has(item.id)) return false
+        if (item.questionId === '') return false
+        if (item.questionId === ALWAYS_NEEDED_QUESTION_ID) {
+            if (validPeopleIds.length === 0) return false
+        } else if (!answeredQuestionIds.has(item.questionId)) {
+            return false
+        }
+        return item.personId === '' || validPeopleIds.includes(item.personId)
+    })
+
+    // Pass 2 — sharing transitions: the same text on the other side of the
+    // communal boundary is the item changing who packs it, not a delete+add.
+    const usedRegen = new Set<PackingListItem>()
+    const usedList = new Set<string>()
+    const textOf = (item: PackingListItem) => item.itemText.trim().toLowerCase()
+    for (const regenItem of unmatchedRegen) {
+        if (usedRegen.has(regenItem)) continue
+        if (regenItem.personId === '') {
+            const copies = unmatchedList.filter(li => !usedList.has(li.id) && li.personId !== '' && textOf(li) === textOf(regenItem))
+            if (copies.length > 0) {
+                usedRegen.add(regenItem)
+                copies.forEach(c => usedList.add(c.id))
+                changes.push({
+                    type: 'sharing',
+                    direction: 'shared',
+                    itemText: regenItem.itemText,
+                    remove: copies,
+                    add: [{ ...regenItem, id: crypto.randomUUID(), packed: copies.every(c => c.packed), lastModified: now }],
+                })
+            }
+        } else {
+            const shared = unmatchedList.find(li => !usedList.has(li.id) && li.personId === '' && textOf(li) === textOf(regenItem))
+            if (shared) {
+                // Collect every per-person replacement for this text in one change
+                const replacements = unmatchedRegen.filter(r => !usedRegen.has(r) && r.personId !== '' && textOf(r) === textOf(regenItem))
+                replacements.forEach(r => usedRegen.add(r))
+                usedList.add(shared.id)
+                changes.push({
+                    type: 'sharing',
+                    direction: 'personal',
+                    itemText: shared.itemText,
+                    remove: [shared],
+                    add: replacements.map(r => ({ ...r, id: crypto.randomUUID(), packed: shared.packed, lastModified: now })),
+                })
+            }
+        }
+    }
+
+    // Pass 3 — renames: within one option and one person, a single item
+    // disappearing while a single one appears is that item under a new name.
+    // More than one on either side is ambiguous, so it falls through to
+    // add + remove rather than guessing pairs.
+    const groupKey = (item: PackingListItem) => `${item.questionId}|${item.optionId}|${item.personId}`
+    const regenByGroup = new Map<string, PackingListItem[]>()
+    for (const item of unmatchedRegen) {
+        if (usedRegen.has(item)) continue
+        const key = groupKey(item)
+        if (!regenByGroup.has(key)) regenByGroup.set(key, [])
+        regenByGroup.get(key)!.push(item)
+    }
+    const listByGroup = new Map<string, PackingListItem[]>()
+    for (const item of unmatchedList) {
+        if (usedList.has(item.id)) continue
+        const key = groupKey(item)
+        if (!listByGroup.has(key)) listByGroup.set(key, [])
+        listByGroup.get(key)!.push(item)
+    }
+    for (const [key, regenItems] of regenByGroup) {
+        const listItems = listByGroup.get(key) ?? []
+        if (regenItems.length === 1 && listItems.length === 1) {
+            const [regenItem] = regenItems
+            const [existing] = listItems
+            usedRegen.add(regenItem)
+            usedList.add(existing.id)
+            const update = buildUpdate(existing, regenItem, now)
+            if (update) changes.push(update)
+        }
+    }
+
+    // What's left is genuinely new or genuinely gone.
+    for (const item of unmatchedRegen) {
+        if (usedRegen.has(item)) continue
+        changes.push({ type: 'add', item: { ...item, id: crypto.randomUUID(), packed: false, lastModified: now } })
+    }
+    for (const item of unmatchedList) {
+        if (usedList.has(item.id)) continue
+        changes.push({ type: 'remove', item })
+    }
+    return changes
+}
+
+// The in-place difference between a list item and its regenerated counterpart,
+// or null when nothing the update flow cares about differs. `after` keeps the
+// item's id and packed state — it's the same item, corrected.
+function buildUpdate(
+    before: PackingListItem,
+    regen: PackingListItem,
+    now: string,
+): Extract<QuestionSetChange, { type: 'update' }> | null {
+    const kinds: UpdateKind[] = []
+    if (before.itemText !== regen.itemText) kinds.push('renamed')
+    // Legacy items carry no category while the generator always assigns one;
+    // that difference is history, not a move.
+    if (before.category !== undefined && before.category !== regen.category) kinds.push('moved')
+    // An absent quantity means 1 on both sides.
+    if ((before.quantity ?? 1) !== (regen.quantity ?? 1)) kinds.push('quantity')
+    if (kinds.length === 0) return null
+    return {
+        type: 'update',
+        before,
+        kinds,
+        after: {
+            ...before,
+            itemText: regen.itemText,
+            ...(kinds.includes('moved') ? { category: regen.category } : {}),
+            ...(kinds.includes('quantity') ? { quantity: regen.quantity } : {}),
+            lastModified: now,
+        },
+    }
 }

--- a/src/edit-questions/types.ts
+++ b/src/edit-questions/types.ts
@@ -53,6 +53,9 @@ export const PersonSchema = z.object({
   gender: GenderSchema.optional(),
   species: PetSpeciesSchema.optional(),
   color: PersonColorSchema.optional(),
+  // Solid WebID of the person, when they have one — lets the app show their
+  // profile photo and could later drive sharing defaults.
+  webId: z.string().optional(),
   lastModified: z.string().optional(),
   deletedAt: z.string().optional(),
 })

--- a/src/hooks/usePersonProfilePhotos.ts
+++ b/src/hooks/usePersonProfilePhotos.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react'
+import type { AppSession } from '../types/AppSession'
+import type { Person } from '../edit-questions/types'
+import type { PackingAppDatabase } from '../services/database'
+import { getPodOwnerProfile } from '../services/solidPod'
+
+/**
+ * Profile photos for people, looked up by name via their Solid WebIDs.
+ *
+ * A person on the questions page can carry a WebID; this hook follows those
+ * WebIDs to their profile cards and returns whatever photos it finds
+ * (vcard:hasPhoto and friends). People without a WebID — guests, pets, or a
+ * profile without a photo — simply stay absent from the map, and callers fall
+ * back to the coloured initial.
+ */
+export function useProfilePhotos(
+    people: readonly Person[],
+    session: AppSession | null | undefined,
+): Record<string, string> {
+    const [photoByName, setPhotoByName] = useState<Record<string, string>>({})
+
+    // Who has which WebID, not the identity of the array holding them — the
+    // callers often rebuild it every render.
+    const rosterKey = people
+        .filter(p => !p.deletedAt && p.webId)
+        .map(p => `${p.name}:${p.webId}`)
+        .join(',')
+
+    useEffect(() => {
+        if (!session || rosterKey === '') return
+        let cancelled = false
+        for (const person of people) {
+            if (person.deletedAt || !person.webId) continue
+            const { name, webId } = person
+            getPodOwnerProfile(session, '', webId)
+                .then(({ photo }) => {
+                    if (photo && !cancelled) {
+                        setPhotoByName(prev => ({ ...prev, [name]: photo }))
+                    }
+                })
+                .catch(() => {})
+        }
+        return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rosterKey stands in for people
+    }, [session, rosterKey])
+
+    return photoByName
+}
+
+/**
+ * The same map, but for the people of the stored question set — read live from
+ * the database (like `usePersonColors`): a photo describes the person, not one
+ * trip. For pages that already hold the people, use `useProfilePhotos`.
+ */
+export function usePersonProfilePhotos(
+    db: PackingAppDatabase | undefined,
+    session: AppSession | null | undefined,
+): Record<string, string> {
+    const [people, setPeople] = useState<Person[]>([])
+
+    useEffect(() => {
+        if (!db) return
+        let cancelled = false
+        Promise.resolve()
+            .then(() => db.getQuestionSet())
+            .then(questionSet => {
+                if (!cancelled) setPeople(questionSet?.people ?? [])
+            })
+            .catch(() => { /* no question set: nobody has a photo */ })
+        return () => { cancelled = true }
+    }, [db, session])
+
+    return useProfilePhotos(people, session)
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+/* Tailwind v4 defaults `dark:` to the OS media query; switching it to a class
+   selector lets ThemeContext toggle dark mode manually as well as follow the OS. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   /* Primary - Very Dark Teal for navigation */
   --color-primary-950: #042f2e;
@@ -121,6 +125,19 @@
 
 body {
   overscroll-behavior: none;
+}
+
+html.dark {
+  color-scheme: dark;
+}
+
+html.dark body {
+  background-color: #0f172a;
+}
+
+html.dark .loading-skeleton-bar {
+  background-color: #334155;
+  background-image: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.08) 50%, transparent 100%);
 }
 
 /* Wizard generation reveal: each line eases in as it is added */

--- a/src/pages/backups.tsx
+++ b/src/pages/backups.tsx
@@ -102,8 +102,8 @@ export function BackupsPage() {
     if (!isLoggedIn) {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
-                <h1 className="text-4xl font-bold text-primary-900 mb-4">Backups</h1>
-                <p className="text-lg text-gray-700 font-medium">
+                <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200 mb-4">Backups</h1>
+                <p className="text-lg text-gray-700 dark:text-gray-300 font-medium">
                     Backups require a Solid Pod login. Please log in to manage your backups.
                 </p>
             </div>
@@ -114,8 +114,8 @@ export function BackupsPage() {
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8 flex justify-between items-start">
                 <div>
-                    <h1 className="text-4xl font-bold text-primary-900">Backups</h1>
-                    <p className="mt-2 text-lg text-gray-700 font-medium">
+                    <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">Backups</h1>
+                    <p className="mt-2 text-lg text-gray-700 dark:text-gray-300 font-medium">
                         Create and restore backups of your packing data.
                     </p>
                 </div>
@@ -132,22 +132,22 @@ export function BackupsPage() {
             {isLoadingBackups ? (
                 <LoadingState message="Loading backups..." rows={2} />
             ) : backups.length === 0 ? (
-                <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
-                    <p className="text-lg text-gray-800 font-semibold">No backups yet</p>
+                <div className="text-center py-12 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft">
+                    <p className="text-lg text-gray-800 dark:text-gray-200 font-semibold">No backups yet</p>
                 </div>
             ) : (
                 <div className="space-y-4">
                     {backups.map(backup => (
                         <div
                             key={backup.url}
-                            className="bg-white rounded-2xl border-2 border-primary-200 shadow-soft p-5"
+                            className="bg-white dark:bg-gray-800 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft p-5"
                         >
                             <div className="flex justify-between items-center">
                                 <div>
-                                    <p className="font-semibold text-gray-900">
+                                    <p className="font-semibold text-gray-900 dark:text-gray-100">
                                         {new Date(backup.createdAt).toLocaleString()}
                                     </p>
-                                    <p className="text-sm text-gray-600 mt-1">
+                                    <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
                                         {backup.packingListCount} packing list{backup.packingListCount !== 1 ? 's' : ''}
                                         {backup.hasQuestionSet ? ' · question set included' : ''}
                                     </p>
@@ -163,7 +163,7 @@ export function BackupsPage() {
                                     <button
                                         type="button"
                                         onClick={() => handleDelete(backup)}
-                                        className="px-4 py-2 rounded-xl font-semibold text-sm text-danger-600 hover:bg-danger-50 border-2 border-danger-200 hover:border-danger-400 transition-all duration-200"
+                                        className="px-4 py-2 rounded-xl font-semibold text-sm text-danger-600 dark:text-danger-400 hover:bg-danger-50 dark:bg-danger-950/40 border-2 border-danger-200 dark:border-danger-800 hover:border-danger-400 transition-all duration-200"
                                     >
                                         Delete
                                     </button>

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -154,11 +154,11 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                         })()
                                     const isShared = communalFlags[item.id] ?? item.communal ?? false
                                     return (
-                                    <div key={item.id} className="flex flex-col gap-2 bg-white rounded border border-amber-200 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+                                    <div key={item.id} className="flex flex-col gap-2 bg-white dark:bg-gray-800 rounded border border-amber-200 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
                                         <div>
-                                            <span className="font-medium text-gray-900">{item.itemText}</span>
+                                            <span className="font-medium text-gray-900 dark:text-gray-100">{item.itemText}</span>
                                             {item.personName && (
-                                                <span className="ml-2 text-sm text-gray-500">for {item.personName}</span>
+                                                <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">for {item.personName}</span>
                                             )}
                                         </div>
                                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -177,7 +177,7 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                                     ))
                                                 )}
                                             </select>
-                                            <label className="flex items-center gap-1.5 text-sm text-gray-600 shrink-0" title="Packed once for the whole group instead of per person">
+                                            <label className="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 shrink-0" title="Packed once for the whole group instead of per person">
                                                 <input
                                                     type="checkbox"
                                                     aria-label={`Save ${item.itemText} as a shared item`}
@@ -268,11 +268,11 @@ function DeletionSuggestionCard({ suggestions, onRemovePermanently, onKeep, onDi
                             <p className="text-sm text-red-700 font-semibold mb-2">From: {listName}</p>
                             <div className="space-y-2">
                                 {items.map(({ listId, item }) => (
-                                    <div key={item.id} className="flex flex-col gap-2 bg-white rounded border border-red-200 px-3 py-2">
+                                    <div key={item.id} className="flex flex-col gap-2 bg-white dark:bg-gray-800 rounded border border-red-200 px-3 py-2">
                                         <div>
-                                            <span className="font-medium text-gray-900">{item.itemText}</span>
+                                            <span className="font-medium text-gray-900 dark:text-gray-100">{item.itemText}</span>
                                             {item.personName && (
-                                                <span className="ml-2 text-sm text-gray-500">for {item.personName}</span>
+                                                <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">for {item.personName}</span>
                                             )}
                                         </div>
                                         <div className="flex gap-2">
@@ -672,23 +672,23 @@ export function CreatePackingList() {
             <>
                 <div className="max-w-4xl mx-auto py-8 px-4">
                     <div className="mb-8">
-                        <h1 className="text-2xl font-bold text-gray-900">Create New Packing List</h1>
-                        <p className="mt-2 text-gray-600">Let's set up your packing list questions first!</p>
+                        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Create New Packing List</h1>
+                        <p className="mt-2 text-gray-600 dark:text-gray-400">Let's set up your packing list questions first!</p>
                     </div>
 
-                    <div className="bg-white rounded-2xl shadow-soft border-2 border-primary-200 p-8">
+                    <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-soft border-2 border-primary-200 dark:border-primary-800 p-8">
                         <div className="text-center mb-6">
                             <div className="text-6xl mb-4">📋</div>
-                            <h2 className="text-2xl font-bold text-gray-900 mb-2">No Questions Found</h2>
-                            <p className="text-gray-600">
+                            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">No Questions Found</h2>
+                            <p className="text-gray-600 dark:text-gray-400">
                                 Before you can create a packing list, you need to set up your packing list questions.
                             </p>
                         </div>
 
                         <div className="space-y-4 max-w-2xl mx-auto">
-                            <div className="bg-gradient-to-br from-primary-50 to-primary-100 p-6 rounded-xl border-2 border-primary-200">
-                                <h3 className="text-lg font-bold text-primary-900 mb-2">✨ Quick Start with Wizard</h3>
-                                <p className="text-gray-700 mb-4">
+                            <div className="bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-primary-100 dark:to-primary-900/30 p-6 rounded-xl border-2 border-primary-200 dark:border-primary-800">
+                                <h3 className="text-lg font-bold text-primary-900 dark:text-primary-200 mb-2">✨ Quick Start with Wizard</h3>
+                                <p className="text-gray-700 dark:text-gray-300 mb-4">
                                     Answer a few simple questions and we'll generate a personalized question set for you.
                                 </p>
                                 <Link to="/wizard">
@@ -699,13 +699,13 @@ export function CreatePackingList() {
                             </div>
 
                             {!isLoggedIn && (
-                                <div className="bg-gradient-to-br from-accent-50 to-accent-100 p-6 rounded-xl border-2 border-accent-200">
-                                    <h3 className="text-lg font-bold text-accent-900 mb-2">🔒 Login to Sync Questions</h3>
-                                    <p className="text-gray-700 mb-4">
+                                <div className="bg-gradient-to-br from-accent-50 dark:from-accent-950/40 to-accent-100 dark:to-accent-900/30 p-6 rounded-xl border-2 border-accent-200 dark:border-accent-800">
+                                    <h3 className="text-lg font-bold text-accent-900 dark:text-accent-200 mb-2">🔒 Login to Sync Questions</h3>
+                                    <p className="text-gray-700 dark:text-gray-300 mb-4">
                                         If you've already created questions and saved them to your Solid Pod, login to sync them.
                                     </p>
                                     <button
-                                        className="text-sm font-semibold text-accent-700 underline hover:text-accent-900"
+                                        className="text-sm font-semibold text-accent-700 dark:text-accent-300 underline hover:text-accent-900 dark:hover:text-accent-300"
                                         onClick={() => setIsProviderSelectorOpen(true)}
                                     >
                                         Login with Solid Pod
@@ -713,9 +713,9 @@ export function CreatePackingList() {
                                 </div>
                             )}
 
-                            <div className="bg-gradient-to-br from-secondary-50 to-secondary-100 p-6 rounded-xl border-2 border-secondary-200">
-                                <h3 className="text-lg font-bold text-secondary-900 mb-2">✏️ Create Manually</h3>
-                                <p className="text-gray-700 mb-4">
+                            <div className="bg-gradient-to-br from-secondary-50 dark:from-secondary-950/40 to-secondary-100 dark:to-secondary-900/30 p-6 rounded-xl border-2 border-secondary-200 dark:border-secondary-800">
+                                <h3 className="text-lg font-bold text-secondary-900 dark:text-secondary-200 mb-2">✏️ Create Manually</h3>
+                                <p className="text-gray-700 dark:text-gray-300 mb-4">
                                     Prefer full control? Create your packing list questions from scratch.
                                 </p>
                                 <Link to="/manage-questions">
@@ -743,8 +743,8 @@ export function CreatePackingList() {
     return (
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8">
-                <h1 className="text-2xl font-bold text-gray-900">Create New Packing List</h1>
-                <p className="mt-2 text-gray-600">Answer the questions below to create your packing list.</p>
+                <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Create New Packing List</h1>
+                <p className="mt-2 text-gray-600 dark:text-gray-400">Answer the questions below to create your packing list.</p>
             </div>
 
             {!foreignPodUrl && (
@@ -792,7 +792,7 @@ export function CreatePackingList() {
                         placeholder="e.g. 3"
                         {...register('nights', { valueAsNumber: true, min: 1 })}
                     />
-                    <p className="mt-1 text-xs text-gray-500">
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                         We'll suggest quantities for items with a per-night amount, like socks — e.g. 3 nights → Socks ×3.
                     </p>
                 </div>
@@ -820,16 +820,16 @@ export function CreatePackingList() {
                             {...register('endDate')}
                         />
                     </div>
-                    <p className="mt-1 text-xs text-gray-500">
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                         Where you're going and when — shown on your lists so you can tell trips apart.
                     </p>
                 </div>
 
                 {/* Person Selection */}
                 {questionSet.people.length > 0 && (
-                    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+                    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
                         <div className="flex items-center justify-between mb-4">
-                            <h3 className="text-lg font-medium text-gray-900">
+                            <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
                                 Who is going on this trip?
                             </h3>
                             <button
@@ -865,10 +865,10 @@ export function CreatePackingList() {
                                         color={personColorFor(person, personIndex)}
                                         size="sm"
                                     />
-                                    <span className="text-gray-700">
+                                    <span className="text-gray-700 dark:text-gray-300">
                                         {person.name}
                                         {person.ageRange && (
-                                            <span className="ml-2 text-sm text-gray-500">({person.ageRange})</span>
+                                            <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">({person.ageRange})</span>
                                         )}
                                     </span>
                                 </label>
@@ -882,11 +882,11 @@ export function CreatePackingList() {
                     const questionType = question.questionType || "single-choice"
 
                     return (
-                    <div key={question.id} className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-                        <h3 className="text-lg font-medium text-gray-900 mb-4">
+                    <div key={question.id} className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
+                        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
                             {question.text}
                             {questionType === "multiple-choice" && (
-                                <span className="ml-2 text-sm text-gray-500">(select all that apply)</span>
+                                <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">(select all that apply)</span>
                             )}
                         </h3>
                         <input
@@ -905,7 +905,7 @@ export function CreatePackingList() {
                                             {...register(`questionAnswers.${index}.selectedOptionIds.0`)}
                                             className="h-4 w-4 text-blue-600"
                                         />
-                                        <span className="text-gray-700">{option.text}</span>
+                                        <span className="text-gray-700 dark:text-gray-300">{option.text}</span>
                                     </label>
                                 ))
                             ) : (
@@ -932,7 +932,7 @@ export function CreatePackingList() {
                                             }}
                                             className="h-4 w-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
                                         />
-                                        <span className="text-gray-700">{option.text}</span>
+                                        <span className="text-gray-700 dark:text-gray-300">{option.text}</span>
                                     </label>
                                     )
                                 })

--- a/src/pages/foreign-packing-lists.tsx
+++ b/src/pages/foreign-packing-lists.tsx
@@ -42,8 +42,8 @@ export function ForeignPackingListsPage() {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
                 <div className="mb-8">
-                    <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
-                    <p className="mt-2 text-lg text-gray-700 font-medium">Shared packing lists.</p>
+                    <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">📦 Packing Lists</h1>
+                    <p className="mt-2 text-lg text-gray-700 dark:text-gray-300 font-medium">Shared packing lists.</p>
                 </div>
                 <LoadingState message="Loading packing lists..." rows={3} />
             </div>
@@ -51,21 +51,21 @@ export function ForeignPackingListsPage() {
     }
 
     const gradients = [
-        'from-primary-50 to-primary-100 border-primary-300',
-        'from-secondary-50 to-secondary-100 border-secondary-300',
-        'from-accent-50 to-accent-100 border-accent-300',
-        'from-success-50 to-success-100 border-success-300',
+        'from-primary-50 dark:from-primary-950/40 to-primary-100 dark:to-primary-900/30 border-primary-300 dark:border-primary-700',
+        'from-secondary-50 dark:from-secondary-950/40 to-secondary-100 dark:to-secondary-900/30 border-secondary-300 dark:border-secondary-700',
+        'from-accent-50 dark:from-accent-950/40 to-accent-100 dark:to-accent-900/30 border-accent-300 dark:border-accent-700',
+        'from-success-50 dark:from-success-950/40 to-success-100 dark:to-success-900/30 border-success-300 dark:border-success-700',
     ]
 
     return (
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8">
-                <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
-                <p className="mt-2 text-lg text-gray-700 font-medium">Shared packing lists.</p>
+                <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">📦 Packing Lists</h1>
+                <p className="mt-2 text-lg text-gray-700 dark:text-gray-300 font-medium">Shared packing lists.</p>
             </div>
             {lists.length === 0 ? (
-                <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
-                    <p className="text-lg text-gray-800 font-semibold">No packing lists found.</p>
+                <div className="text-center py-12 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft">
+                    <p className="text-lg text-gray-800 dark:text-gray-200 font-semibold">No packing lists found.</p>
                 </div>
             ) : (
                 <div className="space-y-4">
@@ -83,15 +83,15 @@ export function ForeignPackingListsPage() {
                                 className={`bg-gradient-to-br ${gradient} rounded-2xl shadow-soft border-2 p-6 hover:shadow-glow-primary hover:scale-[1.02] transition-all duration-200 cursor-pointer`}
                             >
                                 <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
-                                    <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2 flex-wrap">
+                                    <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2 flex-wrap">
                                         ✈️ {list.name}
                                         {list.destination && (
-                                            <span className="text-xs font-medium bg-white/60 text-gray-700 border border-gray-200 px-2 py-0.5 rounded-full">
+                                            <span className="text-xs font-medium bg-white/60 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700 px-2 py-0.5 rounded-full">
                                                 📍 {list.destination}
                                             </span>
                                         )}
                                     </h3>
-                                    <span className="text-sm font-medium text-gray-600 bg-white/60 px-3 py-1 rounded-lg self-start sm:self-auto">
+                                    <span className="text-sm font-medium text-gray-600 dark:text-gray-400 bg-white/60 px-3 py-1 rounded-lg self-start sm:self-auto">
                                         {tripDates
                                             ? `📅 ${tripDates}`
                                             : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
@@ -104,7 +104,7 @@ export function ForeignPackingListsPage() {
                                             style={{ width: `${displayWidth}%` }}
                                         />
                                     </div>
-                                    <span className="text-sm font-bold text-gray-700 bg-white/60 px-3 py-1 rounded-lg">
+                                    <span className="text-sm font-bold text-gray-700 dark:text-gray-300 bg-white/60 px-3 py-1 rounded-lg">
                                         {packed} / {total} ({percent}%)
                                     </span>
                                 </div>

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -11,42 +11,42 @@ export const LandingPage = () => {
     return (
         <>
             {isLoggedIn && (
-                <div className="mb-6 p-4 bg-gradient-to-r from-success-50 to-primary-50 border-2 border-success-300 rounded-2xl shadow-soft animate-fade-in">
-                    <p className="text-success-800 font-semibold">
+                <div className="mb-6 p-4 bg-gradient-to-r from-success-50 dark:from-success-950/40 to-primary-50 dark:to-primary-950/40 border-2 border-success-300 dark:border-success-700 rounded-2xl shadow-soft animate-fade-in">
+                    <p className="text-success-800 dark:text-success-300 font-semibold">
                         🎉 Logged in as: <span className="font-bold">{webId}</span>
                     </p>
                 </div>
             )}
             <div className="max-w-4xl mx-auto">
                 <div className="text-center mb-12 animate-slide-up">
-                    <h1 className="text-5xl font-bold mb-4 text-primary-900">
+                    <h1 className="text-5xl font-bold mb-4 text-primary-900 dark:text-primary-200">
                         Smart Packing Lists, Made Simple
                     </h1>
                 </div>
 
                 <div className="mb-12">
-                    <h2 className="text-center text-sm font-semibold uppercase tracking-widest text-gray-500 mb-6">How it works</h2>
+                    <h2 className="text-center text-sm font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400 mb-6">How it works</h2>
                     <div className="grid md:grid-cols-3 gap-6">
-                        <div className="bg-gradient-to-br from-primary-50 to-primary-100 p-6 rounded-2xl shadow-soft hover:shadow-glow-primary transition-all duration-300 hover:scale-105 border-2 border-primary-200">
+                        <div className="bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-primary-100 dark:to-primary-900/30 p-6 rounded-2xl shadow-soft hover:shadow-glow-primary transition-all duration-300 hover:scale-105 border-2 border-primary-200 dark:border-primary-800">
                             <div className="text-3xl mb-2">✨</div>
-                            <h3 className="text-xl font-bold mb-3 text-primary-900">1. Set up once</h3>
-                            <p className="text-gray-700">
+                            <h3 className="text-xl font-bold mb-3 text-primary-900 dark:text-primary-200">1. Set up once</h3>
+                            <p className="text-gray-700 dark:text-gray-300">
                                 Run the quick wizard — tell us who you travel with and we'll generate a starter set of packing questions for you.
                             </p>
                         </div>
 
-                        <div className="bg-gradient-to-br from-secondary-50 to-secondary-100 p-6 rounded-2xl shadow-soft hover:shadow-glow-secondary transition-all duration-300 hover:scale-105 border-2 border-secondary-200">
+                        <div className="bg-gradient-to-br from-secondary-50 dark:from-secondary-950/40 to-secondary-100 dark:to-secondary-900/30 p-6 rounded-2xl shadow-soft hover:shadow-glow-secondary transition-all duration-300 hover:scale-105 border-2 border-secondary-200 dark:border-secondary-800">
                             <div className="text-3xl mb-2">✏️</div>
-                            <h3 className="text-xl font-bold mb-3 text-secondary-900">2. Fine-tune your questions</h3>
-                            <p className="text-gray-700">
+                            <h3 className="text-xl font-bold mb-3 text-secondary-900 dark:text-secondary-200">2. Fine-tune your questions</h3>
+                            <p className="text-gray-700 dark:text-gray-300">
                                 Add, remove, and customise questions and packing items until they perfectly match how you travel.
                             </p>
                         </div>
 
-                        <div className="bg-gradient-to-br from-success-50 to-success-100 p-6 rounded-2xl shadow-soft hover:shadow-lg transition-all duration-300 hover:scale-105 border-2 border-success-200">
+                        <div className="bg-gradient-to-br from-success-50 dark:from-success-950/40 to-success-100 dark:to-success-900/30 p-6 rounded-2xl shadow-soft hover:shadow-lg transition-all duration-300 hover:scale-105 border-2 border-success-200 dark:border-success-800">
                             <div className="text-3xl mb-2">📋</div>
-                            <h3 className="text-xl font-bold mb-3 text-success-900">3. Pack for every trip</h3>
-                            <p className="text-gray-700">
+                            <h3 className="text-xl font-bold mb-3 text-success-900 dark:text-success-200">3. Pack for every trip</h3>
+                            <p className="text-gray-700 dark:text-gray-300">
                                 Before each trip, answer your questions to instantly generate a personalised packing list.
                             </p>
                         </div>
@@ -75,13 +75,13 @@ export const LandingPage = () => {
                     )}
                 </div>
 
-                <div className="mt-10 p-4 rounded-xl border border-gray-200 bg-gray-50 text-center text-sm text-gray-500">
-                    <h2 className="font-semibold text-gray-600 inline">Own Your Data</h2>
+                <div className="mt-10 p-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-center text-sm text-gray-500 dark:text-gray-400">
+                    <h2 className="font-semibold text-gray-600 dark:text-gray-400 inline">Own Your Data</h2>
                     {' '}— Login with your Solid Pod to store your lists in your own free personal storage you control. Your data saves locally in your browser automatically, even without an account.
                     {!isLoggedIn && (
                         <span className="block mt-1">
                             <button
-                                className="font-semibold text-primary-700 underline hover:text-primary-900"
+                                className="font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-300"
                                 onClick={() => setIsProviderSelectorOpen(true)}
                             >
                                 Get a free Solid Pod

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -10,6 +10,12 @@ vi.mock('../utils/uuid', () => ({
 }))
 
 const mockNavigate = vi.fn()
+
+// Duplicate and Delete live behind each card's three-dot menu.
+// Radix opens its dropdown on pointerdown, not click.
+function openCardMenu() {
+    fireEvent.pointerDown(screen.getAllByRole('button', { name: /more actions/i })[0], { button: 0 })
+}
 vi.mock('react-router-dom', async (importOriginal) => {
     const actual = await importOriginal<typeof import('react-router-dom')>()
     return { ...actual, useNavigate: () => mockNavigate }
@@ -234,6 +240,8 @@ describe('PackingLists delete confirmation', () => {
 
         await screen.findByText(/Summer Holiday/)
 
+        openCardMenu()
+
         fireEvent.click(screen.getByText('🗑️ Delete'))
 
         expect(db.deletePackingList).not.toHaveBeenCalled()
@@ -246,6 +254,8 @@ describe('PackingLists delete confirmation', () => {
         renderComponent()
 
         await screen.findByText(/Summer Holiday/)
+
+        openCardMenu()
 
         fireEvent.click(screen.getByText('🗑️ Delete'))
 
@@ -262,6 +272,8 @@ describe('PackingLists delete confirmation', () => {
         renderComponent()
 
         await screen.findByText(/Summer Holiday/)
+
+        openCardMenu()
 
         fireEvent.click(screen.getByText('🗑️ Delete'))
 
@@ -282,6 +294,8 @@ describe('PackingLists delete confirmation', () => {
         renderComponent()
 
         await screen.findByText(/Summer Holiday/)
+
+        openCardMenu()
 
         fireEvent.click(screen.getByText('🗑️ Delete'))
 
@@ -409,7 +423,7 @@ describe('PackingLists duplicate', () => {
         })
     })
 
-    it('shows a Duplicate button on each list card', async () => {
+    it('offers Duplicate in each card\'s three-dot menu', async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
@@ -417,7 +431,8 @@ describe('PackingLists duplicate', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        expect(screen.getByRole('button', { name: /duplicate/i })).toBeTruthy()
+        openCardMenu()
+        expect(screen.getByRole('menuitem', { name: /duplicate/i })).toBeTruthy()
     })
 
     it('calls savePackingList with a new list named "Copy of {name}" when Duplicate is clicked', async () => {
@@ -428,7 +443,9 @@ describe('PackingLists duplicate', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByRole('button', { name: /duplicate/i }))
+        openCardMenu()
+
+        fireEvent.click(screen.getByRole('menuitem', { name: /duplicate/i }))
 
         await waitFor(() => {
             expect(db.savePackingList).toHaveBeenCalledWith(
@@ -527,7 +544,9 @@ describe('PackingLists pod sync on mutation', () => {
         renderComponent()
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByRole('button', { name: /duplicate/i }))
+        openCardMenu()
+
+        fireEvent.click(screen.getByRole('menuitem', { name: /duplicate/i }))
 
         await waitFor(() => {
             expect(mockSaveRdfToPod).toHaveBeenCalledWith(
@@ -544,6 +563,8 @@ describe('PackingLists pod sync on mutation', () => {
 
         renderComponent()
         await screen.findByText(/Summer Holiday/)
+
+        openCardMenu()
 
         fireEvent.click(screen.getByText('🗑️ Delete'))
         await screen.findByText(/cannot be undone/i)
@@ -571,7 +592,9 @@ describe('PackingLists pod sync on mutation', () => {
         renderComponent()
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByRole('button', { name: /duplicate/i }))
+        openCardMenu()
+
+        fireEvent.click(screen.getByRole('menuitem', { name: /duplicate/i }))
 
         await waitFor(() => {
             expect(makeDb().savePackingList).toBeDefined()
@@ -587,8 +610,10 @@ describe('PackingLists trip destination and dates', () => {
         name: 'Summer Holiday',
         createdAt: '2026-01-01T00:00:00Z',
         destination: 'Lisbon, Portugal',
-        startDate: '2026-07-12',
-        endDate: '2026-07-19',
+        // Far-future dates: these tests are about display, and a past trip
+        // would fold away behind the history accordion
+        startDate: '2099-07-12',
+        endDate: '2099-07-19',
         items: [],
     }
 
@@ -631,7 +656,7 @@ describe('PackingLists trip destination and dates', () => {
         renderWithList(tripList)
         await screen.findByText(/Summer Holiday/)
 
-        const expected = `${localDate(2026, 6, 12)} – ${localDate(2026, 6, 19)}`
+        const expected = `${localDate(2099, 6, 12)} – ${localDate(2099, 6, 19)}`
         expect(screen.getByText(new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))).toBeTruthy()
         expect(screen.queryByText(/📅 Created/)).toBeNull()
     })
@@ -648,5 +673,75 @@ describe('PackingLists trip destination and dates', () => {
         await screen.findByText(/Summer Holiday/)
 
         expect(screen.queryByText(/📍/)).toBeNull()
+    })
+})
+
+describe('PackingLists past trips accordion', () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ now: new Date(2026, 6, 31), shouldAdvanceTime: true })
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn().mockResolvedValue([
+                    { id: 'l-now', name: 'Upcoming Trip', createdAt: '2026-07-01T00:00:00Z', startDate: '2026-08-02', endDate: '2026-08-08', items: [] },
+                    { id: 'l-past', name: 'Old Trip', createdAt: '2026-06-01T00:00:00Z', startDate: '2026-06-01', endDate: '2026-06-08', items: [] },
+                    { id: 'l-undated', name: 'Undated List', createdAt: '2026-07-25T00:00:00Z', items: [] },
+                ]),
+                deletePackingList: vi.fn(),
+                savePackingList: vi.fn(),
+                getSharedListsWithMe: vi.fn().mockResolvedValue({ lists: [], lastModified: '' }),
+            } as unknown as PackingAppDatabase,
+        })
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.restoreAllMocks()
+    })
+
+    it('folds past trips behind a collapsed accordion, keeping current and undated lists visible', async () => {
+        renderComponent()
+
+        await screen.findByText(/Upcoming Trip/)
+        expect(screen.getByText(/Undated List/)).toBeTruthy()
+        expect(screen.queryByText(/Old Trip/)).toBeNull()
+        expect(screen.getByRole('button', { name: /past trips \(1\)/i })).toBeTruthy()
+    })
+
+    it('reveals and hides past trips when the accordion is toggled', async () => {
+        renderComponent()
+
+        await screen.findByText(/Upcoming Trip/)
+        const toggle = screen.getByRole('button', { name: /past trips \(1\)/i })
+
+        fireEvent.click(toggle)
+        expect(screen.getByText(/Old Trip/)).toBeTruthy()
+
+        fireEvent.click(toggle)
+        expect(screen.queryByText(/Old Trip/)).toBeNull()
+    })
+
+    it('shows no accordion when nothing is in the past', async () => {
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn().mockResolvedValue([
+                    { id: 'l-now', name: 'Upcoming Trip', createdAt: '2026-07-01T00:00:00Z', startDate: '2026-08-02', endDate: '2026-08-08', items: [] },
+                ]),
+                deletePackingList: vi.fn(),
+                savePackingList: vi.fn(),
+                getSharedListsWithMe: vi.fn().mockResolvedValue({ lists: [], lastModified: '' }),
+            } as unknown as PackingAppDatabase,
+        })
+        renderComponent()
+
+        await screen.findByText(/Upcoming Trip/)
+        expect(screen.queryByRole('button', { name: /past trips/i })).toBeNull()
     })
 })

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom'
 import { PackingList } from '../create-packing-list/types'
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
+import { ChevronDown, EllipsisVertical, Plus } from 'lucide-react'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { LoadingState } from '../components/LoadingState'
@@ -12,7 +14,7 @@ import { useOwnerDisplayNames } from '../hooks/useOwnerDisplayName'
 import { packingListToDataset } from '../services/rdfSerialization'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { generateUUID } from '../utils/uuid'
-import { formatTripDates } from '../create-packing-list/tripDetails'
+import { formatTripDates, tripIsPast } from '../create-packing-list/tripDetails'
 
 type SharingStatus = 'public' | 'shared' | 'private'
 
@@ -22,6 +24,8 @@ export function PackingLists() {
     const [listToDelete, setListToDelete] = useState<{ id: string; name: string } | null>(null)
     const [listToRename, setListToRename] = useState<{ id: string; name: string } | null>(null)
     const [renameValue, setRenameValue] = useState('')
+    // Past trips fold away by default — they're history, not planning
+    const [showPast, setShowPast] = useState(false)
     const [sharingStatus, setSharingStatus] = useState<Record<string, SharingStatus>>({})
     const navigate = useNavigate()
     const { isLoggedIn, session } = useSolidPod()
@@ -34,8 +38,7 @@ export function PackingLists() {
     const { db, loginSyncVersion, loginSyncInProgress } = useDatabase()
     const handlePodError = usePodErrorHandler()
 
-    const requestDeletePackingList = (id: string, name: string, event: React.MouseEvent) => {
-        event.stopPropagation()
+    const requestDeletePackingList = (id: string, name: string) => {
         setListToDelete({ id, name })
     }
 
@@ -61,8 +64,7 @@ export function PackingLists() {
         }
     }
 
-    const handleDuplicatePackingList = async (list: PackingList, event: React.MouseEvent) => {
-        event.stopPropagation()
+    const handleDuplicatePackingList = async (list: PackingList) => {
         try {
             const newList: PackingList = {
                 id: generateUUID(),
@@ -155,6 +157,132 @@ export function PackingLists() {
         }).catch(() => {})
     }, [packingLists, isLoggedIn, session])
 
+    // A finished trip is history, not planning: fold it away below the
+    // lists that still matter, behind one accordion row.
+    const currentLists = packingLists.filter(l => !tripIsPast(l.startDate, l.endDate))
+    const pastLists = packingLists.filter(l => tripIsPast(l.startDate, l.endDate))
+
+    const renderListCard = (list: PackingList, index: number) => {
+        const packedCount = list.items.filter(item => item.packed).length
+        const totalCount = list.items.length
+        const percentComplete = totalCount > 0 ? Math.round((packedCount / totalCount) * 100) : 0
+        const displayWidth = packedCount === 0 ? 0 : Math.max(percentComplete, 4)
+
+        // Rotate through gradient colors
+        const gradients = [
+            'from-primary-50 to-primary-100 border-primary-300',
+            'from-secondary-50 to-secondary-100 border-secondary-300',
+            'from-accent-50 to-accent-100 border-accent-300',
+            'from-success-50 to-success-100 border-success-300'
+        ]
+        const gradient = gradients[index % gradients.length]
+
+        // Trip dates are what the traveller cares about; the
+        // creation date is only worth showing when there are none.
+        const tripDates = formatTripDates(list.startDate, list.endDate)
+
+        return (
+            <div
+                key={list.id}
+                onClick={() => {
+                    if (list.sharedFromPodUrl) {
+                        navigate(buildSharedListPath(list.id, list.sharedFromPodUrl, list.ownerWebId))
+                    } else {
+                        navigate(`/view-lists/${list.id}`)
+                    }
+                }}
+                className={`bg-gradient-to-br ${gradient} rounded-2xl shadow-soft border-2 p-6 hover:shadow-glow-primary hover:scale-[1.02] transition-all duration-200 cursor-pointer`}
+            >
+                <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
+                    <div className="min-w-0">
+                    <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2 flex-wrap">
+                        ✈️ {list.name}
+                        {list.sharedFromPodUrl ? (
+                            <span className="text-xs font-medium bg-white/60 text-indigo-700 border border-indigo-200 px-2 py-0.5 rounded-full">
+                                👤 From {resolveOwnerDisplayName(ownerNames[list.id], list.ownerWebId, list.sharedFromPodUrl)}
+                            </span>
+                        ) : (
+                            <>
+                                {sharingStatus[list.id] === 'public' && (
+                                    <span className="text-xs font-medium bg-white/60 text-blue-700 px-2 py-0.5 rounded-full">🌐 Public</span>
+                                )}
+                                {sharingStatus[list.id] === 'shared' && (
+                                    <span className="text-xs font-medium bg-white/60 text-indigo-700 px-2 py-0.5 rounded-full">👤 Shared</span>
+                                )}
+                            </>
+                        )}
+                    </h3>
+                    {/* On its own line so a long destination never
+                        pushes the actions onto a second row */}
+                    {list.destination && (
+                        <p className="mt-1 text-sm text-gray-600 truncate">📍 {list.destination}</p>
+                    )}
+                    </div>
+                    <div data-testid="list-actions" className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-medium text-gray-600 bg-white/60 px-3 py-1 rounded-lg">
+                            {tripDates
+                                ? `📅 ${tripDates}`
+                                : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
+                        </span>
+                        <button
+                            onClick={(e) => requestRenamePackingList(list.id, list.name, e)}
+                            className="text-primary-600 hover:text-primary-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
+                        >
+                            ✏️ Rename
+                        </button>
+                        <DropdownMenu.Root>
+                            <DropdownMenu.Trigger asChild>
+                                <button
+                                    aria-label={`More actions for ${list.name}`}
+                                    title="More actions"
+                                    // The card itself navigates on click; a tap on the
+                                    // menu must not also open the list
+                                    onClick={(e) => e.stopPropagation()}
+                                    className="p-1.5 rounded-lg text-gray-600 hover:text-gray-900 bg-white/60 hover:bg-white transition-colors"
+                                >
+                                    <EllipsisVertical className="w-4 h-4" aria-hidden="true" />
+                                </button>
+                            </DropdownMenu.Trigger>
+                            <DropdownMenu.Portal>
+                                <DropdownMenu.Content
+                                    align="end"
+                                    sideOffset={4}
+                                    className="w-36 bg-white rounded-lg shadow-lg border border-gray-100 py-1 z-50"
+                                    onClick={(e) => e.stopPropagation()}
+                                >
+                                    <DropdownMenu.Item
+                                        onSelect={() => handleDuplicatePackingList(list)}
+                                        className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 cursor-default outline-none"
+                                    >
+                                        📋 Duplicate
+                                    </DropdownMenu.Item>
+                                    <DropdownMenu.Item
+                                        onSelect={() => requestDeletePackingList(list.id, list.name)}
+                                        className="px-4 py-2.5 text-sm text-danger-600 hover:bg-danger-50 cursor-default outline-none"
+                                    >
+                                        🗑️ Delete
+                                    </DropdownMenu.Item>
+                                </DropdownMenu.Content>
+                            </DropdownMenu.Portal>
+                        </DropdownMenu.Root>
+                    </div>
+                </div>
+                <div className="flex items-center gap-4">
+                    <div className="flex-1 bg-white/40 rounded-full h-3 overflow-hidden">
+                        <div
+                            data-testid="progress-fill"
+                            className="progress-bar-fill bg-gradient-primary h-full rounded-full"
+                            style={{ width: `${displayWidth}%` }}
+                        ></div>
+                    </div>
+                    <span className="text-sm font-bold text-gray-700 bg-white/60 px-3 py-1 rounded-lg">
+                        {packedCount} / {totalCount} ({percentComplete}%)
+                    </span>
+                </div>
+            </div>
+        )
+    }
+
     if (isLoading || loginSyncInProgress) {
         // Keep the real header in place so only the list area changes when the
         // lists land.
@@ -162,10 +290,10 @@ export function PackingLists() {
             <div className="max-w-4xl mx-auto py-8 px-4">
                 <div className="mb-8 flex justify-between items-start">
                     <div className="mb-2">
-                        <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
-                        <p className="mt-2 text-lg text-gray-700 font-medium">View all your created packing lists.</p>
+                        <h1 className="text-2xl font-bold text-gray-900">📦 Packing Lists</h1>
+                        <p className="mt-1 text-gray-600 text-sm">View all your created packing lists.</p>
                     </div>
-                    <Button variant="primary" onClick={() => navigate('/create-packing-list')}>➕ New List</Button>
+                    <Button variant="primary" className="inline-flex items-center gap-1.5" onClick={() => navigate('/create-packing-list')}><Plus className="w-4 h-4" aria-hidden="true" />New List</Button>
                 </div>
                 <LoadingState message="Loading packing lists..." rows={3} />
             </div>
@@ -176,10 +304,10 @@ export function PackingLists() {
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8 flex justify-between items-start">
                 <div className="mb-2">
-                    <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
-                    <p className="mt-2 text-lg text-gray-700 font-medium">View all your created packing lists.</p>
+                    <h1 className="text-2xl font-bold text-gray-900">📦 Packing Lists</h1>
+                    <p className="mt-1 text-gray-600 text-sm">View all your created packing lists.</p>
                 </div>
-                <Button variant="primary" onClick={() => navigate('/create-packing-list')}>➕ New List</Button>
+                <Button variant="primary" className="inline-flex items-center gap-1.5" onClick={() => navigate('/create-packing-list')}><Plus className="w-4 h-4" aria-hidden="true" />New List</Button>
             </div>
 
             {packingLists.length === 0 ? (
@@ -189,105 +317,32 @@ export function PackingLists() {
                     </p>
                 </div>
             ) : (
-                <div className="space-y-4">
-                    {packingLists.map((list, index) => {
-                        const packedCount = list.items.filter(item => item.packed).length
-                        const totalCount = list.items.length
-                        const percentComplete = totalCount > 0 ? Math.round((packedCount / totalCount) * 100) : 0
-                        const displayWidth = packedCount === 0 ? 0 : Math.max(percentComplete, 4)
-
-                        // Rotate through gradient colors
-                        const gradients = [
-                            'from-primary-50 to-primary-100 border-primary-300',
-                            'from-secondary-50 to-secondary-100 border-secondary-300',
-                            'from-accent-50 to-accent-100 border-accent-300',
-                            'from-success-50 to-success-100 border-success-300'
-                        ]
-                        const gradient = gradients[index % gradients.length]
-
-                        // Trip dates are what the traveller cares about; the
-                        // creation date is only worth showing when there are none.
-                        const tripDates = formatTripDates(list.startDate, list.endDate)
-
-                        return (
-                            <div
-                                key={list.id}
-                                onClick={() => {
-                                    if (list.sharedFromPodUrl) {
-                                        navigate(buildSharedListPath(list.id, list.sharedFromPodUrl, list.ownerWebId))
-                                    } else {
-                                        navigate(`/view-lists/${list.id}`)
-                                    }
-                                }}
-                                className={`bg-gradient-to-br ${gradient} rounded-2xl shadow-soft border-2 p-6 hover:shadow-glow-primary hover:scale-[1.02] transition-all duration-200 cursor-pointer`}
+                <>
+                    <div className="space-y-4">
+                        {currentLists.map(renderListCard)}
+                    </div>
+                    {pastLists.length > 0 && (
+                        <div className="mt-8">
+                            <button
+                                type="button"
+                                onClick={() => setShowPast(v => !v)}
+                                aria-expanded={showPast}
+                                className="flex items-center gap-2 text-sm font-semibold text-gray-600 hover:text-gray-900 transition-colors"
                             >
-                                <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
-                                    <div className="min-w-0">
-                                    <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2 flex-wrap">
-                                        ✈️ {list.name}
-                                        {list.sharedFromPodUrl ? (
-                                            <span className="text-xs font-medium bg-white/60 text-indigo-700 border border-indigo-200 px-2 py-0.5 rounded-full">
-                                                👤 From {resolveOwnerDisplayName(ownerNames[list.id], list.ownerWebId, list.sharedFromPodUrl)}
-                                            </span>
-                                        ) : (
-                                            <>
-                                                {sharingStatus[list.id] === 'public' && (
-                                                    <span className="text-xs font-medium bg-white/60 text-blue-700 px-2 py-0.5 rounded-full">🌐 Public</span>
-                                                )}
-                                                {sharingStatus[list.id] === 'shared' && (
-                                                    <span className="text-xs font-medium bg-white/60 text-indigo-700 px-2 py-0.5 rounded-full">👤 Shared</span>
-                                                )}
-                                            </>
-                                        )}
-                                    </h3>
-                                    {/* On its own line so a long destination never
-                                        pushes the actions onto a second row */}
-                                    {list.destination && (
-                                        <p className="mt-1 text-sm text-gray-600 truncate">📍 {list.destination}</p>
-                                    )}
-                                    </div>
-                                    <div data-testid="list-actions" className="flex items-center gap-2 flex-wrap">
-                                        <span className="text-sm font-medium text-gray-600 bg-white/60 px-3 py-1 rounded-lg">
-                                            {tripDates
-                                                ? `📅 ${tripDates}`
-                                                : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
-                                        </span>
-                                        <button
-                                            onClick={(e) => requestRenamePackingList(list.id, list.name, e)}
-                                            className="text-primary-600 hover:text-primary-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
-                                        >
-                                            ✏️ Rename
-                                        </button>
-                                        <button
-                                            onClick={(e) => handleDuplicatePackingList(list, e)}
-                                            className="text-secondary-600 hover:text-secondary-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
-                                        >
-                                            📋 Duplicate
-                                        </button>
-                                        <button
-                                            onClick={(e) => requestDeletePackingList(list.id, list.name, e)}
-                                            className="text-danger-600 hover:text-danger-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
-                                        >
-                                            🗑️ Delete
-                                        </button>
-                                    </div>
+                                <ChevronDown
+                                    className={`w-4 h-4 transition-transform ${showPast ? '' : '-rotate-90'}`}
+                                    aria-hidden="true"
+                                />
+                                Past trips ({pastLists.length})
+                            </button>
+                            {showPast && (
+                                <div className="space-y-4 mt-4">
+                                    {pastLists.map(renderListCard)}
                                 </div>
-                                <div className="flex items-center gap-4">
-                                    <div className="flex-1 bg-white/40 rounded-full h-3 overflow-hidden">
-                                        <div
-                                            data-testid="progress-fill"
-                                            className="progress-bar-fill bg-gradient-primary h-full rounded-full"
-                                            style={{ width: `${displayWidth}%` }}
-                                        ></div>
-                                    </div>
-                                    <span className="text-sm font-bold text-gray-700 bg-white/60 px-3 py-1 rounded-lg">
-                                        {packedCount} / {totalCount} ({percentComplete}%)
-                                    </span>
-                                </div>
-                            </div>
-                        )
-                    })}
-                </div>
+                            )}
+                        </div>
+                    )}
+                </>
             )}
 
             <ConfirmationDialog

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -170,10 +170,10 @@ export function PackingLists() {
 
         // Rotate through gradient colors
         const gradients = [
-            'from-primary-50 to-primary-100 border-primary-300',
-            'from-secondary-50 to-secondary-100 border-secondary-300',
-            'from-accent-50 to-accent-100 border-accent-300',
-            'from-success-50 to-success-100 border-success-300'
+            'from-primary-50 dark:from-primary-950/40 to-primary-100 dark:to-primary-900/30 border-primary-300 dark:border-primary-700',
+            'from-secondary-50 dark:from-secondary-950/40 to-secondary-100 dark:to-secondary-900/30 border-secondary-300 dark:border-secondary-700',
+            'from-accent-50 dark:from-accent-950/40 to-accent-100 dark:to-accent-900/30 border-accent-300 dark:border-accent-700',
+            'from-success-50 dark:from-success-950/40 to-success-100 dark:to-success-900/30 border-success-300 dark:border-success-700'
         ]
         const gradient = gradients[index % gradients.length]
 
@@ -195,7 +195,7 @@ export function PackingLists() {
             >
                 <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
                     <div className="min-w-0">
-                    <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2 flex-wrap">
+                    <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2 flex-wrap">
                         ✈️ {list.name}
                         {list.sharedFromPodUrl ? (
                             <span className="text-xs font-medium bg-white/60 text-indigo-700 border border-indigo-200 px-2 py-0.5 rounded-full">
@@ -215,18 +215,18 @@ export function PackingLists() {
                     {/* On its own line so a long destination never
                         pushes the actions onto a second row */}
                     {list.destination && (
-                        <p className="mt-1 text-sm text-gray-600 truncate">📍 {list.destination}</p>
+                        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 truncate">📍 {list.destination}</p>
                     )}
                     </div>
                     <div data-testid="list-actions" className="flex items-center gap-2 flex-wrap">
-                        <span className="text-sm font-medium text-gray-600 bg-white/60 px-3 py-1 rounded-lg">
+                        <span className="text-sm font-medium text-gray-600 dark:text-gray-400 bg-white/60 px-3 py-1 rounded-lg">
                             {tripDates
                                 ? `📅 ${tripDates}`
                                 : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
                         </span>
                         <button
                             onClick={(e) => requestRenamePackingList(list.id, list.name, e)}
-                            className="text-primary-600 hover:text-primary-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
+                            className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-300 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
                         >
                             ✏️ Rename
                         </button>
@@ -238,7 +238,7 @@ export function PackingLists() {
                                     // The card itself navigates on click; a tap on the
                                     // menu must not also open the list
                                     onClick={(e) => e.stopPropagation()}
-                                    className="p-1.5 rounded-lg text-gray-600 hover:text-gray-900 bg-white/60 hover:bg-white transition-colors"
+                                    className="p-1.5 rounded-lg text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 bg-white/60 hover:bg-white dark:hover:bg-gray-700 transition-colors"
                                 >
                                     <EllipsisVertical className="w-4 h-4" aria-hidden="true" />
                                 </button>
@@ -247,18 +247,18 @@ export function PackingLists() {
                                 <DropdownMenu.Content
                                     align="end"
                                     sideOffset={4}
-                                    className="w-36 bg-white rounded-lg shadow-lg border border-gray-100 py-1 z-50"
+                                    className="w-36 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-100 dark:border-gray-800 py-1 z-50"
                                     onClick={(e) => e.stopPropagation()}
                                 >
                                     <DropdownMenu.Item
                                         onSelect={() => handleDuplicatePackingList(list)}
-                                        className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 cursor-default outline-none"
+                                        className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none"
                                     >
                                         📋 Duplicate
                                     </DropdownMenu.Item>
                                     <DropdownMenu.Item
                                         onSelect={() => requestDeletePackingList(list.id, list.name)}
-                                        className="px-4 py-2.5 text-sm text-danger-600 hover:bg-danger-50 cursor-default outline-none"
+                                        className="px-4 py-2.5 text-sm text-danger-600 dark:text-danger-400 hover:bg-danger-50 dark:bg-danger-950/40 cursor-default outline-none"
                                     >
                                         🗑️ Delete
                                     </DropdownMenu.Item>
@@ -275,7 +275,7 @@ export function PackingLists() {
                             style={{ width: `${displayWidth}%` }}
                         ></div>
                     </div>
-                    <span className="text-sm font-bold text-gray-700 bg-white/60 px-3 py-1 rounded-lg">
+                    <span className="text-sm font-bold text-gray-700 dark:text-gray-300 bg-white/60 px-3 py-1 rounded-lg">
                         {packedCount} / {totalCount} ({percentComplete}%)
                     </span>
                 </div>
@@ -290,8 +290,8 @@ export function PackingLists() {
             <div className="max-w-4xl mx-auto py-8 px-4">
                 <div className="mb-8 flex justify-between items-start">
                     <div className="mb-2">
-                        <h1 className="text-2xl font-bold text-gray-900">📦 Packing Lists</h1>
-                        <p className="mt-1 text-gray-600 text-sm">View all your created packing lists.</p>
+                        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">📦 Packing Lists</h1>
+                        <p className="mt-1 text-gray-600 dark:text-gray-400 text-sm">View all your created packing lists.</p>
                     </div>
                     <Button variant="primary" className="inline-flex items-center gap-1.5" onClick={() => navigate('/create-packing-list')}><Plus className="w-4 h-4" aria-hidden="true" />New List</Button>
                 </div>
@@ -304,15 +304,15 @@ export function PackingLists() {
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8 flex justify-between items-start">
                 <div className="mb-2">
-                    <h1 className="text-2xl font-bold text-gray-900">📦 Packing Lists</h1>
-                    <p className="mt-1 text-gray-600 text-sm">View all your created packing lists.</p>
+                    <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">📦 Packing Lists</h1>
+                    <p className="mt-1 text-gray-600 dark:text-gray-400 text-sm">View all your created packing lists.</p>
                 </div>
                 <Button variant="primary" className="inline-flex items-center gap-1.5" onClick={() => navigate('/create-packing-list')}><Plus className="w-4 h-4" aria-hidden="true" />New List</Button>
             </div>
 
             {packingLists.length === 0 ? (
-                <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
-                    <p className="text-lg text-gray-800 font-semibold">
+                <div className="text-center py-12 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft">
+                    <p className="text-lg text-gray-800 dark:text-gray-200 font-semibold">
                         No packing lists found. Create your first packing list to get started! 🎒
                     </p>
                 </div>
@@ -327,7 +327,7 @@ export function PackingLists() {
                                 type="button"
                                 onClick={() => setShowPast(v => !v)}
                                 aria-expanded={showPast}
-                                className="flex items-center gap-2 text-sm font-semibold text-gray-600 hover:text-gray-900 transition-colors"
+                                className="flex items-center gap-2 text-sm font-semibold text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
                             >
                                 <ChevronDown
                                     className={`w-4 h-4 transition-transform ${showPast ? '' : '-rotate-90'}`}
@@ -362,7 +362,7 @@ export function PackingLists() {
                         type="text"
                         value={renameValue}
                         onChange={e => setRenameValue(e.target.value)}
-                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-400"
+                        className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-400"
                     />
                     <div className="flex gap-3 justify-end mt-4">
                         <Button variant="ghost" onClick={() => setListToRename(null)}>Cancel</Button>

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -6,18 +6,18 @@ export const PrivacyPolicyPage = () => {
     return (
         <div className="max-w-3xl mx-auto bg-white/60 rounded-2xl shadow-soft p-6 md:p-10 space-y-6">
             <div>
-                <h1 className="text-3xl font-bold text-primary-900 mb-1">Privacy Policy</h1>
-                <p className="text-sm text-gray-500">Last updated: {LAST_UPDATED}</p>
+                <h1 className="text-3xl font-bold text-primary-900 dark:text-primary-200 mb-1">Privacy Policy</h1>
+                <p className="text-sm text-gray-500 dark:text-gray-400">Last updated: {LAST_UPDATED}</p>
             </div>
 
-            <p className="text-gray-700">
+            <p className="text-gray-700 dark:text-gray-300">
                 Pack Me Up ("the app") helps you build and manage packing lists for your trips. This
                 policy explains what information the app handles, where it is stored, and who can see it.
             </p>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Information you provide</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Information you provide</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     The app stores the packing questions, items, and packing lists you create, including
                     any trip or traveller details you choose to enter (such as names or age brackets for
                     the people you're packing for). This information is provided directly by you and is
@@ -26,19 +26,19 @@ export const PrivacyPolicyPage = () => {
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Where your data is stored</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Where your data is stored</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     By default, your data is stored locally on your device, in your browser's or app's
                     local storage. It is not sent to any server we control.
                 </p>
-                <p className="text-gray-700">
+                <p className="text-gray-700 dark:text-gray-300">
                     If you choose to log in with a Solid Pod, your data is also saved to the personal Pod
                     you connect — storage that you own and control, hosted by the Pod provider you select.
                     We do not have our own servers that store your packing data; the app talks directly to
                     your Pod. You can revoke access or delete your data from your Pod at any time through
                     your Pod provider.
                 </p>
-                <p className="text-gray-700">
+                <p className="text-gray-700 dark:text-gray-300">
                     If you use the sharing feature, the packing lists or questions you choose to share are
                     made accessible to the specific people you share them with, via your Pod's access
                     controls.
@@ -46,13 +46,13 @@ export const PrivacyPolicyPage = () => {
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Deleting your data</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Deleting your data</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     You can delete everything the app has stored at any time — from this device, from
                     your Solid Pod, or both — on the{' '}
                     <Link
                         to="/your-data"
-                        className="font-semibold text-primary-700 underline hover:text-primary-900"
+                        className="font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-300"
                     >
                         Your data
                     </Link>{' '}
@@ -61,14 +61,14 @@ export const PrivacyPolicyPage = () => {
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Analytics and error reporting</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Analytics and error reporting</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     We use privacy-friendly, cookie-free analytics to understand overall app usage (such as
                     which pages are visited), and an error-reporting tool to help us diagnose crashes and
                     bugs. Error reports may include technical details like error messages, stack traces,
                     and device/browser information, but do not include the contents of your packing lists.
                 </p>
-                <p className="text-gray-700">
+                <p className="text-gray-700 dark:text-gray-300">
                     Neither is linked to you: we don't attach a name, email or account to them, and we
                     don't collect your IP address. That also means we have no way to single out one
                     person's crash reports or page views on request — there is no identifier to search
@@ -76,7 +76,7 @@ export const PrivacyPolicyPage = () => {
                     asks for your name and email, and emailing us tells us your address; see the{' '}
                     <Link
                         to="/your-data"
-                        className="font-semibold text-primary-700 underline hover:text-primary-900"
+                        className="font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-300"
                     >
                         Your data
                     </Link>{' '}
@@ -85,8 +85,8 @@ export const PrivacyPolicyPage = () => {
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">What we don't do</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">What we don't do</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     We do not sell your data, and we do not use your packing list contents for advertising.
                     We do not have accounts or passwords of our own — authentication, when used, is handled
                     by your chosen Solid Pod provider.
@@ -94,28 +94,28 @@ export const PrivacyPolicyPage = () => {
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Children's privacy</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Children's privacy</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     The app is not directed at children and is not designed to knowingly collect personal
                     information from children.
                 </p>
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Changes to this policy</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Changes to this policy</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     We may update this policy from time to time. Changes will be posted on this page with
                     an updated "Last updated" date.
                 </p>
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Contact us</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Contact us</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     If you have questions about this policy or your data, contact us at{' '}
                     <a
                         href="mailto:tim.packmeup@gmail.com"
-                        className="font-semibold text-primary-700 underline hover:text-primary-900"
+                        className="font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-300"
                     >
                         tim.packmeup@gmail.com
                     </a>

--- a/src/pages/questions-page.option-section.test.tsx
+++ b/src/pages/questions-page.option-section.test.tsx
@@ -329,7 +329,7 @@ describe('OptionSection adding items', () => {
         renderOption(sectioned())
         fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
         expect(screen.queryByTestId('add-to-section')).toBeNull()
-        expect(screen.queryByRole('button', { name: '+ Add item' })).toBeNull()
+        expect(screen.queryByRole('button', { name: 'Add item' })).toBeNull()
     })
 
     it('files an item under the section whose button was tapped', () => {
@@ -420,7 +420,7 @@ describe('OptionSection adding from the foot of the list', () => {
 
     it('offers an add row under an unsectioned list, which has no headings', () => {
         const { onItemAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }))
-        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Add item' }))
         const input = screen.getByRole('combobox')
         fireEvent.change(input, { target: { value: 'Hat' } })
         fireEvent.keyDown(input, { key: 'Enter' })
@@ -432,7 +432,7 @@ describe('OptionSection adding from the foot of the list', () => {
             makeOption({ items: [makeItem('Toothbrush', { category: 'Toiletries' })] }),
             ['Clothes'],
         )
-        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Add item' }))
         fireEvent.change(screen.getByRole('combobox'), { target: { value: 'H' } })
         const options = [...(screen.getByLabelText('Section') as HTMLSelectElement).options].map(o => o.value)
         expect(options).toEqual(['Yes', 'Toiletries', 'Clothes'])
@@ -442,7 +442,7 @@ describe('OptionSection adding from the foot of the list', () => {
         // A section is only ever a name stamped on an item, so an answer can be
         // given its first Toiletries item without anything being created first.
         const { onItemAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }), ['Toiletries'])
-        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Add item' }))
         const input = screen.getByRole('combobox')
         fireEvent.change(input, { target: { value: 'Razor' } })
         fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Toiletries' } })
@@ -452,13 +452,13 @@ describe('OptionSection adding from the foot of the list', () => {
 
     it('replaces the add row with the composer rather than showing both', () => {
         renderAddable(makeOption({ items: [makeItem('Socks')] }))
-        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
-        expect(screen.queryByRole('button', { name: '+ Add item' })).toBeNull()
+        fireEvent.click(screen.getByRole('button', { name: 'Add item' }))
+        expect(screen.queryByRole('button', { name: 'Add item' })).toBeNull()
     })
 
     it('offers a name used elsewhere in the set, with the section it is filed under', () => {
         renderAddable(makeOption({ items: [makeItem('Socks')] }))
-        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Add item' }))
         fireEvent.change(screen.getByRole('combobox'), { target: { value: 'tooth' } })
         fireEvent.click(screen.getByRole('option', { name: /Toothpaste/ }))
         expect((screen.getByLabelText('Section') as HTMLSelectElement).value).toBe('Toiletries')
@@ -496,7 +496,7 @@ describe('OptionSection with no items, once items can be added', () => {
     it('takes the first item, which it had no way to accept before', () => {
         const { onItemAdd } = renderEmpty()
         fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
-        fireEvent.click(screen.getByRole('button', { name: '+ Add item' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Add item' }))
         const input = screen.getByRole('combobox')
         fireEvent.change(input, { target: { value: 'Socks' } })
         fireEvent.keyDown(input, { key: 'Enter' })
@@ -615,12 +615,12 @@ describe('OptionSection: creating a section', () => {
 
     it('offers no "+ Add section" when the page supplies no handler', () => {
         renderEditable(makeOption({ items: [makeItem('Socks')] }))
-        expect(screen.queryByRole('button', { name: '+ Add section' })).toBeNull()
+        expect(screen.queryByRole('button', { name: 'Add section' })).toBeNull()
     })
 
     it('names the new section and creates it', () => {
         const { onSectionAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }))
-        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Add section' }))
         fireEvent.change(screen.getByLabelText('New section name'), { target: { value: 'Beach kit' } })
         fireEvent.click(screen.getByRole('button', { name: 'Add' }))
         expect(onSectionAdd).toHaveBeenCalledWith('q1', 'o1', 'Beach kit')
@@ -628,7 +628,7 @@ describe('OptionSection: creating a section', () => {
 
     it('creates on Enter, so naming several in a row needs no mouse', () => {
         const { onSectionAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }))
-        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Add section' }))
         const input = screen.getByLabelText('New section name')
         fireEvent.change(input, { target: { value: 'Beach kit' } })
         fireEvent.keyDown(input, { key: 'Enter' })
@@ -637,7 +637,7 @@ describe('OptionSection: creating a section', () => {
 
     it('creates nothing on an empty name', () => {
         const { onSectionAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }))
-        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Add section' }))
         fireEvent.click(screen.getByRole('button', { name: 'Add' }))
         expect(onSectionAdd).not.toHaveBeenCalled()
         expect(screen.queryByTestId('add-section')).toBeNull()
@@ -645,7 +645,7 @@ describe('OptionSection: creating a section', () => {
 
     it('abandons the name on Escape', () => {
         const { onSectionAdd } = renderAddable(makeOption({ items: [makeItem('Socks')] }))
-        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Add section' }))
         fireEvent.keyDown(screen.getByLabelText('New section name'), { key: 'Escape' })
         expect(screen.queryByTestId('add-section')).toBeNull()
         expect(onSectionAdd).not.toHaveBeenCalled()
@@ -653,7 +653,7 @@ describe('OptionSection: creating a section', () => {
 
     it('suggests names already used elsewhere, so one section is not spelled two ways', () => {
         renderAddable(makeOption({ items: [makeItem('Socks')] }))
-        fireEvent.click(screen.getByRole('button', { name: '+ Add section' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Add section' }))
         const listId = screen.getByLabelText('New section name').getAttribute('list')
         const options = [...document.querySelectorAll(`#${CSS.escape(listId!)} option`)].map(o => o.getAttribute('value'))
         expect(options).toContain('Toiletries')

--- a/src/pages/questions-page.person-colors.test.tsx
+++ b/src/pages/questions-page.person-colors.test.tsx
@@ -6,7 +6,7 @@ import type { Person } from '../edit-questions/types'
 import { PERSON_COLORS, personColorAt } from '../edit-questions/person-colors'
 
 vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
-vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn() }))
+vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn(() => ({ session: null, isLoggedIn: false })) }))
 vi.mock('../components/ForeignPodContext', () => ({ useForeignPod: vi.fn() }))
 
 const people: Person[] = [

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useId, useRef, useMemo, memo, Fragmen
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useDatabase } from '../components/DatabaseContext'
 import { SectionedItemReorder } from '../components/SectionedItemReorder'
+import { PersonAvatar } from '../components/PersonAvatar'
 import { SectionOrderLegend, SectionOrderModal } from '../components/SectionOrderEditor'
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 import { ALWAYS_NEEDED_CATEGORY, addEmptySection, buildSectionGroups, defaultCategoryFor, reconcileEmptySections, sectionNamesIn, type PositionedItem } from '../edit-questions/item-sections'
@@ -11,12 +12,14 @@ import { DatabaseMigration } from '../services/migration'
 import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, newDraftQuestion, renumberItemOrder, AGE_RANGE_OPTIONS } from '../edit-questions/types'
 import { Link } from 'react-router-dom'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
+import { useProfilePhotos } from '../hooks/usePersonProfilePhotos'
 import { usePodSync } from '../hooks/usePodSync'
 import { mergeQuestionSets } from '../utils/mergeQuestionSets'
-import { POD_CONTAINERS } from '../services/solidPod'
+import { POD_CONTAINERS, getPodOwnerProfile } from '../services/solidPod'
 import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSerialization'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useForeignPod } from '../components/ForeignPodContext'
+import { Plus, X } from 'lucide-react'
 import { AgePromotionCard } from '../components/AgePromotionCard'
 import { TemplateUpdatesCard } from '../components/TemplateUpdatesCard'
 import { LoadingState } from '../components/LoadingState'
@@ -48,32 +51,45 @@ function PersonDot({ person, index, selected }: { person: Person; index: number;
     )
 }
 
-const PersonLegend = memo(function PersonLegend({ people, onEdit }: { people: Person[]; onEdit?: () => void }) {
+/* The same quiet cluster the packing list wears: the first two people, then
+   "+n" for the rest. Tapping it opens the people editor. */
+const PersonLegend = memo(function PersonLegend({ people, photos, onEdit }: { people: Person[]; photos?: Record<string, string>; onEdit?: () => void }) {
     if (people.length < 2 && !onEdit) return null
-    return (
-        <div className="flex items-center gap-2 flex-wrap mb-4">
-            {people.length === 0 && onEdit && (
-                <span className="text-xs text-gray-400">No people added</span>
-            )}
-            {people.map((person, i) => (
-                <span key={person.id} className="flex items-center gap-1 text-xs text-gray-500">
-                    <span className={`inline-flex items-center justify-center w-4 h-4 rounded-full text-[9px] font-bold ${personColorFor(person, i).avatar}`}>
-                        {person.name.charAt(0).toUpperCase()}
-                    </span>
-                    {person.name}
+    const cluster = (
+        <>
+            {people.slice(0, 2).map((person, i) => (
+                <span key={person.id} className="rounded-full ring-2 ring-white">
+                    <PersonAvatar
+                        name={person.name}
+                        color={personColorFor(person, i)}
+                        photoUrl={photos?.[person.name]}
+                    />
                 </span>
             ))}
-            {onEdit && (
+            {people.length > 2 && (
+                <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-gray-200 text-gray-700 text-xs font-semibold ring-2 ring-white">
+                    +{people.length - 2}
+                </span>
+            )}
+            {people.length === 0 && (
+                <span className="text-xs text-gray-600">No people added</span>
+            )}
+        </>
+    )
+    return (
+        <div className="flex items-center mb-4">
+            {onEdit ? (
                 <button
                     type="button"
                     onClick={onEdit}
-                    className="p-1 text-gray-300 hover:text-gray-600 rounded"
                     title="Edit people"
+                    aria-label="Edit people"
+                    className="flex items-center -space-x-2 rounded-full p-1 hover:bg-gray-100 transition-colors"
                 >
-                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                    </svg>
+                    {cluster}
                 </button>
+            ) : (
+                <span className="flex items-center -space-x-2 p-1">{cluster}</span>
             )}
         </div>
     )
@@ -511,17 +527,17 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                         <button
                             type="button"
                             onClick={() => setOpenComposer(LIST_COMPOSER)}
-                            className={`${FOOT_BUTTON} flex-1`}
+                            className={`${FOOT_BUTTON} flex-1 flex items-center justify-center gap-1`}
                         >
-                            + Add item
+                            <Plus className="w-3.5 h-3.5" aria-hidden="true" />Add item
                         </button>
                         {onSectionAdd && (
                             <button
                                 type="button"
                                 onClick={() => setAddingSection(true)}
-                                className={`${FOOT_BUTTON} shrink-0 px-3`}
+                                className={`${FOOT_BUTTON} shrink-0 px-3 flex items-center justify-center gap-1`}
                             >
-                                + Add section
+                                <Plus className="w-3.5 h-3.5" aria-hidden="true" />Add section
                             </button>
                         )}
                     </div>
@@ -613,9 +629,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                                         title={`Add an item to ${group.label}`}
                                         className={`shrink-0 -my-1 rounded p-1.5 ${accent.text} hover:bg-white/70 transition-colors`}
                                     >
-                                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v14M5 12h14" />
-                                        </svg>
+                                        <Plus className="w-4 h-4" aria-hidden="true" />
                                     </button>
                                 )}
                             </div>
@@ -1115,9 +1129,9 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                     <button
                         type="button"
                         onClick={() => onAddOption(question.id)}
-                        className="w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
+                        className="w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors flex items-center justify-center gap-1"
                     >
-                        + Add Option
+                        <Plus className="w-3.5 h-3.5" aria-hidden="true" />Add Option
                     </button>
                 </div>
             )}
@@ -1273,6 +1287,7 @@ export function PeopleModal({ people, onSave, onClose }: {
     onSave: (newPeople: Person[]) => void
     onClose: () => void
 }) {
+    const { session } = useSolidPod()
     const [localPeople, setLocalPeople] = useState<Person[]>(
         people.length > 0 ? people : [{ id: crypto.randomUUID(), name: '' }]
     )
@@ -1295,6 +1310,25 @@ export function PeopleModal({ people, onSave, onClose }: {
         setLocalPeople(prev => prev.map((p, i) => i === idx
             ? { ...p, ageRange: value === '' ? undefined : value as Person['ageRange'] }
             : p))
+    const updateWebId = (idx: number, webId: string) =>
+        setLocalPeople(prev => prev.map((p, i) => i === idx
+            ? { ...p, webId: webId.trim() || undefined }
+            : p))
+    // A WebID profile often already says when its person was born
+    // (vcard:bday) — fill the birthday from there rather than making the
+    // user type it twice. Only into an empty field: a manually set date wins.
+    const fillBirthdayFromProfile = (idx: number, webId: string) => {
+        const trimmed = webId.trim()
+        if (!session || !trimmed) return
+        getPodOwnerProfile(session, '', trimmed)
+            .then(({ birthday }) => {
+                if (!birthday) return
+                setLocalPeople(prev => prev.map((p, i) => i === idx && !p.dateOfBirth
+                    ? { ...p, dateOfBirth: birthday }
+                    : p))
+            })
+            .catch(() => {})
+    }
     // Picking closes the palette: the choice shows immediately on the avatar
     // above it, so leaving the grid open would only hide the confirmation.
     const updateColor = (idx: number, color: PersonColorId) => {
@@ -1373,6 +1407,20 @@ export function PeopleModal({ people, onSave, onClose }: {
                                         </select>
                                     </div>
                                 )}
+                                {!person.species && (
+                                    <div className="ml-9 mt-1">
+                                        <input
+                                            type="url"
+                                            aria-label={`WebID for ${person.name || `Person ${i + 1}`} (optional)`}
+                                            title="Solid WebID (optional) — used to show their profile photo"
+                                            placeholder="WebID (optional), e.g. https://pod.example/name/profile/card#me"
+                                            value={person.webId ?? ''}
+                                            onChange={e => updateWebId(i, e.target.value)}
+                                            onBlur={e => fillBirthdayFromProfile(i, e.target.value)}
+                                            className="w-full min-w-0 border border-gray-300 rounded-lg px-2 py-1.5 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                        />
+                                    </div>
+                                )}
                                 {pickerOpen && (
                                     <PersonColorSwatches
                                         personName={personLabel}
@@ -1388,9 +1436,9 @@ export function PeopleModal({ people, onSave, onClose }: {
                     <button
                         type="button"
                         onClick={addPerson}
-                        className="w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors mb-4"
+                        className="w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors mb-4 flex items-center justify-center gap-1"
                     >
-                        + Add Person
+                        <Plus className="w-3.5 h-3.5" aria-hidden="true" />Add Person
                     </button>
                     <div className="flex gap-2 justify-end">
                         <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
@@ -1486,7 +1534,7 @@ function QuestionModal({ question, onSave, onClose }: {
 
 export function QuestionsPage() {
     const { db, loginSyncInProgress } = useDatabase()
-    const { isLoggedIn } = useSolidPod()
+    const { isLoggedIn, session } = useSolidPod()
     const foreignPodCtx = useForeignPod()
     const foreignPodUrl = foreignPodCtx?.foreignPodUrl
     const isForeign = !!foreignPodUrl
@@ -1506,6 +1554,14 @@ export function QuestionsPage() {
     // Bracket changes made by hand in the people modal; offered the same
     // item-review flow as birthday-driven transitions, then cleared.
     const [manualPromotions, setManualPromotions] = useState<AgeTransition[]>([])
+    // A once-per-device nudge, not a setting — plain localStorage, kept out of
+    // the question set so it never syncs to the pod.
+    const [wizardHintDismissed, setWizardHintDismissed] = useState(() => localStorage.getItem('wizardHintDismissed') === 'true')
+
+    const dismissWizardHint = () => {
+        localStorage.setItem('wizardHintDismissed', 'true')
+        setWizardHintDismissed(true)
+    }
 
     const saveToPodRef = useRef<((data: PackingListQuestionSet) => Promise<boolean>) | undefined>(undefined)
 
@@ -1895,6 +1951,7 @@ export function QuestionsPage() {
     // Memoized so their identity is stable across re-renders that don't change
     // the data (modal opens, sync ticks) — they feed the memoized sections.
     const people = useMemo(() => (data?.people ?? []).filter(p => !p.deletedAt), [data])
+    const personPhotos = useProfilePhotos(people, session)
     const activeQuestions = useMemo(() => (data?.questions ?? []).filter(q => !q.deletedAt), [data])
     const activeAlwaysNeededItems = useMemo(() => (data?.alwaysNeededItems ?? []).filter(i => !i.deletedAt), [data])
 
@@ -1913,7 +1970,20 @@ export function QuestionsPage() {
                 <div className="mb-2">
                     <h1 className="text-2xl font-bold text-gray-900">{isForeign ? 'Questions & Items' : 'My Questions & Items'}</h1>
                     <p className="mt-1 text-gray-600 text-sm">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>
-                    {!isForeign && <p className="mt-1 text-xs text-gray-400">Want to start from scratch? <Link to="/wizard" className="text-primary-600 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</p>}
+                    {!isForeign && !wizardHintDismissed && (
+                        <p className="mt-1 text-xs text-gray-400 flex items-center gap-1.5">
+                            <span>Want to start from scratch? <Link to="/wizard" className="text-primary-600 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</span>
+                            <button
+                                type="button"
+                                onClick={dismissWizardHint}
+                                aria-label="Dismiss"
+                                title="Dismiss"
+                                className="shrink-0 rounded p-0.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+                            >
+                                <X className="w-3.5 h-3.5" aria-hidden="true" />
+                            </button>
+                        </p>
+                    )}
                 </div>
                 {!isForeign && (
                     <AgePromotionCard
@@ -1924,7 +1994,7 @@ export function QuestionsPage() {
                     />
                 )}
                 {!isForeign && <TemplateUpdatesCard questionSet={data} onApply={saveData} />}
-                <PersonLegend people={people} onEdit={openPeopleModal} />
+                <PersonLegend people={people} photos={personPhotos} onEdit={openPeopleModal} />
                 <SectionOrderLegend labels={sectionLabels} onEdit={openSectionOrderModal} />
                 <AlwaysSection
                     items={activeAlwaysNeededItems}
@@ -1965,9 +2035,9 @@ export function QuestionsPage() {
                 <button
                     type="button"
                     onClick={() => setQuestionModal({ question: null })}
-                    className="w-full py-3 border-2 border-dashed border-gray-200 rounded-lg text-sm text-gray-500 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
+                    className="w-full py-3 border-2 border-dashed border-gray-200 rounded-lg text-sm text-gray-500 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors flex items-center justify-center gap-1"
                 >
-                    + Add Question
+                    <Plus className="w-4 h-4" aria-hidden="true" />Add Question
                 </button>
             </div>
             {questionModal !== null && (

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -67,12 +67,12 @@ const PersonLegend = memo(function PersonLegend({ people, photos, onEdit }: { pe
                 </span>
             ))}
             {people.length > 2 && (
-                <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-gray-200 text-gray-700 text-xs font-semibold ring-2 ring-white">
+                <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-gray-200 text-gray-700 dark:text-gray-300 text-xs font-semibold ring-2 ring-white">
                     +{people.length - 2}
                 </span>
             )}
             {people.length === 0 && (
-                <span className="text-xs text-gray-600">No people added</span>
+                <span className="text-xs text-gray-600 dark:text-gray-400">No people added</span>
             )}
         </>
     )
@@ -84,7 +84,7 @@ const PersonLegend = memo(function PersonLegend({ people, photos, onEdit }: { pe
                     onClick={onEdit}
                     title="Edit people"
                     aria-label="Edit people"
-                    className="flex items-center -space-x-2 rounded-full p-1 hover:bg-gray-100 transition-colors"
+                    className="flex items-center -space-x-2 rounded-full p-1 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                 >
                     {cluster}
                 </button>
@@ -111,7 +111,7 @@ const ItemRow = memo(function ItemRow({ item, people, index, isOpen, onOpen }: {
     const showDots = people.length > 1
     const content = (
         <>
-            <span className={`flex-1 min-w-0 text-left ${item.text ? 'text-gray-700' : 'text-gray-400 italic'}`}>
+            <span className={`flex-1 min-w-0 text-left ${item.text ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500 italic'}`}>
                 {item.text || 'no text'}
             </span>
             {item.communal && (
@@ -154,7 +154,7 @@ const ItemRow = memo(function ItemRow({ item, people, index, isOpen, onOpen }: {
             onClick={() => onOpen(index)}
             aria-expanded={isOpen ?? false}
             title={`Edit ${item.text || 'item'}`}
-            className={`group w-full flex items-center gap-2 py-1 px-2 text-sm rounded transition-colors ${isOpen ? 'bg-primary-50' : 'hover:bg-gray-100'}`}
+            className={`group w-full flex items-center gap-2 py-1 px-2 text-sm rounded transition-colors ${isOpen ? 'bg-primary-50 dark:bg-primary-950/40' : 'hover:bg-gray-100 dark:hover:bg-gray-700'}`}
         >
             {content}
             {/* Decorative, not a button of its own: the whole row is the target,
@@ -164,7 +164,7 @@ const ItemRow = memo(function ItemRow({ item, people, index, isOpen, onOpen }: {
             <svg
                 data-testid="item-edit-icon"
                 aria-hidden="true"
-                className={`w-3.5 h-3.5 shrink-0 transition-colors ${isOpen ? 'text-primary-500' : 'text-gray-400 group-hover:text-gray-700'}`}
+                className={`w-3.5 h-3.5 shrink-0 transition-colors ${isOpen ? 'text-primary-500' : 'text-gray-400 dark:text-gray-500 group-hover:text-gray-700 dark:group-hover:text-gray-200'}`}
                 fill="none" viewBox="0 0 24 24" stroke="currentColor"
             >
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -212,12 +212,12 @@ function ReorganiseModal({ items, defaultLabel, emptySections, onChange, onClose
             <div
                 role="dialog"
                 aria-label={`Organise ${defaultLabel} items`}
-                className="bg-white rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
+                className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
                 onClick={e => e.stopPropagation()}
             >
-                <div className="p-5 border-b border-gray-100 flex-shrink-0">
-                    <h2 className="text-lg font-semibold text-gray-900">Organise items</h2>
-                    <p className="mt-0.5 text-sm text-gray-500 truncate">{defaultLabel}</p>
+                <div className="p-5 border-b border-gray-100 dark:border-gray-800 flex-shrink-0">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Organise items</h2>
+                    <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400 truncate">{defaultLabel}</p>
                 </div>
                 <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
                     <SectionedItemReorder
@@ -228,7 +228,7 @@ function ReorganiseModal({ items, defaultLabel, emptySections, onChange, onClose
                         onChange={onChange}
                     />
                 </div>
-                <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex justify-end">
+                <div className="px-5 py-4 border-t border-gray-100 dark:border-gray-800 flex-shrink-0 flex justify-end">
                     <button
                         type="button"
                         onClick={onClose}
@@ -300,7 +300,7 @@ function useDeferredReorder(onReorder?: (items: Item[], emptySections: string[] 
     return { draft, onChange, flush: stop }
 }
 
-const FOOT_BUTTON = 'py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors'
+const FOOT_BUTTON = 'py-2 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg text-xs text-gray-400 dark:text-gray-500 hover:border-primary-300 dark:border-primary-700 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:bg-primary-950/40 transition-colors'
 
 /**
  * Name a new section. Offers the names already used elsewhere in the set, so
@@ -336,7 +336,7 @@ function AddSection({ suggestions, onAdd, onClose }: {
                 }}
                 aria-label="New section name"
                 placeholder="Section name (e.g. Toiletries)"
-                className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
             />
             <datalist id={listId}>
                 {suggestions.map(label => <option key={label} value={label} />)}
@@ -552,7 +552,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
             <button
                 type="button"
                 onClick={() => setOrganising(true)}
-                className="inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 text-primary-600 hover:bg-primary-50 transition-colors"
+                className="inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 text-primary-600 dark:text-primary-400 hover:bg-primary-50 dark:bg-primary-950/40 transition-colors"
             >
                 <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
@@ -604,7 +604,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                             // clipped away to nothing. The heading rounds its own
                             // top corners instead of relying on the card to crop
                             // them.
-                            className={`rounded-lg border ${accent.border} bg-white`}
+                            className={`rounded-lg border ${accent.border} bg-white dark:bg-gray-800`}
                         >
                             <div className={`flex items-center gap-2 rounded-t-lg px-2.5 py-1.5 ${accent.header}`}>
                                 <span
@@ -638,7 +638,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                                     // A section you have just made, before anything is
                                     // in it. Says so rather than drawing a card with a
                                     // blank body, which reads as a rendering fault.
-                                    <p className="px-1.5 py-1 text-xs text-gray-400 italic">
+                                    <p className="px-1.5 py-1 text-xs text-gray-400 dark:text-gray-500 italic">
                                         Nothing here yet — use ＋ to add the first item
                                     </p>
                                 )}
@@ -693,7 +693,7 @@ function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete:
             <DropdownMenu.Trigger asChild>
                 <button
                     type="button"
-                    className="p-2 text-gray-400 hover:text-gray-700 rounded"
+                    className="p-2 text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 rounded"
                     title="More actions"
                 >
                     <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
@@ -707,11 +707,11 @@ function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete:
                 <DropdownMenu.Content
                     align="end"
                     sideOffset={4}
-                    className="w-32 bg-white rounded-lg shadow-lg border border-gray-100 py-1 z-50"
+                    className="w-32 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-100 dark:border-gray-800 py-1 z-50"
                 >
                     <DropdownMenu.Item
                         onSelect={onEdit}
-                        className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 cursor-default outline-none"
+                        className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none"
                     >
                         Edit
                     </DropdownMenu.Item>
@@ -803,24 +803,24 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
             ) : (
                 <svg
                     data-testid="option-expand-chevron"
-                    className={`w-4 h-4 text-gray-400 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                    className={`w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
                     fill="none" viewBox="0 0 24 24" stroke="currentColor"
                 >
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                 </svg>
             )}
-            <span className="text-sm font-medium text-gray-800 flex-1 min-w-0">
-                {option.text || <em className="text-gray-400 font-normal">Untitled option</em>}
+            <span className="text-sm font-medium text-gray-800 dark:text-gray-200 flex-1 min-w-0">
+                {option.text || <em className="text-gray-400 dark:text-gray-500 font-normal">Untitled option</em>}
             </span>
             {isEmpty ? (
-                <span className="text-xs text-gray-400 italic flex-shrink-0 mr-1">No items</span>
+                <span className="text-xs text-gray-400 dark:text-gray-500 italic flex-shrink-0 mr-1">No items</span>
             ) : (
-                <span className="hidden sm:inline text-xs text-gray-400 flex-shrink-0 mr-1">{option.items.length} items</span>
+                <span className="hidden sm:inline text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 mr-1">{option.items.length} items</span>
             )}
         </>
     )
     return (
-        <div data-testid="option-section" className="bg-gray-50 rounded-lg p-3">
+        <div data-testid="option-section" className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">
             <div className={`flex items-center${isExpanded ? ' mb-2' : ''}`}>
                 {!canExpand ? (
                     <div className="flex items-center gap-2 flex-1 text-left min-w-0">
@@ -848,7 +848,7 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
                         <button
                             type="button"
                             onClick={onEdit}
-                            className="p-1 text-gray-300 hover:text-gray-600 rounded"
+                            className="p-1 text-gray-300 hover:text-gray-600 dark:hover:text-gray-300 rounded"
                             title="Edit option"
                         >
                             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -903,16 +903,16 @@ function DeleteConfirmModal({ onConfirm, onCancel }: { onConfirm: () => void; on
             onKeyDown={e => { if (e.key === 'Escape') onCancel() }}
         >
             <div
-                className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6"
+                className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-sm p-6"
                 onClick={e => e.stopPropagation()}
             >
-                <h2 className="text-lg font-semibold text-gray-900 mb-2">Delete question?</h2>
-                <p className="text-sm text-gray-500 mb-6">This will permanently remove the question and all its options.</p>
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Delete question?</h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">This will permanently remove the question and all its options.</p>
                 <div className="flex justify-end gap-3">
                     <button
                         type="button"
                         onClick={onCancel}
-                        className="px-4 py-2 text-sm text-gray-600 rounded-lg hover:bg-gray-100"
+                        className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
                     >
                         Cancel
                     </button>
@@ -943,7 +943,7 @@ function QuestionContextMenu({ onMoveUp, onMoveDown, onEdit, onDelete }: {
                 <DropdownMenu.Trigger asChild>
                     <button
                         type="button"
-                        className="p-2 text-gray-400 hover:text-gray-700 rounded"
+                        className="p-2 text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 rounded"
                         title="More actions"
                     >
                         <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -957,25 +957,25 @@ function QuestionContextMenu({ onMoveUp, onMoveDown, onEdit, onDelete }: {
                     <DropdownMenu.Content
                         align="end"
                         sideOffset={4}
-                        className="w-40 bg-white rounded-lg shadow-lg border border-gray-100 py-1 z-50"
+                        className="w-40 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-100 dark:border-gray-800 py-1 z-50"
                     >
                         <DropdownMenu.Item
                             onSelect={onEdit}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 cursor-default outline-none"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none"
                         >
                             Edit
                         </DropdownMenu.Item>
                         <DropdownMenu.Item
                             onSelect={onMoveUp}
                             disabled={!onMoveUp}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 cursor-default outline-none data-[disabled]:text-gray-300 data-[disabled]:pointer-events-none"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none data-[disabled]:text-gray-300 data-[disabled]:pointer-events-none"
                         >
                             Move Up
                         </DropdownMenu.Item>
                         <DropdownMenu.Item
                             onSelect={onMoveDown}
                             disabled={!onMoveDown}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 cursor-default outline-none data-[disabled]:text-gray-300 data-[disabled]:pointer-events-none"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none data-[disabled]:text-gray-300 data-[disabled]:pointer-events-none"
                         >
                             Move Down
                         </DropdownMenu.Item>
@@ -1030,23 +1030,23 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
     const moveUp = canMoveUp ? () => onMove(question.id, 'up') : undefined
     const moveDown = canMoveDown ? () => onMove(question.id, 'down') : undefined
     return (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
             <div className="flex items-stretch">
                 <button
                     type="button"
                     onClick={() => setIsExpanded(e => !e)}
-                    className="flex items-center gap-3 flex-1 text-left px-4 py-4 sm:px-6 min-w-0 hover:bg-gray-50 transition-colors duration-150"
+                    className="flex items-center gap-3 flex-1 text-left px-4 py-4 sm:px-6 min-w-0 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors duration-150"
                 >
                     <svg
-                        className={`w-5 h-5 text-gray-400 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                        className={`w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
                         fill="none" viewBox="0 0 24 24" stroke="currentColor"
                     >
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                     </svg>
-                    <span className="font-medium text-gray-900 flex-1 min-w-0">
-                        {question.text || <em className="text-gray-400 font-normal">Untitled question</em>}
+                    <span className="font-medium text-gray-900 dark:text-gray-100 flex-1 min-w-0">
+                        {question.text || <em className="text-gray-400 dark:text-gray-500 font-normal">Untitled question</em>}
                     </span>
-                    <span className="hidden sm:inline text-xs text-gray-400 flex-shrink-0 mr-2">{question.options.length} options</span>
+                    <span className="hidden sm:inline text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 mr-2">{question.options.length} options</span>
                 </button>
                 <div className="flex items-center pr-3 flex-shrink-0">
                     {/* Mobile: context menu */}
@@ -1064,7 +1064,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                             type="button"
                             onClick={moveUp}
                             disabled={!canMoveUp}
-                            className={`p-1.5 rounded ${canMoveUp ? 'text-gray-300 hover:text-gray-600' : 'text-gray-100 cursor-not-allowed'}`}
+                            className={`p-1.5 rounded ${canMoveUp ? 'text-gray-300 hover:text-gray-600 dark:hover:text-gray-300' : 'text-gray-100 cursor-not-allowed'}`}
                             title="Move up"
                         >
                             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1075,7 +1075,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                             type="button"
                             onClick={moveDown}
                             disabled={!canMoveDown}
-                            className={`p-1.5 rounded ${canMoveDown ? 'text-gray-300 hover:text-gray-600' : 'text-gray-100 cursor-not-allowed'}`}
+                            className={`p-1.5 rounded ${canMoveDown ? 'text-gray-300 hover:text-gray-600 dark:hover:text-gray-300' : 'text-gray-100 cursor-not-allowed'}`}
                             title="Move down"
                         >
                             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1085,7 +1085,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                         <button
                             type="button"
                             onClick={handleEdit}
-                            className="p-1.5 text-gray-300 hover:text-gray-600 rounded"
+                            className="p-1.5 text-gray-300 hover:text-gray-600 dark:hover:text-gray-300 rounded"
                             title="Edit question"
                         >
                             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1129,7 +1129,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                     <button
                         type="button"
                         onClick={() => onAddOption(question.id)}
-                        className="w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors flex items-center justify-center gap-1"
+                        className="w-full py-2 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg text-xs text-gray-400 dark:text-gray-500 hover:border-primary-300 dark:border-primary-700 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:bg-primary-950/40 transition-colors flex items-center justify-center gap-1"
                     >
                         <Plus className="w-3.5 h-3.5" aria-hidden="true" />Add Option
                     </button>
@@ -1166,7 +1166,7 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections
     const hasExpandedRef = useRef(isExpanded)
     if (isExpanded) hasExpandedRef.current = true
     return (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 sm:p-6">
             <div className="flex items-center">
                 <button
                     type="button"
@@ -1174,14 +1174,14 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections
                     className="flex items-center gap-2 flex-1 text-left min-w-0"
                 >
                     <svg
-                        className={`w-5 h-5 text-gray-400 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                        className={`w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
                         fill="none" viewBox="0 0 24 24" stroke="currentColor"
                     >
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                     </svg>
                     <span className="flex flex-col min-w-0">
-                        <span className="font-medium text-gray-900">Always Needed Items</span>
-                        <span className="hidden sm:inline text-sm font-normal text-gray-500">{items.length} items</span>
+                        <span className="font-medium text-gray-900 dark:text-gray-100">Always Needed Items</span>
+                        <span className="hidden sm:inline text-sm font-normal text-gray-500 dark:text-gray-400">{items.length} items</span>
                     </span>
                 </button>
             </div>
@@ -1247,12 +1247,12 @@ function OptionEditModal({ option, onSave, onClose }: {
             onClick={onClose}
             onKeyDown={e => { if (e.key === 'Escape') onClose() }}
         >
-            <div className="bg-white rounded-xl shadow-xl w-full max-w-md" onClick={e => e.stopPropagation()}>
+            <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-md" onClick={e => e.stopPropagation()}>
                 <div className="p-5">
-                    <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
                         {option ? 'Edit Option' : 'Add Option'}
                     </h2>
-                    <label htmlFor={fieldId} className="block text-sm font-medium text-gray-700 mb-1">Answer text</label>
+                    <label htmlFor={fieldId} className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Answer text</label>
                     <input
                         id={fieldId}
                         autoFocus
@@ -1260,11 +1260,11 @@ function OptionEditModal({ option, onSave, onClose }: {
                         value={text}
                         onChange={e => setText(e.target.value)}
                         placeholder="e.g. Yes"
-                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 mb-5"
+                        className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 mb-5"
                         onKeyDown={e => { if (e.key === 'Enter') handleSave() }}
                     />
                     <div className="flex gap-2 justify-end">
-                        <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
+                        <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">
                             Cancel
                         </button>
                         <button
@@ -1342,9 +1342,9 @@ export function PeopleModal({ people, onSave, onClose }: {
             onClick={onClose}
             onKeyDown={e => { if (e.key === 'Escape') onClose() }}
         >
-            <div className="bg-white rounded-xl shadow-xl w-full max-w-sm" onClick={e => e.stopPropagation()}>
+            <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-sm" onClick={e => e.stopPropagation()}>
                 <div className="p-5">
-                    <h2 className="text-lg font-semibold text-gray-900 mb-4">Edit People</h2>
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Edit People</h2>
                     <div className="space-y-2 mb-3">
                         {localPeople.map((person, i) => {
                             const color = personColorFor(person, i)
@@ -1369,7 +1369,7 @@ export function PeopleModal({ people, onSave, onClose }: {
                                         value={person.name}
                                         onChange={e => updateName(i, e.target.value)}
                                         placeholder={`Person ${i + 1}`}
-                                        className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                        className="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
                                         onKeyDown={e => { if (e.key === 'Enter') addPerson() }}
                                     />
                                     {localPeople.length > 1 && (
@@ -1391,14 +1391,14 @@ export function PeopleModal({ people, onSave, onClose }: {
                                             title="Birthday (optional) — used to keep age-based items up to date"
                                             value={person.dateOfBirth ?? ''}
                                             onChange={e => updateDob(i, e.target.value)}
-                                            className="flex-1 min-w-0 border border-gray-300 rounded-lg px-2 py-1.5 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                            className="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-lg px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500"
                                         />
                                         <select
                                             aria-label={`Age group for ${person.name || `Person ${i + 1}`}`}
                                             title="Age group — change it manually if they're ready for the next one early"
                                             value={person.ageRange ?? ''}
                                             onChange={e => updateAgeRange(i, e.target.value)}
-                                            className="flex-1 min-w-0 border border-gray-300 rounded-lg px-2 py-1.5 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                            className="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-lg px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500"
                                         >
                                             <option value="">Age group…</option>
                                             {AGE_RANGE_OPTIONS.map(option => (
@@ -1417,7 +1417,7 @@ export function PeopleModal({ people, onSave, onClose }: {
                                             value={person.webId ?? ''}
                                             onChange={e => updateWebId(i, e.target.value)}
                                             onBlur={e => fillBirthdayFromProfile(i, e.target.value)}
-                                            className="w-full min-w-0 border border-gray-300 rounded-lg px-2 py-1.5 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                            className="w-full min-w-0 border border-gray-300 dark:border-gray-600 rounded-lg px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500"
                                         />
                                     </div>
                                 )}
@@ -1432,16 +1432,16 @@ export function PeopleModal({ people, onSave, onClose }: {
                             )
                         })}
                     </div>
-                    <p className="text-xs text-gray-400 mb-3">Tap someone's circle to change their colour — it follows them onto every packing list. Birthdays are optional: add one and we'll suggest packing-item updates as they grow, or bump the age group early if they're ready for it.</p>
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-3">Tap someone's circle to change their colour — it follows them onto every packing list. Birthdays are optional: add one and we'll suggest packing-item updates as they grow, or bump the age group early if they're ready for it.</p>
                     <button
                         type="button"
                         onClick={addPerson}
-                        className="w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors mb-4 flex items-center justify-center gap-1"
+                        className="w-full py-2 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg text-xs text-gray-400 dark:text-gray-500 hover:border-primary-300 dark:border-primary-700 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:bg-primary-950/40 transition-colors mb-4 flex items-center justify-center gap-1"
                     >
                         <Plus className="w-3.5 h-3.5" aria-hidden="true" />Add Person
                     </button>
                     <div className="flex gap-2 justify-end">
-                        <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
+                        <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">
                             Cancel
                         </button>
                         <button type="button" onClick={() => onSave(localPeople)} className="px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700">
@@ -1481,29 +1481,29 @@ function QuestionModal({ question, onSave, onClose }: {
             onClick={onClose}
             onKeyDown={e => { if (e.key === 'Escape') onClose() }}
         >
-            <div className="bg-white rounded-xl shadow-xl w-full max-w-md" onClick={e => e.stopPropagation()}>
+            <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-md" onClick={e => e.stopPropagation()}>
                 <div className="p-5">
-                    <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
                         {question ? 'Edit Question' : 'Add Question'}
                     </h2>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Question text</label>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Question text</label>
                     <input
                         autoFocus
                         type="text"
                         value={text}
                         onChange={e => setText(e.target.value)}
                         placeholder="e.g. Are you going to a hot climate?"
-                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 mb-4"
+                        className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 mb-4"
                         onKeyDown={e => { if (e.key === 'Enter' && text.trim()) onSave(text.trim(), type) }}
                     />
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Answer type</label>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Answer type</label>
                     <div className="flex gap-2 mb-5">
                         {(['single-choice', 'multiple-choice'] as QuestionType[]).map(t => (
                             <button
                                 key={t}
                                 type="button"
                                 onClick={() => setType(t)}
-                                className={`flex-1 py-2 rounded-lg text-sm border-2 transition-colors ${type === t ? 'border-primary-400 bg-primary-50 text-primary-900 font-medium' : 'border-gray-200 text-gray-600 hover:border-gray-300'}`}
+                                className={`flex-1 py-2 rounded-lg text-sm border-2 transition-colors ${type === t ? 'border-primary-400 bg-primary-50 dark:bg-primary-950/40 text-primary-900 dark:text-primary-200 font-medium' : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'}`}
                             >
                                 {t === 'single-choice' ? 'Single choice' : 'Multiple choice'}
                             </button>
@@ -1513,7 +1513,7 @@ function QuestionModal({ question, onSave, onClose }: {
                         <button
                             type="button"
                             onClick={onClose}
-                            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100"
+                            className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
                         >
                             Cancel
                         </button>
@@ -1968,17 +1968,17 @@ export function QuestionsPage() {
         <div className="w-full flex flex-col items-center py-8 px-4">
             <div className="w-full max-w-3xl space-y-4">
                 <div className="mb-2">
-                    <h1 className="text-2xl font-bold text-gray-900">{isForeign ? 'Questions & Items' : 'My Questions & Items'}</h1>
-                    <p className="mt-1 text-gray-600 text-sm">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>
+                    <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{isForeign ? 'Questions & Items' : 'My Questions & Items'}</h1>
+                    <p className="mt-1 text-gray-600 dark:text-gray-400 text-sm">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>
                     {!isForeign && !wizardHintDismissed && (
-                        <p className="mt-1 text-xs text-gray-400 flex items-center gap-1.5">
-                            <span>Want to start from scratch? <Link to="/wizard" className="text-primary-600 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</span>
+                        <p className="mt-1 text-xs text-gray-400 dark:text-gray-500 flex items-center gap-1.5">
+                            <span>Want to start from scratch? <Link to="/wizard" className="text-primary-600 dark:text-primary-400 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</span>
                             <button
                                 type="button"
                                 onClick={dismissWizardHint}
                                 aria-label="Dismiss"
                                 title="Dismiss"
-                                className="shrink-0 rounded p-0.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+                                className="shrink-0 rounded p-0.5 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                             >
                                 <X className="w-3.5 h-3.5" aria-hidden="true" />
                             </button>
@@ -2035,7 +2035,7 @@ export function QuestionsPage() {
                 <button
                     type="button"
                     onClick={() => setQuestionModal({ question: null })}
-                    className="w-full py-3 border-2 border-dashed border-gray-200 rounded-lg text-sm text-gray-500 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors flex items-center justify-center gap-1"
+                    className="w-full py-3 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-500 dark:text-gray-400 hover:border-primary-300 dark:border-primary-700 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:bg-primary-950/40 transition-colors flex items-center justify-center gap-1"
                 >
                     <Plus className="w-4 h-4" aria-hidden="true" />Add Question
                 </button>

--- a/src/pages/questions-page.wizard-hint.test.tsx
+++ b/src/pages/questions-page.wizard-hint.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import type { PackingAppDatabase } from '../services/database'
+
+vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
+vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn() }))
+vi.mock('../components/ForeignPodContext', () => ({ useForeignPod: vi.fn() }))
+
+vi.mock('../hooks/useSyncCoordinator', () => ({
+    useSyncCoordinator: vi.fn(() => ({
+        saveWithSyncPrevention: vi.fn(),
+        handleSyncSuccess: vi.fn(),
+        handleSyncError: vi.fn(),
+    })),
+}))
+
+vi.mock('../hooks/usePodSync', () => ({
+    usePodSync: vi.fn(() => ({ saveToPod: vi.fn(), syncFromPod: vi.fn() })),
+}))
+
+vi.mock('../services/migration', () => ({
+    DatabaseMigration: {
+        checkMigrationNeeded: vi.fn().mockResolvedValue({ needed: false }),
+        performMigration: vi.fn(),
+    },
+}))
+
+vi.mock('../services/solidPod', () => ({
+    POD_CONTAINERS: { ROOT: 'pack-me-up/' },
+}))
+
+vi.mock('../services/rdfSerialization', () => ({
+    questionSetToDataset: vi.fn(),
+    datasetToQuestionSet: vi.fn(),
+}))
+
+import { QuestionsPage } from './questions-page'
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+import { useForeignPod } from '../components/ForeignPodContext'
+
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockUseForeignPod = vi.mocked(useForeignPod)
+
+const emptyQuestionSet = { _id: '1', _rev: '1', questions: [], people: [], alwaysNeededItems: [] }
+
+function renderQuestionsPage() {
+    mockUseDatabase.mockReturnValue({
+        db: {
+            getQuestionSet: vi.fn().mockResolvedValue(emptyQuestionSet),
+            saveQuestionSet: vi.fn(),
+        } as unknown as PackingAppDatabase,
+    })
+    return render(
+        <MemoryRouter>
+            <QuestionsPage />
+        </MemoryRouter>
+    )
+}
+
+describe('QuestionsPage wizard hint', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        localStorage.clear()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseForeignPod.mockReturnValue(null)
+    })
+
+    afterEach(() => {
+        cleanup()
+        localStorage.clear()
+    })
+
+    it('shows the redo-the-wizard hint with a dismiss button', async () => {
+        renderQuestionsPage()
+        await waitFor(() => expect(screen.getByText(/start from scratch/i)).toBeTruthy())
+        expect(screen.getByRole('button', { name: /dismiss/i })).toBeTruthy()
+    })
+
+    it('hides the hint when dismissed and remembers the choice', async () => {
+        renderQuestionsPage()
+        await waitFor(() => expect(screen.getByText(/start from scratch/i)).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+
+        expect(screen.queryByText(/start from scratch/i)).toBeNull()
+        expect(localStorage.getItem('wizardHintDismissed')).toBe('true')
+    })
+
+    it('does not show the hint again once dismissed', async () => {
+        localStorage.setItem('wizardHintDismissed', 'true')
+        renderQuestionsPage()
+        await waitFor(() => expect(screen.getByText('My Questions & Items')).toBeTruthy())
+        expect(screen.queryByText(/start from scratch/i)).toBeNull()
+    })
+})

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -205,7 +205,7 @@ export function SharingSettingsPage() {
     if (!isLoggedIn) {
         return (
             <div className="max-w-2xl mx-auto py-8 px-4">
-                <p className="text-gray-700">Please log in to manage sharing settings.</p>
+                <p className="text-gray-700 dark:text-gray-300">Please log in to manage sharing settings.</p>
             </div>
         )
     }
@@ -219,13 +219,13 @@ export function SharingSettingsPage() {
     return (
         <div className="max-w-2xl mx-auto py-8 px-4 space-y-10">
             <div>
-                <h1 className="text-3xl font-bold text-primary-900">Sharing Settings</h1>
+                <h1 className="text-3xl font-bold text-primary-900 dark:text-primary-200">Sharing Settings</h1>
             </div>
 
             {/* Section 1: Grant access to others */}
             <section className="space-y-4">
-                <h2 className="text-xl font-semibold text-gray-900">People who can access my data</h2>
-                <p className="text-sm text-gray-600">
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">People who can access my data</h2>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                     Grant someone access to all your packing lists and questions. They'll be able to view
                     and edit your data.
                 </p>
@@ -236,7 +236,7 @@ export function SharingSettingsPage() {
                         onChange={e => setCollaboratorWebId(e.target.value)}
                         placeholder="Collaborator WebID (e.g. https://alice.solidcommunity.net/profile/card#me)"
                         aria-label="Collaborator WebID"
-                        className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                        className="flex-1 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
                     />
                     <button
                         onClick={handleGrantAccess}
@@ -249,26 +249,26 @@ export function SharingSettingsPage() {
 
                 {inviteLink && (
                     <div className="mt-2">
-                        <label className="block text-sm font-medium text-gray-700 mb-1">Invite link</label>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Invite link</label>
                         <input
                             type="text"
                             readOnly
                             value={inviteLink}
                             aria-label="Invite link"
-                            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-gray-50 focus:outline-none"
+                            className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-gray-50 dark:bg-gray-900 focus:outline-none"
                             onClick={e => (e.target as HTMLInputElement).select()}
                         />
-                        <p className="text-xs text-gray-500 mt-1">Share this link with your collaborator.</p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Share this link with your collaborator.</p>
                     </div>
                 )}
 
                 {isLoadingCollaborators ? (
-                    <p className="text-sm text-gray-500">Loading collaborators…</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">Loading collaborators…</p>
                 ) : collaborators.length > 0 ? (
                     <ul className="space-y-2 mt-2">
                         {collaborators.map(webId => (
-                            <li key={webId} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
-                                <span className="text-sm text-gray-800 truncate flex-1" title={webId}>{webId}</span>
+                            <li key={webId} className="flex items-center justify-between bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
+                                <span className="text-sm text-gray-800 dark:text-gray-200 truncate flex-1" title={webId}>{webId}</span>
                                 <button
                                     onClick={() => handleRevoke(webId)}
                                     disabled={revokingWebId === webId}
@@ -281,27 +281,27 @@ export function SharingSettingsPage() {
                         ))}
                     </ul>
                 ) : (
-                    <p className="text-sm text-gray-500">No collaborators yet.</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">No collaborators yet.</p>
                 )}
             </section>
 
             {/* Section 2: Pods shared with me */}
             <section className="space-y-4">
-                <h2 className="text-xl font-semibold text-gray-900">Data shared with me</h2>
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Data shared with me</h2>
                 {sharedContexts.length === 0 ? (
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
                         No shared pods yet. Visit an invite link to add one.
                     </p>
                 ) : (
                     <ul className="space-y-2">
                         {sharedContexts.map(ctx => (
-                            <li key={ctx.podUrl} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
-                                <span className="text-sm text-gray-800 truncate flex-1" title={ctx.podUrl}>
+                            <li key={ctx.podUrl} className="flex items-center justify-between bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
+                                <span className="text-sm text-gray-800 dark:text-gray-200 truncate flex-1" title={ctx.podUrl}>
                                     {ctx.label ?? resolveOwnerDisplayName(podNames[ctx.podUrl], ctx.webId, ctx.podUrl)}
                                 </span>
                                 <button
                                     onClick={() => navigate(`/pod/${encodeURIComponent(ctx.podUrl)}/view-lists`)}
-                                    className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 text-primary-700 hover:bg-primary-200 transition-colors"
+                                    className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 text-primary-700 dark:text-primary-300 hover:bg-primary-200 transition-colors"
                                 >
                                     Open
                                 </button>
@@ -321,26 +321,26 @@ export function SharingSettingsPage() {
 
             {/* Section 3: Individual lists shared with me */}
             <section className="space-y-4">
-                <h2 className="text-xl font-semibold text-gray-900">Individual lists shared with me</h2>
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Individual lists shared with me</h2>
                 {sharedLists.length === 0 ? (
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
                         No individual lists yet. When someone shares a list link with you and you save it, it will appear here.
                     </p>
                 ) : (
                     <ul className="space-y-2">
                         {sharedLists.map(ctx => (
-                            <li key={`${ctx.listId}-${ctx.podUrl}`} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+                            <li key={`${ctx.listId}-${ctx.podUrl}`} className="flex items-center justify-between bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
                                 <div className="flex flex-col flex-1 min-w-0">
-                                    <span className="text-sm font-medium text-gray-800 truncate">
+                                    <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">
                                         {ctx.label ?? ctx.listId}
                                     </span>
-                                    <span className="text-xs text-gray-500 truncate" title={ctx.podUrl}>
+                                    <span className="text-xs text-gray-500 dark:text-gray-400 truncate" title={ctx.podUrl}>
                                         {resolveOwnerDisplayName(listOwnerNames[ctx.listId], ctx.ownerWebId, ctx.podUrl)}
                                     </span>
                                 </div>
                                 <button
                                     onClick={() => navigate(buildSharedListPath(ctx.listId, ctx.podUrl, ctx.ownerWebId ?? undefined))}
-                                    className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 text-primary-700 hover:bg-primary-200 transition-colors"
+                                    className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 text-primary-700 dark:text-primary-300 hover:bg-primary-200 transition-colors"
                                 >
                                     Open
                                 </button>
@@ -360,14 +360,14 @@ export function SharingSettingsPage() {
 
             {/* Section 4: Individual lists I've shared */}
             <section className="space-y-4">
-                <h2 className="text-xl font-semibold text-gray-900">Individual lists I've shared</h2>
-                <p className="text-sm text-gray-600">
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Individual lists I've shared</h2>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                     Lists you've shared with specific people or publicly. Use "Manage sharing" to update access.
                 </p>
                 {ownLists.length === 0 ? (
-                    <p className="text-sm text-gray-500">No packing lists yet.</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">No packing lists yet.</p>
                 ) : sharedOwnLists.length === 0 && Object.values(sharingStatusByListId).every(s => s !== 'loading') ? (
-                    <p className="text-sm text-gray-500">You haven't shared any individual lists yet.</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">You haven't shared any individual lists yet.</p>
                 ) : (
                     <ul className="space-y-2">
                         {ownLists
@@ -380,10 +380,10 @@ export function SharingSettingsPage() {
                             .map(list => {
                                 const status = sharingStatusByListId[list.id]
                                 return (
-                                    <li key={list.id} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+                                    <li key={list.id} className="flex items-center justify-between bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
                                         <div className="flex flex-col flex-1 min-w-0">
-                                            <span className="text-sm font-medium text-gray-800 truncate">✈️ {list.name}</span>
-                                            <span className="text-xs text-gray-500">
+                                            <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">✈️ {list.name}</span>
+                                            <span className="text-xs text-gray-500 dark:text-gray-400">
                                                 {status === 'loading' ? 'Loading sharing info…' :
                                                     status === 'error' ? 'Could not load sharing info' :
                                                     [
@@ -398,7 +398,7 @@ export function SharingSettingsPage() {
                                                     fileUrl: `${ownPodUrl}${POD_CONTAINERS.PACKING_LISTS}${list.id}.ttl`,
                                                     listId: list.id,
                                                 })}
-                                                className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 text-primary-700 hover:bg-primary-200 transition-colors"
+                                                className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 text-primary-700 dark:text-primary-300 hover:bg-primary-200 transition-colors"
                                             >
                                                 Manage sharing
                                             </button>

--- a/src/pages/solid-pod-handle-redirect-page.tsx
+++ b/src/pages/solid-pod-handle-redirect-page.tsx
@@ -23,7 +23,7 @@ export const SolidPodHandleRedirectPage = () => {
         <div className="flex items-center justify-center min-h-screen">
             <div className="text-center">
                 <h1 className="text-2xl font-bold mb-4">Logging in...</h1>
-                <p className="text-gray-600">Redirecting you back to the app...</p>
+                <p className="text-gray-600 dark:text-gray-400">Redirecting you back to the app...</p>
             </div>
         </div>
     );

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1851,6 +1851,46 @@ describe('ViewPackingList update from questions', () => {
         expect(texts).not.toContain('Swimsuit')
     })
 
+    it('applies a rename and tombstones a removed item', async () => {
+        // The questions now call the swimsuit "Bathing suit" and no longer
+        // mention the goggles the list still carries.
+        const renamedQs = {
+            ...questionSetWithNewItem,
+            questions: [{
+                ...questionSetWithNewItem.questions[0],
+                options: [{
+                    ...questionSetWithNewItem.questions[0].options[0],
+                    items: [{ text: 'Bathing suit', personSelections: [{ personId: 'p1', selected: true }] }],
+                }],
+            }],
+        }
+        const db = renderUpdatable({
+            list: {
+                ...updatablePackingList,
+                items: [
+                    { id: 'item-suit', itemText: 'Swimsuit', personName: 'Alice', personId: 'p1', questionId: 'q-activities', optionId: 'opt-swimming', packed: true },
+                    // In a different group (always-needed) so the rename above stays
+                    // unambiguous — one item changed within one option
+                    { id: 'item-goggles', itemText: 'Goggles', personName: 'Alice', personId: 'p1', questionId: 'always-needed', optionId: '', packed: false },
+                ],
+            },
+            getQuestionSet: vi.fn().mockResolvedValue(renamedQs),
+        })
+        await waitFor(() => expect(screen.getByRole('heading', { name: 'Updatable Trip' })).toBeTruthy())
+
+        fireEvent.click(await screen.findByRole('button', { name: /update from questions/i }))
+        // A mixed selection reads "Apply", not "Add"
+        fireEvent.click(await screen.findByRole('button', { name: /apply 2 changes/i }))
+
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        const saved = db.savePackingList.mock.calls[0][0]
+        const renamed = saved.items.find((i: { id: string }) => i.id === 'item-suit')
+        expect(renamed.itemText).toBe('Bathing suit')
+        expect(renamed.packed).toBe(true)
+        expect(saved.items.find((i: { id: string }) => i.id === 'item-goggles')).toBeUndefined()
+        expect(saved.deletedItems.map((i: { itemText: string }) => i.itemText)).toContain('Goggles')
+    })
+
     it('is hidden for foreign lists', async () => {
         const db = {
             getPackingList: vi.fn().mockResolvedValue(updatablePackingList),

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -44,6 +44,7 @@ vi.mock('../services/solidPod', () => ({
     friendlyWebIdName: vi.fn((url: string) => url),
     resolveOwnerDisplayName: vi.fn((foafName: string | null | undefined, ownerWebId: string | null | undefined, podUrl: string) => foafName ?? ownerWebId ?? podUrl),
     getPodOwnerName: vi.fn().mockResolvedValue(null),
+    getPodOwnerProfile: vi.fn().mockResolvedValue({ name: null, photo: null }),
     deriveWebIdFromPodUrl: vi.fn((url: string) => `${url.replace(/\/+$/, '')}/profile/card#me`),
 }))
 
@@ -431,6 +432,40 @@ describe('ViewPackingList hidden items banner', () => {
         fireEvent.click(screen.getByRole('button', { name: /show packed/i }))
 
         expect(screen.queryByText(/item.* hidden/i)).toBeNull()
+    })
+
+    it('dismisses the banner via its dismiss button and remembers the choice', async () => {
+        localStorage.removeItem('packedHiddenHintDismissed')
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        checkPassport()
+
+        await waitFor(() => expect(screen.getByText(/item.* hidden/i)).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+
+        expect(screen.queryByText(/item.* hidden/i)).toBeNull()
+        expect(localStorage.getItem('packedHiddenHintDismissed')).toBe('true')
+        localStorage.removeItem('packedHiddenHintDismissed')
+    })
+
+    it('does not show the banner again once dismissed', async () => {
+        localStorage.setItem('packedHiddenHintDismissed', 'true')
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        checkPassport()
+
+        // Items are hidden as usual (Show Packed lights up), but the explainer stays away
+        await waitFor(() => {
+            const showPackedBtn = screen.getByRole('button', { name: /show packed/i })
+            expect(showPackedBtn.className).toContain('bg-gradient-primary')
+        })
+        expect(screen.queryByText(/item.* hidden/i)).toBeNull()
+        localStorage.removeItem('packedHiddenHintDismissed')
     })
 
     it('uses primary button variant for "Show Packed" when items are hidden', async () => {
@@ -1106,6 +1141,53 @@ describe('ViewPackingList expandable person sections', () => {
         expect(screen.getByText('Toothbrush')).toBeTruthy()
     })
 
+    it('shows the list people as a stacked avatar cluster that opens the guest form', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+        const cluster = screen.getByTestId('guest-cluster')
+        const avatars = within(cluster).getAllByTestId('person-avatar')
+        expect(avatars.map(a => a.getAttribute('title'))).toEqual(['Alice', 'Bob'])
+        // Two people: nobody left over to count
+        expect(cluster.textContent).not.toContain('+')
+
+        fireEvent.click(cluster)
+        expect(screen.getByPlaceholderText('Guest name...')).toBeTruthy()
+    })
+
+    it('clicking anywhere on a collapsed card expands it', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: /collapse alice's list/i }))
+        expect(screen.queryByText('Toothbrush')).toBeNull()
+
+        const collapsedCard = screen.getByRole('button', { name: /expand alice's list/i }).closest('[data-testid="list-section"]')!
+        fireEvent.click(collapsedCard)
+
+        expect(screen.getByText('Toothbrush')).toBeTruthy()
+    })
+
+    it('the header toggle still works while the whole collapsed card is clickable', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: /collapse alice's list/i }))
+
+        // The button's click must not double-toggle by also bubbling to the card
+        fireEvent.click(screen.getByRole('button', { name: /expand alice's list/i }))
+
+        expect(screen.getByText('Toothbrush')).toBeTruthy()
+    })
+
+    it('clicking the body of an expanded card does not collapse it', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+        const card = screen.getByText('Toothbrush').closest('[data-testid="list-section"]')!
+        fireEvent.click(card)
+
+        expect(screen.getByText('Toothbrush')).toBeTruthy()
+    })
+
     it('add-item input is hidden when person section is collapsed', async () => {
         renderComponentMultiCategory()
         await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
@@ -1591,7 +1673,7 @@ describe('ViewPackingList update from questions', () => {
         expect(screen.getByLabelText(/add goggles/i)).toBeTruthy()
     })
 
-    it('toasts and shows no preview when the list already matches', async () => {
+    it('hides the button when the list already matches the questions', async () => {
         // Question set whose only item is already on the list
         const matchingQs = {
             ...questionSetWithNewItem,
@@ -1603,13 +1685,13 @@ describe('ViewPackingList update from questions', () => {
                 }],
             }],
         }
-        renderUpdatable({ getQuestionSet: vi.fn().mockResolvedValue(matchingQs) })
+        const db = renderUpdatable({ getQuestionSet: vi.fn().mockResolvedValue(matchingQs) })
         await waitFor(() => expect(screen.getByText('Swimsuit')).toBeTruthy())
 
-        fireEvent.click(await screen.findByRole('button', { name: /update from questions/i }))
-
-        await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith('This list already matches your questions', 'success'))
-        expect(screen.queryByRole('button', { name: /add 1 item/i })).toBeNull()
+        // Wait for the availability check to have actually run before
+        // asserting on the button's absence
+        await waitFor(() => expect(db.getQuestionSet).toHaveBeenCalled())
+        expect(screen.queryByRole('button', { name: /update from questions/i })).toBeNull()
     })
 
     it('excludes an unchecked item and persists only the selected additions', async () => {

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useDebouncedCallback } from 'use-debounce'
+import { ArrowLeft, CheckCheck, Plus, Share2, X } from 'lucide-react'
 import { PackingList, PackingListItem } from '../create-packing-list/types'
 import { useDatabase } from '../components/DatabaseContext'
 import { Button } from '../components/Button'
@@ -29,6 +30,8 @@ import { groupItemsByCategory, sortByOrder, type CategoryAccessors } from '../ut
 import { CATEGORY_ORDER } from '../edit-questions/item-sections'
 import { useSectionOrder } from '../hooks/useSectionOrder'
 import { usePersonColors } from '../hooks/usePersonColors'
+import { usePersonProfilePhotos } from '../hooks/usePersonProfilePhotos'
+import { Modal } from '../components/Modal'
 import { PersonAvatar } from '../components/PersonAvatar'
 import { AddItemComposer, UNCATEGORISED_LABEL, type AddItemTarget, type PersonOption } from '../components/AddItemComposer'
 import { buildSuggestionIndex } from '../utils/itemSuggestions'
@@ -175,7 +178,7 @@ export function ViewPackingList() {
     // Additions computed from the question set; non-null opens the preview modal.
     const [questionUpdateAdditions, setQuestionUpdateAdditions] = useState<PackingListItem[] | null>(null)
     // Whether the question set exists locally (gates the "Update from questions" button).
-    const [hasQuestionSet, setHasQuestionSet] = useState(false)
+    const [questionUpdateAvailable, setQuestionUpdateAvailable] = useState(false)
     const [ownPodUrl, setOwnPodUrl] = useState<string | null>(null)
     // Tracks whether initial data has been loaded (local DB or pod).
     // Used to surface a real error to the user instead of hanging on "Loading…"
@@ -192,6 +195,14 @@ export function ViewPackingList() {
     // one moment worth explaining, and only until the user touches anything.
     const [foldedOnOpen, setFoldedOnOpen] = useState(false)
     const [showPacked, setShowPacked] = useState(storedPreferences.showPacked)
+    // A once-per-device explainer for where packed items go — plain localStorage,
+    // same treatment as the wizard hint on the questions page.
+    const [packedHintDismissed, setPackedHintDismissed] = useState(() => localStorage.getItem('packedHiddenHintDismissed') === 'true')
+
+    const dismissPackedHint = () => {
+        localStorage.setItem('packedHiddenHintDismissed', 'true')
+        setPackedHintDismissed(true)
+    }
     const [viewMode, setViewMode] = useState<ListViewMode>(storedPreferences.viewMode)
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
     // Which section has an add-item composer open inside it. Only one is mounted
@@ -312,17 +323,23 @@ export function ViewPackingList() {
 
     // The "Update from questions" action only applies to the user's own lists,
     // regenerating them from their local question set. Foreign lists belong to
-    // someone else, so gate the button on a question set existing locally.
+    // someone else, and a list the questions have nothing new for has nothing
+    // to update — so the button only shows when the diff is non-empty.
     useEffect(() => {
-        if (foreignPodUrl || !db) {
-            setHasQuestionSet(false)
+        if (foreignPodUrl || !db || !packingList) {
+            setQuestionUpdateAvailable(false)
             return
         }
+        let cancelled = false
         Promise.resolve()
             .then(() => db.getQuestionSet())
-            .then(() => setHasQuestionSet(true))
-            .catch(() => setHasQuestionSet(false))
-    }, [db, foreignPodUrl])
+            .then(questionSet => {
+                if (cancelled) return
+                setQuestionUpdateAvailable(computeQuestionSetAdditions(packingList, questionSet).length > 0)
+            })
+            .catch(() => { if (!cancelled) setQuestionUpdateAvailable(false) })
+        return () => { cancelled = true }
+    }, [db, foreignPodUrl, packingList])
 
     useEffect(() => {
         if (!packingList || !foreignPodUrl || !id || !sharedListsWithMe) return
@@ -394,6 +411,8 @@ export function ViewPackingList() {
     // guests, or the whole cast of a shared list — still come out in colours
     // nobody else here is wearing.
     const personColor = usePersonColors(db, peopleOptions)
+    // Profile photos for people whose question-set entry names a WebID
+    const personPhoto = usePersonProfilePhotos(db, session)
 
 
     const { register, setValue, getValues, control, reset } = useForm<FormData>({
@@ -1213,6 +1232,15 @@ export function ViewPackingList() {
         <div className="w-full flex flex-col items-center py-8 px-4">
             {/* Non-sticky header: name, actions */}
             <div className="w-full max-w-screen-2xl mb-3">
+                <button
+                    type="button"
+                    onClick={() => navigate(backPath)}
+                    aria-label="Back to lists"
+                    title="Back to lists"
+                    className="mb-1 -ml-1.5 inline-flex items-center justify-center rounded-lg p-1.5 text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+                >
+                    <ArrowLeft className="w-5 h-5" aria-hidden="true" />
+                </button>
                 <div className="flex flex-wrap items-center justify-between gap-3">
                     <div className="flex items-center gap-3 min-w-0">
                         <h1 className="text-xl font-bold text-gray-900 truncate">{packingList.name}</h1>
@@ -1236,20 +1264,12 @@ export function ViewPackingList() {
                                 type="button"
                                 variant="secondary"
                                 onClick={() => setShowSharedSection(true)}
+                                className="inline-flex items-center gap-1.5"
                             >
-                                + Add Shared Items
+                                <Plus className="w-4 h-4" aria-hidden="true" />Add Shared Items
                             </Button>
                         )}
-                        {!foreignPodUrl && (
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                onClick={() => { setShowAddGuest(v => !v); setNewGuestName('') }}
-                            >
-                                + Add Guest
-                            </Button>
-                        )}
-                        {!foreignPodUrl && hasQuestionSet && (
+                        {!foreignPodUrl && questionUpdateAvailable && (
                             <Button
                                 type="button"
                                 variant="secondary"
@@ -1258,23 +1278,53 @@ export function ViewPackingList() {
                                 Update from questions
                             </Button>
                         )}
-                        {isLoggedIn && !foreignPodUrl && (
-                            <Button
+                        {!foreignPodUrl && (
+                            /* The list's cast, folded into a quiet cluster: the first two
+                               people, then "+n" for the rest. Tapping it is how a guest
+                               joins — adding a person starts from the people already here. */
+                            <button
                                 type="button"
-                                variant="secondary"
+                                onClick={() => { setShowAddGuest(v => !v); setNewGuestName('') }}
+                                aria-label="Add Guest"
+                                title="Add Guest"
+                                aria-expanded={showAddGuest}
+                                data-testid="guest-cluster"
+                                className="flex items-center -space-x-2 rounded-full p-1 hover:bg-gray-100 transition-colors"
+                            >
+                                {peopleOptions.slice(0, 2).map(person => (
+                                    <span key={person.name} className="rounded-full ring-2 ring-white">
+                                        <PersonAvatar
+                                            name={person.name}
+                                            color={personColor({ id: person.id ?? '', name: person.name })}
+                                            photoUrl={personPhoto[person.name]}
+                                        />
+                                    </span>
+                                ))}
+                                {peopleOptions.length > 2 && (
+                                    <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-gray-200 text-gray-700 text-xs font-semibold ring-2 ring-white">
+                                        +{peopleOptions.length - 2}
+                                    </span>
+                                )}
+                                {peopleOptions.length === 0 && (
+                                    // A list that names nobody yet still needs a way in
+                                    <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-gray-200 text-gray-700 ring-2 ring-white">
+                                        <Plus className="w-4 h-4" aria-hidden="true" />
+                                    </span>
+                                )}
+                            </button>
+                        )}
+                        {isLoggedIn && !foreignPodUrl && (
+                            <button
+                                type="button"
                                 onClick={() => setShareModalOpen(true)}
                                 disabled={!ownPodUrl}
+                                aria-label="Share"
+                                title="Share"
+                                className="inline-flex items-center justify-center rounded-lg p-2 text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                             >
-                                Share
-                            </Button>
+                                <Share2 className="w-5 h-5" aria-hidden="true" />
+                            </button>
                         )}
-                        <Button
-                            type="button"
-                            variant="secondary"
-                            onClick={() => navigate(backPath)}
-                        >
-                            Back to Lists
-                        </Button>
                     </div>
                 </div>
                 {(packingList.destination || tripDates) && (
@@ -1435,21 +1485,55 @@ export function ViewPackingList() {
 
             {/* Hidden packed items banner — at 100% it's just noise next to the
                 celebration, and the Show Packed button is right there anyway */}
-            {hiddenPackedCount > 0 && !allPacked && (
+            {hiddenPackedCount > 0 && !allPacked && !packedHintDismissed && (
                 <div className="w-full max-w-screen-2xl mb-4">
-                    <div className="bg-amber-50 border border-amber-200 rounded-xl px-4 py-3">
+                    <div className="bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 flex items-center justify-between gap-2">
                         <p className="text-sm text-amber-800">
                             {hiddenPackedCount} packed item{hiddenPackedCount !== 1 ? 's' : ''} hidden — tap <strong>Show Packed</strong> to see them.
                         </p>
+                        <button
+                            type="button"
+                            onClick={dismissPackedHint}
+                            aria-label="Dismiss"
+                            title="Dismiss"
+                            className="shrink-0 rounded p-1 text-amber-600 hover:text-amber-800 hover:bg-amber-100 transition-colors"
+                        >
+                            <X className="w-4 h-4" aria-hidden="true" />
+                        </button>
                     </div>
                 </div>
             )}
 
             {/* Main content */}
             <div className="w-full">
-                {/* Add Guest inline form — appears just above the grid */}
-                {showAddGuest && (
-                    <div className="mb-4 flex gap-2 max-w-sm">
+                {/* Add Guest modal — who's already here, then who's joining */}
+                <Modal
+                    isOpen={showAddGuest}
+                    onClose={() => { setShowAddGuest(false); setNewGuestName('') }}
+                    title="Add Guest"
+                >
+                    {peopleOptions.length > 0 && (
+                        <div className="mb-4">
+                            <p className="text-xs text-gray-500 mb-2">Already on this list</p>
+                            <ul className="flex flex-wrap gap-2">
+                                {peopleOptions.map(person => (
+                                    <li
+                                        key={person.name}
+                                        className="flex items-center gap-1.5 text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-full pl-1 pr-3 py-0.5"
+                                    >
+                                        <PersonAvatar
+                                            name={person.name}
+                                            color={personColor({ id: person.id ?? '', name: person.name })}
+                                            photoUrl={personPhoto[person.name]}
+                                            size="sm"
+                                        />
+                                        {person.name}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                    <div className="flex gap-2">
                         <input
                             type="text"
                             value={newGuestName}
@@ -1477,7 +1561,7 @@ export function ViewPackingList() {
                             Cancel
                         </button>
                     </div>
-                )}
+                </Modal>
                 <div>
                     {/* Once everything is packed the cards hold nothing but empty
                         celebrations, so they fold away and leave the banner as the
@@ -1511,7 +1595,16 @@ export function ViewPackingList() {
                                 ? 'border-emerald-300 bg-emerald-50'
                                 : `bg-white ${sectionPersonColor?.border ?? (isShared ? 'border-blue-200' : 'border-gray-200')}`
                             return (
-                            <div key={sectionKey} data-testid="list-section" className={`border rounded-lg p-4 shadow-sm mb-4 transition-colors duration-300 ${sectionBorder}`} style={{ breakInside: 'avoid' }}>
+                            <div
+                                key={sectionKey}
+                                data-testid="list-section"
+                                // A folded card is all heading, so the whole card expands it —
+                                // the header button stays the accessible toggle. Unfolded, the
+                                // body is full of its own controls, so only the header toggles.
+                                onClick={isSectionCollapsed ? () => toggleSection(sectionKey) : undefined}
+                                className={`border rounded-lg p-4 shadow-sm mb-4 transition-colors duration-300 ${sectionBorder} ${isSectionCollapsed ? 'cursor-pointer' : ''}`}
+                                style={{ breakInside: 'avoid' }}
+                            >
                                 {/* The rule under the heading separates it from the items
                                     below; a folded card has none, so it would just be a
                                     line ruling off empty space. */}
@@ -1537,12 +1630,12 @@ export function ViewPackingList() {
                                             <button
                                                 type="button"
                                                 aria-label={`${isSectionCollapsed ? 'Expand' : 'Collapse'} ${collapseLabelTarget} list`}
-                                                onClick={() => toggleSection(sectionKey)}
+                                                onClick={e => { e.stopPropagation(); toggleSection(sectionKey) }}
                                                 className="flex items-center gap-2 flex-1 min-w-0 text-left"
                                             >
                                                 <span className="shrink-0 text-sm text-gray-400">{isSectionCollapsed ? '▶' : '▼'}</span>
                                                 {sectionPersonColor && (
-                                                    <PersonAvatar name={section.name} color={sectionPersonColor} />
+                                                    <PersonAvatar name={section.name} color={sectionPersonColor} photoUrl={personPhoto[section.name]} />
                                                 )}
                                                 <span className="text-xl font-semibold text-gray-800">{title}</span>
                                                 {/* Never let a count break across lines — "9 /" above "9" is
@@ -1569,7 +1662,7 @@ export function ViewPackingList() {
                                                 <button
                                                     type="button"
                                                     aria-label={`Rename ${section.name}`}
-                                                    onClick={() => { setRenamingGuestId(guestId); setRenamingGuestName(section.name) }}
+                                                    onClick={e => { e.stopPropagation(); setRenamingGuestId(guestId); setRenamingGuestName(section.name) }}
                                                     className="p-2 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-md transition-colors"
                                                 >
                                                     <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
@@ -1579,7 +1672,7 @@ export function ViewPackingList() {
                                                 <button
                                                     type="button"
                                                     aria-label={`Remove ${section.name}`}
-                                                    onClick={() => setGuestToRemove(guestId)}
+                                                    onClick={e => { e.stopPropagation(); setGuestToRemove(guestId) }}
                                                     className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
                                                 >
                                                     <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
@@ -1656,6 +1749,7 @@ export function ViewPackingList() {
                                                                 name={label}
                                                                 color={personColor({ id: personIdByName.get(label) ?? '', name: label })}
                                                                 size="sm"
+                                                                photoUrl={personPhoto[label]}
                                                             />
                                                         )}
                                                         <span>{label}</span>
@@ -1671,18 +1765,20 @@ export function ViewPackingList() {
                                                                 aria-label={`Add item to ${groupLabel}`}
                                                                 aria-expanded={composerOpen}
                                                                 onClick={() => setOpenComposerKey(composerOpen ? null : categoryKey)}
-                                                                className={`rounded-full border px-2.5 py-1 text-xs font-semibold transition-colors ${composerOpen ? 'border-blue-300 bg-blue-100 text-blue-800' : 'border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100'}`}
+                                                                className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold transition-colors ${composerOpen ? 'border-blue-300 bg-blue-100 text-blue-800' : 'border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100'}`}
                                                             >
                                                                 {/* A section name is what the heading is for; on a
                                                                     phone the word "Add" is what pushes it off. */}
-                                                                {isDesktop ? '+ Add' : '+'}
+                                                                <Plus className="w-3.5 h-3.5" aria-hidden="true" />
+                                                                {isDesktop && 'Add'}
                                                             </button>
                                                             <button
                                                                 type="button"
                                                                 aria-label="Check all"
                                                                 onClick={() => handleCheckAll(catItems)}
-                                                                className="text-xs text-blue-600 hover:text-blue-800"
+                                                                className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-100 transition-colors"
                                                             >
+                                                                <CheckCheck className="w-3.5 h-3.5" aria-hidden="true" />
                                                                 Check all
                                                             </button>
                                                         </div>

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1243,7 +1243,7 @@ export function ViewPackingList() {
                 </button>
                 <div className="flex flex-wrap items-center justify-between gap-3">
                     <div className="flex items-center gap-3 min-w-0">
-                        <h1 className="text-xl font-bold text-gray-900 truncate">{packingList.name}</h1>
+                        <h1 className="text-2xl font-bold text-gray-900 truncate">{packingList.name}</h1>
                         {foreignPodUrl && (
                             <span className="text-xs font-medium text-blue-700 bg-blue-100 border border-blue-200 rounded-full px-2 py-0.5 shrink-0">
                                 Shared list

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -22,7 +22,7 @@ import { UpdateFromQuestionsModal } from '../components/UpdateFromQuestionsModal
 import { useForeignPod } from '../components/ForeignPodContext'
 import { useSharedListsSync } from '../hooks/useSharedListsSync'
 import { mergePackingLists } from '../utils/mergePackingLists'
-import { computeQuestionSetAdditions } from '../create-packing-list/updateFromQuestions'
+import { computeQuestionSetChanges, type QuestionSetChange } from '../create-packing-list/updateFromQuestions'
 import { MILESTONE_MESSAGES, resolveMilestone } from './packing-milestones'
 import { formatTripDates } from '../create-packing-list/tripDetails'
 import { tapFeedback } from '../utils/haptics'
@@ -181,7 +181,7 @@ export function ViewPackingList() {
     // sharing rather than a generic "set up a pod" pitch.
     const [signInToSharePromptOpen, setSignInToSharePromptOpen] = useState(false)
     // Additions computed from the question set; non-null opens the preview modal.
-    const [questionUpdateAdditions, setQuestionUpdateAdditions] = useState<PackingListItem[] | null>(null)
+    const [questionUpdateChanges, setQuestionUpdateChanges] = useState<QuestionSetChange[] | null>(null)
     // Whether the question set exists locally (gates the "Update from questions" button).
     const [questionUpdateAvailable, setQuestionUpdateAvailable] = useState(false)
     const [ownPodUrl, setOwnPodUrl] = useState<string | null>(null)
@@ -352,7 +352,7 @@ export function ViewPackingList() {
             .then(() => db.getQuestionSet())
             .then(questionSet => {
                 if (cancelled) return
-                setQuestionUpdateAvailable(computeQuestionSetAdditions(packingList, questionSet).length > 0)
+                setQuestionUpdateAvailable(computeQuestionSetChanges(packingList, questionSet).length > 0)
             })
             .catch(() => { if (!cancelled) setQuestionUpdateAvailable(false) })
         return () => { cancelled = true }
@@ -731,35 +731,59 @@ export function ViewPackingList() {
         if (!packingList) return
         try {
             const questionSet = await db.getQuestionSet()
-            const additions = computeQuestionSetAdditions(packingList, questionSet)
-            if (additions.length === 0) {
+            const changes = computeQuestionSetChanges(packingList, questionSet)
+            if (changes.length === 0) {
                 showToast('This list already matches your questions', 'success')
                 return
             }
-            setQuestionUpdateAdditions(additions)
+            setQuestionUpdateChanges(changes)
         } catch (err) {
             const details = reportError(err, 'Error computing question updates')
             showToast('Failed to check for question updates', 'error', details)
         }
     }
 
-    const handleConfirmQuestionUpdate = async (selected: PackingListItem[]) => {
+    const handleConfirmQuestionUpdate = async (selected: QuestionSetChange[]) => {
         if (!packingList || selected.length === 0) {
-            setQuestionUpdateAdditions(null)
+            setQuestionUpdateChanges(null)
             return
         }
         try {
-            const updatedList: PackingList = {
-                ...packingList,
-                items: [...packingList.items, ...selected],
+            let items = [...packingList.items]
+            const deletedItems = [...(packingList.deletedItems ?? [])]
+            const now = new Date().toISOString()
+            for (const change of selected) {
+                switch (change.type) {
+                    case 'add':
+                        items.push(change.item)
+                        break
+                    case 'update':
+                        items = items.map(i => i.id === change.before.id ? change.after : i)
+                        break
+                    case 'remove':
+                        // Tombstoned like a hand-deleted item, so sync merges
+                        // agree it's gone and additions never resurrect it.
+                        items = items.filter(i => i.id !== change.item.id)
+                        deletedItems.push({ ...change.item, reviewed: false, lastModified: now })
+                        break
+                    case 'sharing': {
+                        // Replaced, not deleted — no tombstone, so flipping the
+                        // question back later re-offers the old shape.
+                        const removed = new Set(change.remove.map(r => r.id))
+                        items = items.filter(i => !removed.has(i.id))
+                        items.push(...change.add)
+                        break
+                    }
+                }
             }
+            const updatedList: PackingList = { ...packingList, items, deletedItems }
             await persistPackingList(updatedList)
-            showToast(`Added ${selected.length} item${selected.length === 1 ? '' : 's'} from your questions`, 'success')
+            showToast(`Applied ${selected.length} update${selected.length === 1 ? '' : 's'} from your questions`, 'success')
         } catch (err) {
-            const details = reportError(err, 'Error adding question updates')
-            showToast('Failed to add items', 'error', details)
+            const details = reportError(err, 'Error applying question updates')
+            showToast('Failed to apply updates', 'error', details)
         } finally {
-            setQuestionUpdateAdditions(null)
+            setQuestionUpdateChanges(null)
         }
     }
 
@@ -1378,14 +1402,13 @@ export function ViewPackingList() {
                 </div>
             )}
 
-            {/* Slim sticky progress strip */}
+            {/* Slim sticky progress strip: the progress card carries the bar and
+                Show Packed (they're both about what's visible of the packing
+                state); the view controls sit in their own card to the right. */}
             <div className="sticky top-0 z-50 w-full mb-4 flex justify-center">
-                <div className="w-full max-w-screen-2xl">
-                    <div className="backdrop-blur-md bg-white/90 border border-gray-200 shadow-sm rounded-lg px-4 py-2">
-                        {/* Counts and bar share a line with the controls where there is
-                            room; at 390px the controls drop to a line of their own
-                            rather than squeezing everything into wrapped fragments. */}
-                        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+                <div className="w-full max-w-screen-2xl flex flex-wrap items-stretch gap-2">
+                    <div className="flex-1 min-w-0 backdrop-blur-md bg-white/90 border border-gray-200 shadow-sm rounded-lg px-4 py-2">
+                        <div className="h-full flex flex-wrap items-center gap-x-3 gap-y-2">
                             <span className={`text-sm font-medium whitespace-nowrap ${allPacked ? 'text-emerald-600' : 'text-gray-600'}`}>
                                 {allPacked ? '🎉 All packed!' : `${packedCount} / ${totalCount} packed (${percentComplete}%)`}
                             </span>
@@ -1413,7 +1436,17 @@ export function ViewPackingList() {
                                     </span>
                                 )}
                             </div>
-                            <div className="w-full sm:w-auto flex flex-wrap items-center justify-end gap-2">
+                            <Button
+                                type="button"
+                                variant={hiddenPackedCount > 0 ? 'primary' : 'secondary'}
+                                onClick={() => setShowPacked(!showPacked)}
+                            >
+                                {showPacked ? 'Hide Packed' : 'Show Packed'}
+                            </Button>
+                        </div>
+                    </div>
+                    <div className="backdrop-blur-md bg-white/90 border border-gray-200 shadow-sm rounded-lg px-3 py-2 shrink-0">
+                        <div className="h-full flex flex-wrap items-center justify-end gap-2">
                                 {showFoldAllControl && (
                                     <button
                                         type="button"
@@ -1453,14 +1486,6 @@ export function ViewPackingList() {
                                         {isDesktop ? 'Question View' : 'Question'}
                                     </button>
                                 </div>
-                                <Button
-                                    type="button"
-                                    variant={hiddenPackedCount > 0 ? 'primary' : 'secondary'}
-                                    onClick={() => setShowPacked(!showPacked)}
-                                >
-                                    {showPacked ? 'Hide Packed' : 'Show Packed'}
-                                </Button>
-                            </div>
                         </div>
                     </div>
                 </div>
@@ -2026,9 +2051,9 @@ export function ViewPackingList() {
             />
         )}
         <UpdateFromQuestionsModal
-            isOpen={questionUpdateAdditions !== null}
-            onClose={() => setQuestionUpdateAdditions(null)}
-            additions={questionUpdateAdditions ?? []}
+            isOpen={questionUpdateChanges !== null}
+            onClose={() => setQuestionUpdateChanges(null)}
+            changes={questionUpdateChanges ?? []}
             onConfirm={handleConfirmQuestionUpdate}
         />
         </>

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1237,13 +1237,13 @@ export function ViewPackingList() {
                     onClick={() => navigate(backPath)}
                     aria-label="Back to lists"
                     title="Back to lists"
-                    className="mb-1 -ml-1.5 inline-flex items-center justify-center rounded-lg p-1.5 text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+                    className="mb-1 -ml-1.5 inline-flex items-center justify-center rounded-lg p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                 >
                     <ArrowLeft className="w-5 h-5" aria-hidden="true" />
                 </button>
                 <div className="flex flex-wrap items-center justify-between gap-3">
                     <div className="flex items-center gap-3 min-w-0">
-                        <h1 className="text-2xl font-bold text-gray-900 truncate">{packingList.name}</h1>
+                        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 truncate">{packingList.name}</h1>
                         {foreignPodUrl && (
                             <span className="text-xs font-medium text-blue-700 bg-blue-100 border border-blue-200 rounded-full px-2 py-0.5 shrink-0">
                                 Shared list
@@ -1289,7 +1289,7 @@ export function ViewPackingList() {
                                 title="Add Guest"
                                 aria-expanded={showAddGuest}
                                 data-testid="guest-cluster"
-                                className="flex items-center -space-x-2 rounded-full p-1 hover:bg-gray-100 transition-colors"
+                                className="flex items-center -space-x-2 rounded-full p-1 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                             >
                                 {peopleOptions.slice(0, 2).map(person => (
                                     <span key={person.name} className="rounded-full ring-2 ring-white">
@@ -1301,13 +1301,13 @@ export function ViewPackingList() {
                                     </span>
                                 ))}
                                 {peopleOptions.length > 2 && (
-                                    <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-gray-200 text-gray-700 text-xs font-semibold ring-2 ring-white">
+                                    <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-gray-200 text-gray-700 dark:text-gray-300 text-xs font-semibold ring-2 ring-white">
                                         +{peopleOptions.length - 2}
                                     </span>
                                 )}
                                 {peopleOptions.length === 0 && (
                                     // A list that names nobody yet still needs a way in
-                                    <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-gray-200 text-gray-700 ring-2 ring-white">
+                                    <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-gray-200 text-gray-700 dark:text-gray-300 ring-2 ring-white">
                                         <Plus className="w-4 h-4" aria-hidden="true" />
                                     </span>
                                 )}
@@ -1320,7 +1320,7 @@ export function ViewPackingList() {
                                 disabled={!ownPodUrl}
                                 aria-label="Share"
                                 title="Share"
-                                className="inline-flex items-center justify-center rounded-lg p-2 text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                className="inline-flex items-center justify-center rounded-lg p-2 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                                 <Share2 className="w-5 h-5" aria-hidden="true" />
                             </button>
@@ -1330,7 +1330,7 @@ export function ViewPackingList() {
                 {(packingList.destination || tripDates) && (
                     <div
                         data-testid="trip-details"
-                        className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600"
+                        className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600 dark:text-gray-400"
                     >
                         {packingList.destination && <span>📍 {packingList.destination}</span>}
                         {tripDates && <span>📅 {tripDates}</span>}
@@ -1350,12 +1350,12 @@ export function ViewPackingList() {
             {/* Slim sticky progress strip */}
             <div className="sticky top-0 z-50 w-full mb-4 flex justify-center">
                 <div className="w-full max-w-screen-2xl">
-                    <div className="backdrop-blur-md bg-white/90 border border-gray-200 shadow-sm rounded-lg px-4 py-2">
+                    <div className="backdrop-blur-md bg-white/90 border border-gray-200 dark:border-gray-700 shadow-sm rounded-lg px-4 py-2">
                         {/* Counts and bar share a line with the controls where there is
                             room; at 390px the controls drop to a line of their own
                             rather than squeezing everything into wrapped fragments. */}
                         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-                            <span className={`text-sm font-medium whitespace-nowrap ${allPacked ? 'text-emerald-600' : 'text-gray-600'}`}>
+                            <span className={`text-sm font-medium whitespace-nowrap ${allPacked ? 'text-emerald-600' : 'text-gray-600 dark:text-gray-400'}`}>
                                 {allPacked ? '🎉 All packed!' : `${packedCount} / ${totalCount} packed (${percentComplete}%)`}
                             </span>
                             {/* The bar shrinks to its minimum before the encouragement
@@ -1377,7 +1377,7 @@ export function ViewPackingList() {
                                     ></div>
                                 </div>
                                 {milestoneMessage && (
-                                    <span data-testid="progress-milestone" className="text-xs font-semibold text-primary-700 whitespace-nowrap">
+                                    <span data-testid="progress-milestone" className="text-xs font-semibold text-primary-700 dark:text-primary-300 whitespace-nowrap">
                                         {milestoneMessage}
                                     </span>
                                 )}
@@ -1388,12 +1388,12 @@ export function ViewPackingList() {
                                         type="button"
                                         onClick={toggleAllSections}
                                         title={everySectionFolded ? 'Open every section' : 'Fold every section down to its header'}
-                                        className="shrink-0 flex items-center gap-1 rounded-md border border-gray-300 bg-white px-2.5 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                                        className="shrink-0 flex items-center gap-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2.5 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
                                     >
                                         {/* Same glyph the section headers use for the same
                                             state, so the toolbar and the cards never point
                                             opposite ways at each other. */}
-                                        <span aria-hidden="true" className="text-xs text-gray-400">{everySectionFolded ? '▶' : '▼'}</span>
+                                        <span aria-hidden="true" className="text-xs text-gray-400 dark:text-gray-500">{everySectionFolded ? '▶' : '▼'}</span>
                                         {/* The word "all" is what tips this row onto a second
                                             line on a phone, and the icon already says it. */}
                                         {everySectionFolded ? (isDesktop ? 'Expand all' : 'Expand') : (isDesktop ? 'Collapse all' : 'Collapse')}
@@ -1402,13 +1402,13 @@ export function ViewPackingList() {
                                 {/* "View" is what the group is labelled; repeating it in both
                                     buttons is what pushes this row off a 390px screen. The
                                     accessible name keeps the full wording either way. */}
-                                <div className="flex shrink-0 items-center rounded-md border border-gray-300 overflow-hidden" role="group" aria-label="View mode">
+                                <div className="flex shrink-0 items-center rounded-md border border-gray-300 dark:border-gray-600 overflow-hidden" role="group" aria-label="View mode">
                                     <button
                                         type="button"
                                         aria-pressed={viewMode === 'person'}
                                         aria-label="Person View"
                                         onClick={() => setViewMode('person')}
-                                        className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors ${viewMode === 'person' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                                        className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors ${viewMode === 'person' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'}`}
                                     >
                                         {isDesktop ? 'Person View' : 'Person'}
                                     </button>
@@ -1417,7 +1417,7 @@ export function ViewPackingList() {
                                         aria-pressed={viewMode === 'question'}
                                         aria-label="Question View"
                                         onClick={() => setViewMode('question')}
-                                        className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors border-l border-gray-300 ${viewMode === 'question' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                                        className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors border-l border-gray-300 dark:border-gray-600 ${viewMode === 'question' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'}`}
                                     >
                                         {isDesktop ? 'Question View' : 'Question'}
                                     </button>
@@ -1475,7 +1475,7 @@ export function ViewPackingList() {
                         <button
                             type="button"
                             onClick={toggleAllSections}
-                            className="shrink-0 rounded-md border border-blue-300 bg-white px-3 py-1.5 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100"
+                            className="shrink-0 rounded-md border border-blue-300 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100"
                         >
                             Expand all
                         </button>
@@ -1514,12 +1514,12 @@ export function ViewPackingList() {
                 >
                     {peopleOptions.length > 0 && (
                         <div className="mb-4">
-                            <p className="text-xs text-gray-500 mb-2">Already on this list</p>
+                            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Already on this list</p>
                             <ul className="flex flex-wrap gap-2">
                                 {peopleOptions.map(person => (
                                     <li
                                         key={person.name}
-                                        className="flex items-center gap-1.5 text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-full pl-1 pr-3 py-0.5"
+                                        className="flex items-center gap-1.5 text-sm text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-full pl-1 pr-3 py-0.5"
                                     >
                                         <PersonAvatar
                                             name={person.name}
@@ -1544,7 +1544,7 @@ export function ViewPackingList() {
                             }}
                             placeholder="Guest name..."
                             autoFocus
-                            className="flex-1 min-w-0 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                            className="flex-1 min-w-0 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
                         />
                         <button
                             type="button"
@@ -1556,7 +1556,7 @@ export function ViewPackingList() {
                         <button
                             type="button"
                             onClick={() => { setShowAddGuest(false); setNewGuestName('') }}
-                            className="shrink-0 px-3 py-2 text-gray-600 hover:text-gray-900 border border-gray-300 rounded-md text-sm"
+                            className="shrink-0 px-3 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 border border-gray-300 dark:border-gray-600 rounded-md text-sm"
                         >
                             Cancel
                         </button>
@@ -1593,7 +1593,7 @@ export function ViewPackingList() {
                                 : personColor({ id: guestId ?? personIdByName.get(section.name) ?? '', name: section.name })
                             const sectionBorder = isComplete
                                 ? 'border-emerald-300 bg-emerald-50'
-                                : `bg-white ${sectionPersonColor?.border ?? (isShared ? 'border-blue-200' : 'border-gray-200')}`
+                                : `bg-white dark:bg-gray-800 ${sectionPersonColor?.border ?? (isShared ? 'border-blue-200' : 'border-gray-200 dark:border-gray-700')}`
                             return (
                             <div
                                 key={sectionKey}
@@ -1608,11 +1608,11 @@ export function ViewPackingList() {
                                 {/* The rule under the heading separates it from the items
                                     below; a folded card has none, so it would just be a
                                     line ruling off empty space. */}
-                                <div className={isSectionCollapsed ? undefined : 'mb-4 pb-2 border-b border-gray-200'}>
+                                <div className={isSectionCollapsed ? undefined : 'mb-4 pb-2 border-b border-gray-200 dark:border-gray-700'}>
                                     <div className="flex flex-wrap items-center gap-1 min-h-[2rem]">
                                         {isGuest && renamingGuestId === guestId ? (
                                             <>
-                                                <span className="text-sm text-gray-400 px-1" aria-hidden>▼</span>
+                                                <span className="text-sm text-gray-400 dark:text-gray-500 px-1" aria-hidden>▼</span>
                                                 <input
                                                     type="text"
                                                     value={renamingGuestName}
@@ -1623,7 +1623,7 @@ export function ViewPackingList() {
                                                     }}
                                                     onBlur={() => handleRenameGuest(guestId, renamingGuestName)}
                                                     autoFocus
-                                                    className="flex-1 px-2 py-1 border border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-lg font-semibold text-gray-800"
+                                                    className="flex-1 px-2 py-1 border border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-lg font-semibold text-gray-800 dark:text-gray-200"
                                                 />
                                             </>
                                         ) : (
@@ -1633,14 +1633,14 @@ export function ViewPackingList() {
                                                 onClick={e => { e.stopPropagation(); toggleSection(sectionKey) }}
                                                 className="flex items-center gap-2 flex-1 min-w-0 text-left"
                                             >
-                                                <span className="shrink-0 text-sm text-gray-400">{isSectionCollapsed ? '▶' : '▼'}</span>
+                                                <span className="shrink-0 text-sm text-gray-400 dark:text-gray-500">{isSectionCollapsed ? '▶' : '▼'}</span>
                                                 {sectionPersonColor && (
                                                     <PersonAvatar name={section.name} color={sectionPersonColor} photoUrl={personPhoto[section.name]} />
                                                 )}
-                                                <span className="text-xl font-semibold text-gray-800">{title}</span>
+                                                <span className="text-xl font-semibold text-gray-800 dark:text-gray-200">{title}</span>
                                                 {/* Never let a count break across lines — "9 /" above "9" is
                                                     a fraction the eye has to reassemble. */}
-                                                <span className="ml-1 shrink-0 whitespace-nowrap text-sm font-normal text-gray-500">{stats.packed} / {stats.total}</span>
+                                                <span className="ml-1 shrink-0 whitespace-nowrap text-sm font-normal text-gray-500 dark:text-gray-400">{stats.packed} / {stats.total}</span>
                                             </button>
                                         )}
                                         {isComplete && (
@@ -1663,7 +1663,7 @@ export function ViewPackingList() {
                                                     type="button"
                                                     aria-label={`Rename ${section.name}`}
                                                     onClick={e => { e.stopPropagation(); setRenamingGuestId(guestId); setRenamingGuestName(section.name) }}
-                                                    className="p-2 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-md transition-colors"
+                                                    className="p-2 text-gray-400 dark:text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-md transition-colors"
                                                 >
                                                     <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
                                                         <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
@@ -1673,7 +1673,7 @@ export function ViewPackingList() {
                                                     type="button"
                                                     aria-label={`Remove ${section.name}`}
                                                     onClick={e => { e.stopPropagation(); setGuestToRemove(guestId) }}
-                                                    className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                                                    className="p-2 text-gray-400 dark:text-gray-500 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
                                                 >
                                                     <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
                                                         <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
@@ -1688,7 +1688,7 @@ export function ViewPackingList() {
                                         part of the target the card already knows: a person's card
                                         knows who, and asks which section; a section's card knows
                                         which section, and asks who. */}
-                                    <div className="mb-4 pb-4 border-b border-gray-200">
+                                    <div className="mb-4 pb-4 border-b border-gray-200 dark:border-gray-700">
                                         <AddItemComposer
                                             personName={isCategorySection ? '' : section.name}
                                             personId={isCategorySection ? '' : (guestId ?? personIdByName.get(section.name) ?? '')}
@@ -1738,7 +1738,7 @@ export function ViewPackingList() {
                                                         type="button"
                                                         aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${label}`}
                                                         onClick={() => toggleGroup(categoryKey)}
-                                                        className="flex items-center gap-1 text-left text-sm font-semibold text-gray-600 hover:text-gray-900"
+                                                        className="flex items-center gap-1 text-left text-sm font-semibold text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
                                                     >
                                                         <span>{isCollapsed ? '▶' : '▼'}</span>
                                                         {/* A category card's groups are people, so each one
@@ -1753,7 +1753,7 @@ export function ViewPackingList() {
                                                             />
                                                         )}
                                                         <span>{label}</span>
-                                                        <span className="ml-1 shrink-0 whitespace-nowrap text-xs font-normal text-gray-400">{groupStat.packed} / {groupStat.total}</span>
+                                                        <span className="ml-1 shrink-0 whitespace-nowrap text-xs font-normal text-gray-400 dark:text-gray-500">{groupStat.packed} / {groupStat.total}</span>
                                                     </button>
                                                     {!isCollapsed && (
                                                         <div className="flex shrink-0 items-center gap-2">
@@ -1810,7 +1810,7 @@ export function ViewPackingList() {
                                                                     if (el) itemRowRefs.current.set(item.id, el)
                                                                     else itemRowRefs.current.delete(item.id)
                                                                 }}
-                                                                className={`relative rounded-lg p-3 transition-colors duration-1000 ${item.id === recentlyAddedItemId ? 'bg-green-100 ring-2 ring-green-400' : 'bg-gray-50'} ${item.id === flourish?.itemId ? 'item-row-packed' : ''}`}
+                                                                className={`relative rounded-lg p-3 transition-colors duration-1000 ${item.id === recentlyAddedItemId ? 'bg-green-100 ring-2 ring-green-400' : 'bg-gray-50 dark:bg-gray-900'} ${item.id === flourish?.itemId ? 'item-row-packed' : ''}`}
                                                             >
                                                                 {item.id === flourish?.itemId && (
                                                                     <span
@@ -1823,7 +1823,7 @@ export function ViewPackingList() {
                                                                         // so no translate utilities here. Themed green rather than
                                                                         // text-green-600 — that class belongs to the "Saved" indicator,
                                                                         // which the e2e suite waits on by selector.
-                                                                        className="item-packed-tick pointer-events-none absolute left-[22px] top-1/2 z-10 text-xl font-bold text-success-600"
+                                                                        className="item-packed-tick pointer-events-none absolute left-[22px] top-1/2 z-10 text-xl font-bold text-success-600 dark:text-success-400"
                                                                     >
                                                                         ✓
                                                                     </span>
@@ -1835,7 +1835,7 @@ export function ViewPackingList() {
                                                                             {...register(`items.${item.id}`, {
                                                                                 onChange: (e) => handleItemToggle(item.id, e.target.checked),
                                                                             })}
-                                                                            className="h-5 w-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+                                                                            className="h-5 w-5 text-blue-600 rounded border-gray-300 dark:border-gray-600 focus:ring-blue-500"
                                                                         />
                                                                         {editingItemId === item.id ? (
                                                                             <span
@@ -1855,7 +1855,7 @@ export function ViewPackingList() {
                                                                                     }}
                                                                                     autoFocus
                                                                                     aria-label="Edit item name"
-                                                                                    className="flex-1 min-w-0 px-2 py-1 border border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm text-gray-700"
+                                                                                    className="flex-1 min-w-0 px-2 py-1 border border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm text-gray-700 dark:text-gray-300"
                                                                                 />
                                                                                 <input
                                                                                     type="number"
@@ -1869,12 +1869,12 @@ export function ViewPackingList() {
                                                                                     placeholder="Qty"
                                                                                     aria-label="Edit item quantity"
                                                                                     title="How many to pack (leave blank for no quantity)"
-                                                                                    className="w-12 sm:w-16 shrink-0 px-1.5 sm:px-2 py-1 border border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm text-gray-700"
+                                                                                    className="w-12 sm:w-16 shrink-0 px-1.5 sm:px-2 py-1 border border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm text-gray-700 dark:text-gray-300"
                                                                                 />
                                                                             </span>
                                                                         ) : (
                                                                             <span
-                                                                                className={watchedItems[item.id] ? 'text-gray-400 line-through' : 'text-gray-700'}
+                                                                                className={watchedItems[item.id] ? 'text-gray-400 dark:text-gray-500 line-through' : 'text-gray-700 dark:text-gray-300'}
                                                                                 onDoubleClick={() => handleStartEdit(item)}
                                                                             >
                                                                                 {item.itemText}
@@ -1890,7 +1890,7 @@ export function ViewPackingList() {
                                                                         <button
                                                                             type="button"
                                                                             onClick={() => handleStartEdit(item)}
-                                                                            className="ml-1 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-md p-1 transition-colors"
+                                                                            className="ml-1 text-gray-400 dark:text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-md p-1 transition-colors"
                                                                             title="Edit item"
                                                                         >
                                                                             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -163,23 +163,23 @@ export const Wizard = () => {
     return (
         <div className="max-w-3xl mx-auto">
             <div className="mb-8 text-center animate-slide-up">
-                <h1 className="text-4xl font-bold mb-4 text-primary-900">
+                <h1 className="text-4xl font-bold mb-4 text-primary-900 dark:text-primary-200">
                     Create Your Packing Questions
                 </h1>
-                <p className="text-lg text-gray-700">
+                <p className="text-lg text-gray-700 dark:text-gray-300">
                     Tell us who you travel with — we'll generate a starter set of packing questions tailored to your group.
                 </p>
-                <p className="text-sm text-gray-500 mt-2 italic">
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 italic">
                     Do this once to get started. Afterwards, fine-tune your questions and packing items from 'My Questions &amp; Items' to match exactly what you need.
                 </p>
             </div>
 
             {hasExistingData && (
-                <div className="mb-6 p-4 bg-warning-50 border-2 border-warning-300 rounded-2xl">
-                    <p className="text-warning-900 font-semibold">
+                <div className="mb-6 p-4 bg-warning-50 dark:bg-warning-950/40 border-2 border-warning-300 dark:border-warning-700 rounded-2xl">
+                    <p className="text-warning-900 dark:text-warning-200 font-semibold">
                         ⚠️ You already have packing list questions set up. Completing this wizard will replace them.
                     </p>
-                    <p className="text-sm text-warning-800 mt-1">
+                    <p className="text-sm text-warning-800 dark:text-warning-300 mt-1">
                         To keep your existing questions, go to{' '}
                         <Link to="/manage-questions" className="underline font-semibold">Edit Questions</Link> instead.
                     </p>
@@ -188,16 +188,16 @@ export const Wizard = () => {
 
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
                 {/* People Section */}
-                <div className="bg-white p-6 rounded-2xl shadow-soft border-2 border-primary-200">
+                <div className="bg-white dark:bg-gray-800 p-6 rounded-2xl shadow-soft border-2 border-primary-200 dark:border-primary-800">
                     <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-2xl font-bold text-primary-900">👥 Who's Packing?</h2>
-                        <span className="text-sm text-gray-600 font-medium">
+                        <h2 className="text-2xl font-bold text-primary-900 dark:text-primary-200">👥 Who's Packing?</h2>
+                        <span className="text-sm text-gray-600 dark:text-gray-400 font-medium">
                             {fields.length} in your group
                         </span>
                     </div>
 
                     {isPrefilled && (
-                        <p className="mb-4 text-sm text-gray-600">
+                        <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
                             We've filled in the people from your current setup — add, remove or change anyone before generating.
                         </p>
                     )}
@@ -207,18 +207,18 @@ export const Wizard = () => {
                             const dob = field.kind === 'person' ? watch(`people.${index}.dateOfBirth`) : undefined
                             const derivedAgeRange = dob ? deriveAgeRange(dob) : undefined
                             return (
-                            <div key={field.id} className="bg-primary-50 p-4 rounded-xl border border-primary-200">
+                            <div key={field.id} className="bg-primary-50 dark:bg-primary-950/40 p-4 rounded-xl border border-primary-200 dark:border-primary-800">
                                 <div className="flex items-start gap-4">
                                     <div className="flex-1 grid grid-cols-1 md:grid-cols-3 gap-4">
                                         <div>
-                                            <label htmlFor={`person-name-${index}`} className="block text-sm font-semibold text-gray-700 mb-2">
+                                            <label htmlFor={`person-name-${index}`} className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
                                                 Name
                                             </label>
                                             <input
                                                 id={`person-name-${index}`}
                                                 type="text"
                                                 {...register(`people.${index}.name`)}
-                                                className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                className="w-full px-4 py-2 border-2 border-gray-300 dark:border-gray-600 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
                                             />
                                             {errors.people?.[index]?.name && (
                                                 <p className="text-danger-500 text-sm mt-1">{errors.people[index]?.name?.message}</p>
@@ -226,12 +226,12 @@ export const Wizard = () => {
                                         </div>
                                         {field.kind === 'pet' ? (
                                             <div>
-                                                <label className="block text-sm font-semibold text-gray-700 mb-2">
+                                                <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
                                                     Species
                                                 </label>
                                                 <select
                                                     {...register(`people.${index}.species`)}
-                                                    className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                    className="w-full px-4 py-2 border-2 border-gray-300 dark:border-gray-600 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
                                                 >
                                                     <option value="">Select species...</option>
                                                     {PET_SPECIES_OPTIONS.map(option => (
@@ -247,8 +247,8 @@ export const Wizard = () => {
                                         ) : (
                                             <>
                                                 <div>
-                                                    <label className="block text-sm font-semibold text-gray-700 mb-2">
-                                                        Birthday <span className="text-gray-400 font-normal">(optional)</span>
+                                                    <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                                                        Birthday <span className="text-gray-400 dark:text-gray-500 font-normal">(optional)</span>
                                                     </label>
                                                     <input
                                                         type="date"
@@ -258,19 +258,19 @@ export const Wizard = () => {
                                                                 if (derived) setValue(`people.${index}.ageRange`, derived)
                                                             },
                                                         })}
-                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                        className="w-full px-4 py-2 border-2 border-gray-300 dark:border-gray-600 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
                                                     />
                                                     {derivedAgeRange && (
-                                                        <p className="text-xs text-gray-500 mt-1">Age group filled in from birthday — adjust it if they're ahead or behind</p>
+                                                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Age group filled in from birthday — adjust it if they're ahead or behind</p>
                                                     )}
                                                 </div>
                                                 <div>
-                                                    <label className="block text-sm font-semibold text-gray-700 mb-2">
+                                                    <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
                                                         Age Range
                                                     </label>
                                                     <select
                                                         {...register(`people.${index}.ageRange`)}
-                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                        className="w-full px-4 py-2 border-2 border-gray-300 dark:border-gray-600 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
                                                     >
                                                         <option value="">Select age range...</option>
                                                         {AGE_RANGE_OPTIONS.map(option => (
@@ -284,12 +284,12 @@ export const Wizard = () => {
                                                     )}
                                                 </div>
                                                 <div>
-                                                    <label className="block text-sm font-semibold text-gray-700 mb-2">
+                                                    <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
                                                         Gender
                                                     </label>
                                                     <select
                                                         {...register(`people.${index}.gender`)}
-                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                        className="w-full px-4 py-2 border-2 border-gray-300 dark:border-gray-600 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
                                                     >
                                                         <option value="">Select gender...</option>
                                                         {GENDER_OPTIONS.map(option => (
@@ -305,7 +305,7 @@ export const Wizard = () => {
                                     <button
                                         type="button"
                                         onClick={() => handleRemovePerson(index)}
-                                        className="mt-8 p-2 text-danger-500 hover:bg-danger-50 rounded-lg transition-colors"
+                                        className="mt-8 p-2 text-danger-500 hover:bg-danger-50 dark:bg-danger-950/40 rounded-lg transition-colors"
                                         title={field.kind === 'pet' ? 'Remove pet' : 'Remove person'}
                                     >
                                         <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
@@ -322,7 +322,7 @@ export const Wizard = () => {
                         <button
                             type="button"
                             onClick={handleAddPerson}
-                            className="w-full py-3 px-4 border-2 border-dashed border-primary-300 rounded-xl text-primary-700 font-semibold hover:border-primary-500 hover:bg-primary-50 transition-all duration-200 flex items-center justify-center gap-2"
+                            className="w-full py-3 px-4 border-2 border-dashed border-primary-300 dark:border-primary-700 rounded-xl text-primary-700 dark:text-primary-300 font-semibold hover:border-primary-500 hover:bg-primary-50 dark:bg-primary-950/40 transition-all duration-200 flex items-center justify-center gap-2"
                         >
                             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                 <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
@@ -332,7 +332,7 @@ export const Wizard = () => {
                         <button
                             type="button"
                             onClick={handleAddPet}
-                            className="w-full py-3 px-4 border-2 border-dashed border-primary-300 rounded-xl text-primary-700 font-semibold hover:border-primary-500 hover:bg-primary-50 transition-all duration-200 flex items-center justify-center gap-2"
+                            className="w-full py-3 px-4 border-2 border-dashed border-primary-300 dark:border-primary-700 rounded-xl text-primary-700 dark:text-primary-300 font-semibold hover:border-primary-500 hover:bg-primary-50 dark:bg-primary-950/40 transition-all duration-200 flex items-center justify-center gap-2"
                         >
                             <span className="text-lg leading-none">🐾</span>
                             Add a Pet
@@ -383,7 +383,7 @@ Are you sure you want to continue?"
                             {revealSteps.slice(0, revealedCount).map(step => (
                                 <li
                                     key={step.personId}
-                                    className="reveal-line flex gap-2 text-gray-700 break-words"
+                                    className="reveal-line flex gap-2 text-gray-700 dark:text-gray-300 break-words"
                                 >
                                     <span aria-hidden="true">✨</span>
                                     <span className="flex-1 min-w-0">{step.text}</span>
@@ -396,7 +396,7 @@ Are you sure you want to continue?"
                         <div className="flex justify-center">
                             <button
                                 onClick={handleSkipReveal}
-                                className="text-sm font-semibold text-primary-700 underline hover:text-primary-900"
+                                className="text-sm font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-300"
                             >
                                 Skip ›
                             </button>
@@ -406,12 +406,12 @@ Are you sure you want to continue?"
                     {isRevealComplete && (
                         <>
                             {summary && (
-                                <p className="text-center font-bold text-primary-900 break-words">
+                                <p className="text-center font-bold text-primary-900 dark:text-primary-200 break-words">
                                     {summary.text}
                                 </p>
                             )}
 
-                            <p className="text-gray-700 text-center">
+                            <p className="text-gray-700 dark:text-gray-300 text-center">
                                 Your starter questions are ready! Head to 'My Questions &amp; Items' to add, remove, or tweak them to match how you travel — then create your first list.
                             </p>
 
@@ -431,7 +431,7 @@ Are you sure you want to continue?"
                                 </button>
                             </div>
 
-                            <p className="text-sm text-gray-500 text-center mt-4">
+                            <p className="text-sm text-gray-500 dark:text-gray-400 text-center mt-4">
                                 You can always access these options from the navigation menu above
                             </p>
                         </>

--- a/src/pages/your-data.tsx
+++ b/src/pages/your-data.tsx
@@ -85,8 +85,8 @@ export function YourDataPage() {
     return (
         <div className="max-w-3xl mx-auto bg-white/60 rounded-2xl shadow-soft p-6 md:p-10 space-y-6">
             <div>
-                <h1 className="text-3xl font-bold text-primary-900 mb-1">Your data</h1>
-                <p className="text-gray-700">
+                <h1 className="text-3xl font-bold text-primary-900 dark:text-primary-200 mb-1">Your data</h1>
+                <p className="text-gray-700 dark:text-gray-300">
                     Pack Me Up keeps your packing lists on your own device, and — if you choose to sign
                     in — in a Solid Pod that belongs to you. There are no Pack Me Up servers holding your
                     lists. This page is where you delete any of it.
@@ -94,14 +94,14 @@ export function YourDataPage() {
             </div>
 
             <section className="space-y-3">
-                <h2 className="text-xl font-bold text-primary-900">On this device</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">On this device</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     Your packing lists, your questions and items, and your app settings are stored on
                     this device so the app works offline. Deleting them removes them from this device
                     only — other devices you've used keep their own copies.
                 </p>
                 {isLoggedIn && (
-                    <p className="text-gray-700 font-medium">
+                    <p className="text-gray-700 dark:text-gray-300 font-medium">
                         You're signed in, so anything also saved in your pod will sync back to this device
                         next time you sign in. To remove it for good, use "Delete everything" below.
                     </p>
@@ -114,17 +114,17 @@ export function YourDataPage() {
                 >
                     Delete all data on this device
                 </Button>
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                     You can also do this without opening the app: on Android, Settings → Apps → Pack Me Up
                     → Storage → Clear storage. Uninstalling the app removes it as well.
                 </p>
             </section>
 
             <section className="space-y-3">
-                <h2 className="text-xl font-bold text-primary-900">In your Solid Pod</h2>
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">In your Solid Pod</h2>
                 {isLoggedIn ? (
                     <>
-                        <p className="text-gray-700">
+                        <p className="text-gray-700 dark:text-gray-300">
                             Everything the app has saved lives in a single <code>pack-me-up</code> folder
                             in your pod{podUrl ? <> (<span className="break-all">{podUrl}</span>)</> : null},
                             including your backups. Deleting it leaves the rest of your pod untouched.
@@ -137,21 +137,21 @@ export function YourDataPage() {
                         >
                             Delete everything
                         </Button>
-                        <p className="text-sm text-gray-600">
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
                             This removes your pod copy and this device's copy together. There's no
                             pod-only option because it wouldn't hold: signing in again re-uploads whatever
                             is still on this device, rebuilding the folder you just deleted.
                         </p>
                     </>
                 ) : (
-                    <p className="text-gray-700">
+                    <p className="text-gray-700 dark:text-gray-300">
                         If you've signed in with a Solid Pod, everything the app saved is in a single{' '}
                         <code>pack-me-up</code> folder in that pod. Sign in here to delete it with one tap,
                         or delete the folder yourself using your pod provider's file manager — you don't
                         need this app installed to do that.
                     </p>
                 )}
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                     If you've shared a list with someone, deleting your copy doesn't delete theirs. Revoke
                     their access from the list's share dialog before deleting if you want it gone from
                     their view too.
@@ -159,8 +159,8 @@ export function YourDataPage() {
             </section>
 
             <section className="space-y-3">
-                <h2 className="text-xl font-bold text-primary-900">Error reports and analytics</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Error reports and analytics</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     The only things that leave your device to us are crash reports and page-view counts,
                     and neither is linked to you. A crash report carries the error message, a stack trace
                     and your browser or device type — no name, no email, no account, and no IP address.
@@ -169,14 +169,14 @@ export function YourDataPage() {
                     for one person — and equally nothing in them that points back to you. Crash reports
                     are deleted automatically after {ERROR_REPORT_RETENTION} either way.
                 </p>
-                <p className="text-gray-700">
+                <p className="text-gray-700 dark:text-gray-300">
                     The exception is anything you send us on purpose. If you report a bug with the app's
                     feedback button, or email us directly, we have whatever you chose to put in it —
                     including your name and email address if you filled those in. Ask us to delete it and
                     we will:{' '}
                     <a
                         href={`mailto:${SUPPORT_EMAIL}`}
-                        className="font-semibold text-primary-700 underline hover:text-primary-900"
+                        className="font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-300"
                     >
                         {SUPPORT_EMAIL}
                     </a>

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -3,6 +3,7 @@ import {
     setThing,
     buildThing,
     getThing,
+    getUrl,
     getUrlAll,
     getStringNoLocale,
     getStringNoLocaleAll,
@@ -365,6 +366,7 @@ function personToThing(person: Person, personUrl: string): Thing {
     if (person.species) t = t.addStringNoLocale(PMU.species, person.species)
     if (person.dateOfBirth) t = t.addStringNoLocale(PMU.dateOfBirth, person.dateOfBirth)
     if (person.color) t = t.addStringNoLocale(PMU.personColor, person.color)
+    if (person.webId) t = t.addUrl(PMU.personWebId, person.webId)
     if (person.lastModified) t = t.addDatetime(PMU.personLastModified, new Date(person.lastModified))
     if (person.deletedAt) t = t.addDatetime(PMU.personDeletedAt, new Date(person.deletedAt))
 
@@ -380,6 +382,7 @@ function thingToPerson(thing: Thing | null, url: string): Person | null {
     const species = getStringNoLocale(thing, PMU.species) ?? undefined
     const dateOfBirth = getStringNoLocale(thing, PMU.dateOfBirth) ?? undefined
     const color = getStringNoLocale(thing, PMU.personColor) ?? undefined
+    const webId = getUrl(thing, PMU.personWebId) ?? undefined
     const lastModified = getDatetime(thing, PMU.personLastModified)?.toISOString()
     const deletedAt = getDatetime(thing, PMU.personDeletedAt)?.toISOString()
     return {
@@ -390,6 +393,7 @@ function thingToPerson(thing: Thing | null, url: string): Person | null {
         ...(species !== undefined ? { species: species as Person['species'] } : {}),
         ...(dateOfBirth !== undefined ? { dateOfBirth } : {}),
         ...(color !== undefined ? { color: color as Person['color'] } : {}),
+        ...(webId !== undefined ? { webId } : {}),
         ...(lastModified !== undefined ? { lastModified } : {}),
         ...(deletedAt !== undefined ? { deletedAt } : {}),
     }

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -70,6 +70,8 @@ export const PMU = {
     // 'rose' looks like, and an older client that doesn't know an id just falls
     // back to the person's position.
     personColor: `${PMU_NS}personColor`,
+    // The person's Solid WebID, when they have one
+    personWebId: `${PMU_NS}webId`,
     personLastModified: `${PMU_NS}personLastModified`,
     personDeletedAt: `${PMU_NS}personDeletedAt`,
 

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -18,6 +18,7 @@ import {
     revokeCollaboratorAccess,
     getCollaborators,
     getPodOwnerName,
+    getPodOwnerProfile,
     friendlyPodName,
     getPrimaryPodUrl,
     derivePodUrlFromWebId,
@@ -1089,6 +1090,64 @@ describe('getPodOwnerName', () => {
 
         expect(result).toBe('Alice')
         expect(mockGetSolidDataset).toHaveBeenCalledWith(EXPLICIT_WEB_ID, expect.objectContaining({ fetch: mockSession.fetch }))
+    })
+})
+
+// ─── getPodOwnerProfile ──────────────────────────────────────────────────────
+
+describe('getPodOwnerProfile', () => {
+    const POD = 'https://pod.example.com/'
+    const WEB_ID = 'https://pod.example.com/profile/card#me'
+
+    it('prefers vcard:fn over foaf:name and returns the vcard:hasPhoto and vcard:bday', async () => {
+        const { buildThing, setThing, createSolidDataset } = await import('@inrupt/solid-client')
+        const thing = buildThing({ url: WEB_ID })
+            .addStringNoLocale('http://www.w3.org/2006/vcard/ns#fn', 'Alice Example')
+            .addStringNoLocale('http://xmlns.com/foaf/0.1/name', 'alice-foaf')
+            .addUrl('http://www.w3.org/2006/vcard/ns#hasPhoto', 'https://pod.example.com/profile/avatar.jpg')
+            .addStringNoLocale('http://www.w3.org/2006/vcard/ns#bday', '1990-05-04')
+            .build()
+        const dataset = setThing(createSolidDataset(), thing)
+        mockGetSolidDataset.mockResolvedValueOnce(dataset as unknown as SolidDataset & WithServerResourceInfo)
+
+        const result = await getPodOwnerProfile(mockSession, POD)
+
+        expect(result).toEqual({ name: 'Alice Example', photo: 'https://pod.example.com/profile/avatar.jpg', birthday: '1990-05-04' })
+    })
+
+    it('reads vcard:bday stored as an xsd:date literal', async () => {
+        const { buildThing, setThing, createSolidDataset } = await import('@inrupt/solid-client')
+        const thing = buildThing({ url: WEB_ID })
+            .addDate('http://www.w3.org/2006/vcard/ns#bday', new Date('1990-05-04'))
+            .build()
+        const dataset = setThing(createSolidDataset(), thing)
+        mockGetSolidDataset.mockResolvedValueOnce(dataset as unknown as SolidDataset & WithServerResourceInfo)
+
+        const result = await getPodOwnerProfile(mockSession, POD)
+
+        expect(result.birthday).toBe('1990-05-04')
+    })
+
+    it('falls back to foaf:name and foaf:img when vcard terms are absent', async () => {
+        const { buildThing, setThing, createSolidDataset } = await import('@inrupt/solid-client')
+        const thing = buildThing({ url: WEB_ID })
+            .addStringNoLocale('http://xmlns.com/foaf/0.1/name', 'Alice Smith')
+            .addUrl('http://xmlns.com/foaf/0.1/img', 'https://pod.example.com/alice.png')
+            .build()
+        const dataset = setThing(createSolidDataset(), thing)
+        mockGetSolidDataset.mockResolvedValueOnce(dataset as unknown as SolidDataset & WithServerResourceInfo)
+
+        const result = await getPodOwnerProfile(mockSession, POD)
+
+        expect(result).toEqual({ name: 'Alice Smith', photo: 'https://pod.example.com/alice.png', birthday: null })
+    })
+
+    it('returns nulls when the profile card fetch fails', async () => {
+        mockGetSolidDataset.mockRejectedValueOnce(new Error('Not found'))
+
+        const result = await getPodOwnerProfile(mockSession, POD)
+
+        expect(result).toEqual({ name: null, photo: null, birthday: null })
     })
 })
 

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -1,5 +1,5 @@
 import { AppSession as Session } from '../types/AppSession'
-import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile, solidDatasetAsTurtle, universalAccess, getResourceInfoWithAcl, hasResourceAcl, hasFallbackAcl, hasAccessibleAcl, getResourceAcl, createAclFromFallbackAcl, saveAclFor, setAgentResourceAccess, setAgentDefaultAccess, createContainerAt, acp_ess_2, getThing, getStringNoLocale } from '@inrupt/solid-client'
+import { getPodUrlAll, overwriteFile, getSolidDataset, getContainedResourceUrlAll, getFile, deleteFile, solidDatasetAsTurtle, universalAccess, getResourceInfoWithAcl, hasResourceAcl, hasFallbackAcl, hasAccessibleAcl, getResourceAcl, createAclFromFallbackAcl, saveAclFor, setAgentResourceAccess, setAgentDefaultAccess, createContainerAt, acp_ess_2, getThing, getStringNoLocale, getUrl, getDate, getDatetime } from '@inrupt/solid-client'
 import type { SolidDataset, Access } from '@inrupt/solid-client'
 const { getAgentAccessAll, setPublicAccess, getPublicAccess } = universalAccess
 import { PackingAppDatabase } from './database'
@@ -174,16 +174,52 @@ export function deriveWebIdFromPodUrl(podUrl: string): string {
 }
 
 export async function getPodOwnerName(session: Session, podUrl: string, explicitWebId?: string): Promise<string | null> {
+    return (await getPodOwnerProfile(session, podUrl, explicitWebId)).name
+}
+
+export interface PodOwnerProfile {
+    name: string | null
+    /** URL of the profile photo (vcard:hasPhoto, foaf:img or foaf:depiction). */
+    photo: string | null
+    /** Birthday (vcard:bday) as a plain YYYY-MM-DD string. */
+    birthday: string | null
+}
+
+export async function getPodOwnerProfile(session: Session, podUrl: string, explicitWebId?: string): Promise<PodOwnerProfile> {
     const webId = explicitWebId ?? deriveWebIdFromPodUrl(podUrl)
     const profileCardUrl = webId.replace(/#.*$/, '')
     try {
         const dataset = await getSolidDataset(profileCardUrl, { fetch: session.fetch })
         const profile = getThing(dataset, webId)
-        if (!profile) return null
-        return getStringNoLocale(profile, 'http://xmlns.com/foaf/0.1/name') ?? null
+        if (!profile) return { name: null, photo: null, birthday: null }
+        return {
+            name: getStringNoLocale(profile, 'http://www.w3.org/2006/vcard/ns#fn')
+                ?? getStringNoLocale(profile, 'http://xmlns.com/foaf/0.1/name')
+                ?? null,
+            photo: getUrl(profile, 'http://www.w3.org/2006/vcard/ns#hasPhoto')
+                ?? getUrl(profile, 'http://xmlns.com/foaf/0.1/img')
+                ?? getUrl(profile, 'http://xmlns.com/foaf/0.1/depiction')
+                ?? null,
+            birthday: readBirthday(profile),
+        }
     } catch {
-        return null
+        return { name: null, photo: null, birthday: null }
     }
+}
+
+/**
+ * vcard:bday as YYYY-MM-DD, however the profile stored it — some editors write
+ * a plain string literal, others a typed xsd:date.
+ */
+function readBirthday(profile: NonNullable<ReturnType<typeof getThing>>): string | null {
+    const BDAY = 'http://www.w3.org/2006/vcard/ns#bday'
+    const asString = getStringNoLocale(profile, BDAY)
+    if (asString) {
+        const match = /^\d{4}-\d{2}-\d{2}/.exec(asString.trim())
+        return match ? match[0] : null
+    }
+    const asDate = getDate(profile, BDAY) ?? getDatetime(profile, BDAY)
+    return asDate ? asDate.toISOString().slice(0, 10) : null
 }
 
 /**

--- a/src/test-utils/fullyPopulatedFixtures.ts
+++ b/src/test-utils/fullyPopulatedFixtures.ts
@@ -96,6 +96,7 @@ const fullyPopulatedPerson: Required<Person> = {
     gender: 'female',
     species: 'dog',
     color: 'fuchsia',
+    webId: 'https://alice.solidpod.example/profile/card#me',
     lastModified: '2025-01-02T00:00:00.000Z',
     deletedAt: '2025-01-03T00:00:00.000Z',
 }


### PR DESCRIPTION
## Summary

- **Profile photos on person avatars** — `PersonAvatar` now shows a person's Solid pod profile photo (via their WebID) when one is available, ringed in their assigned colour, and falls back to the coloured initial on load failure or absence. Backed by a new `usePersonProfilePhotos`/`useProfilePhotos` hook pair (`src/hooks/usePersonProfilePhotos.ts`) that resolves photos by following each person's WebID to their profile card.
- **Past trips fold away** — `PackingLists` now splits lists into current and past (via a new `tripIsPast` helper in `tripDetails.ts`) and collapses past trips behind an accordion row by default, so the main view only shows lists still worth planning.
- **Packing list card rework** — card layout, click-to-open behaviour, and the delete/duplicate actions were reworked to use a `Radix UI` dropdown menu (`@radix-ui/react-dropdown-menu`) and `lucide-react` icons instead of inline stop-propagation handlers on individual buttons.
- **Navigation and questions-page updates** — accompanying changes to `Navigation.tsx` and `questions-page.tsx` (including a new wizard hint, covered by `questions-page.wizard-hint.test.tsx`).
- Supporting changes to `solidPod.ts` / `rdfSerialization.ts` / `rdfVocab.ts` to support resolving profile photos from a WebID, plus test coverage across the touched areas (`PersonAvatar.test.tsx`, `Navigation.test.tsx`, `packing-lists.test.tsx`, `solidPod.test.ts`, etc.) and minor e2e test adjustments.

## Test plan

- [ ] `npm test` (typecheck + vitest)
- [ ] Manually verify a person avatar shows their pod profile photo when they have a WebID with `vcard:hasPhoto`, and falls back to the initial otherwise
- [ ] Manually verify past trips collapse into the "past" section and current trips remain visible by default
- [ ] `npm run test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165LTZCp9BEDsg6QTwkL4SR