### PR TITLE
Stop reporting errors thrown by scripts injected into the page

### DIFF
--- a/src/sentry.test.ts
+++ b/src/sentry.test.ts
@@ -8,7 +8,62 @@ vi.mock('@sentry/react', () => ({
     browserTracingIntegration: () => ({ name: 'BrowserTracing' }),
 }))
 
-import { initSentry } from './sentry'
+import type { ErrorEvent, StackFrame } from '@sentry/react'
+
+import { initSentry, isThirdPartyScriptError } from './sentry'
+
+function errorEvent(...frameSets: (StackFrame[] | undefined)[]): ErrorEvent {
+    return {
+        type: undefined,
+        exception: {
+            values: frameSets.map(frames => ({
+                type: 'Error',
+                value: 'boom',
+                stacktrace: frames && { frames },
+            })),
+        },
+    }
+}
+
+// Sentry stores frames oldest-first, so the frame that actually threw is last.
+const ourFrame: StackFrame = { function: 'r', filename: 'app:///assets/index-DhPzMc-b.js', lineno: 535 }
+const injectedFrame: StackFrame = { function: 'scanForForms', filename: 'app:///<anonymous>', lineno: 65 }
+
+describe('isThirdPartyScriptError', () => {
+    it('drops an error thrown by an injected script through our wrapped setTimeout', () => {
+        // The reported issue: a WebView form scanner we don't ship calls a native
+        // JavaScript interface we don't register, and fails.
+        expect(isThirdPartyScriptError(errorEvent([ourFrame, injectedFrame]))).toBe(true)
+    })
+
+    it.each(['<anonymous>', '<unknown>', 'app:///<unknown>', '', undefined])(
+        'treats a throwing frame with filename %p as third-party',
+        filename => {
+            expect(isThirdPartyScriptError(errorEvent([ourFrame, { function: 'scanForForms', filename }]))).toBe(true)
+        },
+    )
+
+    it('keeps an error thrown from our own bundle', () => {
+        expect(isThirdPartyScriptError(errorEvent([injectedFrame, ourFrame]))).toBe(false)
+    })
+
+    it('keeps an error whose whole stack is ours', () => {
+        expect(isThirdPartyScriptError(errorEvent([ourFrame, { ...ourFrame, function: 'savePackingList' }]))).toBe(false)
+    })
+
+    it('keeps a chained exception when any link was thrown by our code', () => {
+        expect(isThirdPartyScriptError(errorEvent([ourFrame], [ourFrame, injectedFrame]))).toBe(false)
+    })
+
+    it.each([
+        ['no stacktrace', errorEvent(undefined)],
+        ['an empty stack', errorEvent([])],
+        ['no exception at all', { type: undefined } as ErrorEvent],
+        ['no exception values', { type: undefined, exception: {} } as ErrorEvent],
+    ])('keeps an event with %s rather than guessing', (_label, event) => {
+        expect(isThirdPartyScriptError(event)).toBe(false)
+    })
+})
 
 describe('initSentry', () => {
     beforeEach(() => {
@@ -51,5 +106,20 @@ describe('initSentry', () => {
         initSentry()
 
         expect(init).toHaveBeenCalledOnce()
+    })
+
+    it('filters third-party script errors out of what it sends', () => {
+        vi.stubEnv('MODE', 'production')
+
+        initSentry()
+
+        const { beforeSend } = init.mock.calls[0][0] as {
+            beforeSend: (event: ErrorEvent) => ErrorEvent | null
+        }
+        const injected = errorEvent([ourFrame, injectedFrame])
+        const ours = errorEvent([ourFrame, { ...ourFrame, function: 'savePackingList' }])
+
+        expect(beforeSend(injected)).toBeNull()
+        expect(beforeSend(ours)).toBe(ours)
     })
 })

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/capacitor'
 import * as SentryReact from '@sentry/react'
+import type { ErrorEvent, Exception } from '@sentry/react'
 
 // Sentry DSNs are public identifiers, safe to ship in client-side code.
 const SENTRY_DSN = 'https://a331ffe142776c6dd8d5fcecfb2a4a97@o4511757730578432.ingest.de.sentry.io/4511757737525328'
@@ -11,6 +12,54 @@ const SENTRY_DSN = 'https://a331ffe142776c6dd8d5fcecfb2a4a97@o4511757730578432.i
 function isSentryEnabled() {
   if (import.meta.env.VITE_SENTRY_ENABLED === 'true') return true
   return import.meta.env.MODE !== 'development' && import.meta.env.MODE !== 'test'
+}
+
+/**
+ * A frame from a script that was evaluated without a source URL.
+ *
+ * Everything we ship is loaded from a file, so every frame of ours carries a
+ * filename (`app:///assets/index-*.js`, once @sentry/capacitor's rewriteFrames
+ * has normalised it). Code injected straight into the page — via the WebView's
+ * `evaluateJavascript`, an extension, or an `eval` — has no file to point at,
+ * so Sentry records it as `<anonymous>`, `<unknown>` or nothing at all.
+ */
+const NO_SOURCE_FILE = /^(?:app:\/\/\/)?(?:<anonymous>|<unknown>)$/
+
+/**
+ * Was this error thrown by a script that isn't ours?
+ *
+ * Sentry's browserApiErrorsIntegration patches the *global* `setTimeout`, so it
+ * wraps timer callbacks belonging to every script sharing the page — including
+ * ones the host injects and we have no control over (Android autofill, password
+ * managers, in-app-browser overlays). When such a callback throws, our wrapper
+ * catches it, reports it to this project and rethrows, so the event arrives
+ * looking like ours: the injected frame sits directly on top of a frame from our
+ * own bundle, which is only Sentry's wrapper.
+ *
+ * That is where "Error invoking log: Java bridge method invocation error" at
+ * `scanForForms` came from — a WebView form scanner we don't ship, calling a
+ * native JavaScript interface we don't register. Nothing in our code can fix or
+ * even reach it, and reporting it buries real bugs.
+ *
+ * The message is the host's to change, so match on origin instead: the innermost
+ * frame is the one that actually threw, and if it has no source file the failure
+ * happened outside our bundle. Anything thrown by our own code — a genuine
+ * Capacitor bridge failure included — still has a real filename there and is kept.
+ */
+export function isThirdPartyScriptError(event: ErrorEvent): boolean {
+  const values = event.exception?.values
+  if (!values?.length) return false
+  // `every`, so a chained exception survives if any link came from our code.
+  return values.every(threwFromScriptWithoutSource)
+}
+
+function threwFromScriptWithoutSource(value: Exception): boolean {
+  const frames = value.stacktrace?.frames
+  // Frames are stored oldest first, so the frame that threw is the last one.
+  const threw = frames?.[frames.length - 1]
+  // No stack at all says nothing about whose code failed — keep it rather than guess.
+  if (!threw) return false
+  return !threw.filename || NO_SOURCE_FILE.test(threw.filename)
 }
 
 export function initSentry() {
@@ -26,6 +75,7 @@ export function initSentry() {
         SentryReact.browserTracingIntegration(),
       ],
       tracesSampleRate: 0.1,
+      beforeSend: event => (isThirdPartyScriptError(event) ? null : event),
     },
     SentryReact.init,
   )


### PR DESCRIPTION
Sentry's browserApiErrorsIntegration patches the global setTimeout, so it
wraps timer callbacks from every script sharing the page — including ones
the host injects into the WebView and we have no control over. When such a
callback throws, our wrapper catches it, reports it to our project and
rethrows, so the event arrives looking like ours.

That produced "Error invoking log: Java bridge method invocation error" at
scanForForms, an Android WebView form scanner we don't ship calling a native
JavaScript interface we don't register. The only frame of ours in the stack
was Sentry's own wrapper.

Filter on origin rather than message, since the message is the host's to
change: the innermost frame is the one that threw, and injected scripts are
evaluated without a source URL, so it has no filename. Errors thrown by our
own code keep a real filename there and are still reported.