### PR TITLE
Stop a deleted packing list coming back from another device

### DIFF
--- a/e2e/tests/f-sync.spec.ts
+++ b/e2e/tests/f-sync.spec.ts
@@ -227,4 +227,51 @@ test.describe('F – Solid Pod Sync', () => {
     await expect(page2.locator('input[type="checkbox"]:checked').first()).toBeVisible({ timeout: 10_000 })
     await context2.close()
   })
+
+  // F3 deletes with only one device that has ever seen the list. The bug this
+  // covers needs a *second* device that still holds a local copy: its login sync
+  // saw a list on the device but not on the pod, called it local-only and
+  // uploaded it again, so the delete undid itself everywhere.
+  test('F7: a list deleted on one device is not resurrected by another that still has it', async ({ browser }) => {
+    // A second list that is never deleted: seeing it arrive is how a device that
+    // reads the pod from scratch signals that its sync has finished, so the
+    // absence checks below cannot pass just by being early.
+    const keeperListName = `Delete Resurrect Control ${Date.now()}`
+    await createList(keeperListName)
+    await syncListToPod()
+
+    const f7ListName = `Delete Resurrect Test ${Date.now()}`
+    await createList(f7ListName)
+    await syncListToPod()
+
+    // Device B: log in and let the list land in its local database.
+    const { ctx: contextB, pg: pageB } = await freshLogin(browser)
+    await pageB.goto('/#/view-lists')
+    await expect(pageB.getByText(f7ListName)).toBeVisible({ timeout: 75_000 })
+
+    // Device A: delete the list.
+    await page.goto('/#/view-lists')
+    await page.locator('.rounded-2xl').filter({ hasText: f7ListName }).getByRole('button', { name: /Delete/i }).click()
+    await page.getByRole('button', { name: /^Delete$/ }).click()
+    await expect(page.getByRole('heading').filter({ hasText: f7ListName })).not.toBeVisible({ timeout: 5_000 })
+
+    // Device B: reload so its login sync runs again against the pod. Before the
+    // fix this is where the list came back — and went back to the pod with it.
+    // The card starts out on screen, so the wait is for the sync to take it
+    // away; there is no window in which this passes by being early.
+    await pageB.goto('/#/view-lists')
+    await pageB.reload()
+    await expect(pageB.getByRole('heading').filter({ hasText: f7ListName })).not.toBeVisible({ timeout: 75_000 })
+
+    // Device C: a device that has never seen the list reads the pod from
+    // scratch, so what it shows is exactly what device B left on the pod. The
+    // keeper list arriving proves that read finished.
+    const { ctx: contextC, pg: pageC } = await freshLogin(browser)
+    await pageC.goto('/#/view-lists')
+    await expect(pageC.getByText(keeperListName)).toBeVisible({ timeout: 75_000 })
+    await expect(pageC.getByRole('heading').filter({ hasText: f7ListName })).not.toBeVisible()
+
+    await contextB.close()
+    await contextC.close()
+  })
 })

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -38,7 +38,10 @@ vi.mock('../services/solidPod', () => ({
     getCollaborators: vi.fn().mockResolvedValue([]),
     isPubliclyAccessible: vi.fn().mockResolvedValue(false),
     friendlyPodName: vi.fn((url: string) => url),
-    POD_CONTAINERS: { PACKING_LISTS: '/packing-lists/' },
+    getPodOwnerName: vi.fn().mockResolvedValue(null),
+    resolveOwnerDisplayName: vi.fn((_name: string | null, _webId: string | null, podUrl: string) => podUrl),
+    buildSharedListPath: vi.fn((id: string, podUrl: string) => `/view-lists/${id}?pod=${podUrl}`),
+    POD_CONTAINERS: { PACKING_LISTS: '/packing-lists/', DELETED_PACKING_LISTS: '/deleted-packing-lists.ttl' },
     POD_ERROR_MESSAGES: {
         NOT_LOGGED_IN: 'Not logged in',
         NOT_LOGGED_IN_LOAD: 'Not logged in to load',
@@ -290,7 +293,29 @@ describe('PackingLists delete confirmation', () => {
         fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
 
         await waitFor(() => {
-            expect(db.deletePackingList).toHaveBeenCalledWith('list-1')
+            // The tombstone is the point: without it another device that still
+            // holds this list uploads it back on its next login sync.
+            expect(db.deletePackingList).toHaveBeenCalledWith('list-1', { recordDeletion: true })
+        })
+    })
+
+    it('does not tombstone a list that is only a cached copy of a shared one', async () => {
+        const db = makeDb()
+        db.getAllPackingLists = vi.fn().mockResolvedValue([
+            { ...testList, sharedFromPodUrl: 'https://someone-else.example/' },
+        ])
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByText('🗑️ Delete'))
+        await screen.findByText(/cannot be undone/i)
+        fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+
+        await waitFor(() => {
+            expect(db.deletePackingList).toHaveBeenCalledWith('list-1', { recordDeletion: false })
         })
     })
 })

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -10,7 +10,7 @@ import { Modal } from '../components/Modal'
 import { SyncAcrossDevicesPrompt } from '../components/SyncAcrossDevicesPrompt'
 import { getPrimaryPodUrl, saveRdfToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES, getCollaborators, isPubliclyAccessible, resolveOwnerDisplayName, buildSharedListPath } from '../services/solidPod'
 import { useOwnerDisplayNames } from '../hooks/useOwnerDisplayName'
-import { packingListToDataset } from '../services/rdfSerialization'
+import { packingListToDataset, deletedPackingListsToDataset } from '../services/rdfSerialization'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { generateUUID } from '../utils/uuid'
 import { formatTripDates } from '../create-packing-list/tripDetails'
@@ -83,10 +83,14 @@ export function PackingLists() {
     const confirmDeletePackingList = async () => {
         if (!listToDelete) return
         const { id } = listToDelete
+        // A cached copy of somebody else's shared list only leaves this device:
+        // the pod file is theirs, and the id is theirs to reuse, so it gets no
+        // tombstone of ours.
+        const isForeign = !!packingLists.find(list => list.id === id)?.sharedFromPodUrl
         try {
-            await db.deletePackingList(id)
+            await db.deletePackingList(id, { recordDeletion: !isForeign })
             setPackingLists(packingLists.filter(list => list.id !== id))
-            await removeListFromPod(id)
+            if (!isForeign) await removeListFromPod(id)
         } catch (err) {
             console.error('Error deleting packing list:', err)
         } finally {
@@ -116,6 +120,15 @@ export function PackingLists() {
             const podUrl = await getPrimaryPodUrl(session)
             if (!podUrl) return
             await deleteFileFromPod(session!, `${podUrl}${POD_CONTAINERS.PACKING_LISTS}${id}.ttl`)
+            // Removing the file is not enough on its own: a device that still
+            // holds the list would see it missing from the pod and upload it
+            // again. The tombstone is what tells it the list is gone.
+            await saveRdfToPod({
+                session: session!,
+                fileUrl: `${podUrl}${POD_CONTAINERS.DELETED_PACKING_LISTS}`,
+                data: await db.getDeletedPackingLists(),
+                serializer: deletedPackingListsToDataset,
+            })
         } catch (error) {
             handlePodError(error, POD_ERROR_MESSAGES.SAVE_FAILED)
         }

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -192,7 +192,9 @@ export function SharingSettingsPage() {
                 lists: existing.lists.filter(l => l.listId !== listId),
                 lastModified: new Date().toISOString(),
             })
-            await db.deletePackingList(listId).catch(() => {})
+            // Only the local cache of the owner's list goes; their id is not
+            // ours to tombstone, and they may share it with us again.
+            await db.deletePackingList(listId, { recordDeletion: false }).catch(() => {})
             showToast('Removed', 'success')
         } catch (err) {
             const details = reportError(err, 'SharingSettingsPage: failed to remove shared list')

--- a/src/services/database.test.ts
+++ b/src/services/database.test.ts
@@ -390,6 +390,72 @@ describe('PackingAppDatabase', () => {
     })
   })
 
+  // A delete that leaves no trace is indistinguishable, on the next
+  // device, from a list that was never uploaded — so it gets uploaded again.
+  describe('deletion tombstones', () => {
+    const mockPackingList: PackingList = {
+      id: 'pl-1',
+      name: 'Beach Trip',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      items: [],
+    }
+
+    it('starts with an empty registry rather than throwing', async () => {
+      expect(await db.getDeletedPackingLists()).toEqual({
+        deletions: [],
+        lastModified: new Date(0).toISOString(),
+      })
+    })
+
+    it('records a tombstone when a list is deleted', async () => {
+      await db.savePackingList(mockPackingList)
+      await db.deletePackingList('pl-1')
+
+      const { deletions } = await db.getDeletedPackingLists()
+      expect(deletions).toHaveLength(1)
+      expect(deletions[0].listId).toBe('pl-1')
+      expect(new Date(deletions[0].deletedAt).getTime()).toBeGreaterThan(0)
+    })
+
+    it('records nothing when the caller opts out', async () => {
+      await db.savePackingList(mockPackingList)
+      await db.deletePackingList('pl-1', { recordDeletion: false })
+
+      expect((await db.getDeletedPackingLists()).deletions).toEqual([])
+    })
+
+    it('records nothing when the delete itself fails', async () => {
+      await expect(db.deletePackingList('nonexistent')).rejects.toThrow()
+      expect((await db.getDeletedPackingLists()).deletions).toEqual([])
+    })
+
+    it('accumulates tombstones across deletes', async () => {
+      await db.savePackingList(mockPackingList)
+      await db.savePackingList({ ...mockPackingList, id: 'pl-2' })
+      await db.deletePackingList('pl-1')
+      await db.deletePackingList('pl-2')
+
+      const { deletions } = await db.getDeletedPackingLists()
+      expect(deletions.map(d => d.listId).sort()).toEqual(['pl-1', 'pl-2'])
+    })
+
+    it('keeps tombstones out of getAllPackingLists', async () => {
+      await db.savePackingList(mockPackingList)
+      await db.deletePackingList('pl-1')
+
+      expect(await db.getAllPackingLists()).toEqual([])
+    })
+
+    it('survives a save/read round trip', async () => {
+      const registry = {
+        deletions: [{ listId: 'a', deletedAt: '2026-05-01T09:00:00.000Z' }],
+        lastModified: '2026-05-01T09:00:00.000Z',
+      }
+      await db.saveDeletedPackingLists(registry)
+      expect(await db.getDeletedPackingLists()).toEqual(registry)
+    })
+  })
+
   // Regression guard for #260: savePackingList built its PouchDB document from a
   // hand-maintained field allowlist, so `nights`, `questionAnswers` and
   // `selectedPeopleIds` never reached local storage — no type error, no test
@@ -641,6 +707,19 @@ describe('PackingAppDatabase', () => {
       const target = PackingAppDatabase.getInstance('copy-noop-target')
       await target.copyAllDataFrom(source)
       expect(await target.isEmpty()).toBe(true)
+    })
+
+    // Leaving these behind would let the target namespace push already-deleted
+    // lists back to the pod on its first sync.
+    it('copies deletion tombstones from source to target', async () => {
+      const source = PackingAppDatabase.getInstance('copy-tombstones-source')
+      const target = PackingAppDatabase.getInstance('copy-tombstones-target')
+      await source.savePackingList({ id: 'gone', name: 'Gone', createdAt: '2026-01-01T00:00:00.000Z', items: [] })
+      await source.deletePackingList('gone')
+
+      await target.copyAllDataFrom(source)
+
+      expect((await target.getDeletedPackingLists()).deletions.map(d => d.listId)).toEqual(['gone'])
     })
 
     it('does not copy _rev so documents save cleanly in target', async () => {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1,9 +1,10 @@
 import PouchDB from 'pouchdb'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList } from '../create-packing-list/types'
-import type { SharedWithMeList, SharedListsWithMe } from './rdfSerialization'
+import type { SharedWithMeList, SharedListsWithMe, DeletedPackingLists } from './rdfSerialization'
+import { emptyDeletedPackingLists, withDeletion } from '../utils/packingListDeletions'
 
-export type DocumentType = 'question-set' | 'packing-list' | 'shared-with-me' | 'shared-lists-with-me'
+export type DocumentType = 'question-set' | 'packing-list' | 'shared-with-me' | 'shared-lists-with-me' | 'deleted-packing-lists'
 
 export interface BaseDocument {
     _id: string
@@ -33,7 +34,12 @@ export interface SharedListsWithMeDocument extends BaseDocument {
     data: SharedListsWithMe
 }
 
-export type AppDocument = QuestionSetDocument | PackingListDocument | SharedWithMeDocument | SharedListsWithMeDocument
+export interface DeletedPackingListsDocument extends BaseDocument {
+    docType: 'deleted-packing-lists'
+    data: DeletedPackingLists
+}
+
+export type AppDocument = QuestionSetDocument | PackingListDocument | SharedWithMeDocument | SharedListsWithMeDocument | DeletedPackingListsDocument
 
 /**
  * Namespace used when the user is not logged into a pod.
@@ -306,7 +312,21 @@ export class PackingAppDatabase {
         }
     }
 
-    public async deletePackingList(id: string): Promise<void> {
+    /**
+     * Removes a packing list and, by default, records a tombstone for it.
+     *
+     * The tombstone is what stops another device that still holds the list from
+     * treating it as "local-only, never uploaded" and pushing it back to the pod
+     * Recording is the default precisely so a new caller cannot forget
+     * it; pass `recordDeletion: false` only for a list whose id is not ours to
+     * tombstone — a cached copy of somebody else's shared list, whose id lives
+     * in their pod and may legitimately come back.
+     */
+    public async deletePackingList(
+        id: string,
+        options: { recordDeletion?: boolean } = {}
+    ): Promise<void> {
+        const { recordDeletion = true } = options
         try {
             const doc = await this.db.get(`packing-list:${id}`)
             await this.db.remove(doc)
@@ -314,6 +334,80 @@ export class PackingAppDatabase {
             console.error('Error deleting packing list:', err)
             throw err
         }
+        if (recordDeletion) {
+            await this.recordPackingListDeletion(id)
+        }
+    }
+
+    /**
+     * Returns the deletion tombstones for this namespace.
+     *
+     * Unlike the other getters this resolves to an empty registry rather than
+     * throwing when nothing has been written: having deleted nothing yet is the
+     * normal state, and every caller would otherwise have to catch not_found.
+     */
+    public async getDeletedPackingLists(): Promise<DeletedPackingLists> {
+        try {
+            const doc = await this.db.get('deleted-packing-lists:1')
+            if (doc.docType !== 'deleted-packing-lists') {
+                throw new Error('Invalid document type for deleted-packing-lists')
+            }
+            return doc.data
+        } catch (err: unknown) {
+            if (hasName(err) && err.name === 'not_found') {
+                return emptyDeletedPackingLists()
+            }
+            throw err
+        }
+    }
+
+    public async saveDeletedPackingLists(data: DeletedPackingLists): Promise<{ rev: string }> {
+        const docId = 'deleted-packing-lists:1'
+        const now = new Date().toISOString()
+        const MAX_RETRIES = 3
+
+        for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                let existingDoc: DeletedPackingListsDocument | undefined
+                try {
+                    const doc = await this.db.get(docId)
+                    if (doc.docType === 'deleted-packing-lists') {
+                        existingDoc = doc
+                    }
+                } catch (err: unknown) {
+                    if (!hasName(err) || err.name !== 'not_found') {
+                        throw err
+                    }
+                }
+
+                const docToSave: DeletedPackingListsDocument = {
+                    _id: docId,
+                    _rev: existingDoc?._rev,
+                    docType: 'deleted-packing-lists',
+                    createdAt: existingDoc?.createdAt || now,
+                    updatedAt: now,
+                    data,
+                }
+
+                const result = await this.db.put(docToSave)
+                return { rev: result.rev }
+            } catch (err) {
+                if (hasName(err) && err.name === 'conflict' && attempt < MAX_RETRIES) {
+                    continue
+                }
+                console.error('Error saving deleted packing lists:', err)
+                throw err
+            }
+        }
+        throw new Error('saveDeletedPackingLists: max retries exceeded')
+    }
+
+    public async recordPackingListDeletion(
+        id: string,
+        deletedAt: string = new Date().toISOString()
+    ): Promise<void> {
+        const registry = await this.getDeletedPackingLists()
+        await this.saveDeletedPackingLists(withDeletion(registry, id, deletedAt))
     }
 
     public async getSharedWithMe(): Promise<SharedWithMeList> {
@@ -490,6 +584,13 @@ export class PackingAppDatabase {
         const lists = await source.getAllPackingLists()
         for (const list of lists) {
             await this.savePackingList({ ...list, _rev: undefined })
+        }
+
+        // Tombstones travel with the data: dropping them here would let the
+        // copied-into namespace re-upload lists the user has already deleted.
+        const deletions = await source.getDeletedPackingLists()
+        if (deletions.deletions.length > 0) {
+            await this.saveDeletedPackingLists(deletions)
         }
     }
 }

--- a/src/services/rdfSerialization.test.ts
+++ b/src/services/rdfSerialization.test.ts
@@ -7,10 +7,12 @@ import {
     datasetToQuestionSet,
     sharedListsWithMeToDataset,
     datasetToSharedListsWithMe,
+    deletedPackingListsToDataset,
+    datasetToDeletedPackingLists,
 } from './rdfSerialization'
 import type { PackingList, PackingListItem } from '../create-packing-list/types'
 import type { PackingListQuestionSet, Person, Question, Option } from '../edit-questions/types'
-import type { SharedListsWithMe } from './rdfSerialization'
+import type { SharedListsWithMe, DeletedPackingLists } from './rdfSerialization'
 import {
     fullyPopulatedPackingList,
     fullyPopulatedQuestionSet,
@@ -634,6 +636,52 @@ describe('sharedListsWithMeToDataset / datasetToSharedListsWithMe', () => {
         const result = roundTripSlwm(data)
         expect(result.lists[0].ownerWebId).toBeUndefined()
         expect(result.lists[0].label).toBeUndefined()
+    })
+})
+
+// ── DeletedPackingLists ───────────────────────────────────────────────────────
+
+const DELETIONS_DATASET_URL = 'https://pod.example.com/pack-me-up/deleted-packing-lists.ttl'
+
+function roundTripDeletions(data: DeletedPackingLists): DeletedPackingLists {
+    return datasetToDeletedPackingLists(
+        deletedPackingListsToDataset(data, DELETIONS_DATASET_URL),
+        DELETIONS_DATASET_URL,
+    )
+}
+
+describe('deletedPackingListsToDataset / datasetToDeletedPackingLists', () => {
+    it('round-trips an empty registry', () => {
+        const result = roundTripDeletions({ deletions: [], lastModified: '2026-01-01T00:00:00.000Z' })
+        expect(result.deletions).toEqual([])
+        expect(result.lastModified).toBe('2026-01-01T00:00:00.000Z')
+    })
+
+    it('round-trips a tombstone', () => {
+        const result = roundTripDeletions({
+            deletions: [{ listId: 'list-abc', deletedAt: '2026-02-01T12:00:00.000Z' }],
+            lastModified: '2026-02-01T12:00:00.000Z',
+        })
+        expect(result.deletions).toEqual([{ listId: 'list-abc', deletedAt: '2026-02-01T12:00:00.000Z' }])
+    })
+
+    it('round-trips several tombstones without losing any', () => {
+        const deletions = [
+            { listId: 'list-1', deletedAt: '2026-02-01T12:00:00.000Z' },
+            { listId: 'list-2', deletedAt: '2026-03-01T12:00:00.000Z' },
+            { listId: 'list-3', deletedAt: '2026-04-01T12:00:00.000Z' },
+        ]
+        const result = roundTripDeletions({ deletions, lastModified: '2026-04-01T12:00:00.000Z' })
+        expect(result.deletions).toHaveLength(3)
+        expect(result.deletions).toEqual(expect.arrayContaining(deletions))
+    })
+
+    it('drops a tombstone with no list id rather than guessing one', () => {
+        const dataset = deletedPackingListsToDataset(
+            { deletions: [{ listId: '', deletedAt: '2026-02-01T12:00:00.000Z' }], lastModified: '2026-02-01T12:00:00.000Z' },
+            DELETIONS_DATASET_URL,
+        )
+        expect(datasetToDeletedPackingLists(dataset, DELETIONS_DATASET_URL).deletions).toEqual([])
     })
 })
 

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -705,6 +705,73 @@ export function datasetToSharedListsWithMe(dataset: SolidDataset, datasetUrl: st
     return { lists, lastModified }
 }
 
+// ── DeletedPackingLists ───────────────────────────────────────────────────────
+
+export interface PackingListDeletion {
+    listId: string
+    deletedAt: string
+}
+
+/**
+ * Tombstones for packing lists the user has deleted.
+ *
+ * Without these, a device holding a list the pod does not have cannot tell a
+ * list deleted on another device from one it has never uploaded, so login sync
+ * uploads it again and the delete undoes itself everywhere.
+ */
+export interface DeletedPackingLists {
+    deletions: PackingListDeletion[]
+    lastModified: string
+}
+
+export function deletedPackingListsToDataset(data: DeletedPackingLists, datasetUrl: string): SolidDataset {
+    let ds = createSolidDataset()
+
+    let rootBuilder = buildThing({ url: datasetUrl })
+        .addUrl(RDF.type, PMU.DeletedPackingLists)
+        .addDatetime(DCTERMS.modified, new Date(data.lastModified))
+
+    for (let i = 0; i < data.deletions.length; i++) {
+        const deletion = data.deletions[i]
+        const deletionUrl = `${datasetUrl}#deletion-${i}`
+        rootBuilder = rootBuilder.addUrl(PMU.hasPackingListDeletion, deletionUrl)
+
+        ds = setThing(
+            ds,
+            buildThing({ url: deletionUrl })
+                .addUrl(RDF.type, PMU.PackingListDeletion)
+                .addStringNoLocale(PMU.deletedListId, deletion.listId)
+                .addDatetime(PMU.listDeletedAt, new Date(deletion.deletedAt))
+                .build()
+        )
+    }
+
+    return setThing(ds, rootBuilder.build())
+}
+
+export function datasetToDeletedPackingLists(dataset: SolidDataset, datasetUrl: string): DeletedPackingLists {
+    const rootThing = getThing(dataset, datasetUrl)
+    if (!rootThing) throw new Error(`No root Thing at ${datasetUrl}`)
+
+    const lastModified = getDatetime(rootThing, DCTERMS.modified)?.toISOString() ?? new Date().toISOString()
+    const deletionUrls = getUrlAll(rootThing, PMU.hasPackingListDeletion)
+
+    const deletions: PackingListDeletion[] = deletionUrls
+        .map(url => {
+            const t = getThing(dataset, url)
+            if (!t) return null
+            const listId = getStringNoLocale(t, PMU.deletedListId)
+            const deletedAt = getDatetime(t, PMU.listDeletedAt)?.toISOString()
+            // A tombstone with no id or no time cannot be acted on — dropping it
+            // is safer than inventing a value that could delete the wrong list.
+            if (!listId || !deletedAt) return null
+            return { listId, deletedAt }
+        })
+        .filter((d): d is PackingListDeletion => d !== null)
+
+    return { deletions, lastModified }
+}
+
 function thingToQuestionItem(dataset: SolidDataset, url: string): Item | null {
     const thing = getThing(dataset, url)
     if (!thing) return null

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -115,6 +115,17 @@ export const PMU = {
     sharedLabel: `${PMU_NS}sharedLabel`,
     sharedAddedAt: `${PMU_NS}sharedAddedAt`,
 
+    // DeletedPackingLists classes. A deleted list leaves a tombstone rather than
+    // simply vanishing: a device that still holds a copy has no other way to
+    // tell "deleted elsewhere" from "not uploaded yet", and would re-upload it.
+    DeletedPackingLists: `${PMU_NS}DeletedPackingLists`,
+    PackingListDeletion: `${PMU_NS}PackingListDeletion`,
+
+    // DeletedPackingLists predicates
+    hasPackingListDeletion: `${PMU_NS}hasPackingListDeletion`,
+    deletedListId: `${PMU_NS}deletedListId`,
+    listDeletedAt: `${PMU_NS}listDeletedAt`,
+
     // SharedListsWithMe classes
     SharedListContext: `${PMU_NS}SharedListContext`,
     SharedListsWithMe: `${PMU_NS}SharedListsWithMe`,

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -26,7 +26,9 @@ import { AuthenticationError } from './solidPod'
 import { PackingAppDatabase } from './database'
 import type { PackingListQuestionSet } from '../edit-questions/types'
 import type { PackingList } from '../create-packing-list/types'
-import { packingListToDataset, questionSetToDataset } from './rdfSerialization'
+import { packingListToDataset, questionSetToDataset, deletedPackingListsToDataset } from './rdfSerialization'
+import type { DeletedPackingLists } from './rdfSerialization'
+import { emptyDeletedPackingLists } from '../utils/packingListDeletions'
 import { fullyPopulatedPackingList, withoutLocalOnlyFields } from '../test-utils/fullyPopulatedFixtures'
 
 // Most tests here use a stubbed db (see makeDb); the field-fidelity test uses a
@@ -259,9 +261,11 @@ function makePackingList(id: string, overrides: Partial<PackingList> = {}): Pack
 function makeDb(overrides: Partial<{
     questionSet: PackingListQuestionSet | null
     packingLists: PackingList[]
+    deletions: DeletedPackingLists
 }> = {}): PackingAppDatabase {
     const questionSet = overrides.questionSet !== undefined ? overrides.questionSet : null
     const packingLists = overrides.packingLists ?? []
+    const deletions = overrides.deletions ?? emptyDeletedPackingLists()
 
     return {
         getQuestionSet: vi.fn().mockImplementation(() =>
@@ -273,6 +277,8 @@ function makeDb(overrides: Partial<{
         getAllPackingLists: vi.fn().mockResolvedValue(packingLists),
         savePackingList: vi.fn().mockResolvedValue({ rev: 'rev-pl' }),
         deletePackingList: vi.fn().mockResolvedValue(undefined),
+        getDeletedPackingLists: vi.fn().mockResolvedValue(deletions),
+        saveDeletedPackingLists: vi.fn().mockResolvedValue({ rev: 'rev-del' }),
     } as unknown as PackingAppDatabase
 }
 
@@ -290,10 +296,42 @@ function makeRdfListDataset(list: PackingList) {
     return packingListToDataset(list, url) as unknown as SolidDataset & WithServerResourceInfo
 }
 
-function makeContainerDataset(fileUrls: string[]) {
-    const ds = {} as SolidDataset & WithServerResourceInfo
-    mockGetContainedResourceUrlAll.mockReturnValueOnce(fileUrls)
-    return ds
+const DELETIONS_URL = `${POD_URL}${POD_CONTAINERS.DELETED_PACKING_LISTS}`
+
+const EMPTY_DATASET = {} as SolidDataset & WithServerResourceInfo
+
+/**
+ * Answers getSolidDataset by URL rather than by call order.
+ *
+ * syncAllDataFromPod asks for the question set, the packing-list container and
+ * the deletion tombstones concurrently, so a queue of mockResolvedValueOnce
+ * hands each result to whichever request happens to go first — adding a fourth
+ * read would silently re-point the other three. Anything not listed here (a
+ * missing question set, an absent tombstone file) answers 404, which is what a
+ * pod without that resource does.
+ */
+function stubPod(contents: {
+    questionSet?: PackingListQuestionSet
+    lists?: PackingList[]
+    deletions?: DeletedPackingLists
+}) {
+    const { questionSet, lists = [], deletions } = contents
+    mockGetContainedResourceUrlAll.mockReturnValue(lists.map(l => `${LISTS_CONTAINER_URL}${l.id}.ttl`))
+    mockGetSolidDataset.mockImplementation(async (url: string) => {
+        if (url === QUESTIONS_URL) {
+            if (!questionSet) throw { statusCode: 404 }
+            return makeRdfQsDataset(questionSet)
+        }
+        if (url === DELETIONS_URL) {
+            if (!deletions) throw { statusCode: 404 }
+            return deletedPackingListsToDataset(deletions, DELETIONS_URL) as unknown as SolidDataset & WithServerResourceInfo
+        }
+        const list = lists.find(l => `${LISTS_CONTAINER_URL}${l.id}.ttl` === url)
+        if (list) return makeRdfListDataset(list)
+        // The list container itself, and the container probes ensureContainerExists
+        // makes before a write.
+        return EMPTY_DATASET
+    })
 }
 
 describe('syncAllDataFromPod', () => {
@@ -373,18 +411,9 @@ describe('syncAllDataFromPod', () => {
 
     describe('packing lists sync', () => {
         it('saves all pod packing lists to local DB', async () => {
-            const podList1 = makePackingList('list-1')
-            const podList2 = makePackingList('list-2')
             const db = makeDb({ questionSet: null, packingLists: [] })
 
-            const list1Url = `${LISTS_CONTAINER_URL}list-1.ttl`
-            const list2Url = `${LISTS_CONTAINER_URL}list-2.ttl`
-
-            mockGetSolidDataset
-                .mockRejectedValueOnce({ statusCode: 404 }) // no question set
-                .mockResolvedValueOnce(makeContainerDataset([list1Url, list2Url]))
-                .mockResolvedValueOnce(makeRdfListDataset(podList1))
-                .mockResolvedValueOnce(makeRdfListDataset(podList2))
+            stubPod({ lists: [makePackingList('list-1'), makePackingList('list-2')] })
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
 
@@ -396,11 +425,7 @@ describe('syncAllDataFromPod', () => {
             const localOnlyList = makePackingList('local-only')
             const db = makeDb({ questionSet: null, packingLists: [localOnlyList] })
 
-            mockGetSolidDataset
-                .mockRejectedValueOnce({ statusCode: 404 }) // no question set
-                .mockResolvedValueOnce(makeContainerDataset([])) // empty container
-                .mockResolvedValueOnce({} as unknown as SolidDataset & WithServerResourceInfo) // ensureContainerExists in saveRdfToPod
-
+            stubPod({ lists: [] })
             mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
@@ -414,18 +439,10 @@ describe('syncAllDataFromPod', () => {
         })
 
         it('returns correct counts when both pod and local lists exist', async () => {
-            const podList = makePackingList('pod-list')
             const localOnlyList = makePackingList('local-only')
             const db = makeDb({ questionSet: null, packingLists: [localOnlyList] })
 
-            const podListUrl = `${LISTS_CONTAINER_URL}pod-list.ttl`
-
-            mockGetSolidDataset
-                .mockRejectedValueOnce({ statusCode: 404 }) // no question set
-                .mockResolvedValueOnce(makeContainerDataset([podListUrl]))
-                .mockResolvedValueOnce(makeRdfListDataset(podList))
-                .mockResolvedValueOnce({} as unknown as SolidDataset & WithServerResourceInfo) // ensureContainerExists in saveRdfToPod
-
+            stubPod({ lists: [makePackingList('pod-list')] })
             mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, db)
@@ -440,18 +457,158 @@ describe('syncAllDataFromPod', () => {
         it('keeps every pod-serialisable field of a synced list in the local DB', async () => {
             const podList: PackingList = { ...fullyPopulatedPackingList, id: 'pod-full' }
             const realDb = PackingAppDatabase.getInstance('sync-field-fidelity')
-            const podListUrl = `${LISTS_CONTAINER_URL}pod-full.ttl`
 
-            mockGetSolidDataset
-                .mockRejectedValueOnce({ statusCode: 404 }) // no question set
-                .mockResolvedValueOnce(makeContainerDataset([podListUrl]))
-                .mockResolvedValueOnce(makeRdfListDataset(podList))
+            stubPod({ lists: [podList] })
 
             const result = await syncAllDataFromPod(mockSession, POD_URL, realDb)
 
             expect(result.packingListsSynced).toBe(1)
             const stored = await realDb.getPackingList('pod-full')
             expect(stored).toEqual({ ...withoutLocalOnlyFields(podList), _rev: expect.any(String) })
+        })
+    })
+
+    // A list deleted on one device used to come back everywhere, because a device
+    // that still held it saw "on this device, not on the pod" and uploaded it.
+    describe('deleted packing lists', () => {
+        // Relative to now, not fixed dates: tombstones older than the retention
+        // window are pruned, so hard-coded ones quietly stop being tombstones.
+        const beforeDelete = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString()
+        const deletedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+        const afterDelete = new Date(Date.now() - 30 * 60 * 1000).toISOString()
+
+        function makeDeletions(...ids: string[]): DeletedPackingLists {
+            return { deletions: ids.map(listId => ({ listId, deletedAt })), lastModified: deletedAt }
+        }
+
+        it('does not re-upload a local list the pod says was deleted', async () => {
+            const deletedList = makePackingList('deleted-list', { lastModified: beforeDelete })
+            const db = makeDb({ questionSet: null, packingLists: [deletedList] })
+
+            stubPod({ lists: [], deletions: makeDeletions('deleted-list') })
+            mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(mockOverwriteFile).not.toHaveBeenCalledWith(
+                expect.stringContaining('deleted-list.ttl'),
+                expect.anything(),
+                expect.anything()
+            )
+            expect(result.packingListsUploaded).toBe(0)
+        })
+
+        it('removes the local copy of a list deleted on another device', async () => {
+            const deletedList = makePackingList('deleted-list', { lastModified: beforeDelete })
+            const db = makeDb({ questionSet: null, packingLists: [deletedList] })
+
+            stubPod({ lists: [], deletions: makeDeletions('deleted-list') })
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(db.deletePackingList).toHaveBeenCalledWith('deleted-list', { recordDeletion: false })
+            expect(result.packingListsDeleted).toBe(1)
+        })
+
+        it('leaves lists without a tombstone alone', async () => {
+            const keptList = makePackingList('kept-list')
+            const db = makeDb({ questionSet: null, packingLists: [keptList] })
+
+            stubPod({ lists: [], deletions: makeDeletions('some-other-list') })
+            mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(db.deletePackingList).not.toHaveBeenCalled()
+            expect(result.packingListsUploaded).toBe(1)
+        })
+
+        it('keeps a cached shared list even when its id is tombstoned', async () => {
+            const sharedList = makePackingList('shared-list', {
+                lastModified: beforeDelete,
+                sharedFromPodUrl: 'https://someone-else.example/',
+            })
+            const db = makeDb({ questionSet: null, packingLists: [sharedList] })
+
+            stubPod({ lists: [], deletions: makeDeletions('shared-list') })
+            mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(db.deletePackingList).not.toHaveBeenCalled()
+            expect(result.packingListsDeleted).toBe(0)
+        })
+
+        it('takes a tombstoned list off the pod as well', async () => {
+            const podList = makePackingList('deleted-list', { lastModified: beforeDelete })
+            const db = makeDb({ questionSet: null, packingLists: [] })
+
+            stubPod({ lists: [podList], deletions: makeDeletions('deleted-list') })
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(mockDeleteFile).toHaveBeenCalledWith(
+                `${LISTS_CONTAINER_URL}deleted-list.ttl`,
+                expect.objectContaining({ fetch: mockSession.fetch })
+            )
+            expect(db.savePackingList).not.toHaveBeenCalled()
+            expect(result.packingListsSynced).toBe(0)
+        })
+
+        // Deleting is not final: a copy edited after the delete is the user
+        // coming back to the list, and must not be deleted a second time.
+        it('keeps a list edited after it was deleted, and drops the tombstone', async () => {
+            const revivedList = makePackingList('revived-list', { lastModified: afterDelete })
+            const db = makeDb({ questionSet: null, packingLists: [], deletions: makeDeletions('revived-list') })
+
+            stubPod({ lists: [revivedList], deletions: makeDeletions('revived-list') })
+            mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(mockDeleteFile).not.toHaveBeenCalled()
+            expect(result.packingListsSynced).toBe(1)
+            expect(db.saveDeletedPackingLists).toHaveBeenCalledWith(
+                expect.objectContaining({ deletions: [] })
+            )
+        })
+
+        it('pushes local tombstones the pod has not seen', async () => {
+            const db = makeDb({ questionSet: null, packingLists: [], deletions: makeDeletions('deleted-here') })
+
+            stubPod({ lists: [] })
+            mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
+
+            await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(mockOverwriteFile).toHaveBeenCalledWith(
+                DELETIONS_URL,
+                expect.any(Blob),
+                expect.objectContaining({ fetch: mockSession.fetch, contentType: 'text/turtle' })
+            )
+        })
+
+        it('saves pod tombstones locally so the next sync starts from them', async () => {
+            const db = makeDb({ questionSet: null, packingLists: [] })
+
+            stubPod({ lists: [], deletions: makeDeletions('deleted-elsewhere') })
+
+            await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(db.saveDeletedPackingLists).toHaveBeenCalledWith(
+                expect.objectContaining({ deletions: [{ listId: 'deleted-elsewhere', deletedAt }] })
+            )
+        })
+
+        it('syncs normally when the pod has no tombstone file yet', async () => {
+            const db = makeDb({ questionSet: null, packingLists: [] })
+
+            stubPod({ lists: [makePackingList('list-1')] })
+
+            const result = await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(result.packingListsSynced).toBe(1)
+            expect(result.packingListsDeleted).toBe(0)
         })
     })
 })

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -5,8 +5,9 @@ const { getAgentAccessAll, setPublicAccess, getPublicAccess } = universalAccess
 import { PackingAppDatabase } from './database'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { PackingList } from '../create-packing-list/types'
-import { packingListToDataset, datasetToPackingList, datasetToQuestionSet, datasetToSharedWithMe, datasetToSharedListsWithMe } from './rdfSerialization'
-import type { SharedWithMeList, SharedListsWithMe } from './rdfSerialization'
+import { packingListToDataset, datasetToPackingList, datasetToQuestionSet, datasetToSharedWithMe, datasetToSharedListsWithMe, deletedPackingListsToDataset, datasetToDeletedPackingLists } from './rdfSerialization'
+import type { SharedWithMeList, SharedListsWithMe, DeletedPackingLists } from './rdfSerialization'
+import { deletionsById, emptyDeletedPackingLists, isNewerThanDeletion, mergeDeletedPackingLists, pruneDeletions, registriesEqual, withoutDeletion } from '../utils/packingListDeletions'
 
 /**
  * Pod container paths under the user's Pod root
@@ -20,6 +21,7 @@ export const POD_CONTAINERS = {
     BACKUPS: 'pack-me-up/backups/',
     SHARED_WITH_ME: 'pack-me-up/shared-with-me.ttl',
     SHARED_LISTS_WITH_ME: 'pack-me-up/shared-lists-with-me.ttl',
+    DELETED_PACKING_LISTS: 'pack-me-up/deleted-packing-lists.ttl',
 } as const
 
 /**
@@ -974,6 +976,8 @@ export interface SyncAllResult {
     packingListsSynced: number
     /** number of local-only packing lists uploaded to pod */
     packingListsUploaded: number
+    /** number of local packing lists removed because they were deleted elsewhere */
+    packingListsDeleted: number
     /** true if the shared-with-me list was synced from pod */
     sharedWithMeSynced: boolean
     /** true if the shared-lists-with-me list was synced from pod */
@@ -987,7 +991,14 @@ export interface SyncAllResult {
  *   strategy). If no local copy exists, the pod data is always saved.
  * - Packing lists: all lists present on the pod are saved locally (pod wins for
  *   any conflicting IDs). Local-only lists (not yet on the pod) are uploaded so
- *   data is never lost.
+ *   data is never lost — unless they carry a deletion tombstone, in which case
+ *   they are removed locally instead. Without that check "deleted on the other
+ *   device" and "not uploaded yet" look identical from here, and every device
+ *   still holding a copy puts it back.
+ * - Deletion tombstones: the pod and local registries are merged (union, latest
+ *   wins per list) and written back to both, so a deletion made on any device
+ *   reaches all of them. A list whose `lastModified` is newer than its tombstone
+ *   has been resurrected deliberately, so the tombstone is dropped instead.
  *
  * 404 responses are treated as "no data" and handled gracefully.
  * Authentication errors (401/403) are re-thrown immediately.
@@ -1002,13 +1013,15 @@ export async function syncAllDataFromPod(
     let questionSetSynced = false
     let packingListsSynced = 0
     let packingListsUploaded = 0
+    let packingListsDeleted = 0
     let sharedWithMeSynced = false
     let sharedListsWithMeSynced = false
 
     const containerUrl = `${podUrl}${POD_CONTAINERS.PACKING_LISTS}`
+    const deletionsUrl = `${podUrl}${POD_CONTAINERS.DELETED_PACKING_LISTS}`
 
-    // ── Download question set and packing lists in parallel ──────────────────
-    const [podQsResult, podListsResult] = await Promise.allSettled([
+    // ── Download question set, packing lists and tombstones in parallel ──────
+    const [podQsResult, podListsResult, podDeletionsResult] = await Promise.allSettled([
         loadRdfFromPod<PackingListQuestionSet>(
             session,
             `${podUrl}${POD_CONTAINERS.QUESTIONS}`,
@@ -1018,6 +1031,11 @@ export async function syncAllDataFromPod(
             session,
             containerUrl,
             datasetToPackingList,
+        ),
+        loadRdfFromPod<DeletedPackingLists>(
+            session,
+            deletionsUrl,
+            datasetToDeletedPackingLists,
         ),
     ])
 
@@ -1054,32 +1072,100 @@ export async function syncAllDataFromPod(
         // 404 = no question set on pod yet → silently skip
     }
 
-    // ── 2. Packing lists ─────────────────────────────────────────────────────
+    // ── 2. Deletion tombstones ───────────────────────────────────────────────
+    // Read before the lists are reconciled: which lists survive depends on them.
+    let podDeletions = emptyDeletedPackingLists()
+    if (podDeletionsResult.status === 'fulfilled') {
+        podDeletions = podDeletionsResult.value
+    } else {
+        const err = podDeletionsResult.reason
+        if (err instanceof AuthenticationError) throw err
+        const status = getStatusCode(err)
+        if (status !== 404) {
+            console.error('syncAllDataFromPod: error loading deleted packing lists', err)
+        }
+        // 404 = nothing deleted on this pod yet → empty registry
+    }
+
+    let localDeletions = emptyDeletedPackingLists()
+    try {
+        localDeletions = await db.getDeletedPackingLists()
+    } catch (err) {
+        console.error('syncAllDataFromPod: error loading local deleted packing lists', err)
+    }
+
+    let deletions = pruneDeletions(mergeDeletedPackingLists(localDeletions, podDeletions))
+
+    // ── 3. Packing lists ─────────────────────────────────────────────────────
     if (podListsResult.status === 'rejected') {
         const err = podListsResult.reason
         if (err instanceof AuthenticationError) throw err
         console.error('syncAllDataFromPod: error loading packing lists', err)
-        return { questionSetSynced, packingListsSynced, packingListsUploaded, sharedWithMeSynced, sharedListsWithMeSynced }
+        return { questionSetSynced, packingListsSynced, packingListsUploaded, packingListsDeleted, sharedWithMeSynced, sharedListsWithMeSynced }
     }
 
     const { data: podLists } = podListsResult.value
     const podListIds = new Set(podLists.map((l) => l.id))
 
-    // Save all pod lists to local DB in parallel (pod wins for conflicting IDs)
+    // A list still on the pod but tombstoned was deleted on another device
+    // before this one uploaded it back, or while this device was offline. Take
+    // the pod copy down too, unless it is newer than the tombstone — that means
+    // it was edited after the delete, so the edit wins and the tombstone goes.
+    const listsToSaveLocally: PackingList[] = []
+    for (const podList of podLists) {
+        const deletedAt = deletionsById(deletions).get(podList.id)
+        if (deletedAt === undefined) {
+            listsToSaveLocally.push(podList)
+            continue
+        }
+        if (isNewerThanDeletion(podList, deletedAt)) {
+            deletions = withoutDeletion(deletions, podList.id)
+            listsToSaveLocally.push(podList)
+            continue
+        }
+        try {
+            await deleteFileFromPod(session, `${containerUrl}${podList.id}.ttl`)
+            podListIds.delete(podList.id)
+        } catch (err) {
+            if (err instanceof AuthenticationError) throw err
+            console.error(`syncAllDataFromPod: error removing deleted list ${podList.id} from pod`, err)
+        }
+    }
+
+    // Save the surviving pod lists to local DB in parallel (pod wins for conflicting IDs)
     const saveResults = await Promise.allSettled(
-        podLists.map(podList => db.savePackingList({ ...podList, _rev: undefined }))
+        listsToSaveLocally.map(podList => db.savePackingList({ ...podList, _rev: undefined }))
     )
     for (let i = 0; i < saveResults.length; i++) {
         if (saveResults[i].status === 'fulfilled') {
             packingListsSynced++
         } else {
-            console.error(`syncAllDataFromPod: error saving packing list ${podLists[i].id}`, (saveResults[i] as PromiseRejectedResult).reason)
+            console.error(`syncAllDataFromPod: error saving packing list ${listsToSaveLocally[i].id}`, (saveResults[i] as PromiseRejectedResult).reason)
         }
     }
 
-    // Upload any local-only lists to the pod so they are not lost
     const localLists = await db.getAllPackingLists()
+    const deletedAtById = deletionsById(deletions)
     for (const localList of localLists) {
+        // A cached copy of somebody else's shared list is not ours to delete or
+        // to tombstone; its id lives in their pod.
+        const deletedAt = localList.sharedFromPodUrl ? undefined : deletedAtById.get(localList.id)
+
+        // Deleted elsewhere and not edited since: this copy is what would have
+        // been re-uploaded, so remove it instead of putting it back.
+        if (deletedAt !== undefined && !isNewerThanDeletion(localList, deletedAt)) {
+            try {
+                // The tombstone already exists — recording it again would only
+                // push its timestamp forward past any concurrent edit.
+                await db.deletePackingList(localList.id, { recordDeletion: false })
+                packingListsDeleted++
+            } catch (err) {
+                console.error(`syncAllDataFromPod: error deleting local list ${localList.id}`, err)
+            }
+            continue
+        }
+
+        // Upload any local-only lists to the pod so they are not lost
         if (podListIds.has(localList.id)) continue
         try {
             await saveRdfToPod({
@@ -1095,7 +1181,26 @@ export async function syncAllDataFromPod(
         }
     }
 
-    // ── 3. SharedWithMe ──────────────────────────────────────────────────────
+    // Write the merged registry back to both sides so the next sync on any
+    // device — this one included — starts from the same set of tombstones.
+    try {
+        if (!registriesEqual(deletions, localDeletions)) {
+            await db.saveDeletedPackingLists(deletions)
+        }
+        if (!registriesEqual(deletions, podDeletions)) {
+            await saveRdfToPod({
+                session,
+                fileUrl: deletionsUrl,
+                data: deletions,
+                serializer: deletedPackingListsToDataset,
+            })
+        }
+    } catch (err) {
+        if (err instanceof AuthenticationError) throw err
+        console.error('syncAllDataFromPod: error saving deleted packing lists', err)
+    }
+
+    // ── 4. SharedWithMe ──────────────────────────────────────────────────────
     try {
         const podSwm = await loadRdfFromPod<SharedWithMeList>(
             session,
@@ -1117,7 +1222,7 @@ export async function syncAllDataFromPod(
         // 404 = no shared-with-me yet → silently skip
     }
 
-    // ── 4. SharedListsWithMe ─────────────────────────────────────────────────
+    // ── 5. SharedListsWithMe ─────────────────────────────────────────────────
     try {
         const podSlwm = await loadRdfFromPod<SharedListsWithMe>(
             session,
@@ -1139,5 +1244,5 @@ export async function syncAllDataFromPod(
         // 404 = no shared-lists-with-me yet → silently skip
     }
 
-    return { questionSetSynced, packingListsSynced, packingListsUploaded, sharedWithMeSynced, sharedListsWithMeSynced }
+    return { questionSetSynced, packingListsSynced, packingListsUploaded, packingListsDeleted, sharedWithMeSynced, sharedListsWithMeSynced }
 }

--- a/src/utils/packingListDeletions.test.ts
+++ b/src/utils/packingListDeletions.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import {
+    DELETION_RETENTION_DAYS,
+    deletionsById,
+    emptyDeletedPackingLists,
+    isNewerThanDeletion,
+    mergeDeletedPackingLists,
+    pruneDeletions,
+    registriesEqual,
+    withDeletion,
+    withoutDeletion,
+} from './packingListDeletions'
+import type { DeletedPackingLists } from '../services/rdfSerialization'
+
+const EARLY = '2026-01-01T10:00:00.000Z'
+const LATE = '2026-01-02T10:00:00.000Z'
+
+function registry(
+    deletions: Array<[string, string]>,
+    lastModified = LATE
+): DeletedPackingLists {
+    return { deletions: deletions.map(([listId, deletedAt]) => ({ listId, deletedAt })), lastModified }
+}
+
+describe('emptyDeletedPackingLists', () => {
+    it('starts with no tombstones and a timestamp any pod copy beats', () => {
+        const empty = emptyDeletedPackingLists()
+        expect(empty.deletions).toEqual([])
+        expect(new Date(empty.lastModified).getTime()).toBe(0)
+    })
+})
+
+describe('mergeDeletedPackingLists', () => {
+    it('keeps tombstones from both sides', () => {
+        const merged = mergeDeletedPackingLists(registry([['a', EARLY]]), registry([['b', EARLY]]))
+        expect(deletionsById(merged)).toEqual(new Map([['a', EARLY], ['b', EARLY]]))
+    })
+
+    it('keeps the later time when both sides know the same list', () => {
+        const merged = mergeDeletedPackingLists(registry([['a', EARLY]]), registry([['a', LATE]]))
+        expect(merged.deletions).toEqual([{ listId: 'a', deletedAt: LATE }])
+    })
+
+    it('is order-independent', () => {
+        const a = registry([['a', EARLY], ['b', LATE]])
+        const b = registry([['a', LATE], ['c', EARLY]])
+        expect(mergeDeletedPackingLists(a, b).deletions).toEqual(mergeDeletedPackingLists(b, a).deletions)
+    })
+
+    it('takes the later lastModified of the two registries', () => {
+        const merged = mergeDeletedPackingLists(registry([], EARLY), registry([], LATE))
+        expect(merged.lastModified).toBe(LATE)
+    })
+
+    // Two devices each deleting a different list offline is exactly the case a
+    // last-writer-wins whole-file merge would get wrong.
+    it('loses neither deletion when two devices delete different lists offline', () => {
+        const deviceA = withDeletion(emptyDeletedPackingLists(), 'holiday', EARLY)
+        const deviceB = withDeletion(emptyDeletedPackingLists(), 'ski-trip', LATE)
+        const merged = mergeDeletedPackingLists(deviceA, deviceB)
+        expect(merged.deletions.map(d => d.listId).sort()).toEqual(['holiday', 'ski-trip'])
+    })
+})
+
+describe('withDeletion', () => {
+    it('adds a tombstone', () => {
+        const result = withDeletion(emptyDeletedPackingLists(), 'a', EARLY)
+        expect(result.deletions).toEqual([{ listId: 'a', deletedAt: EARLY }])
+        expect(result.lastModified).toBe(EARLY)
+    })
+
+    it('moves an existing tombstone forward, never back', () => {
+        const result = withDeletion(registry([['a', LATE]]), 'a', EARLY)
+        expect(result.deletions).toEqual([{ listId: 'a', deletedAt: LATE }])
+    })
+})
+
+describe('withoutDeletion', () => {
+    it('drops the tombstone and stamps the registry', () => {
+        const result = withoutDeletion(registry([['a', EARLY], ['b', EARLY]]), 'a', LATE)
+        expect(result.deletions).toEqual([{ listId: 'b', deletedAt: EARLY }])
+        expect(result.lastModified).toBe(LATE)
+    })
+
+    it('leaves the registry untouched when there is no such tombstone', () => {
+        const before = registry([['a', EARLY]])
+        expect(withoutDeletion(before, 'b')).toBe(before)
+    })
+})
+
+describe('pruneDeletions', () => {
+    const now = new Date('2026-06-01T00:00:00.000Z').getTime()
+    const day = 24 * 60 * 60 * 1000
+
+    it('keeps tombstones inside the retention window', () => {
+        const recent = new Date(now - 10 * day).toISOString()
+        expect(pruneDeletions(registry([['a', recent]]), now).deletions).toHaveLength(1)
+    })
+
+    it('drops tombstones past the retention window', () => {
+        const ancient = new Date(now - (DELETION_RETENTION_DAYS + 1) * day).toISOString()
+        expect(pruneDeletions(registry([['a', ancient]]), now).deletions).toEqual([])
+    })
+
+    it('returns the same object when nothing is pruned', () => {
+        const before = registry([['a', new Date(now - day).toISOString()]])
+        expect(pruneDeletions(before, now)).toBe(before)
+    })
+})
+
+describe('isNewerThanDeletion', () => {
+    it('is true for a list edited after it was deleted', () => {
+        expect(isNewerThanDeletion({ lastModified: LATE }, EARLY)).toBe(true)
+    })
+
+    it('is false for a list last touched before it was deleted', () => {
+        expect(isNewerThanDeletion({ lastModified: EARLY }, LATE)).toBe(false)
+    })
+
+    it('is false at exactly the deletion time — the delete came last', () => {
+        expect(isNewerThanDeletion({ lastModified: EARLY }, EARLY)).toBe(false)
+    })
+
+    it('is false for a list with no timestamp to make the claim with', () => {
+        expect(isNewerThanDeletion({}, EARLY)).toBe(false)
+    })
+})
+
+describe('registriesEqual', () => {
+    it('ignores ordering and the registry timestamp', () => {
+        expect(registriesEqual(
+            registry([['a', EARLY], ['b', LATE]], EARLY),
+            registry([['b', LATE], ['a', EARLY]], LATE),
+        )).toBe(true)
+    })
+
+    it('is false when a tombstone differs', () => {
+        expect(registriesEqual(registry([['a', EARLY]]), registry([['a', LATE]]))).toBe(false)
+        expect(registriesEqual(registry([['a', EARLY]]), registry([]))).toBe(false)
+    })
+})

--- a/src/utils/packingListDeletions.ts
+++ b/src/utils/packingListDeletions.ts
@@ -1,0 +1,114 @@
+import type { DeletedPackingLists, PackingListDeletion } from '../services/rdfSerialization'
+import type { PackingList } from '../create-packing-list/types'
+
+/**
+ * How long a tombstone is kept before it is dropped.
+ *
+ * The registry is replicated to the pod, so it cannot grow without bound. A
+ * device that has been offline for longer than this can still resurrect a list
+ * it holds; a year is long enough that this is a fair trade for a file that
+ * stays small.
+ */
+export const DELETION_RETENTION_DAYS = 365
+
+/** Timestamp used for a registry that has never been written. Any pod copy wins. */
+export const EMPTY_REGISTRY_TIMESTAMP = new Date(0).toISOString()
+
+export function emptyDeletedPackingLists(): DeletedPackingLists {
+    return { deletions: [], lastModified: EMPTY_REGISTRY_TIMESTAMP }
+}
+
+function time(iso: string | undefined): number {
+    if (!iso) return 0
+    const ms = new Date(iso).getTime()
+    return Number.isNaN(ms) ? 0 : ms
+}
+
+/**
+ * Combines two registries: every tombstone from either side, keeping the later
+ * `deletedAt` when both know about the same list.
+ *
+ * Deliberately a union rather than last-writer-wins on the whole file: two
+ * devices that each delete a different list offline would otherwise lose one of
+ * the deletions when they meet.
+ */
+export function mergeDeletedPackingLists(
+    a: DeletedPackingLists,
+    b: DeletedPackingLists
+): DeletedPackingLists {
+    const byListId = new Map<string, PackingListDeletion>()
+    for (const deletion of [...a.deletions, ...b.deletions]) {
+        const existing = byListId.get(deletion.listId)
+        if (!existing || time(deletion.deletedAt) > time(existing.deletedAt)) {
+            byListId.set(deletion.listId, deletion)
+        }
+    }
+    return {
+        deletions: sortDeletions([...byListId.values()]),
+        lastModified: time(a.lastModified) >= time(b.lastModified) ? a.lastModified : b.lastModified,
+    }
+}
+
+/** Adds (or refreshes) the tombstone for a list. */
+export function withDeletion(
+    registry: DeletedPackingLists,
+    listId: string,
+    deletedAt: string
+): DeletedPackingLists {
+    return mergeDeletedPackingLists(registry, {
+        deletions: [{ listId, deletedAt }],
+        lastModified: deletedAt,
+    })
+}
+
+/** Removes the tombstone for a list, e.g. once a newer copy has resurrected it. */
+export function withoutDeletion(
+    registry: DeletedPackingLists,
+    listId: string,
+    now: string = new Date().toISOString()
+): DeletedPackingLists {
+    if (!registry.deletions.some(d => d.listId === listId)) return registry
+    return {
+        deletions: registry.deletions.filter(d => d.listId !== listId),
+        lastModified: now,
+    }
+}
+
+/** Drops tombstones older than the retention window. */
+export function pruneDeletions(
+    registry: DeletedPackingLists,
+    now: number = Date.now()
+): DeletedPackingLists {
+    const cutoff = now - DELETION_RETENTION_DAYS * 24 * 60 * 60 * 1000
+    const kept = registry.deletions.filter(d => time(d.deletedAt) >= cutoff)
+    if (kept.length === registry.deletions.length) return registry
+    return { deletions: kept, lastModified: registry.lastModified }
+}
+
+export function deletionsById(registry: DeletedPackingLists): Map<string, string> {
+    return new Map(registry.deletions.map(d => [d.listId, d.deletedAt]))
+}
+
+/**
+ * Whether a copy of a list outlives its tombstone.
+ *
+ * A list edited *after* it was deleted has been deliberately brought back (or
+ * the delete lost a race with an edit), so the newer copy wins and the tombstone
+ * is dropped. A list with no `lastModified` at all cannot make that claim.
+ */
+export function isNewerThanDeletion(
+    list: Pick<PackingList, 'lastModified'>,
+    deletedAt: string
+): boolean {
+    return time(list.lastModified) > time(deletedAt)
+}
+
+export function registriesEqual(a: DeletedPackingLists, b: DeletedPackingLists): boolean {
+    if (a.deletions.length !== b.deletions.length) return false
+    const bById = deletionsById(b)
+    return a.deletions.every(d => bById.get(d.listId) === d.deletedAt)
+}
+
+function sortDeletions(deletions: PackingListDeletion[]): PackingListDeletion[] {
+    return [...deletions].sort((x, y) => x.listId.localeCompare(y.listId))
+}


### PR DESCRIPTION
## The bug

Delete a list on device A and it goes locally and from the pod. Open the app on device B, which still has its own copy, and the list is back — on B, on the pod, and on A the next time it syncs.

The cause is in `syncAllDataFromPod`. A delete left no record of itself, so its "upload any local-only lists to the pod so they are not lost" step could not tell these two situations apart:

- a list on this device that has never been uploaded → upload it
- a list on this device that was deleted on another device → it is supposed to be gone

Both look like "present locally, absent from the pod", so B uploaded it and the delete undid itself everywhere.

## The fix

Deletions now leave a tombstone — the same shape the app already uses for deleted people, questions and items, lifted to whole lists.

- **New registry**, local and on the pod. A PouchDB document plus `pack-me-up/deleted-packing-lists.ttl`, holding `{ listId, deletedAt }` per deleted list. New vocab terms `DeletedPackingLists` / `PackingListDeletion` and a serialiser pair alongside the existing ones.
- **Deleting records one.** `db.deletePackingList` writes the tombstone by default, and `packing-lists.tsx` pushes the updated registry to the pod right after removing the `.ttl`.
- **Login sync honours it.** The pod and local registries are merged — a union keeping the later time per list, so two devices deleting different lists offline lose neither — then a tombstoned list is removed locally, taken off the pod if still there, and skipped by the upload step. The merged registry is written back to both sides.
- **Deleting is not final.** A list whose `lastModified` is newer than its tombstone was edited after the delete, so the copy wins and the tombstone is dropped instead.
- **The registry stays small.** Tombstones older than a year are pruned.

Two ids are deliberately not tombstoned: a cached copy of someone else's shared list, removed either from Sharing settings or from the list page. That id lives in their pod and may legitimately be shared again. Recording is the default everywhere else, so a new delete site cannot quietly forget to.

## Test report

**E2E — reproduction, `f-sync.spec.ts` F7 (new).** Three browser contexts against a local CSS: A creates and syncs a list; B logs in and caches it; A deletes it; B reloads; C logs in fresh and reads the pod from scratch.

| | before | after |
|---|---|---|
| F7 | ❌ list visible again on B after its sync | ✅ |

Verified failing on the pre-fix code with `9 × locator resolved to <h3>…✈️ Delete Resurrect Test…` on device B — the resurrection itself, not a proxy for it. The existing F3 passed throughout, because its second device has no local copy and so never hits this path.

**Full suites, after the fix:**

- `npm run test:e2e` — **74 passed** (all suites, not just F)
- `npm test` (typecheck + vitest) — **1485 passed**, up from 1444; 41 new tests
- `npm run lint` — 0 errors (12 pre-existing warnings, untouched)

New unit coverage: the merge / prune / resurrect / equality rules (`packingListDeletions.test.ts`), the local registry and the `recordDeletion` opt-out (`database.test.ts`), the RDF round-trip including a malformed tombstone (`rdfSerialization.test.ts`), and the sync paths — no re-upload, local removal, pod removal, shared lists left alone, resurrection, and pushing local-only tombstones (`solidPod.test.ts`).

One test-infrastructure change worth flagging: the `syncAllDataFromPod` tests stubbed `getSolidDataset` with a queue of `mockResolvedValueOnce`, which binds results to call *order*. Adding a fourth concurrent read silently re-pointed the other three. They now stub by URL instead.

## Note on scope

`syncAllDataFromPod`'s upload step also uploads cached copies of other people's shared lists into your own pod container — `getAllPackingLists()` returns those too and only the tombstone check here filters on `sharedFromPodUrl`. That looked like a separate bug and I left it alone rather than widen this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPJToreLGBcx6yvAHy4Cid

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPJToreLGBcx6yvAHy4Cid)_