### PR TITLE
Fix mobile freezing on My Questions & Items via conditional pod polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,13 @@ playwright-report/
 test-results/
 .e2e-css-pid
 
+# Perf harness output — traces/cpuprofiles capture whatever real data was
+# loaded on the page (screenshots + DOM snapshots), so these must never be committed.
+scripts/perf/results/
+
+# Real personal data used for local perf/repro testing — never commit.
+example-large-backup.json
+
 # Capacitor Android build artifacts
 android/.gradle/
 android/app/build/

--- a/docs/questions-page-mobile-performance.md
+++ b/docs/questions-page-mobile-performance.md
@@ -1,0 +1,251 @@
+# "My Questions & Items" mobile performance investigation
+
+**Symptom reported:** fine on desktop, "almost unusable" on mobile web and the
+Android WebView app on a Fairphone 4.
+
+**Result:** reproduced, root-caused, instrumented, and fixed. The dominant
+cost was the page's background Solid Pod sync — not rendering, not the data
+volume itself. It re-fetched and fully re-parsed the entire question-set RDF
+graph every 5 seconds, indefinitely, whether or not anything changed, and the
+parse step was expensive enough that on a phone-class CPU it could freeze the
+main thread for well over a second **while the user was mid-interaction**,
+not just on page load. The fix (conditional GET, §"Fix implemented" below)
+makes an unchanged poll cost a cheap `304` with no parsing at all — measured
+after the fix, the recurring freeze is gone and logged-in performance is
+statistically indistinguishable from a no-polling baseline.
+
+## Data used
+
+Real personal data was used to get realistic scale, restored into a local
+Solid pod via the app's own Restore flow. It stays untracked
+(`example-large-backup.json`, now added to `.gitignore`) and isn't reproduced here — only
+shapes and counts:
+
+| | count |
+|---|---|
+| People | 5 |
+| Questions | 12 |
+| Options (answers) across all questions | 54 |
+| Items inside question options | 332 |
+| "Always needed" items | 46 |
+| Packing lists | 15 |
+| Question-set RDF graph, serialised | 976 KB, **10,617 quads** |
+
+This is a realistic "someone who's used the app for a while" dataset, not an
+extreme outlier — no artificial data was generated to make the problem show
+up.
+
+## Reproduction method
+
+Chrome's DevTools UI wasn't available in this environment, so the repro was
+built as a standalone, reusable **Playwright + Chrome DevTools Protocol
+script** instead: `scripts/perf/mobile-repro.mjs` (see
+`scripts/perf/README.md` for full usage). It:
+
+1. Logs into a local Community Solid Server through the app's real login UI
+   and restores the backup via the app's real Backups page, so local PouchDB
+   and the pod end up in the state a real user's device would have.
+2. Switches to a phone viewport (393×851 CSS px, 2.75x DPR — a Fairphone 4)
+   and a mobile Chrome user agent.
+3. Applies a CDP CPU throttle (`Emulation.setCPUThrottlingRate`) to stand in
+   for a mid-range Android SoC being slower than a dev laptop at
+   single-thread JS. 6x was used as the headline scenario; Fairphone 4's
+   Helio G95 is commonly 4-8x slower than a modern laptop chip on
+   single-thread JS work — see below for a measurement showing the same
+   long task is still substantial (1.4s) even unthrottled, so this is a
+   reasonable midpoint, not a worst case.
+4. Drives the page the way a user actually would: expand several question
+   sections, scroll the list, tap "add item" and type a word.
+5. Records long tasks (`PerformanceObserver`), a CDP CPU profile with
+   per-function sample counts, and a Playwright trace, tagged with which
+   interaction phase was running when each long task started.
+
+Two scenarios were compared, both throttled identically:
+
+- **logged-in** — normal state, the page's pod polling is active.
+- **logged-out** — same locally-stored data, logged out first, so pod
+  polling is disabled (`enabled: isLoggedIn || isForeign` in
+  `usePodSync`). This isolates "cost of rendering/using this page" from
+  "cost of the recurring pod sync."
+
+## Findings
+
+### 1. The recurring pod poll is the dominant cost, and it can hit mid-interaction
+
+`QuestionsPage` calls `usePodSync` with `pollInterval: 5000`
+(`src/pages/questions-page.tsx`) — every 5 seconds, forever, while the page
+is open, it re-fetches the pod's `packing-list-questions.ttl` and re-parses
+it into a full `SolidDataset`, then deserialises that into a
+`PackingListQuestionSet` (`datasetToQuestionSet`). `useSyncCoordinator`
+*does* skip the resulting re-render when the data is unchanged — but that
+check (`JSON.stringify` equality) runs **after** the fetch and the RDF parse
+have already happened, so it saves a render, not the CPU cost that dominates
+this page.
+
+Measured over an identical ~7-11s interaction window, 6x CPU throttle:
+
+| scenario | total blocking time | longest single task | long tasks |
+|---|---:|---:|---:|
+| logged-out (polling disabled) | 1.8s | 1.42s | 3 |
+| logged-in (polling every 5s) | 12.1s | 9.05s | 6 |
+
+The `longest task` in the logged-in run landed with the phase label
+`phase:scroll-end +9047ms` — i.e. it started right as the scripted user
+finished scrolling and was about to start typing into the "add item" box.
+This is the freeze-while-using-it behaviour reported, reproduced directly:
+it isn't confined to initial load, it recurs on a ~5s cadence for as long as
+the page stays open, and it can land in the middle of any interaction.
+
+At **1x (unthrottled) CPU**, the same single poll-triggered task still took
+**1.42s** — so this isn't purely a throttling artifact. On a dev laptop it's
+a brief, easy-to-miss stutter (explaining "fine on desktop"); on a mid-range
+phone CPU, commonly several times slower single-thread, that same task
+stretches past the point of being usable.
+
+### 2. It's `@inrupt/solid-client`'s dataset construction, not React
+
+A CDP CPU profile taken during the logged-in run's blocking window shows two
+functions, both internal to `@inrupt/solid-client`'s Turtle→`SolidDataset`
+builder, accounting for the large majority of samples:
+
+```
+UZ  — index-*.js:571   (6,290 / 2,639 samples across runs)
+BZ  — index-*.js:571   (5,717 / 2,545 samples across runs)
+```
+
+De-minifying against the built bundle, `UZ`/`BZ` are the library's per-quad
+graph/subject insertion functions — each call does an **immutable object
+spread** to add one quad into the nested `{ graphs: { [graph]: { [subject]:
+{...} } } }` structure that backs a `SolidDataset`. That's run once per quad
+in the fetched graph (10,617 of them here), each copying the
+already-accumulated structure — the classic shape of `@inrupt/solid-client`'s
+known dataset-construction cost blowing up on larger graphs. N3's own Turtle
+tokenizer (`_tokenizeToEnd`, `_readPunctuation`, `_findInIndex` — real,
+non-minified method names from the `n3` package) shows up further down the
+same profile, confirming this is Turtle parsing + dataset indexing, not
+something in the page's own rendering code. None of these functions appear
+at all in the logged-out profile — direct confirmation they're specific to
+the poll, not a general cost of this page.
+
+This also means the page's own code (`datasetToQuestionSet`, all the
+`getThing`/`getThingAll` calls in `rdfSerialization.ts`) is not the primary
+cost here — the expensive part happens one layer down, inside
+`getSolidDataset()` itself, before the page's deserialiser even starts
+walking the result.
+
+### 3. A smaller, separate cost: initial mount
+
+Even in the logged-out control (no pod activity at all), mounting this page
+with this dataset still cost **1.8s of total blocking / 1.42s single task**
+under 6x throttle, all before any of the scripted interactions began. Two
+likely contributors, not fully separated in this pass:
+
+- The production build ships **one 1.5MB JS chunk** (466KB gzipped, see
+  `vite build` output) — no route-level code splitting. Parsing/compiling
+  that is pure main-thread cost on every cold load, and matters more on a
+  WebView cold start than on a warm desktop tab.
+- A first render of ~380 items across 12 questions/54 options plus building
+  the item-suggestion index (`buildQuestionSetSuggestions`) over all of
+  them.
+
+This is real but secondary — an order of magnitude smaller than the
+recurring poll cost, and it only happens once per page load rather than
+every 5 seconds.
+
+## Profiling infrastructure added
+
+Two durable pieces, so the next regression doesn't need a fresh manual repro:
+
+1. **`scripts/perf/mobile-repro.mjs`** (+ `scripts/perf/README.md`) — the
+   harness described above. Reusable for any page: point it at a route,
+   adjust the interaction script, compare `summary.json` before/after a
+   change. Deliberately kept out of `npm test`/CI — it needs seeded pod data
+   and takes 10-20s per run, so it's a manual diagnostic tool, not a gate.
+
+2. **Sentry performance tracing** (`src/sentry.ts`) — added
+   `browserTracingIntegration()` and `tracesSampleRate: 0.1` to the existing
+   Sentry setup. This starts collecting long-task, slow-interaction (INP),
+   and navigation timing data from real usage, including the Android
+   WebView (`@sentry/capacitor` ships the same tracing integrations) — so a
+   regression like this one would show up as a Sentry performance issue on
+   the actual device it happens on, rather than needing someone to notice
+   and describe it first. Kept at the existing dev/test-disabled default
+   (`VITE_SENTRY_ENABLED` opts local dev back in).
+
+## Fix implemented
+
+**Make the poll cheap when nothing changed**, via a conditional `GET`.
+`loadRdfFromPod` (`src/services/solidPod.ts`) now remembers the `ETag` of the
+last successful load per URL and sends it as `If-None-Match` on the next
+request. Community Solid Server (and Solid pods generally) respond `304 Not
+Modified` with no body when the resource hasn't changed since — and because
+`getSolidDataset` treats any non-2xx response as an error, that `304` makes
+it fail *before* it ever reaches the Turtle parser. `loadRdfFromPod` catches
+exactly that case and returns the previously-deserialized result instead of
+re-parsing. When the pod file *has* changed, the response is a normal `200`
+with a new `ETag`, and the full fetch-parse-deserialize path runs as before
+— so genuine updates (from another device, or a sync from a save) are
+unaffected; only the "nothing changed" case, which is the overwhelming
+majority of polls on a page nobody else is editing at the same time, gets
+cheap.
+
+This is a change to `loadRdfFromPod`, the shared low-level function behind
+`usePodSync`'s polling — so it also benefits `view-packing-list.tsx`, which
+polls its own list on the same 5s interval and was presumably paying a
+smaller version of the same cost (not separately measured here, since the
+reported symptom was on the Questions & Items page).
+
+No sync semantics changed: conflict resolution, merge, and the
+`useSyncCoordinator` unchanged-data guard are all unaffected — this only
+changes whether a "nothing changed" poll causes the network fetch's response
+body to be a few KB (`304`, no body) or ~1MB (`200`, full graph), and whether
+Turtle-parses it.
+
+Verified with unit tests (`src/services/solidPod.test.ts`, `loadRdfFromPod`
+describe block): sends `If-None-Match` with the previously-seen ETag; returns
+the cached result without invoking the deserializer again on a `304`; still
+re-parses and returns fresh data on a genuine change (new `ETag`, `200`).
+
+### Before / after, measured with the harness
+
+Same script, same seeded data, same 6x CPU throttle, same interaction
+sequence, logged-in scenario (pod polling active) both times:
+
+| | total blocking time | longest single task | where the longest task landed |
+|---|---:|---:|---|
+| before | 12.1s | 9.05s | mid-interaction (`phase:scroll-end`) |
+| after | 1.8–3.3s | 1.4s | initial mount only (`before-first-mark`) |
+
+After the fix, every long task lands during initial mount — none during
+interaction — matching the logged-out (no-polling) control from the original
+investigation (1.8s / 1.4s) to within run-to-run noise. Re-run with a 26s
+settle window (~5 poll cycles instead of ~1) to check the fix holds over
+time: still zero long tasks outside the initial mount window, and the CPU
+profile's `@inrupt/solid-client` dataset-construction functions (`UZ`, `BZ`,
+N3's tokenizer) that dominated the "before" profile don't appear at all
+after the fix — direct confirmation the parse is actually being skipped, not
+just coincidentally faster.
+
+The remaining ~1.4s at mount (present before and after, unaffected by this
+fix) is the separate, smaller cost described in finding 3 above.
+
+## Further recommendations (not implemented)
+
+Smaller, lower-priority than the fix above — worth doing if this page's
+performance needs more headroom later, not needed to resolve the reported
+symptom:
+
+1. **Reconsider the poll interval.** 5 seconds is aggressive for a
+   single-user-editing-on-one-device-at-a-time page. An unchanged poll is
+   cheap now, but a longer interval still means less network chatter and
+   fewer 304 round-trips.
+2. **Move parsing off the main thread.** For the case where the pod *did*
+   change, the full parse cost from finding 2 still applies. `getSolidDataset`'s
+   Turtle parse and dataset construction don't touch the DOM, making them a
+   candidate for a Web Worker — only worth the complexity (message-passing a
+   10k-quad result back, `session.fetch`'s auth can't cross directly into a
+   worker) if genuine-change polls turn out to be frequent enough in practice
+   to matter (Sentry tracing, added in this pass, would show that).
+3. **Code-split the JS bundle.** Unrelated to polling — a straightforward win
+   for cold-start cost on WebView specifically — route-level `React.lazy` for
+   the heavier, less-common pages.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,82 @@
+# Mobile performance repro harness
+
+`mobile-repro.mjs` is a standalone Playwright + CDP script for measuring
+main-thread blocking on a mobile-class device profile. It is **not** part of
+`npm test` or `npm run test:e2e` — it's a diagnostic tool you run on demand
+when investigating a perf regression, not a CI gate (it needs real seeded pod
+data and takes 10-20s per run).
+
+Background and findings from the investigation this was built for:
+`docs/questions-page-mobile-performance.md`.
+
+## What it does
+
+1. Logs into a local Community Solid Server account through the app's real
+   OIDC login UI (reuses the same flow as `e2e/helpers/login.ts`).
+2. Restores a backup already sitting in that account's pod (see setup below)
+   via the app's actual Backups page — so the local PouchDB and the pod both
+   end up in the same state a real user's device would.
+3. Resizes to a phone viewport, applies a CDP CPU throttle (`--cpu`, default
+   6x — roughly a mid-range Android SoC vs. a dev laptop), and drives the
+   Questions & Items page: expands question sections, scrolls, types into an
+   "add item" composer.
+4. Records:
+   - Long tasks (`PerformanceObserver({type:'longtask'})`) with a "which
+     phase of the interaction was running" label, so a multi-second block can
+     be pinned to a specific action (or to background activity, if it lands
+     between actions).
+   - A CPU profile (`Profiler.start`/`stop` over CDP) with a self-time
+     ranking by function name, to name the hot code path without opening
+     DevTools by hand.
+   - A Playwright trace (`.trace.zip`, viewable at `trace.playwright.dev` or
+     `npx playwright show-trace`).
+
+Two scenarios:
+- `--scenario=logged-in` — normal logged-in state, pod polling active
+  (`usePodSync`'s `pollInterval`).
+- `--scenario=logged-out` — same local data, but logged out first, so pod
+  polling is disabled. This is the control: it isolates "cost of rendering
+  this page" from "cost of the recurring pod sync".
+
+## One-time setup
+
+1. Start a local CSS instance and create an account + pod (the `solid-dev`
+   skill's `start.sh` does this, or do it by hand — see that skill).
+2. Seed a backup file into the account's pod at
+   `pack-me-up/backups/<name>.json` — the app's Restore flow reads it from
+   there. `pod-seed.ts`-style client-credentials auth works for this; there's
+   no UI for uploading a backup file directly. Any `BackupFile`-shaped JSON
+   works (`{ createdAt, version: 1, questionSet, packingLists }`) — a real
+   export from the app's own "Create Backup" button is the easiest source.
+3. Build and serve the production bundle (measurements on `npm run dev` are
+   skewed by HMR/dev-mode overhead):
+   ```
+   npm run build
+   npm run preview -- --port 4173
+   ```
+
+## Running
+
+```
+PERF_CSS_ORIGIN=http://localhost:4000 \
+PERF_CSS_EMAIL=test@example.com \
+PERF_CSS_PASSWORD=test1234 \
+node scripts/perf/mobile-repro.mjs --scenario=logged-in --cpu=6 --label=logged-in
+```
+
+Output lands in `scripts/perf/results/<label>.{summary.json,trace.zip,cpuprofile}`.
+Env vars default to the values above, which match what `solid-dev`'s
+`start.sh` provisions.
+
+`--settleMs` (default `6000`) controls how long the script idles after the
+scripted interaction, to let pod poll cycles land — bump it (e.g. `26000` for
+~5 cycles at the default 5s poll interval) to check a fix holds over
+multiple polls, not just the first one.
+
+## Reading the output
+
+`<label>.summary.json` has the headline numbers (`totalBlockingTimeMs`,
+`longestTaskMs`, which phase each long task landed in, top functions by
+sample hit count). For anything deeper, load `<label>.trace.zip` into
+`npx playwright show-trace scripts/perf/results/<label>.trace.zip`, or open
+`<label>.cpuprofile` in Chrome DevTools' Performance panel ("Load profile").

--- a/scripts/perf/mobile-repro.mjs
+++ b/scripts/perf/mobile-repro.mjs
@@ -1,0 +1,234 @@
+// Reusable mobile-perf reproduction harness for the "My Questions & Items" page.
+//
+// Not part of `npm test` / `npm run test:e2e` — this is a standalone diagnostic
+// tool, run on demand, not a CI gate. See docs/questions-page-mobile-performance.md
+// for how it was used and what it found.
+//
+// Usage:
+//   node scripts/perf/mobile-repro.mjs --scenario=logged-in  --cpu=6 --label=run-a
+//   node scripts/perf/mobile-repro.mjs --scenario=logged-out --cpu=6 --label=run-b
+//
+// Requires: a CSS pod running at CSS_ORIGIN with the seeded test account below,
+// and the app served (production build) at APP_ORIGIN. See scripts/perf/README.md.
+
+import { chromium } from '@playwright/test'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const APP_ORIGIN = process.env.PERF_APP_ORIGIN ?? 'http://localhost:4173'
+const CSS_ORIGIN = process.env.PERF_CSS_ORIGIN ?? 'http://localhost:4000'
+const EMAIL = process.env.PERF_CSS_EMAIL ?? 'test@example.com'
+const PASSWORD = process.env.PERF_CSS_PASSWORD ?? 'test1234'
+
+const args = Object.fromEntries(
+  process.argv.slice(2).map(arg => {
+    const [key, value] = arg.replace(/^--/, '').split('=')
+    return [key, value ?? true]
+  })
+)
+
+const scenario = args.scenario ?? 'logged-in' // 'logged-in' | 'logged-out'
+const cpuThrottle = Number(args.cpu ?? 6) // CDP CPU slowdown multiplier; a mid-range Android phone vs a dev laptop is roughly in this range
+const label = args.label ?? scenario
+const outDir = path.resolve('scripts/perf/results')
+fs.mkdirSync(outDir, { recursive: true })
+
+// Moto/Fairphone-class viewport (Fairphone 4: 1080x2340 @ ~2.75x dpr -> ~393x851 CSS px)
+const MOBILE_VIEWPORT = { width: 393, height: 851 }
+
+async function loginToCss(page) {
+  await page.getByRole('button', { name: 'Login with Solid Pod' }).click()
+  await page.getByRole('dialog').waitFor()
+  await page.getByText('Other providers').click()
+  await page.getByRole('button', { name: 'Use Custom Provider' }).click()
+  await page.getByLabel('Custom Provider URL').fill(CSS_ORIGIN)
+  await page.getByRole('button', { name: 'Connect' }).click()
+
+  await page.waitForURL(
+    url => url.hostname === 'localhost' && url.port === new URL(CSS_ORIGIN).port && url.pathname.includes('/login/password'),
+    { timeout: 20_000 }
+  )
+  const loginBtn = page.locator('button[type="submit"][name="submit"]')
+  await loginBtn.waitFor({ timeout: 10_000 })
+  await page.waitForFunction(() => {
+    const btn = document.querySelector('button[type="submit"][name="submit"]')
+    return btn && !btn.disabled
+  }, { timeout: 10_000 })
+  await page.locator('#email').fill(EMAIL)
+  await page.locator('#password').fill(PASSWORD)
+  await loginBtn.click()
+
+  await page.waitForURL(url => url.pathname.includes('/oidc/prompt') || url.pathname.includes('consent'), { timeout: 20_000 })
+  const authorizeBtn = page.locator('#authorize')
+  await authorizeBtn.waitFor({ timeout: 10_000 })
+  await page.waitForFunction(() => {
+    const btn = document.querySelector('#authorize')
+    return btn && !btn.disabled
+  }, { timeout: 10_000 })
+  await authorizeBtn.click()
+
+  await page.waitForURL(new RegExp(new URL(APP_ORIGIN).host), { timeout: 20_000 })
+  await page.getByRole('button', { name: 'Logout' }).first().waitFor({ timeout: 20_000 })
+}
+
+async function restoreSeededBackup(page) {
+  await page.goto(`${APP_ORIGIN}/#/backups`)
+  page.once('dialog', dialog => dialog.accept())
+  await page.getByRole('button', { name: /Restore/i }).first().click()
+  await page.getByText(/restored successfully/i).waitFor({ timeout: 30_000 })
+}
+
+async function installLongTaskObserver(page) {
+  await page.addInitScript(() => {
+    window.__perf = { longTasks: [], marks: [] }
+    try {
+      const po = new PerformanceObserver(list => {
+        for (const entry of list.getEntries()) {
+          window.__perf.longTasks.push({ start: entry.startTime, duration: entry.duration })
+        }
+      })
+      po.observe({ type: 'longtask', buffered: true })
+    } catch { /* longtask not supported */ }
+  })
+}
+
+async function collectPerf(page) {
+  return page.evaluate(() => window.__perf)
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true })
+  const context = await browser.newContext({
+    userAgent: 'Mozilla/5.0 (Linux; Android 12; Fairphone 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36',
+    deviceScaleFactor: 2.75,
+    isMobile: true,
+    hasTouch: true,
+  })
+  const page = await context.newPage()
+  await installLongTaskObserver(page)
+
+  const cdp = await context.newCDPSession(page)
+  // CPU throttling only (no network throttling — we want to isolate main-thread cost)
+  await cdp.send('Emulation.setCPUThrottlingRate', { rate: 1 })
+
+  // Login/restore at a desktop-width viewport — the nav's login control is
+  // hidden behind a hamburger menu below the md breakpoint, and there's no
+  // need to pay mobile-viewport cost for one-time setup.
+  console.log(`[${label}] logging in / preparing data...`)
+  await page.goto(APP_ORIGIN)
+  if (scenario === 'logged-in') {
+    await loginToCss(page)
+    await restoreSeededBackup(page)
+  } else {
+    // logged-out scenario still needs the data locally: log in once, restore,
+    // then log out so PouchDB keeps the data but pod polling is disabled.
+    await loginToCss(page)
+    await restoreSeededBackup(page)
+    await page.getByRole('button', { name: 'Logout' }).first().click()
+    await page.getByRole('button', { name: 'Login with Solid Pod' }).first().waitFor({ timeout: 10_000 })
+  }
+
+  await page.setViewportSize(MOBILE_VIEWPORT)
+  await page.goto(`${APP_ORIGIN}/#/manage-questions`)
+  await page.getByRole('heading', { name: /My Questions/i }).waitFor({ timeout: 20_000 }).catch(() => {})
+  await page.waitForTimeout(1000)
+
+  console.log(`[${label}] applying ${cpuThrottle}x CPU throttle and starting trace...`)
+  await cdp.send('Emulation.setCPUThrottlingRate', { rate: cpuThrottle })
+  await context.tracing.start({ screenshots: true, snapshots: true, title: label })
+  await cdp.send('Profiler.enable')
+  await cdp.send('Profiler.setSamplingInterval', { interval: 200 })
+  await cdp.send('Profiler.start')
+
+  const t0 = Date.now()
+  const mark = async (name) => page.evaluate((n) => window.__perf.marks.push({ label: n, t: performance.now() }), name)
+
+  await mark('phase:expand-start')
+  // Expand every question section (each mounts an OptionSection tree)
+  const questionToggles = await page.locator('main button:has(svg)').all()
+  for (const [i, toggle] of questionToggles.slice(0, 8).entries()) {
+    await mark(`expand:${i}:before`)
+    await toggle.click().catch(() => {})
+    await mark(`expand:${i}:after`)
+    await page.waitForTimeout(150)
+  }
+
+  await mark('phase:scroll-start')
+  // Scroll through the list, as a user would while looking for a question
+  for (let i = 0; i < 10; i++) {
+    await page.mouse.wheel(0, 400)
+    await page.waitForTimeout(120)
+  }
+  await mark('phase:scroll-end')
+
+  // Type into an "add item" composer, character by character — the closest
+  // proxy to INP (input latency) on a real keyboard
+  const addItemButton = page.getByRole('button', { name: /Add item/i }).first()
+  if (await addItemButton.isVisible().catch(() => false)) {
+    await mark('phase:type-start')
+    await addItemButton.click()
+    const input = page.locator('input[placeholder*="Add"]').first()
+    await input.click().catch(() => {})
+    for (const ch of 'Sunscreen') {
+      await page.keyboard.type(ch, { delay: 80 })
+    }
+    await mark('phase:type-end')
+  }
+
+  // Let pod poll cycles land (polling is every 5s when logged in) — default
+  // covers one, --settleMs overrides for a longer multi-cycle observation.
+  await page.waitForTimeout(Number(args.settleMs ?? 6000))
+
+  const totalDuration = Date.now() - t0
+  const { profile } = await cdp.send('Profiler.stop')
+  await context.tracing.stop({ path: path.join(outDir, `${label}.trace.zip`) })
+  fs.writeFileSync(path.join(outDir, `${label}.cpuprofile`), JSON.stringify(profile))
+
+  // Aggregate sample hit-counts per function so the hottest call site is
+  // nameable without opening the .cpuprofile in DevTools.
+  const hitsByFn = new Map()
+  for (const node of profile.nodes) {
+    const key = `${node.callFrame.functionName || '(anonymous)'} — ${node.callFrame.url.split('/').pop()}:${node.callFrame.lineNumber}`
+    hitsByFn.set(key, (hitsByFn.get(key) ?? 0) + (node.hitCount ?? 0))
+  }
+  const topFunctions = [...hitsByFn.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 15)
+    .map(([fn, hits]) => ({ fn, hits }))
+
+  const perf = await collectPerf(page)
+  const longTasks = perf?.longTasks ?? []
+  const marks = perf?.marks ?? []
+  const totalBlockingTime = longTasks.reduce((sum, t) => sum + Math.max(0, t.duration - 50), 0)
+
+  // Which action-phase mark each long task's start time falls closest after,
+  // so a 9s block can be pinned to "scroll" vs "typing" vs "expand".
+  const longTasksWithPhase = longTasks.map(t => {
+    const precedingMarks = marks.filter(m => m.t <= t.start)
+    const phase = precedingMarks.length ? precedingMarks[precedingMarks.length - 1].label : 'before-first-mark'
+    return { ...t, nearestPrecedingMark: phase }
+  })
+
+  const summary = {
+    label,
+    scenario,
+    cpuThrottle,
+    totalDurationMs: totalDuration,
+    longTaskCount: longTasks.length,
+    longTaskTotalMs: Math.round(longTasks.reduce((s, t) => s + t.duration, 0)),
+    totalBlockingTimeMs: Math.round(totalBlockingTime),
+    longestTaskMs: longTasks.length ? Math.round(Math.max(...longTasks.map(t => t.duration))) : 0,
+    longTasks: longTasksWithPhase.map(t => ({ ...t, duration: Math.round(t.duration), start: Math.round(t.start) })),
+    marks: marks.map(m => ({ ...m, t: Math.round(m.t) })),
+    topFunctionsBySampleHits: topFunctions,
+  }
+
+  fs.writeFileSync(path.join(outDir, `${label}.summary.json`), JSON.stringify(summary, null, 2))
+  console.log(`[${label}] done:`, { ...summary, longTasks: undefined, marks: undefined, topFunctionsBySampleHits: undefined })
+  console.log(`[${label}] long tasks by phase:`, longTasksWithPhase.map(t => `${t.nearestPrecedingMark} +${Math.round(t.duration)}ms`))
+  console.log(`[${label}] top functions by sample hits:`, topFunctions.slice(0, 10))
+
+  await browser.close()
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/src/sentry.test.ts
+++ b/src/sentry.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const init = vi.fn()
 vi.mock('@sentry/capacitor', () => ({ init: (...args: unknown[]) => init(...args) }))
-vi.mock('@sentry/react', () => ({ init: vi.fn(), feedbackIntegration: () => ({ name: 'Feedback' }) }))
+vi.mock('@sentry/react', () => ({
+    init: vi.fn(),
+    feedbackIntegration: () => ({ name: 'Feedback' }),
+    browserTracingIntegration: () => ({ name: 'BrowserTracing' }),
+}))
 
 import { initSentry } from './sentry'
 

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -20,7 +20,12 @@ export function initSentry() {
     {
       dsn: SENTRY_DSN,
       environment: import.meta.env.MODE,
-      integrations: [SentryReact.feedbackIntegration({ colorScheme: 'system' })],
+      integrations: [
+        SentryReact.feedbackIntegration({ colorScheme: 'system' }),
+        // Field-data counterpart to scripts/perf/mobile-repro.mjs — see docs/questions-page-mobile-performance.md.
+        SentryReact.browserTracingIntegration(),
+      ],
+      tracesSampleRate: 0.1,
     },
     SentryReact.init,
   )

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -472,8 +472,15 @@ describe('loadRdfFromPod', () => {
             return { id: 'test-id', name: 'Test', createdAt: new Date().toISOString(), items: [] }
         })
 
-        expect(mockGetSolidDataset).toHaveBeenCalledWith(url, expect.objectContaining({ fetch: mockSession.fetch }))
         expect(result.id).toBe('test-id')
+        // The `fetch` passed to getSolidDataset is a conditional-GET wrapper
+        // (see the loadRdfFromPod tests below), not the session's fetch
+        // directly — assert it delegates to the session's fetch instead of
+        // checking identity.
+        const passedFetch = mockGetSolidDataset.mock.calls[0][1]?.fetch
+        mockSession.fetch.mockResolvedValueOnce(new Response(null, { status: 200 }))
+        await passedFetch?.(url)
+        expect(mockSession.fetch).toHaveBeenCalledWith(url, expect.anything())
     })
 
     it('throws AuthenticationError on 401', async () => {
@@ -497,10 +504,98 @@ describe('loadRdfFromPod', () => {
         mockGetSolidDataset.mockResolvedValueOnce(
             packingListToDataset(list, url) as unknown as SolidDataset & WithServerResourceInfo
         )
+        const globalFetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(null, { status: 200 }))
 
         await loadRdfFromPod(null, url, (_ds, _u) => ({ id: 'pub-id', name: 'Public', createdAt: '', items: [] }))
 
-        expect(mockGetSolidDataset).toHaveBeenCalledWith(url, expect.objectContaining({ fetch: globalThis.fetch }))
+        const passedFetch = mockGetSolidDataset.mock.calls[0][1]?.fetch
+        await passedFetch?.(url)
+        expect(globalFetchSpy).toHaveBeenCalledWith(url, expect.anything())
+    })
+
+    it('sends the previously seen ETag as If-None-Match on the next load of the same URL', async () => {
+        const url = `${POD_URL}pack-me-up/packing-lists/etag-test.ttl`
+        const list = makePackingList('etag-id')
+        const dataset = packingListToDataset(list, url) as unknown as SolidDataset & WithServerResourceInfo
+
+        // First load: the pod responds with an ETag, which getSolidDataset's
+        // fetch wrapper should observe.
+        mockGetSolidDataset.mockImplementationOnce(async (u, options) => {
+            await options!.fetch!(u as string)
+            return dataset
+        })
+        mockSession.fetch.mockResolvedValueOnce(new Response(null, { status: 200, headers: { etag: '"v1"' } }))
+        await loadRdfFromPod(mockSession, url, () => ({ id: 'etag-id', name: '', createdAt: '', items: [] }))
+
+        // Second load: getSolidDataset's fetch wrapper should now send
+        // If-None-Match with the ETag observed above.
+        mockGetSolidDataset.mockImplementationOnce(async (u, options) => {
+            await options!.fetch!(u as string)
+            return dataset
+        })
+        mockSession.fetch.mockResolvedValueOnce(new Response(null, { status: 200 }))
+        await loadRdfFromPod(mockSession, url, () => ({ id: 'etag-id', name: '', createdAt: '', items: [] }))
+
+        const secondCallHeaders = new Headers(mockSession.fetch.mock.calls[1][1]?.headers)
+        expect(secondCallHeaders.get('If-None-Match')).toBe('"v1"')
+    })
+
+    it('returns the cached result without re-running the deserializer when the pod responds 304', async () => {
+        const url = `${POD_URL}pack-me-up/packing-lists/not-modified.ttl`
+        const list = makePackingList('cached-id')
+        const dataset = packingListToDataset(list, url) as unknown as SolidDataset & WithServerResourceInfo
+        const deserializer = vi.fn(() => ({ id: 'cached-id', name: 'Cached', createdAt: '', items: [] }))
+
+        mockGetSolidDataset.mockImplementationOnce(async (u, options) => {
+            await options!.fetch!(u as string)
+            return dataset
+        })
+        mockSession.fetch.mockResolvedValueOnce(new Response(null, { status: 200, headers: { etag: '"v1"' } }))
+        const first = await loadRdfFromPod(mockSession, url, deserializer)
+        expect(deserializer).toHaveBeenCalledTimes(1)
+
+        // Mirrors what getSolidDataset itself does for any non-2xx response
+        // (see @inrupt/solid-client's internal_isUnsuccessfulResponse): a 304
+        // makes it throw before ever reaching the parser.
+        mockGetSolidDataset.mockImplementationOnce(async (u, options) => {
+            const response = await options!.fetch!(u as string)
+            if (!response.ok) throw { statusCode: response.status }
+            return dataset
+        })
+        mockSession.fetch.mockResolvedValueOnce(new Response(null, { status: 304 }))
+        const second = await loadRdfFromPod(mockSession, url, deserializer)
+
+        expect(second).toEqual(first)
+        expect(deserializer).toHaveBeenCalledTimes(1) // not called again for the 304
+    })
+
+    it('re-parses and returns fresh data when the pod content actually changed (new ETag)', async () => {
+        const url = `${POD_URL}pack-me-up/packing-lists/changed.ttl`
+        const datasetV1 = packingListToDataset(makePackingList('v1'), url) as unknown as SolidDataset & WithServerResourceInfo
+        const datasetV2 = packingListToDataset(makePackingList('v2'), url) as unknown as SolidDataset & WithServerResourceInfo
+        const deserializer = vi.fn((ds: SolidDataset) => ds === datasetV2
+            ? { id: 'v2', name: 'Updated', createdAt: '', items: [] }
+            : { id: 'v1', name: 'Original', createdAt: '', items: [] })
+
+        mockGetSolidDataset.mockImplementationOnce(async (u, options) => {
+            await options!.fetch!(u as string)
+            return datasetV1
+        })
+        mockSession.fetch.mockResolvedValueOnce(new Response(null, { status: 200, headers: { etag: '"v1"' } }))
+        const first = await loadRdfFromPod(mockSession, url, deserializer)
+        expect(first.id).toBe('v1')
+
+        // Another device changed the pod resource: server returns 200 with a
+        // new ETag and body, same as a first-ever load.
+        mockGetSolidDataset.mockImplementationOnce(async (u, options) => {
+            await options!.fetch!(u as string)
+            return datasetV2
+        })
+        mockSession.fetch.mockResolvedValueOnce(new Response(null, { status: 200, headers: { etag: '"v2"' } }))
+        const second = await loadRdfFromPod(mockSession, url, deserializer)
+
+        expect(second.id).toBe('v2')
+        expect(deserializer).toHaveBeenCalledTimes(2)
     })
 })
 

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -634,7 +634,30 @@ export interface SaveRdfToPodOptions<T> {
 }
 
 /**
+ * Last-seen ETag + deserialized result per URL, so a poll that finds nothing
+ * changed can skip both the RDF parse and the deserializer walk entirely.
+ *
+ * Module-level and unbounded: keyed by full URL, so switching pods just adds
+ * inert entries for the old one rather than serving stale data, and the
+ * number of distinct RDF resources a session polls is small.
+ */
+const lastSeenByUrl = new Map<string, { etag: string; result: unknown }>()
+
+/**
  * Loads an RDF dataset from a Pod URL and deserializes it via the provided function.
+ *
+ * Sends a conditional GET (`If-None-Match` against the ETag of whatever we
+ * last parsed from this URL) so a poll that finds nothing changed gets back
+ * a body-less 304 instead of the full resource. That matters because parsing
+ * a Turtle response into a SolidDataset is expensive for a graph of any real
+ * size — @inrupt/solid-client builds it by copying the accumulated
+ * graphs/subjects/predicates structure once per quad — and a page that polls
+ * on a timer (see `usePodSync`'s `pollInterval`) was paying that cost on
+ * every tick even when the pod hadn't changed since the last one. See
+ * docs/questions-page-mobile-performance.md for the investigation that found
+ * this. A 304 makes `getSolidDataset` throw (it treats any non-2xx as an
+ * error) before it ever reaches the parser, which is exactly the point —
+ * the cached result from last time is still correct and is returned instead.
  */
 export async function loadRdfFromPod<T>(
     session: Session | null,
@@ -642,10 +665,24 @@ export async function loadRdfFromPod<T>(
     deserializer: (dataset: SolidDataset, datasetUrl: string) => T
 ): Promise<T> {
     const fetchFn = session?.fetch ?? globalThis.fetch
+    const lastSeen = lastSeenByUrl.get(fileUrl)
+    let observedEtag: string | null = null
+    const conditionalFetch: typeof fetch = (input, init) => {
+        const headers = new Headers(init?.headers)
+        if (lastSeen) headers.set('If-None-Match', lastSeen.etag)
+        return fetchFn(input, { ...init, headers }).then(response => {
+            observedEtag = response.headers.get('etag')
+            return response
+        })
+    }
     try {
-        const dataset = await getSolidDataset(fileUrl, { fetch: fetchFn })
-        return deserializer(dataset, fileUrl)
+        const dataset = await getSolidDataset(fileUrl, { fetch: conditionalFetch })
+        const result = deserializer(dataset, fileUrl)
+        if (observedEtag) lastSeenByUrl.set(fileUrl, { etag: observedEtag, result })
+        else lastSeenByUrl.delete(fileUrl)
+        return result
     } catch (error: unknown) {
+        if (getStatusCode(error) === 304 && lastSeen) return lastSeen.result as T
         if (session && isAuthenticationError(error)) handlePodError(error)
         throw error
     }


### PR DESCRIPTION
## Summary
- Root-caused the reported "almost unusable on mobile" behaviour on My Questions & Items: `usePodSync`'s 5s pod poll (`src/pages/questions-page.tsx`) re-fetched and fully re-parsed the entire question-set RDF graph on every cycle, even when nothing had changed. On a realistic dataset (~10k quads) that's over a second of main-thread blocking per cycle, recurring indefinitely and capable of landing mid-interaction — see `docs/questions-page-mobile-performance.md` for the full writeup, evidence, and CPU-profile analysis.
- Fixed in `loadRdfFromPod` (`src/services/solidPod.ts`): sends a conditional GET (`If-None-Match` against the last-seen `ETag`), so an unchanged poll gets a body-less `304` and skips the parse entirely. Genuine changes still fetch and parse as before — no sync/conflict semantics changed. Also benefits `view-packing-list.tsx`, which polls on the same interval through the same shared function.
- Added a reusable Playwright+CDP performance harness (`scripts/perf/mobile-repro.mjs`, `scripts/perf/README.md`) for reproducing mobile-class CPU-throttled scenarios against real seeded pod data — used to measure both the bug and the fix, and left in place for future regressions. Not part of CI; a manual diagnostic tool.
- Added Sentry performance tracing (`browserTracingIntegration`, 10% sample rate) so a regression like this would show up as real performance data from actual devices, including the Android WebView.

## Measured impact (6x CPU throttle, mobile viewport, logged-in/polling active)
| | total blocking time | longest single task | where it landed |
|---|---:|---:|---|
| before | 12.1s | 9.05s | mid-interaction |
| after | 1.8–3.3s | 1.4s | initial mount only |

After the fix, logged-in performance (polling active) matches the logged-out (no-polling) control to within run-to-run noise, and holds across multiple poll cycles (re-verified with a 26s settle window, ~5 cycles). The CPU profile's `@inrupt/solid-client` dataset-construction hot functions that dominated the "before" profile are absent afterward — confirming the parse is actually skipped, not just coincidentally faster.

## Test plan
- [x] `npm test` (typecheck + full vitest suite) passes — 1439 tests
- [x] New unit tests in `src/services/solidPod.test.ts` (`loadRdfFromPod` describe block): sends `If-None-Match` with the previously-seen ETag; returns cached result without re-invoking the deserializer on a `304`; still re-parses and returns fresh data on a genuine change (new ETag/200)
- [x] Verified against a real local Community Solid Server that it honors conditional GET (`curl` round-trip returning `304`)
- [x] Before/after measured with `scripts/perf/mobile-repro.mjs` against real backup data restored through the app's own Restore flow, at 1x and 6x CPU throttle, both single-cycle and extended (~5 cycle) windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)