### PR TITLE
Show local packing lists while the pod sync runs

### DIFF
--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -651,6 +651,77 @@ describe('PackingLists trip destination and dates', () => {
     })
 })
 
+describe('PackingLists during the login pod sync', () => {
+    const loggedInSession = { fetch: vi.fn() } as unknown as Session
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: loggedInSession,
+            webId: 'https://timgent.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        } as unknown as ReturnType<typeof useSolidPod>)
+        mockGetPrimaryPodUrl.mockResolvedValue('https://timgent.solidcommunity.net')
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function renderSyncing(lists: Record<string, unknown>[], loginSyncInProgress: boolean) {
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn().mockResolvedValue(lists),
+                deletePackingList: vi.fn(),
+                savePackingList: vi.fn(),
+                getSharedListsWithMe: vi.fn().mockResolvedValue({ lists: [], lastModified: '' }),
+            } as unknown as PackingAppDatabase,
+            loginSyncVersion: 0,
+            loginSyncInProgress,
+        })
+        return renderComponent()
+    }
+
+    it('shows locally stored lists without waiting for the pod sync to finish', async () => {
+        renderSyncing([testPackingList], true)
+
+        expect(await screen.findByText(/Beach Trip/)).toBeTruthy()
+        expect(screen.queryByText('Loading packing lists...')).toBeNull()
+    })
+
+    it('flags that a pod sync is still running', async () => {
+        renderSyncing([testPackingList], true)
+
+        await screen.findByText(/Beach Trip/)
+        expect(screen.getByTestId('pod-sync-indicator')).toBeTruthy()
+    })
+
+    it('drops the indicator once the pod sync has finished', async () => {
+        renderSyncing([testPackingList], false)
+
+        await screen.findByText(/Beach Trip/)
+        expect(screen.queryByTestId('pod-sync-indicator')).toBeNull()
+    })
+
+    it('keeps waiting rather than claiming there are no lists while a fresh device is still filling up', async () => {
+        renderSyncing([], true)
+
+        await waitFor(() => {
+            expect(screen.getByRole('status').textContent).toContain('Loading packing lists...')
+        })
+        expect(screen.queryByText(/No packing lists found/i)).toBeNull()
+    })
+
+    it('reports an empty pod once the sync has finished', async () => {
+        renderSyncing([], false)
+
+        await waitFor(() => expect(screen.getByText(/No packing lists found/i)).toBeTruthy())
+    })
+})
+
 describe('PackingLists sync-across-devices prompt', () => {
     beforeEach(() => {
         sessionStorage.clear()

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -156,7 +156,13 @@ export function PackingLists() {
         }).catch(() => {})
     }, [packingLists, isLoggedIn, session])
 
-    if (isLoading || loginSyncInProgress) {
+    // The local PouchDB read is the only thing worth blocking on — it resolves in
+    // milliseconds. The pod sync runs for as long as the pod takes to answer, and
+    // the effect above re-fetches when loginSyncVersion bumps, so local lists can
+    // be shown straight away and quietly refreshed when the pod catches up. The
+    // one case that still has to wait is an empty device on first login: there is
+    // nothing local to show and "No packing lists found" would be a lie.
+    if (isLoading || (packingLists.length === 0 && loginSyncInProgress)) {
         // Keep the real header in place so only the list area changes when the
         // lists land.
         return (
@@ -182,6 +188,20 @@ export function PackingLists() {
                 </div>
                 <Button variant="primary" onClick={() => navigate('/create-packing-list')}>➕ New List</Button>
             </div>
+
+            {/* The lists below are the local copy; say so while the pod is still
+                being read, so anything that appears or changes makes sense. */}
+            {loginSyncInProgress && (
+                <div
+                    data-testid="pod-sync-indicator"
+                    role="status"
+                    aria-live="polite"
+                    className="mb-4 flex items-center gap-2 text-sm font-medium text-gray-600"
+                >
+                    <span aria-hidden="true" className="loading-suitcase text-base leading-none">🧳</span>
+                    Checking your Pod for changes...
+                </div>
+            )}
 
             {/* Only worth asking once there is something to sync */}
             {packingLists.length > 0 && <SyncAcrossDevicesPrompt />}

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -663,6 +663,93 @@ describe('loadMultipleRdfFromPod', () => {
         expect(data).toHaveLength(0)
     })
 
+    it('fetches the files in parallel rather than one round trip at a time', async () => {
+        const urls = ['a', 'b', 'c'].map(id => `${LISTS_CONTAINER_URL}${id}.ttl`)
+        mockGetContainedResourceUrlAll.mockReturnValueOnce(urls)
+
+        let inFlight = 0
+        let peakInFlight = 0
+        const release: Array<() => void> = []
+
+        mockGetSolidDataset.mockImplementation((url: string) => {
+            if (url === LISTS_CONTAINER_URL) {
+                return Promise.resolve({} as unknown as SolidDataset & WithServerResourceInfo)
+            }
+            inFlight++
+            peakInFlight = Math.max(peakInFlight, inFlight)
+            return new Promise(resolve => {
+                release.push(() => {
+                    inFlight--
+                    resolve({} as unknown as SolidDataset & WithServerResourceInfo)
+                })
+            })
+        })
+
+        const pending = loadMultipleRdfFromPod(mockSession, LISTS_CONTAINER_URL,
+            (_ds, url) => ({ id: url, name: '', createdAt: '', items: [] }))
+
+        // Let the container listing settle so the file requests get issued.
+        await vi.waitFor(() => expect(release).toHaveLength(urls.length))
+
+        release.forEach(fn => fn())
+        const { data, result } = await pending
+
+        expect(peakInFlight).toBe(urls.length)
+        expect(result.successCount).toBe(urls.length)
+        expect(data).toHaveLength(urls.length)
+    })
+
+    it('keeps the loaded items in container order when the requests settle out of order', async () => {
+        const urls = ['first', 'second'].map(id => `${LISTS_CONTAINER_URL}${id}.ttl`)
+        mockGetContainedResourceUrlAll.mockReturnValueOnce(urls)
+
+        const resolvers = new Map<string, () => void>()
+        mockGetSolidDataset.mockImplementation((url: string) => {
+            if (url === LISTS_CONTAINER_URL) {
+                return Promise.resolve({} as unknown as SolidDataset & WithServerResourceInfo)
+            }
+            return new Promise(resolve => {
+                resolvers.set(url, () => resolve({} as unknown as SolidDataset & WithServerResourceInfo))
+            })
+        })
+
+        const pending = loadMultipleRdfFromPod(mockSession, LISTS_CONTAINER_URL,
+            (_ds, url) => ({ id: url.split('/').pop()!.replace('.ttl', ''), name: '', createdAt: '', items: [] }))
+
+        await vi.waitFor(() => expect(resolvers.size).toBe(urls.length))
+
+        // Second file comes back first — the results must not follow arrival order.
+        resolvers.get(urls[1])!()
+        resolvers.get(urls[0])!()
+
+        const { data } = await pending
+
+        expect(data.map(l => l.id)).toEqual(['first', 'second'])
+    })
+
+    it('still reports the files that failed when others succeed', async () => {
+        const urls = ['ok', 'bad'].map(id => `${LISTS_CONTAINER_URL}${id}.ttl`)
+        mockGetContainedResourceUrlAll.mockReturnValueOnce(urls)
+
+        mockGetSolidDataset.mockImplementation((url: string) => {
+            if (url === LISTS_CONTAINER_URL) {
+                return Promise.resolve({} as unknown as SolidDataset & WithServerResourceInfo)
+            }
+            if (url.endsWith('bad.ttl')) return Promise.reject({ statusCode: 500 })
+            return Promise.resolve({} as unknown as SolidDataset & WithServerResourceInfo)
+        })
+
+        const onError = vi.fn()
+        const { data, result } = await loadMultipleRdfFromPod(mockSession, LISTS_CONTAINER_URL,
+            (_ds, url) => ({ id: url, name: '', createdAt: '', items: [] }), onError)
+
+        expect(data).toHaveLength(1)
+        expect(result.successCount).toBe(1)
+        expect(result.failCount).toBe(1)
+        expect(result.success).toBe(false)
+        expect(onError).toHaveBeenCalledWith(urls[1], expect.anything())
+    })
+
     it('ignores non-ttl files', async () => {
         mockGetSolidDataset.mockResolvedValueOnce({} as unknown as SolidDataset & WithServerResourceInfo)
         mockGetContainedResourceUrlAll.mockReturnValueOnce([

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -701,14 +701,26 @@ export async function loadMultipleRdfFromPod<T>(
         return { data: [], result: { success: true, successCount: 0, failCount: 0, totalCount: 0 } }
     }
 
+    // Load all files in parallel for faster sync — one round trip per list adds
+    // up to a long wait on login for anyone with more than a handful of lists.
+    // Settled results stay in ttlUrls order, so the caller sees container order
+    // regardless of which responses arrive first.
+    const settled = await Promise.allSettled(
+        ttlUrls.map(fileUrl => getSolidDataset(fileUrl, { fetch: session.fetch }))
+    )
+
     const loadedData: T[] = []
     let successCount = 0
     let failCount = 0
 
-    for (const fileUrl of ttlUrls) {
+    for (let i = 0; i < settled.length; i++) {
+        const outcome = settled[i]
+        const fileUrl = ttlUrls[i]
         try {
-            const fileDataset = await getSolidDataset(fileUrl, { fetch: session.fetch })
-            loadedData.push(deserializer(fileDataset, fileUrl))
+            if (outcome.status === 'rejected') throw outcome.reason
+            // Deserialization stays inside the try: a malformed file must count
+            // as one failure, not abandon the rest of the container.
+            loadedData.push(deserializer(outcome.value, fileUrl))
             successCount++
         } catch (error: unknown) {
             if (isAuthenticationError(error)) handlePodError(error)


### PR DESCRIPTION
The packing lists page gated its whole list area on loginSyncInProgress, so
a logged-in user saw "Loading packing lists..." on every startup even though
the lists were already in local PouchDB and had loaded milliseconds earlier.
The wait was really the pod sync: a container listing, one request per list,
uploads of local-only lists and two more fetches, all before the flag cleared.

Nothing required that wait. The fetch effect already re-runs on loginSyncVersion,
so the local copy can render immediately and be refreshed when the pod answers.
A small indicator says a sync is in flight so anything that changes underneath
makes sense.

The empty case still waits: a fresh device on first login has nothing local to
show, and "No packing lists found" would be wrong until the sync lands.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012DHMLZjFS2dAm1i2vqn1HU