### PR TITLE
Stop reporting a not-yet-synced list as a Sentry error

### DIFF
--- a/src/errorReporting.test.ts
+++ b/src/errorReporting.test.ts
@@ -41,3 +41,60 @@ describe('reportError', () => {
         expect(details).toContain('a plain string error')
     })
 })
+
+/**
+ * Mirrors Sentry's `eventFromUnknownInput`: anything captured that isn't an
+ * Error loses its message and stack and is titled by its keys instead. That is
+ * how a thrown `{ name, message }` object reached Sentry as the useless
+ * "Object captured as exception with keys: message, name", with only Sentry's
+ * own minified frames attached.
+ */
+function sentryTitle(captured: unknown): string {
+    if (captured instanceof Error) return `${captured.name}: ${captured.message}`
+    if (typeof captured === 'object' && captured !== null) {
+        return `Object captured as exception with keys: ${Object.keys(captured).sort().join(', ')}`
+    }
+    return String(captured)
+}
+
+describe('reportError with values that are not Errors', () => {
+    beforeEach(() => {
+        captureException.mockClear()
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    it('sends a thrown { name, message } object to Sentry as a real Error', () => {
+        reportError({ name: 'not_found', message: 'Packing list not found' }, 'Error fetching packing list')
+
+        const captured = captureException.mock.calls[0][0]
+        expect(sentryTitle(captured)).not.toBe('Object captured as exception with keys: message, name')
+        expect(captured).toBeInstanceOf(Error)
+        expect((captured as Error).name).toBe('not_found')
+        expect((captured as Error).message).toBe('Packing list not found')
+        expect((captured as Error).stack).toBeTruthy()
+    })
+
+    it('sends a thrown string to Sentry as a real Error carrying that message', () => {
+        reportError('403 Forbidden', 'Save to Pod error')
+
+        const captured = captureException.mock.calls[0][0]
+        expect(captured).toBeInstanceOf(Error)
+        expect((captured as Error).message).toBe('403 Forbidden')
+    })
+
+    it('keeps the original value in the console log and in the copyable details', () => {
+        const thrown = { name: 'not_found', message: 'Packing list not found' }
+        const details = reportError(thrown, 'Error fetching packing list')
+
+        expect(console.error).toHaveBeenCalledWith('Error fetching packing list', thrown)
+        expect(details).toContain('not_found')
+        expect(details).toContain('Packing list not found')
+    })
+
+    it('preserves extra properties of the thrown object as Sentry context', () => {
+        reportError({ name: 'conflict', message: 'Document update conflict', status: 409 })
+
+        const captured = captureException.mock.calls[0][0] as Error & { cause?: unknown }
+        expect(captured.cause).toEqual({ name: 'conflict', message: 'Document update conflict', status: 409 })
+    })
+})

--- a/src/errorReporting.ts
+++ b/src/errorReporting.ts
@@ -2,13 +2,53 @@ import * as Sentry from '@sentry/capacitor'
 
 export function reportError(error: unknown, context?: string): string {
     console.error(context ?? 'Unhandled error', error)
-    Sentry.captureException(error)
+    Sentry.captureException(toReportableError(error))
     return formatErrorDetails(error, context)
 }
 
+/**
+ * Sentry can only build a useful event out of an `Error`. Anything else is
+ * titled by its own keys — a thrown `{ name, message }` object arrives as
+ * "Object captured as exception with keys: message, name", with no message and
+ * only Sentry's own minified frames for a stack, which says nothing about where
+ * it came from.
+ *
+ * So wrap non-Errors in a real Error that keeps the original message and name,
+ * and hang the original value off `cause` so any extra properties survive.
+ */
+function toReportableError(error: unknown): Error {
+    if (error instanceof Error) return error
+
+    const wrapped = new Error(messageFor(error)) as Error & { cause?: unknown }
+    wrapped.cause = error
+    if (typeof error === 'object' && error !== null) {
+        const { name } = error as { name?: unknown }
+        if (typeof name === 'string' && name) wrapped.name = name
+    }
+    return wrapped
+}
+
+function messageFor(error: unknown): string {
+    if (typeof error === 'object' && error !== null) {
+        const { message } = error as { message?: unknown }
+        if (typeof message === 'string' && message) return message
+        try {
+            return JSON.stringify(error)
+        } catch {
+            return String(error)
+        }
+    }
+    return String(error)
+}
+
 function formatErrorDetails(error: unknown, context?: string): string {
+    const reportable = toReportableError(error)
+    const heading = `${reportable.name}: ${reportable.message}`
     const lines = [`Time: ${new Date().toISOString()}`]
     if (context) lines.push(context)
-    lines.push(error instanceof Error ? (error.stack ?? `${error.name}: ${error.message}`) : String(error))
+    // The stack usually already opens with "<name>: <message>", but a wrapped
+    // non-Error's stack was captured before its name was restored, so the
+    // heading is added separately when it isn't there.
+    lines.push(reportable.stack?.startsWith(heading) ? reportable.stack : [heading, reportable.stack].filter(Boolean).join('\n'))
     return lines.join('\n')
 }

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -66,6 +66,11 @@ vi.mock('../utils/haptics', () => ({
     tapFeedback: () => mockTapFeedback(),
 }))
 
+const mockCaptureException = vi.fn()
+vi.mock('@sentry/capacitor', () => ({
+    captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockUsePodSync = vi.mocked(usePodSync)
@@ -1266,6 +1271,131 @@ describe('ViewPackingList foreign pod (?pod= param)', () => {
             'error',
             expect.any(String)
         )
+    })
+})
+
+// ─── Own-pod list not in local storage yet ──────────────────────────────────
+//
+// DatabaseContext renders the app as soon as the pod database is resolved and
+// runs `syncAllDataFromPod` in the background, so a device that has never seen
+// a list locally (a fresh browser, or a deep link to a list created on another
+// device) hits `getPackingList` before the login sync has written it. That is
+// not an error — the pod poll hydrates the page moments later — but it used to
+// be captured, and because the miss is thrown as a plain `{ name, message }`
+// object it reached Sentry as "Object captured as exception with keys:
+// message, name" with no usable stack.
+
+describe('ViewPackingList when an own-pod list is not in local storage yet', () => {
+    function renderMissingLocally(extraDbContext: Record<string, unknown> = {}) {
+        const getPackingList = vi.fn().mockRejectedValue({ name: 'not_found', message: 'Packing list not found' })
+        mockUseDatabase.mockReturnValue({
+            db: { ...makeDb(), getPackingList } as unknown as PackingAppDatabase,
+            ...extraDbContext,
+        })
+        const result = render(
+            <MemoryRouter initialEntries={['/view-list/test-list-1']}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+        return { ...result, getPackingList }
+    }
+
+    beforeEach(() => {
+        mockCaptureException.mockClear()
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: { info: { isLoggedIn: true, webId: 'https://own.solidcommunity.net/profile/card#me' }, fetch: vi.fn() },
+            webId: 'https://own.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('does not report the local miss to Sentry', async () => {
+        const { getPackingList } = renderMissingLocally()
+
+        await waitFor(() => expect(getPackingList).toHaveBeenCalled())
+        await waitFor(() => expect(screen.getByText('Packing list not found')).toBeTruthy())
+        expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('does not read from local storage while the login sync is still running', async () => {
+        const { getPackingList } = renderMissingLocally({ loginSyncInProgress: true })
+
+        await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Loading packing list...'))
+        expect(getPackingList).not.toHaveBeenCalled()
+        expect(screen.queryByText('Packing list not found')).toBeNull()
+    })
+
+    it('reads local storage once the login sync finishes', async () => {
+        const getPackingList = vi.fn().mockRejectedValue({ name: 'not_found', message: 'Packing list not found' })
+        const db = { ...makeDb(), getPackingList } as unknown as PackingAppDatabase
+        mockUseDatabase.mockReturnValue({ db, loginSyncInProgress: true })
+
+        const { rerender } = render(
+            <MemoryRouter initialEntries={['/view-list/test-list-1']}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+        expect(getPackingList).not.toHaveBeenCalled()
+
+        mockUseDatabase.mockReturnValue({ db, loginSyncInProgress: false })
+        rerender(
+            <MemoryRouter initialEntries={['/view-list/test-list-1']}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+
+        await waitFor(() => expect(getPackingList).toHaveBeenCalledWith('test-list-1'))
+        expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('hydrates from the pod once the poll succeeds', async () => {
+        renderMissingLocally()
+
+        await waitFor(() => expect(mockUsePodSync).toHaveBeenCalled())
+        const updateFormAndState = mockUseSyncCoordinator.mock.calls[mockUseSyncCoordinator.mock.calls.length - 1][0]
+            .updateFormAndState as (data: unknown, rev: string) => void
+        act(() => updateFormAndState(testPackingList, '2'))
+
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+        expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('still reports a genuine load failure to Sentry', async () => {
+        const failure = new Error('IndexedDB unavailable')
+        mockUseDatabase.mockReturnValue({
+            db: { ...makeDb(), getPackingList: vi.fn().mockRejectedValue(failure) } as unknown as PackingAppDatabase,
+        })
+
+        render(
+            <MemoryRouter initialEntries={['/view-list/test-list-1']}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+
+        await waitFor(() => expect(mockCaptureException).toHaveBeenCalledWith(failure))
     })
 })
 

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -300,7 +300,7 @@ export function ViewPackingList() {
     const isDesktop = useIsDesktop()
     const { isLoggedIn, session } = useSolidPod()
     const { showToast } = useToast()
-    const { db } = useDatabase()
+    const { db, loginSyncInProgress } = useDatabase()
     // Read from the question set on every visit, not copied onto the list when
     // it was generated — the order is one global setting, so changing it has to
     // reach the lists that already exist. See `useSectionOrder`.
@@ -555,6 +555,14 @@ export function ViewPackingList() {
     }, [saveToPod])
 
     useEffect(() => {
+        // The login sync (pod -> local) runs in the background while the app is
+        // already rendering, so reading local storage before it finishes would
+        // miss any list this device hasn't seen yet — a fresh browser, or a link
+        // to a list created on another device. Wait for it and keep the spinner
+        // up; the effect re-runs when the sync finishes. Same guard as
+        // create-packing-list and questions-page.
+        if (loginSyncInProgress) return
+
         const fetchPackingList = async () => {
             try {
                 const doc = await db.getPackingList(id!)
@@ -572,17 +580,23 @@ export function ViewPackingList() {
                 setIsLoading(false)
             } catch (err) {
                 const isNotFound = typeof err === 'object' && err !== null && (err as { name?: string }).name === 'not_found'
-                if (isNotFound && foreignPodUrl) {
-                    // Leave isLoading=true — the first pod poll will hydrate via handleSyncSuccess
-                } else {
-                    reportError(err, 'Error fetching packing list')
-                    setIsLoading(false)
+                if (isNotFound) {
+                    // Not an error: the list simply isn't on this device. On a
+                    // foreign pod the first poll hydrates it via
+                    // handleSyncSuccess, so hold the spinner. Otherwise the
+                    // login sync has already had its turn and the list really is
+                    // gone, so fall through to "Packing list not found" — but
+                    // never report it, a missing list is a normal outcome.
+                    if (!foreignPodUrl) setIsLoading(false)
+                    return
                 }
+                reportError(err, 'Error fetching packing list')
+                setIsLoading(false)
             }
         }
 
         fetchPackingList()
-    }, [db, id, setValue, foreignPodUrl])
+    }, [db, id, setValue, foreignPodUrl, loginSyncInProgress])
 
     const handleItemChange = useDebouncedCallback(async () => {
         if (!packingList) {

--- a/src/services/database.test.ts
+++ b/src/services/database.test.ts
@@ -189,10 +189,14 @@ describe('PackingAppDatabase', () => {
     })
 
     it('should throw not_found error when question set does not exist', async () => {
-      await expect(db.getQuestionSet()).rejects.toEqual({
+      await expect(db.getQuestionSet()).rejects.toMatchObject({
         name: 'not_found',
         message: 'Question set not found'
       })
+    })
+
+    it('should throw a real Error for a missing question set, so Sentry gets a stack', async () => {
+      await expect(db.getQuestionSet()).rejects.toBeInstanceOf(Error)
     })
 
     it('should preserve createdAt timestamp when updating', async () => {
@@ -311,10 +315,22 @@ describe('PackingAppDatabase', () => {
     })
 
     it('should throw not_found error when packing list does not exist', async () => {
-      await expect(db.getPackingList('nonexistent')).rejects.toEqual({
+      await expect(db.getPackingList('nonexistent')).rejects.toMatchObject({
         name: 'not_found',
         message: 'Packing list not found'
       })
+    })
+
+    // A plain `{ name, message }` object reaches Sentry as "Object captured as
+    // exception with keys: message, name" — no message, no stack, nothing to
+    // act on. Every not_found the app throws must be a real Error.
+    it('should throw a real Error for a missing packing list, so Sentry gets a stack', async () => {
+      await expect(db.getPackingList('nonexistent')).rejects.toBeInstanceOf(Error)
+    })
+
+    it('should throw a real Error for missing shared-with-me and shared-lists-with-me docs', async () => {
+      await expect(db.getSharedWithMe()).rejects.toBeInstanceOf(Error)
+      await expect(db.getSharedListsWithMe()).rejects.toBeInstanceOf(Error)
     })
 
     it('should retrieve all packing lists', async () => {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -61,6 +61,23 @@ function hasName(err: unknown): err is { name: string } {
 }
 
 /**
+ * Thrown when a document isn't in the local database.
+ *
+ * A real Error rather than an object literal: a plain `{ name, message }` that
+ * reaches `Sentry.captureException` is reported as "Object captured as
+ * exception with keys: message, name" — no message, no app stack frames,
+ * nothing to act on. `name` stays `'not_found'` so that PouchDB's own
+ * `err.name === 'not_found'` convention, which callers across the app check
+ * against, keeps working unchanged.
+ */
+export class NotFoundError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'not_found'
+    }
+}
+
+/**
  * Builds a document's `data` payload from an entity by *omitting* the keys the
  * document itself owns (`id` / `_id` / `_rev`), plus any explicitly-undefined
  * values so absent fields stay absent in PouchDB.
@@ -145,7 +162,7 @@ export class PackingAppDatabase {
             }
         } catch (err: unknown) {
             if (hasName(err) && err.name === 'not_found') {
-                throw { name: 'not_found', message: 'Question set not found' }
+                throw new NotFoundError('Question set not found')
             }
             throw err
         }
@@ -208,7 +225,7 @@ export class PackingAppDatabase {
             }
         } catch (err: unknown) {
             if (hasName(err) && err.name === 'not_found') {
-                throw { name: 'not_found', message: 'Packing list not found' }
+                throw new NotFoundError('Packing list not found')
             }
             throw err
         }
@@ -308,7 +325,7 @@ export class PackingAppDatabase {
             return doc.data
         } catch (err: unknown) {
             if (hasName(err) && err.name === 'not_found') {
-                throw { name: 'not_found', message: 'SharedWithMe not found' }
+                throw new NotFoundError('SharedWithMe not found')
             }
             throw err
         }
@@ -364,7 +381,7 @@ export class PackingAppDatabase {
             return doc.data
         } catch (err: unknown) {
             if (hasName(err) && err.name === 'not_found') {
-                throw { name: 'not_found', message: 'SharedListsWithMe not found' }
+                throw new NotFoundError('SharedListsWithMe not found')
             }
             throw err
         }


### PR DESCRIPTION
Sentry issue 06f4da0145cd481d8fcecf440125ef41, "Object captured as
exception with keys: message, name", fired from #/view-lists/<id>.

DatabaseContext renders the app as soon as the pod database resolves and
runs syncAllDataFromPod in the background, so view-packing-list read local
PouchDB before the login sync had written the list. On a device that had
never seen it — a fresh browser, or a link to a list created elsewhere —
getPackingList missed and the miss was reported as an error. It was also
thrown as a plain `{ name, message }` object, which Sentry cannot build an
event from: no message, and only its own minified frames for a stack.

Three fixes:

- view-packing-list waits for loginSyncInProgress before reading local
  storage, the same guard create-packing-list and questions-page already
  use, and never reports a not_found. On a foreign pod the spinner is held
  for the pod poll to hydrate; otherwise the login sync has had its turn
  and the list really is missing, so "Packing list not found" is shown.
- database.ts throws a NotFoundError instead of an object literal. `name`
  stays 'not_found' so every existing caller check is unaffected.
- reportError wraps any non-Error in a real Error before capture, keeping
  the original message and name and hanging the value off `cause`, so a
  stray throw can never again arrive as an untitled object. The copyable
  toast details gain the same treatment, replacing "[object Object]".

Verified by driving a real PouchDB miss through the real reportError: the
Sentry title goes from "Object captured as exception with keys: message,
name" with no app frames to "not_found: Packing list not found" stacked at
database.ts.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XqDEkVu1RsjBB4h6f8pAF8