### PR TITLE
Show a packing list edit before writing it to the pod

### DIFF
--- a/docs/packing-list-delete-performance.md
+++ b/docs/packing-list-delete-performance.md
@@ -1,0 +1,186 @@
+# Deleting an item from a packing list: performance investigation
+
+**Symptom reported:** deleting items from a packing list is slow to respond,
+and the UI locks up for a moment. Suspected cause: the pod sync — either the
+UI waiting on the write, or the sync burning CPU.
+
+**Result:** reproduced, root-caused, instrumented, fixed and re-measured. Both
+suspicions were right, in that order of size. The dominant cost was the UI
+waiting on the pod write, and that write was three sequential network round
+trips where one would do; the freeze on top of it is main-thread work (the
+local database write and the RDF serialisation) running before the browser got
+to paint the deletion. Measured on a 150-item list with a mobile-class CPU
+throttle and 150 ms of pod latency, the row now leaves the screen in **79 ms
+instead of 984 ms**.
+
+## Reproduction method
+
+`scripts/perf/delete-item-repro.mjs` (see `scripts/perf/README.md`), built in
+the same shape as the existing `mobile-repro.mjs`: a standalone Playwright +
+CDP script, deliberately outside `npm test` and `npm run test:e2e`. It seeds a
+150-item list into a local Community Solid Server as a backup file, restores it
+through the app's own Backups page, then deletes items from the list and
+records, per delete:
+
+- **perceived latency** — from the app's own `delete.click` mark, recorded
+  inside the delete handler, to the animation frame in which the row actually
+  left the DOM. This is the wait the user sits through.
+- **longest frozen frame** — the largest gap between animation frames over that
+  window: how long the UI was frozen, as opposed to merely slow.
+- a **phase breakdown** from the profiling marks described below.
+- long tasks and a CPU profile, as `mobile-repro.mjs` does.
+
+Two knobs drive the attribution:
+
+- `--podLatency` injects a round-trip delay on every request to the pod. A
+  local CSS answers in ~2 ms, which no real user ever sees; a phone on mobile
+  data sees 100–300 ms.
+- `--cpu` applies a CDP CPU throttle.
+
+Runs below use a 150-item list, `--cpu=4`, `--podLatency=150` unless stated.
+
+## Profiling instrumentation added
+
+`src/utils/profiling.ts` — opt-in timing marks, off unless
+`localStorage['packMeUp.profiling'] === '1'`, so the cost in normal use is one
+boolean check per call. Completed measurements go to
+`window.__packMeUpProfile__` and the console, so a run can be read by eye or by
+a script. Marks were added around the pod write's phases
+(`pod.getPrimaryPodUrl`, `pod.save.ensureContainer`, `pod.save.serialize`,
+`pod.save.turtle`, `pod.save.put`), the poll's read path, the local database
+write, and the delete handler itself.
+
+## What the profile showed
+
+One delete, before the fix — offsets are milliseconds from the click:
+
+```
+     0ms  delete.click
+     2ms  delete.setFormValues            6.9
+    11ms  save.localDb                   99.2
+   112ms  pod.getPrimaryPodUrl          188.2   ← network
+   303ms  pod.save.ensureContainer      190.7   ← network
+   495ms  pod.save.serialize             82.6   ← CPU
+   579ms  pod.save.turtle                52.6   ← CPU
+   639ms  pod.save.put                  186.7   ← network
+   833ms  delete.done
+```
+
+The row was still on screen for all of it. `persistPackingList` awaited
+`saveWithSyncPrevention`, which awaited the pod write, and only then updated
+React state — so the item the user had just confirmed deleting sat there for
+the whole of a local database write plus three sequential network round trips.
+
+Two of those round trips were avoidable. Every single save resolved the user's
+pod URL by fetching their WebID profile (`getPrimaryPodUrl`), and then asked
+the server whether the container existed (`ensureContainerExists`) — for two
+answers that cannot change while the app is open. Of 705 ms spent in the pod
+write, 379 ms was these two questions and only 187 ms was the write itself.
+
+Attribution, median perceived latency over three deletes:
+
+| | `--podLatency=0` | `--podLatency=150` |
+|---|---:|---:|
+| `--cpu=1` | — | 593 ms |
+| `--cpu=4` | 334 ms | 884 ms |
+
+Removing the pod latency takes 550 ms off; removing the CPU throttle takes
+291 ms off and drops the longest frozen frame from 161 ms to 42 ms. So: the
+network round trips are the bulk of the wait, and the main-thread work is what
+makes the wait feel like a freeze rather than a lag.
+
+## Fix implemented
+
+Four changes, each measured.
+
+**1. The pod write no longer blocks the UI** (`useSyncCoordinator.ts`).
+`saveWithSyncPrevention` now resolves as soon as the local database — the
+guaranteed store — has the data, and pushes to the pod in the background. Pod
+failures were already surfaced independently of this await, via `usePodSync`'s
+`onSaveError`, so nothing is lost by not waiting for it. The save stays counted
+as in-flight until the push settles, so a poll landing in the meantime still
+can't apply its now-stale copy over the edit; the in-flight counter replaced a
+boolean so two quick edits can't clear the guard out from under each other.
+
+**2. Resolve the pod URL and the container once per session, not per save**
+(`solidPod.ts`). `getPrimaryPodUrl` memoises the resolved pod URL per WebID,
+sharing the in-flight request between simultaneous callers, and caching only an
+answer actually read from the profile — a fallback or a failure is retried.
+`ensureContainerExists` remembers containers already established. Both caches
+are cleared by `resetPodSessionCaches()` on logout and after a pod-data
+deletion. This takes two round trips out of every pod write and every poll.
+
+**3. Push after the paint, not before** (`useSyncCoordinator.ts`). Even in the
+background, serialising the list to RDF is ~100 ms of main-thread work, and
+running it in the same task as the state update held up the paint of the
+deletion — the freeze. The push now waits for an animation frame plus a task,
+with a 100 ms timer as a floor so a hidden tab (which gets no animation frames)
+still gets its data to the pod. This one change took perceived latency from
+299 ms to 148 ms and the frozen frame from 151 ms to 78 ms.
+
+**4. Render the edit before persisting it** (`view-packing-list.tsx`).
+`persistPackingList` updates React state first and then writes; the saves
+correct the state when they land and report their own failures. This takes the
+local database write off the critical path too.
+
+### Two correctness fixes the above required
+
+Making the pod write best-effort exposed a hole it had been hiding: the app
+could now reach a state where the local copy of a list was ahead of the pod's,
+which previously only happened while a save was visibly in progress.
+
+- **The login sync overwrote local lists with pod copies unconditionally**
+  (`syncAllDataFromPod`) — "pod wins for conflicting IDs", with no timestamp
+  comparison, unlike the question set beside it. An edit whose pod write hadn't
+  landed before a reload was silently lost. It now merges the two copies with
+  `mergePackingLists`, the same function the live sync uses, and pushes the
+  result back up when the local copy came out ahead.
+- **A pod poll could land before the page had read its local copy**
+  (`view-packing-list.tsx`). With no local state to compare against,
+  `shouldApplyPodData`'s fresh-load fallback let the pod copy win, which then
+  overwrote the newer local copy in the database. Pod syncing on that page now
+  waits until the local database has been consulted. This was reachable before
+  these changes too — an edit made offline, then the list reopened — it just
+  needed the pod to be behind, which the old blocking write made rare.
+
+Both were caught by the e2e suite (F5, then C8's strict-mode match once the
+list started updating before the modal closed — the preview now closes before
+the save rather than after it). Both have unit tests.
+
+### Before / after, measured with the harness
+
+Same script, same seeded 150-item list, `--cpu=4 --podLatency=150`, four
+deletes, medians:
+
+| | perceived latency | longest frozen frame |
+|---|---:|---:|
+| before | 984 ms | 153 ms |
+| after | **79 ms** | **107 ms** |
+
+The shape of a delete afterwards, same format as above:
+
+```
+     0ms  delete.click
+     3ms  delete.setFormValues            9.2
+    14ms  save.localDb                  145.2
+   (row gone at 79ms — before the database write has even finished)
+   206ms  pod.save.ensureContainer        0     ← cached
+   206ms  pod.save.serialize             69.9
+```
+
+Everything expensive now happens after the user has seen their edit.
+
+## Further recommendations (not implemented)
+
+1. **The remaining freeze is the local database write** (~145 ms at 4x
+   throttle) plus the RDF serialisation (~70 ms). Both now run after the paint,
+   so they no longer delay the deletion, but they still block the main thread
+   immediately afterwards — a second delete inside that window waits. Both
+   re-serialise the entire list for a one-item change.
+2. **Coalesce rapid pod pushes.** Deleting five items in a row currently
+   serialises and uploads the whole list five times. A short trailing debounce
+   on the pod push (the local write must stay immediate) would collapse those
+   into one.
+3. **Reconsider the 5s poll interval**, as the questions-page investigation
+   also suggested. Each poll is now a cheap conditional GET with one fewer round
+   trip in front of it, but it is still a poll.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-packing-app",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-packing-app",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "dependencies": {
         "@capacitor/android": "^8.3.4",
         "@capacitor/app": "^8.1.0",

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,4 +1,16 @@
-# Mobile performance repro harness
+# Performance repro harnesses
+
+Two standalone diagnostic scripts, neither part of `npm test` or
+`npm run test:e2e`. Both need a local Community Solid Server and the app's
+production build being served.
+
+- `mobile-repro.mjs` — main-thread blocking on the "My Questions & Items"
+  page (below).
+- `delete-item-repro.mjs` — how long deleting an item from a packing list
+  takes to show on screen ("Deleting an item from a packing list", further
+  down).
+
+## `mobile-repro.mjs`
 
 `mobile-repro.mjs` is a standalone Playwright + CDP script for measuring
 main-thread blocking on a mobile-class device profile. It is **not** part of
@@ -80,3 +92,39 @@ multiple polls, not just the first one.
 sample hit count). For anything deeper, load `<label>.trace.zip` into
 `npx playwright show-trace scripts/perf/results/<label>.trace.zip`, or open
 `<label>.cpuprofile` in Chrome DevTools' Performance panel ("Load profile").
+
+## Deleting an item from a packing list
+
+`delete-item-repro.mjs` measures the wait between confirming a deletion and
+the row leaving the screen, and how long the UI is frozen while it happens.
+Background and findings: `docs/packing-list-delete-performance.md`.
+
+Unlike `mobile-repro.mjs` it needs no manual data setup — it seeds its own
+backup file into the pod over the CSS account API and restores it through the
+app's Backups page:
+
+```
+node scripts/perf/delete-item-repro.mjs --label=before --items=150 --deletes=4 --cpu=4 --podLatency=150
+```
+
+| flag | default | meaning |
+|---|---|---|
+| `--items` | `150` | size of the seeded list |
+| `--deletes` | `4` | how many items to delete and time |
+| `--cpu` | `4` | CDP CPU throttle multiplier |
+| `--podLatency` | `150` | delay (ms) injected on every request to the pod |
+| `--settleMs` | `4000` | how long to keep recording after each delete |
+| `--label` | `delete-item` | output filename prefix |
+
+`--podLatency` and `--cpu` are the attribution levers: if a number tracks the
+first, the UI is waiting on the network; if it tracks the second, it is
+main-thread work. A local pod answers in ~2ms, which is not a latency any real
+user has, so measuring against it alone will hide a round-trip problem.
+
+The script turns on the app's own profiling marks
+(`localStorage['packMeUp.profiling']`, see `src/utils/profiling.ts`), so
+`<label>.summary.json` carries a per-delete phase breakdown — local database
+write, pod URL lookup, container check, RDF serialisation, PUT — alongside
+`medianPerceivedMs` and `medianMaxFrameGapMs`. Against a build without those
+marks it falls back to timing from the click, so before/after comparisons
+across a revert still work.

--- a/scripts/perf/delete-item-repro.mjs
+++ b/scripts/perf/delete-item-repro.mjs
@@ -1,0 +1,341 @@
+// Standalone repro harness for "deleting an item from a packing list is slow
+// and the UI locks up for a moment".
+//
+// Not part of `npm test` / `npm run test:e2e` — a diagnostic tool, run on
+// demand. See scripts/perf/README.md for setup and
+// docs/packing-list-delete-performance.md for what it found.
+//
+// Usage:
+//   node scripts/perf/delete-item-repro.mjs --label=before --items=150 --deletes=4 --cpu=4 --podLatency=150
+//
+// The two levers that matter:
+//   --podLatency  round-trip delay injected on every request to the pod. A
+//                 local CSS answers in ~2ms, which no real user ever sees; a
+//                 phone on mobile data sees 100-300ms. If delete latency
+//                 tracks this number, the UI is waiting on the network.
+//   --cpu         CDP CPU throttle multiplier. If delete latency tracks this
+//                 instead, the cost is main-thread work.
+//
+// Requires a local CSS (the `solid-dev` skill) and the app's production build
+// being served (npm run build && npm run preview -- --port 4173).
+
+import { chromium } from '@playwright/test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { authenticateForPod, loginToCss } from './lib/css.mjs'
+
+const APP_ORIGIN = process.env.PERF_APP_ORIGIN ?? 'http://localhost:4173'
+const CSS_ORIGIN = process.env.PERF_CSS_ORIGIN ?? 'http://localhost:4000'
+const EMAIL = process.env.PERF_CSS_EMAIL ?? 'test@example.com'
+const PASSWORD = process.env.PERF_CSS_PASSWORD ?? 'test1234'
+const POD_NAME = process.env.PERF_POD_NAME ?? 'test'
+
+const args = Object.fromEntries(
+  process.argv.slice(2).map(arg => {
+    const [key, value] = arg.replace(/^--/, '').split('=')
+    return [key, value ?? true]
+  })
+)
+
+const label = args.label ?? 'delete-item'
+const itemCount = Number(args.items ?? 150)
+const deleteCount = Number(args.deletes ?? 4)
+const cpuThrottle = Number(args.cpu ?? 4)
+const podLatencyMs = Number(args.podLatency ?? 150)
+// How long to keep watching after the row disappears, so the debounced
+// auto-save that follows a delete lands inside the measured window.
+const settleMs = Number(args.settleMs ?? 4000)
+
+const outDir = path.resolve('scripts/perf/results')
+fs.mkdirSync(outDir, { recursive: true })
+
+const POD_URL = `${CSS_ORIGIN}/${POD_NAME}/`
+const WEB_ID = `${CSS_ORIGIN}/${POD_NAME}/profile/card#me`
+const LIST_ID = 'perf-delete-list'
+const MOBILE_VIEWPORT = { width: 393, height: 851 }
+
+const PEOPLE = [
+  { id: 'p1', name: 'Ada' },
+  { id: 'p2', name: 'Bram' },
+  { id: 'p3', name: 'Cleo' },
+  { id: 'p4', name: 'Dev' },
+]
+const CATEGORIES = ['Day Bag', 'Documents & Money', 'Toiletries', 'Clothes', 'Sleep & Comfort', 'Kit & Gear']
+
+/** A list big enough to be realistic for a family trip, deterministic run to run. */
+function buildPackingList() {
+  const items = []
+  for (let i = 0; i < itemCount; i++) {
+    const person = PEOPLE[i % PEOPLE.length]
+    items.push({
+      id: `perf-item-${i}`,
+      itemText: `Item ${String(i).padStart(3, '0')}`,
+      personId: person.id,
+      personName: person.name,
+      questionId: `q-${i % 12}`,
+      optionId: `o-${i % 5}`,
+      packed: false,
+      quantity: (i % 3) + 1,
+      category: CATEGORIES[i % CATEGORIES.length],
+      order: i,
+    })
+  }
+  return {
+    id: LIST_ID,
+    name: 'Perf: delete item',
+    createdAt: new Date().toISOString(),
+    lastModified: new Date().toISOString(),
+    nights: 7,
+    destination: 'Perfland',
+    items,
+    deletedItems: [],
+    guests: PEOPLE.map(p => ({ id: p.id, name: p.name })),
+    questionAnswers: [],
+    selectedPeopleIds: PEOPLE.map(p => p.id),
+  }
+}
+
+/** Put a restorable backup in the pod — the app's own Restore flow loads it. */
+async function seedBackup() {
+  const token = await authenticateForPod(CSS_ORIGIN, { email: EMAIL, password: PASSWORD, webId: WEB_ID })
+  const backup = {
+    createdAt: new Date().toISOString(),
+    version: 1,
+    questionSet: null,
+    packingLists: [buildPackingList()],
+  }
+  const url = `${POD_URL}pack-me-up/backups/perf-delete-item.json`
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(backup),
+  })
+  if (!res.ok) throw new Error(`Failed to seed backup: ${res.status} ${await res.text()}`)
+  console.log(`[${label}] seeded a ${itemCount}-item list into ${url}`)
+}
+
+async function installObservers(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('packMeUp.profiling', '1')
+    window.__perf = { longTasks: [], podRequests: [] }
+    try {
+      const po = new PerformanceObserver(list => {
+        for (const entry of list.getEntries()) {
+          window.__perf.longTasks.push({ start: entry.startTime, duration: entry.duration })
+        }
+      })
+      po.observe({ type: 'longtask', buffered: true })
+    } catch { /* longtask unsupported */ }
+  })
+}
+
+/** Expand every collapsed section so item rows are actually in the DOM. */
+async function expandSections(page) {
+  for (let attempt = 0; attempt < 12; attempt++) {
+    const expanders = await page.getByRole('button', { name: /^Expand / }).all()
+    if (expanders.length === 0) break
+    for (const expander of expanders) await expander.click({ timeout: 5000 }).catch(() => {})
+    await page.waitForTimeout(200)
+  }
+}
+
+/**
+ * Delete one item and time it from the app's own point of view.
+ *
+ * `perceivedMs` is measured from the `delete.click` mark the app records inside
+ * its delete handler to the frame in which the row actually left the DOM — the
+ * wait the user sits through. `maxFrameGapMs` is the longest gap between
+ * animation frames over that window: how long the UI was frozen, as opposed to
+ * merely slow.
+ */
+async function measureDelete(page, itemId) {
+  await page.evaluate(() => { window.__packMeUpProfile__ = [] })
+
+  const row = page.locator(`[data-testid="item-row-${itemId}"]`)
+  await row.scrollIntoViewIfNeeded()
+  await row.getByTitle('Delete item').click()
+
+  const dialogConfirm = page.getByRole('button', { name: 'Remove', exact: true })
+  await dialogConfirm.waitFor({ timeout: 10_000 })
+
+  // Arm the watcher before the click that starts the work.
+  await page.evaluate((id) => {
+    // Fallback origin for perceivedMs when the build has no profiling marks.
+    window.__perf.armedAt = performance.now()
+    window.__perf.rowWatch = new Promise(resolve => {
+      let lastFrame = performance.now()
+      let maxFrameGap = 0
+      const tick = () => {
+        const now = performance.now()
+        maxFrameGap = Math.max(maxFrameGap, now - lastFrame)
+        lastFrame = now
+        if (!document.querySelector(`[data-testid="item-row-${id}"]`)) {
+          resolve({ goneAt: now, maxFrameGap })
+        } else {
+          requestAnimationFrame(tick)
+        }
+      }
+      requestAnimationFrame(tick)
+    })
+  }, itemId)
+
+  await dialogConfirm.click()
+  const { goneAt, maxFrameGap } = await page.evaluate(() => window.__perf.rowWatch)
+  const armedAt = await page.evaluate(() => window.__perf.armedAt)
+
+  // Keep watching long enough for the debounced follow-up save to land.
+  await page.waitForTimeout(settleMs)
+
+  const entries = await page.evaluate(() => window.__packMeUpProfile__ ?? [])
+  // Prefer the app's own mark (exact); fall back to when the click was armed,
+  // so an uninstrumented build still yields a comparable number.
+  const clickMark = entries.find(e => e.label === 'delete.click')
+  const clickedAt = clickMark ? clickMark.startMs : armedAt
+
+  const phase = (name) => {
+    const found = entries.filter(e => e.label === name)
+    return found.length ? Math.round(found.reduce((sum, e) => sum + e.durationMs, 0)) : 0
+  }
+
+  return {
+    itemId,
+    perceivedMs: Math.round(goneAt - clickedAt),
+    maxFrameGapMs: Math.round(maxFrameGap),
+    breakdown: {
+      persistTotal: phase('delete.persist'),
+      localDb: phase('save.localDb'),
+      podSaveTotal: phase('save.pod'),
+      podGetPodUrl: phase('pod.getPrimaryPodUrl'),
+      podEnsureContainer: phase('pod.save.ensureContainer'),
+      podSerialize: phase('pod.save.serialize'),
+      podTurtle: phase('pod.save.turtle'),
+      podPut: phase('pod.save.put'),
+      podLoadFetch: phase('pod.load.fetch'),
+      podLoadDeserialize: phase('pod.load.deserialize'),
+      syncMerge: phase('sync.merge'),
+      syncStringify: phase('sync.stringify'),
+    },
+    // Everything recorded in the window, including the follow-up saves that
+    // happen after the row is already gone.
+    entries: entries.map(e => ({
+      label: e.label,
+      atMs: Math.round(e.startMs - clickedAt),
+      durationMs: Math.round(e.durationMs * 10) / 10,
+    })),
+  }
+}
+
+async function main() {
+  await seedBackup()
+
+  // Use a locally-installed Chromium when there is one, matching playwright.config.ts
+  const localChromium = process.env.CHROMIUM_PATH ?? '/opt/pw-browsers/chromium-1194/chrome-linux/chrome'
+  const executablePath = fs.existsSync(localChromium) ? localChromium : undefined
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  })
+  const context = await browser.newContext({
+    userAgent: 'Mozilla/5.0 (Linux; Android 12; Fairphone 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36',
+    deviceScaleFactor: 2.75,
+    isMobile: true,
+    hasTouch: true,
+  })
+  const page = await context.newPage()
+  await installObservers(page)
+
+  const cdp = await context.newCDPSession(page)
+  await cdp.send('Emulation.setCPUThrottlingRate', { rate: 1 })
+
+  // Desktop width for the one-time setup: the login control hides behind a
+  // hamburger below the md breakpoint.
+  console.log(`[${label}] logging in and restoring the seeded list...`)
+  await page.setViewportSize({ width: 1280, height: 900 })
+  await page.goto(APP_ORIGIN)
+  await loginToCss(page, { appOrigin: APP_ORIGIN, cssOrigin: CSS_ORIGIN, email: EMAIL, password: PASSWORD })
+
+  await page.goto(`${APP_ORIGIN}/#/backups`)
+  page.once('dialog', dialog => dialog.accept())
+  await page.getByRole('button', { name: /Restore/i }).first().click()
+  await page.getByText(/restored successfully/i).waitFor({ timeout: 60_000 })
+
+  await page.setViewportSize(MOBILE_VIEWPORT)
+  await page.goto(`${APP_ORIGIN}/#/view-lists/${LIST_ID}`)
+  await page.getByRole('heading', { name: /Perf: delete item/i }).waitFor({ timeout: 30_000 })
+  await expandSections(page)
+  await page.locator('[data-testid^="item-row-"]').first().waitFor({ timeout: 30_000 })
+  await page.waitForTimeout(1500)
+
+  // Only now apply the conditions being measured, so setup isn't slowed by them.
+  if (podLatencyMs > 0) {
+    await context.route(`${CSS_ORIGIN}/**`, async route => {
+      await new Promise(r => setTimeout(r, podLatencyMs))
+      await route.continue()
+    })
+  }
+  await cdp.send('Emulation.setCPUThrottlingRate', { rate: cpuThrottle })
+  console.log(`[${label}] measuring ${deleteCount} deletes (cpu=${cpuThrottle}x, podLatency=${podLatencyMs}ms)...`)
+
+  await cdp.send('Profiler.enable')
+  await cdp.send('Profiler.setSamplingInterval', { interval: 200 })
+  await cdp.send('Profiler.start')
+
+  const results = []
+  for (let i = 0; i < deleteCount; i++) {
+    const itemId = await page.evaluate(() => {
+      const el = document.querySelector('[data-testid^="item-row-"]')
+      return el ? el.getAttribute('data-testid').replace('item-row-', '') : null
+    })
+    if (!itemId) break
+    const result = await measureDelete(page, itemId)
+    results.push(result)
+    console.log(
+      `[${label}] delete ${i + 1}/${deleteCount}: perceived ${result.perceivedMs}ms, ` +
+      `longest frozen frame ${result.maxFrameGapMs}ms`,
+      result.breakdown
+    )
+  }
+
+  const { profile: cpuProfile } = await cdp.send('Profiler.stop')
+  fs.writeFileSync(path.join(outDir, `${label}.cpuprofile`), JSON.stringify(cpuProfile))
+
+  const hitsByFn = new Map()
+  for (const node of cpuProfile.nodes) {
+    const key = `${node.callFrame.functionName || '(anonymous)'} — ${node.callFrame.url.split('/').pop()}:${node.callFrame.lineNumber}`
+    hitsByFn.set(key, (hitsByFn.get(key) ?? 0) + (node.hitCount ?? 0))
+  }
+  const topFunctions = [...hitsByFn.entries()].sort((a, b) => b[1] - a[1]).slice(0, 15).map(([fn, hits]) => ({ fn, hits }))
+
+  const perf = await page.evaluate(() => window.__perf)
+  const longTasks = (perf?.longTasks ?? []).map(t => ({ start: Math.round(t.start), duration: Math.round(t.duration) }))
+  const median = (values) => {
+    if (values.length === 0) return null
+    const sorted = [...values].sort((a, b) => a - b)
+    return sorted[Math.floor(sorted.length / 2)]
+  }
+
+  const summary = {
+    label,
+    itemCount,
+    cpuThrottle,
+    podLatencyMs,
+    medianPerceivedMs: median(results.map(r => r.perceivedMs)),
+    medianMaxFrameGapMs: median(results.map(r => r.maxFrameGapMs)),
+    deletes: results,
+    longTaskCount: longTasks.length,
+    longestTaskMs: longTasks.length ? Math.max(...longTasks.map(t => t.duration)) : 0,
+    longTasks,
+    topFunctionsBySampleHits: topFunctions,
+  }
+  fs.writeFileSync(path.join(outDir, `${label}.summary.json`), JSON.stringify(summary, null, 2))
+
+  console.log(`[${label}] median perceived delete latency: ${summary.medianPerceivedMs}ms`)
+  console.log(`[${label}] median longest frozen frame:     ${summary.medianMaxFrameGapMs}ms`)
+  console.log(`[${label}] longest long task:               ${summary.longestTaskMs}ms`)
+  console.log(`[${label}] wrote ${path.join(outDir, `${label}.summary.json`)}`)
+
+  await browser.close()
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/scripts/perf/lib/css.mjs
+++ b/scripts/perf/lib/css.mjs
@@ -1,0 +1,97 @@
+// Shared helpers for the standalone perf harnesses in scripts/perf.
+//
+// Everything here talks to a local Community Solid Server (the `solid-dev`
+// skill's start.sh, or any CSS with an email/password account) over its plain
+// HTTP account API, so these files stay dependency-free .mjs and can seed a pod
+// without importing the app's TypeScript.
+
+/** Log in to an existing CSS account and return the CSS-Account-Token. */
+export async function loginToCssAccount(cssOrigin, email, password) {
+  const res = await fetch(`${cssOrigin}/.account/login/password/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+  if (!res.ok) throw new Error(`CSS login failed: ${res.status} ${await res.text()}`)
+  return (await res.json()).authorization
+}
+
+/** Create OAuth client credentials for a CSS account. */
+export async function createClientCredentials(cssOrigin, accountToken, webId) {
+  const controlsRes = await fetch(`${cssOrigin}/.account/`, {
+    headers: { Authorization: `CSS-Account-Token ${accountToken}` },
+  })
+  if (!controlsRes.ok) throw new Error(`CSS controls fetch failed: ${controlsRes.status}`)
+  const credentialsUrl = (await controlsRes.json()).controls?.account?.clientCredentials
+  if (!credentialsUrl) throw new Error('No controls.account.clientCredentials in CSS controls response')
+
+  const credRes = await fetch(credentialsUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `CSS-Account-Token ${accountToken}` },
+    body: JSON.stringify({ name: 'perf-harness', webId }),
+  })
+  if (!credRes.ok) throw new Error(`CSS client credentials failed: ${credRes.status} ${await credRes.text()}`)
+  const { id, secret } = await credRes.json()
+  return { id, secret }
+}
+
+/** Exchange client credentials for a Bearer token via the client_credentials grant. */
+export async function getBearerToken(cssOrigin, clientId, clientSecret, webId) {
+  const oidcRes = await fetch(`${cssOrigin}/.well-known/openid-configuration`)
+  if (!oidcRes.ok) throw new Error(`OIDC config fetch failed: ${oidcRes.status}`)
+  const { token_endpoint: tokenEndpoint } = await oidcRes.json()
+
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+  const tokenRes = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Authorization: `Basic ${basic}` },
+    body: new URLSearchParams({ grant_type: 'client_credentials', webid: webId, scope: 'webid' }).toString(),
+  })
+  if (!tokenRes.ok) throw new Error(`CSS token exchange failed: ${tokenRes.status} ${await tokenRes.text()}`)
+  return (await tokenRes.json()).access_token
+}
+
+/** One call from account credentials to a Bearer token for that account's pod. */
+export async function authenticateForPod(cssOrigin, { email, password, webId }) {
+  const accountToken = await loginToCssAccount(cssOrigin, email, password)
+  const { id, secret } = await createClientCredentials(cssOrigin, accountToken, webId)
+  return getBearerToken(cssOrigin, id, secret, webId)
+}
+
+/**
+ * Drive the app's real Solid login UI (same flow as e2e/helpers/login.ts).
+ */
+export async function loginToCss(page, { appOrigin, cssOrigin, email, password }) {
+  await page.getByRole('button', { name: 'Login with Solid Pod' }).click()
+  await page.getByRole('dialog').waitFor()
+  await page.getByText('Other providers').click()
+  await page.getByRole('button', { name: 'Use Custom Provider' }).click()
+  await page.getByLabel('Custom Provider URL').fill(cssOrigin)
+  await page.getByRole('button', { name: 'Connect' }).click()
+
+  await page.waitForURL(
+    url => url.hostname === 'localhost' && url.port === new URL(cssOrigin).port && url.pathname.includes('/login/password'),
+    { timeout: 20_000 }
+  )
+  const loginBtn = page.locator('button[type="submit"][name="submit"]')
+  await loginBtn.waitFor({ timeout: 10_000 })
+  await page.waitForFunction(() => {
+    const btn = document.querySelector('button[type="submit"][name="submit"]')
+    return btn && !btn.disabled
+  }, { timeout: 10_000 })
+  await page.locator('#email').fill(email)
+  await page.locator('#password').fill(password)
+  await loginBtn.click()
+
+  await page.waitForURL(url => url.pathname.includes('/oidc/prompt') || url.pathname.includes('consent'), { timeout: 20_000 })
+  const authorizeBtn = page.locator('#authorize')
+  await authorizeBtn.waitFor({ timeout: 10_000 })
+  await page.waitForFunction(() => {
+    const btn = document.querySelector('#authorize')
+    return btn && !btn.disabled
+  }, { timeout: 10_000 })
+  await authorizeBtn.click()
+
+  await page.waitForURL(new RegExp(new URL(appOrigin).host), { timeout: 20_000 })
+  await page.getByRole('button', { name: 'Logout' }).first().waitFor({ timeout: 20_000 })
+}

--- a/scripts/perf/mobile-repro.mjs
+++ b/scripts/perf/mobile-repro.mjs
@@ -14,6 +14,7 @@
 import { chromium } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
+import { loginToCss } from './lib/css.mjs'
 
 const APP_ORIGIN = process.env.PERF_APP_ORIGIN ?? 'http://localhost:4173'
 const CSS_ORIGIN = process.env.PERF_CSS_ORIGIN ?? 'http://localhost:4000'
@@ -35,41 +36,6 @@ fs.mkdirSync(outDir, { recursive: true })
 
 // Moto/Fairphone-class viewport (Fairphone 4: 1080x2340 @ ~2.75x dpr -> ~393x851 CSS px)
 const MOBILE_VIEWPORT = { width: 393, height: 851 }
-
-async function loginToCss(page) {
-  await page.getByRole('button', { name: 'Login with Solid Pod' }).click()
-  await page.getByRole('dialog').waitFor()
-  await page.getByText('Other providers').click()
-  await page.getByRole('button', { name: 'Use Custom Provider' }).click()
-  await page.getByLabel('Custom Provider URL').fill(CSS_ORIGIN)
-  await page.getByRole('button', { name: 'Connect' }).click()
-
-  await page.waitForURL(
-    url => url.hostname === 'localhost' && url.port === new URL(CSS_ORIGIN).port && url.pathname.includes('/login/password'),
-    { timeout: 20_000 }
-  )
-  const loginBtn = page.locator('button[type="submit"][name="submit"]')
-  await loginBtn.waitFor({ timeout: 10_000 })
-  await page.waitForFunction(() => {
-    const btn = document.querySelector('button[type="submit"][name="submit"]')
-    return btn && !btn.disabled
-  }, { timeout: 10_000 })
-  await page.locator('#email').fill(EMAIL)
-  await page.locator('#password').fill(PASSWORD)
-  await loginBtn.click()
-
-  await page.waitForURL(url => url.pathname.includes('/oidc/prompt') || url.pathname.includes('consent'), { timeout: 20_000 })
-  const authorizeBtn = page.locator('#authorize')
-  await authorizeBtn.waitFor({ timeout: 10_000 })
-  await page.waitForFunction(() => {
-    const btn = document.querySelector('#authorize')
-    return btn && !btn.disabled
-  }, { timeout: 10_000 })
-  await authorizeBtn.click()
-
-  await page.waitForURL(new RegExp(new URL(APP_ORIGIN).host), { timeout: 20_000 })
-  await page.getByRole('button', { name: 'Logout' }).first().waitFor({ timeout: 20_000 })
-}
 
 async function restoreSeededBackup(page) {
   await page.goto(`${APP_ORIGIN}/#/backups`)
@@ -117,12 +83,12 @@ async function main() {
   console.log(`[${label}] logging in / preparing data...`)
   await page.goto(APP_ORIGIN)
   if (scenario === 'logged-in') {
-    await loginToCss(page)
+    await loginToCss(page, { appOrigin: APP_ORIGIN, cssOrigin: CSS_ORIGIN, email: EMAIL, password: PASSWORD })
     await restoreSeededBackup(page)
   } else {
     // logged-out scenario still needs the data locally: log in once, restore,
     // then log out so PouchDB keeps the data but pod polling is disabled.
-    await loginToCss(page)
+    await loginToCss(page, { appOrigin: APP_ORIGIN, cssOrigin: CSS_ORIGIN, email: EMAIL, password: PASSWORD })
     await restoreSeededBackup(page)
     await page.getByRole('button', { name: 'Logout' }).first().click()
     await page.getByRole('button', { name: 'Login with Solid Pod' }).first().waitFor({ timeout: 10_000 })

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, ReactNode, useContext, useState, useEffect, useRef } from "react";
 import { SessionCore, type SessionStateChangeDetail } from "@uvdsl/solid-oidc-client-browser/core";
 import { SessionIDB } from "@uvdsl/solid-oidc-client-browser";
-import { isAuthenticationError } from "../services/solidPod";
+import { isAuthenticationError, resetPodSessionCaches } from "../services/solidPod";
 import { AUTH_RETURN_TO_KEY } from "../pages/solid-pod-handle-redirect-page";
 import { AppSession } from "../types/AppSession";
 
@@ -170,6 +170,9 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
   const logout = async () => {
     intentionalLogoutRef.current = true;
     await uvdslSession.logout();
+    // Which pod a WebID lives in, and which of its containers exist, are facts
+    // about the identity that just went away.
+    resetPodSessionCaches();
     setIsLoggedIn(false);
     setWebId(undefined);
   };

--- a/src/hooks/usePodSync.ts
+++ b/src/hooks/usePodSync.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { SolidDataset } from '@inrupt/solid-client';
 import { useSolidPod } from '../components/SolidPodContext';
 import { getPrimaryPodUrl, loadRdfFromPod, saveRdfToPod, AuthenticationError } from '../services/solidPod';
+import { profile, profileEvent } from '../utils/profiling';
 
 /**
  * Configuration for Pod file paths
@@ -214,6 +215,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
     }
 
     isSyncingRef.current = true;
+    profileEvent('podSync.syncFromPod.start');
     setError(null);
 
     try {
@@ -230,7 +232,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
         return;
       }
 
-      const data = await loadRdfFromPod<T>(session ?? null, fileUrl, rdfRef.current.deserialize);
+      const data = await profile('podSync.syncFromPod.load', () => loadRdfFromPod<T>(session ?? null, fileUrl, rdfRef.current.deserialize), { fileUrl });
 
       lastSyncRef.current = new Date();
 
@@ -268,6 +270,7 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
     }
 
     setError(null);
+    profileEvent('podSync.saveToPod.start');
 
     try {
       const podUrl = pathConfigRef.current.podUrl ?? await getPrimaryPodUrl(session!);
@@ -282,12 +285,12 @@ export function usePodSync<T>(options: PodSyncOptions<T>): PodSyncState<T> {
         throw new Error('Cannot save: missing resource ID');
       }
 
-      await saveRdfToPod({
+      await profile('podSync.saveToPod.write', () => saveRdfToPod({
         session: isLoggedIn ? session! : null,
         fileUrl,
         data,
         serializer: rdfRef.current.serialize,
-      });
+      }), { fileUrl });
 
       lastSyncRef.current = new Date();
 

--- a/src/hooks/useSyncCoordinator.test.ts
+++ b/src/hooks/useSyncCoordinator.test.ts
@@ -195,6 +195,121 @@ describe('useSyncCoordinator', () => {
   })
 
   // ─────────────────────────────────────────────────────────────────
+  // The pod write is off the critical path
+  // ─────────────────────────────────────────────────────────────────
+
+  describe('background pod save', () => {
+    // The push is deferred a task so the browser can paint the edit first;
+    // this lets it start.
+    const startBackgroundPush = () => act(async () => { await new Promise(resolve => setTimeout(resolve, 0)) })
+
+    it('resolves as soon as the local save is done, without waiting for the pod', async () => {
+      // The caller updates the UI from what this resolves with, so waiting for a
+      // network round trip here is a round trip the user spends staring at the
+      // item they just deleted.
+      const saveToLocalDb = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+      const podSaveStarted = vi.fn()
+      // Never resolves — stands in for a slow (or offline) pod
+      const saveToPod = vi.fn().mockImplementation(() => {
+        podSaveStarted()
+        return new Promise<boolean>(() => {})
+      })
+
+      const options = makeOptions({ saveToLocalDb })
+      const { result } = renderHook(() => useSyncCoordinator<TestData>(options))
+
+      let savedData: TestData | null = null
+      await act(async () => {
+        savedData = await result.current.saveWithSyncPrevention(makeTestData(), saveToPod)
+      })
+
+      expect(savedData).toMatchObject({ id: 'test-1', _rev: 'rev-1' })
+      expect(podSaveStarted).not.toHaveBeenCalled()
+
+      await startBackgroundPush()
+      expect(podSaveStarted).toHaveBeenCalledOnce()
+    })
+
+    it('keeps skipping pod updates while the background pod save is still in flight', async () => {
+      // Returning early must not reopen the sync-loop window: until the push
+      // lands, the pod's copy is older than what we hold, and applying it would
+      // resurrect the deleted item.
+      const saveToLocalDb = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+      const updateFormAndState = vi.fn()
+      let resolvePodSave!: (value: boolean) => void
+      const saveToPod = vi.fn().mockImplementation(
+        () => new Promise<boolean>(resolve => { resolvePodSave = resolve })
+      )
+
+      const options = makeOptions({ saveToLocalDb, updateFormAndState, conflictStrategy: 'fallback-to-pod' })
+      const { result } = renderHook(() => useSyncCoordinator<TestData>(options))
+
+      await act(async () => {
+        await result.current.saveWithSyncPrevention(makeTestData(), saveToPod)
+      })
+      await startBackgroundPush()
+
+      const newerPodData = makeTestData({ lastModified: new Date(9999999999999).toISOString() })
+      await act(async () => {
+        await result.current.handleSyncSuccess(newerPodData)
+      })
+
+      expect(updateFormAndState).not.toHaveBeenCalled()
+
+      // Cleanup: let the pending pod save settle
+      await act(async () => { resolvePodSave(true) })
+    })
+
+    it('does not reject the caller when the pod save fails', async () => {
+      const saveToLocalDb = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+      const saveToPod = vi.fn().mockRejectedValue(new Error('pod unreachable'))
+
+      const options = makeOptions({ saveToLocalDb })
+      const { result } = renderHook(() => useSyncCoordinator<TestData>(options))
+
+      let savedData: TestData | null = null
+      await act(async () => {
+        savedData = await result.current.saveWithSyncPrevention(makeTestData(), saveToPod)
+      })
+
+      expect(savedData).toMatchObject({ _rev: 'rev-1' })
+    })
+
+    it('still guards against pod updates when saves overlap', async () => {
+      // Two quick deletes: the first push must not clear the guard while the
+      // second is still in flight.
+      const saveToLocalDb = vi.fn().mockResolvedValue({ rev: 'rev-1' })
+      const updateFormAndState = vi.fn()
+      const resolvers: Array<(value: boolean) => void> = []
+      const saveToPod = vi.fn().mockImplementation(
+        () => new Promise<boolean>(resolve => { resolvers.push(resolve) })
+      )
+
+      const options = makeOptions({ saveToLocalDb, updateFormAndState, conflictStrategy: 'fallback-to-pod' })
+      const { result } = renderHook(() => useSyncCoordinator<TestData>(options))
+
+      await act(async () => {
+        await result.current.saveWithSyncPrevention(makeTestData(), saveToPod)
+      })
+      await act(async () => {
+        await result.current.saveWithSyncPrevention(makeTestData({ value: 'second' }), saveToPod)
+      })
+      await startBackgroundPush()
+
+      // First push completes; the second is still outstanding
+      await act(async () => { resolvers[0](true) })
+
+      await act(async () => {
+        await result.current.handleSyncSuccess(makeTestData({ lastModified: new Date(9999999999999).toISOString() }))
+      })
+
+      expect(updateFormAndState).not.toHaveBeenCalled()
+
+      await act(async () => { resolvers[1](true) })
+    })
+  })
+
+  // ─────────────────────────────────────────────────────────────────
   // CRDT merge function
   // ─────────────────────────────────────────────────────────────────
 

--- a/src/hooks/useSyncCoordinator.ts
+++ b/src/hooks/useSyncCoordinator.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
+import { profile } from '../utils/profiling';
 
 /**
  * Data with timestamp for conflict resolution
@@ -92,6 +93,30 @@ export interface SyncCoordinatorState<T extends TimestampedData> {
 }
 
 /**
+ * Longest we'll hold work waiting for a paint that may never come — a hidden
+ * tab gets no animation frames, and a packing list still has to reach the pod.
+ */
+const AFTER_PAINT_FALLBACK_MS = 100;
+
+/**
+ * Run `callback` once the browser has had the chance to paint, or after
+ * `AFTER_PAINT_FALLBACK_MS`, whichever comes first. The animation frame lands
+ * before the paint, so the timer inside it is what puts the work after it.
+ */
+function afterNextPaint(callback: () => void): void {
+  let done = false;
+  const run = () => {
+    if (done) return;
+    done = true;
+    callback();
+  };
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => setTimeout(run, 0));
+  }
+  setTimeout(run, AFTER_PAINT_FALLBACK_MS);
+}
+
+/**
  * Hook to coordinate bidirectional sync between local state, local DB, and Pod
  *
  * Handles:
@@ -138,8 +163,10 @@ export function useSyncCoordinator<T extends TimestampedData>(
   const saveToLocalDbRef = useRef(saveToLocalDb);
   saveToLocalDbRef.current = saveToLocalDb;
 
-  // Track whether a save is currently in-progress (set before first await, cleared in finally)
-  const saveInProgressRef = useRef(false);
+  // How many saves are in-flight. A save counts as in-flight from before its
+  // first await until its background pod push settles, so overlapping saves
+  // (two quick edits) can't clear the guard out from under each other.
+  const savesInFlightRef = useRef(0);
 
   // Track the lastModified timestamp of the most recently saved data for echo detection
   const lastSavedTimestampRef = useRef<string | null>(null);
@@ -232,7 +259,7 @@ export function useSyncCoordinator<T extends TimestampedData>(
       }
 
       // Skip if a save operation is currently in-flight (set before first await)
-      if (saveInProgressRef.current) {
+      if (savesInFlightRef.current > 0) {
         console.log('Synced data from Pod - skipping because save is in-progress');
         return;
       }
@@ -259,7 +286,7 @@ export function useSyncCoordinator<T extends TimestampedData>(
       }
 
       // Compare the incoming data with what we last synced (to avoid unnecessary re-renders)
-      const incomingDataString = JSON.stringify(data);
+      const incomingDataString = profile('sync.stringify', () => JSON.stringify(data));
       if (lastSyncedDataRef.current === incomingDataString) {
         console.log('Synced data from Pod - timestamps indicate update, but data is identical (skipping re-render)');
         return;
@@ -274,7 +301,7 @@ export function useSyncCoordinator<T extends TimestampedData>(
       try {
         // Apply merge function if provided, otherwise use pod data as-is
         const resolved: T = mergeFunction && currentData
-          ? mergeFunction(currentData, data)
+          ? profile('sync.merge', () => mergeFunction(currentData, data))
           : { ...data };
 
         // Remove _rev to avoid conflicts with local database version
@@ -333,9 +360,11 @@ export function useSyncCoordinator<T extends TimestampedData>(
    */
   const saveWithSyncPrevention = useCallback(
     async (data: T, saveToPod: (data: T) => Promise<boolean>): Promise<T | null> => {
-      // Mark save as in-progress before any async work so handleSyncSuccess
+      // Count the save as in-flight before any async work so handleSyncSuccess
       // cannot slip through the unguarded window before isLocalChangeRef is set.
-      saveInProgressRef.current = true;
+      savesInFlightRef.current += 1;
+
+      let savedData: T;
       try {
         // Add monotonically increasing timestamp for conflict resolution.
         // Uses max(wallClock, maxSeen+1) so that saves are always strictly newer
@@ -352,33 +381,53 @@ export function useSyncCoordinator<T extends TimestampedData>(
         lastSavedTimestampRef.current = dataWithTimestamp.lastModified!;
 
         // Save to local database first (guaranteed)
-        const dbResult = await saveToLocalDbRef.current(dataWithTimestamp);
+        const dbResult = await profile('save.localDb', () => saveToLocalDbRef.current(dataWithTimestamp));
 
         // Update with new revision
-        const savedData = {
+        savedData = {
           ...dataWithTimestamp,
           _rev: dbResult.rev,
         } as T;
 
-        // Save to Pod (best effort)
-        isLocalChangeRef.current = true;
-        await saveToPod(savedData);
-
         // Update the last synced data ref
         lastSyncedDataRef.current = JSON.stringify(savedData);
-
-        // Reset the flag after the sync prevention window
-        setTimeout(() => {
-          isLocalChangeRef.current = false;
-        }, SYNC_PREVENTION_WINDOW_MS);
-
-        return savedData;
       } catch (err) {
         console.error('Error in saveWithSyncPrevention:', err);
+        savesInFlightRef.current -= 1;
         return null;
-      } finally {
-        saveInProgressRef.current = false;
       }
+
+      // Push to the Pod in the background. The local database is the guaranteed
+      // store and the caller renders from what we return here, so awaiting the
+      // Pod would make every edit cost a network round trip on screen — several,
+      // in fact, since a write resolves the Pod URL and checks the container
+      // before it writes. Failures still reach the user: usePodSync reports them
+      // through onSaveError.
+      //
+      // The save stays counted as in-flight until the push settles, so a Pod
+      // poll landing in the meantime can't apply its now-stale copy on top of
+      // the edit we have already shown.
+      isLocalChangeRef.current = true;
+      // Hold the push until the edit is on screen. Serialising the list to RDF
+      // is a solid chunk of main-thread work, and running it before the browser
+      // has painted is what makes a delete feel like a freeze rather than a
+      // wait.
+      afterNextPaint(() => {
+        profile('save.pod', () => saveToPod(savedData))
+          .catch((err: unknown) => {
+            console.error('Error saving to Pod:', err);
+            return false;
+          })
+          .finally(() => {
+            savesInFlightRef.current -= 1;
+            // Reset the flag after the sync prevention window
+            setTimeout(() => {
+              isLocalChangeRef.current = false;
+            }, SYNC_PREVENTION_WINDOW_MS);
+          });
+      });
+
+      return savedData;
     },
     []
   );

--- a/src/pages/sharing-settings.test.tsx
+++ b/src/pages/sharing-settings.test.tsx
@@ -85,7 +85,8 @@ describe('SharingSettingsPage — remove shared context', () => {
                 expect.objectContaining({ contexts: [] })
             )
         })
-        expect(mockSaveRdfToPod).toHaveBeenCalled()
+        // The pod write is deferred until after the local change is on screen
+        await waitFor(() => expect(mockSaveRdfToPod).toHaveBeenCalled())
     })
 
     it('removes the entry from the UI after clicking Remove', async () => {

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -189,6 +189,28 @@ describe('ViewPackingList item deletion confirmation', () => {
             expect(screen.queryByText('Passport')).toBeNull()
         })
     })
+
+    it('removes the row without waiting for the save to come back', async () => {
+        // A save that never settles — stands in for a slow phone, or a pod on
+        // the end of a bad connection. The row still has to go straight away.
+        mockUseDatabase.mockReturnValue({
+            db: {
+                ...makeDb(),
+                savePackingList: vi.fn(() => new Promise(() => {})),
+            } as unknown as PackingAppDatabase,
+        })
+
+        renderComponent()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+
+        fireEvent.click(screen.getByTitle('Delete item'))
+        fireEvent.click(screen.getByRole('button', { name: /^remove$/i }))
+
+        await waitFor(() => {
+            expect(screen.queryByText('Passport')).toBeNull()
+        })
+    })
 })
 
 const multiCategoryPackingList = {
@@ -1164,6 +1186,46 @@ describe('ViewPackingList foreign pod (?pod= param)', () => {
 
     afterEach(() => {
         vi.restoreAllMocks()
+    })
+
+    it('does not sync from the pod until the local copy has been read', async () => {
+        // A pod copy applied before the page knows what is on the device
+        // overwrites it — including an edit whose pod write hasn't landed yet.
+        mockUseDatabase.mockReturnValue({
+            db: {
+                ...makeDb(),
+                getPackingList: vi.fn(() => new Promise(() => {})),
+            } as unknown as PackingAppDatabase,
+        })
+
+        render(
+            <MemoryRouter initialEntries={['/view-list/test-list-1']}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+
+        await waitFor(() => expect(mockUsePodSync).toHaveBeenCalled())
+        for (const [options] of mockUsePodSync.mock.calls) {
+            expect(options.enabled).toBe(false)
+        }
+    })
+
+    it('syncs from the pod once the local copy has been read', async () => {
+        render(
+            <MemoryRouter initialEntries={['/view-list/test-list-1']}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
+
+        expect(mockUsePodSync).toHaveBeenLastCalledWith(
+            expect.objectContaining({ enabled: true })
+        )
     })
 
     it('passes pathConfig.podUrl to usePodSync when ?pod= param is present', async () => {

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -36,6 +36,7 @@ import { AddItemComposer, UNCATEGORISED_LABEL, type AddItemTarget, type PersonOp
 import { buildSuggestionIndex } from '../utils/itemSuggestions'
 import { useIsDesktop } from '../hooks/useIsDesktop'
 import { loadListViewPreferences, saveListViewPreferences, hasStoredListViewPreferences, type ListViewMode } from '../utils/listViewPreferences'
+import { profile, profileEvent } from '../utils/profiling'
 
 type FormData = {
     items: Record<string, boolean>
@@ -173,6 +174,11 @@ export function ViewPackingList() {
         : '/view-lists'
     const [packingList, setPackingList] = useState<PackingList | null>(null)
     const [isLoading, setIsLoading] = useState(true)
+    // Whether this page has looked in the local database yet. Pod syncing waits
+    // on it: a pod copy applied before we know what is on the device overwrites
+    // it, and the device's copy can be the newer one — the pod write for the
+    // last edit is best effort and may not have landed before the page closed.
+    const [localCopyChecked, setLocalCopyChecked] = useState(false)
     const [shareModalOpen, setShareModalOpen] = useState(false)
     // Sharing needs a pod, so a logged-out sharer gets the ask framed around
     // sharing rather than a generic "set up a pod" pitch.
@@ -542,7 +548,9 @@ export function ViewPackingList() {
         },
         rdf: { serialize: packingListToDataset, deserialize: datasetToPackingList },
         pollInterval: 5000, // Poll every 5 seconds for faster sync
-        enabled: isLoggedIn || !!foreignPodUrl, // Allow reading public shared lists without login
+        // Allow reading public shared lists without login, but never before the
+        // local database has been consulted — see localCopyChecked.
+        enabled: localCopyChecked && (isLoggedIn || !!foreignPodUrl),
         onSyncSuccess: handleSyncSuccess,
         onSyncError: handleViewSyncError,
         onSaveSuccess: handleSaveSuccess,
@@ -566,6 +574,7 @@ export function ViewPackingList() {
         const fetchPackingList = async () => {
             try {
                 const doc = await db.getPackingList(id!)
+                setLocalCopyChecked(true)
                 setPackingList(doc)
                 // Use reset (not setValue) so _defaultValues is updated too.
                 // register() initialises each checkbox from _defaultValues; setValue
@@ -579,6 +588,7 @@ export function ViewPackingList() {
                 hasLoadedRef.current = true
                 setIsLoading(false)
             } catch (err) {
+                setLocalCopyChecked(true)
                 const isNotFound = typeof err === 'object' && err !== null && (err as { name?: string }).name === 'not_found'
                 if (isNotFound) {
                     // Not an error: the list simply isn't on this device. On a
@@ -695,6 +705,13 @@ export function ViewPackingList() {
     }, [watchedItems, handleItemChange])
 
     const persistPackingList = async (updatedPackingList: PackingList) => {
+        // Show the change now. What follows is only writing down what is already
+        // on screen, and holding the render until the database (let alone the
+        // pod) comes back leaves the item the user just deleted sitting there
+        // while it happens. The saves below correct the state when they land,
+        // and report their own failures.
+        setPackingList(updatedPackingList)
+
         if (isLoggedIn || foreignPodUrl) {
             const savedPackingList = await saveWithSyncPrevention(updatedPackingList, saveToPod)
             if (savedPackingList) {
@@ -729,6 +746,10 @@ export function ViewPackingList() {
             setQuestionUpdateAdditions(null)
             return
         }
+        // Close the preview first. The items appear on the list as soon as they
+        // are added now, and leaving the preview up over a list that already has
+        // them reads as the click not having worked.
+        setQuestionUpdateAdditions(null)
         try {
             const updatedList: PackingList = {
                 ...packingList,
@@ -739,14 +760,13 @@ export function ViewPackingList() {
         } catch (err) {
             const details = reportError(err, 'Error adding question updates')
             showToast('Failed to add items', 'error', details)
-        } finally {
-            setQuestionUpdateAdditions(null)
         }
     }
 
     const handleDeleteItem = async (itemId: string) => {
         if (!packingList) return
 
+        profileEvent('delete.click', { itemId, itemCount: packingList.items.length })
         try {
             setAutoSaveStatus('saving')
 
@@ -768,10 +788,11 @@ export function ViewPackingList() {
             // Remove from form values
             const currentFormValues = getValues('items')
             delete currentFormValues[itemId]
-            setValue('items', currentFormValues)
+            profile('delete.setFormValues', () => setValue('items', currentFormValues))
 
-            await persistPackingList(updatedPackingList)
+            await profile('delete.persist', () => persistPackingList(updatedPackingList))
 
+            profileEvent('delete.done', { itemId })
             setAutoSaveStatus('saved')
             setTimeout(() => setAutoSaveStatus('idle'), 2000)
         } catch (err) {

--- a/src/services/dataDeletion.ts
+++ b/src/services/dataDeletion.ts
@@ -8,7 +8,7 @@ import {
     LOCAL_NAMESPACE,
     databaseNameForNamespace,
 } from './database'
-import { POD_CONTAINERS, isAuthenticationError, handlePodError } from './solidPod'
+import { POD_CONTAINERS, isAuthenticationError, handlePodError, resetPodSessionCaches } from './solidPod'
 
 /**
  * Deleting everything the app has stored — the Google Play "data deletion"
@@ -126,6 +126,9 @@ export async function deleteAllLocalData(): Promise<void> {
  */
 export async function deleteAllPodData(session: Session, podUrl: string): Promise<void> {
     await deleteContainerRecursively(session, `${podUrl}${POD_CONTAINERS.ROOT}`)
+    // The containers we just removed are still in the "known to exist" set —
+    // forget them, so the next write recreates them instead of assuming.
+    resetPodSessionCaches()
 }
 
 async function deleteContainerRecursively(session: Session, containerUrl: string): Promise<void> {

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -21,6 +21,7 @@ import {
     friendlyPodName,
     getPrimaryPodUrl,
     derivePodUrlFromWebId,
+    resetPodSessionCaches,
 } from './solidPod'
 import { AuthenticationError } from './solidPod'
 import { PackingAppDatabase } from './database'
@@ -95,7 +96,12 @@ const POD_URL = 'https://pod.example.com/'
 
 // Ensure each test starts with clean mock state (vi.restoreAllMocks in inner afterEach
 // hooks doesn't fully clear permanent mockRejectedValue defaults on vi.fn() mocks).
-beforeEach(() => { vi.resetAllMocks() })
+beforeEach(() => {
+    vi.resetAllMocks()
+    // The pod URL and known-container caches live for the length of a session;
+    // each test is its own session.
+    resetPodSessionCaches()
+})
 
 describe('hasPodData', () => {
     beforeEach(() => {
@@ -419,6 +425,77 @@ describe('syncAllDataFromPod', () => {
 
             expect(db.savePackingList).toHaveBeenCalledTimes(2)
             expect(result.packingListsSynced).toBe(2)
+        })
+
+        it('keeps a local edit the pod has not caught up with', async () => {
+            // The pod write for the last edit is best-effort and can be cut off
+            // by a reload. The local copy is the one that is guaranteed, so an
+            // older pod copy must not flatten it on the next login.
+            const item = { id: 'i1', itemText: 'Passport', personId: 'p1', personName: 'Ann', questionId: 'q1', optionId: 'o1' }
+            const podList = makePackingList('list-1', {
+                lastModified: '2024-01-01T10:00:00.000Z',
+                items: [{ ...item, packed: false }],
+            })
+            const locallyEdited = makePackingList('list-1', {
+                lastModified: '2024-06-01T10:00:00.000Z',
+                items: [{ ...item, packed: true }],
+            })
+            const db = makeDb({ questionSet: null, packingLists: [locallyEdited] })
+
+            stubPod({ lists: [podList] })
+            mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
+
+            await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(db.savePackingList).toHaveBeenCalledWith(expect.objectContaining({
+                items: [expect.objectContaining({ id: 'i1', packed: true })],
+            }))
+        })
+
+        it('puts a local edit the pod has not caught up with back on the pod', async () => {
+            const item = { id: 'i1', itemText: 'Passport', personId: 'p1', personName: 'Ann', questionId: 'q1', optionId: 'o1' }
+            const podList = makePackingList('list-1', {
+                lastModified: '2024-01-01T10:00:00.000Z',
+                items: [{ ...item, packed: false }],
+            })
+            const locallyEdited = makePackingList('list-1', {
+                lastModified: '2024-06-01T10:00:00.000Z',
+                items: [{ ...item, packed: true }],
+            })
+            const db = makeDb({ questionSet: null, packingLists: [locallyEdited] })
+
+            stubPod({ lists: [podList] })
+            mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
+
+            await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(mockOverwriteFile).toHaveBeenCalledWith(
+                expect.stringContaining('list-1.ttl'),
+                expect.any(Blob),
+                expect.objectContaining({ contentType: 'text/turtle' })
+            )
+        })
+
+        it('takes the pod copy when it is the newer one', async () => {
+            const item = { id: 'i1', itemText: 'Passport', personId: 'p1', personName: 'Ann', questionId: 'q1', optionId: 'o1' }
+            const podList = makePackingList('list-1', {
+                lastModified: '2024-06-01T10:00:00.000Z',
+                items: [{ ...item, packed: true }],
+            })
+            const staleLocal = makePackingList('list-1', {
+                lastModified: '2024-01-01T10:00:00.000Z',
+                items: [{ ...item, packed: false }],
+            })
+            const db = makeDb({ questionSet: null, packingLists: [staleLocal] })
+
+            stubPod({ lists: [podList] })
+
+            await syncAllDataFromPod(mockSession, POD_URL, db)
+
+            expect(db.savePackingList).toHaveBeenCalledWith(expect.objectContaining({
+                items: [expect.objectContaining({ id: 'i1', packed: true })],
+            }))
+            expect(mockOverwriteFile).not.toHaveBeenCalled()
         })
 
         it('uploads local-only packing lists to pod', async () => {
@@ -779,6 +856,26 @@ describe('saveRdfToPod', () => {
             expect.any(Blob),
             expect.objectContaining({ fetch: mockSession.fetch, contentType: 'text/turtle' })
         )
+    })
+
+    it('checks the parent container only once per session, not on every save', async () => {
+        // Every save used to spend a round trip asking whether the container was
+        // there. On a slow connection that doubled the cost of saving an edit.
+        const url = `${POD_URL}pack-me-up/packing-lists/my-list.ttl`
+        mockGetSolidDataset.mockResolvedValue({} as unknown as SolidDataset & WithServerResourceInfo)
+        mockOverwriteFile.mockResolvedValue({} as unknown as Response & { internal_resourceInfo: unknown })
+
+        for (let i = 0; i < 3; i++) {
+            await saveRdfToPod({
+                session: mockSession,
+                fileUrl: url,
+                data: makePackingList('my-list'),
+                serializer: packingListToDataset,
+            })
+        }
+
+        expect(mockGetSolidDataset).toHaveBeenCalledOnce()
+        expect(mockOverwriteFile).toHaveBeenCalledTimes(3)
     })
 
     it('skips container creation and proceeds if caller lacks read access (403) on foreign pod', async () => {
@@ -1525,6 +1622,43 @@ describe('getPrimaryPodUrl', () => {
 
         mockGetPodUrlAll.mockRejectedValueOnce(new TypeError('Failed to fetch'))
 
+        expect(await getPrimaryPodUrl(session)).toBe(ESS_POD_URL)
+    })
+
+    it('reads the WebID profile only once per session', async () => {
+        // Resolving the pod URL is a network round trip, and it ran on every
+        // save and every poll — for an answer that cannot change under us.
+        mockGetPodUrlAll.mockResolvedValue([ESS_POD_URL])
+        const session = sessionFor(ESS_WEB_ID)
+
+        expect(await getPrimaryPodUrl(session)).toBe(ESS_POD_URL)
+        expect(await getPrimaryPodUrl(session)).toBe(ESS_POD_URL)
+        expect(await getPrimaryPodUrl(session)).toBe(ESS_POD_URL)
+
+        expect(mockGetPodUrlAll).toHaveBeenCalledOnce()
+    })
+
+    it('resolves the profile once when several callers ask at the same time', async () => {
+        // Opening the app fires a burst of these at once (page load, poll, save).
+        mockGetPodUrlAll.mockResolvedValue([ESS_POD_URL])
+        const session = sessionFor(ESS_WEB_ID)
+
+        const results = await Promise.all([
+            getPrimaryPodUrl(session),
+            getPrimaryPodUrl(session),
+            getPrimaryPodUrl(session),
+        ])
+
+        expect(results).toEqual([ESS_POD_URL, ESS_POD_URL, ESS_POD_URL])
+        expect(mockGetPodUrlAll).toHaveBeenCalledOnce()
+    })
+
+    it('retries after a failure rather than caching the failure', async () => {
+        mockGetPodUrlAll.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        const session = sessionFor(ESS_WEB_ID)
+        expect(await getPrimaryPodUrl(session)).toBeNull()
+
+        mockGetPodUrlAll.mockResolvedValueOnce([ESS_POD_URL])
         expect(await getPrimaryPodUrl(session)).toBe(ESS_POD_URL)
     })
 

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -8,6 +8,8 @@ import { PackingList } from '../create-packing-list/types'
 import { packingListToDataset, datasetToPackingList, datasetToQuestionSet, datasetToSharedWithMe, datasetToSharedListsWithMe, deletedPackingListsToDataset, datasetToDeletedPackingLists } from './rdfSerialization'
 import type { SharedWithMeList, SharedListsWithMe, DeletedPackingLists } from './rdfSerialization'
 import { deletionsById, emptyDeletedPackingLists, isNewerThanDeletion, mergeDeletedPackingLists, pruneDeletions, registriesEqual, withoutDeletion } from '../utils/packingListDeletions'
+import { mergePackingLists } from '../utils/mergePackingLists'
+import { profile } from '../utils/profiling'
 
 /**
  * Pod container paths under the user's Pod root
@@ -419,19 +421,35 @@ async function addAcpMemberAccess(session: Session, containerUrl: string): Promi
     }
 }
 
+/**
+ * Containers this session has already established are there. A container that
+ * exists doesn't stop existing while the app is open, and the check is a round
+ * trip in front of every single write — the one saving an item deletion
+ * included. Cleared by `resetPodSessionCaches` when the session changes or the
+ * user deletes their pod data.
+ */
+const knownContainers = new Set<string>()
+
 async function ensureContainerExists(session: Session, containerUrl: string): Promise<void> {
+    if (knownContainers.has(containerUrl)) return
     try {
         await getSolidDataset(containerUrl, { fetch: session.fetch })
+        knownContainers.add(containerUrl)
     } catch (err) {
         const status = getStatusCode(err)
         // No read access — assume the container exists and let the write reveal any real problem
-        if (status === 401 || status === 403) return
+        if (status === 401 || status === 403) {
+            knownContainers.add(containerUrl)
+            return
+        }
         if (status !== 404) throw err
         try {
             await createContainerAt(containerUrl, { fetch: session.fetch })
+            knownContainers.add(containerUrl)
         } catch (createErr) {
             // 409 Conflict = container was created concurrently; ignore
             if (getStatusCode(createErr) !== 409) throw createErr
+            knownContainers.add(containerUrl)
         }
     }
 }
@@ -494,21 +512,66 @@ export async function getPrimaryPodUrl(session: Session | null): Promise<string 
 
     const webId = session.info.webId
 
+    // Reading the profile is a network round trip, and this is called before
+    // every pod read and every pod write. The answer is a property of the
+    // WebID, so resolve it once per session and share the in-flight request
+    // with anyone who asks while it's still running.
+    const inFlight = podUrlByWebId.get(webId)
+    if (inFlight) return inFlight
+
+    const resolution = resolvePrimaryPodUrl(session, webId)
+    const podUrl = resolution.then(result => result.podUrl)
+    podUrlByWebId.set(webId, podUrl)
+    // Only an answer actually read from the profile is worth keeping for the
+    // session. A fallback — or a failure — says nothing about where the Pod is,
+    // and caching it would leave the app stuck on one dropped request.
+    resolution.then(
+        result => { if (!result.authoritative) podUrlByWebId.delete(webId) },
+        () => podUrlByWebId.delete(webId)
+    )
+    return podUrl
+}
+
+/**
+ * The pod URL resolved for each WebID this session has asked about, including
+ * requests still in flight. Cleared by `resetPodSessionCaches`.
+ */
+const podUrlByWebId = new Map<string, Promise<string | null>>()
+
+/**
+ * Forget everything cached for the length of a session: which pod a WebID
+ * lives in, and which containers are known to exist. Call this when the
+ * identity behind the session changes (login, logout) or when pod data is
+ * deleted underneath us.
+ */
+export function resetPodSessionCaches(): void {
+    podUrlByWebId.clear()
+    knownContainers.clear()
+}
+
+/**
+ * `authoritative` marks an answer that came from the profile itself, as opposed
+ * to a last-known-good fallback — only the former is worth remembering.
+ */
+async function resolvePrimaryPodUrl(
+    session: Session,
+    webId: string
+): Promise<{ podUrl: string | null; authoritative: boolean }> {
     let podUrls: string[]
     try {
-        podUrls = await getPodUrlAll(webId, { fetch: session.fetch })
+        podUrls = await profile('pod.getPrimaryPodUrl', () => getPodUrlAll(webId, { fetch: session.fetch }), { webId })
     } catch (err) {
         // The profile document itself couldn't be fetched (transient network
         // error, DPoP nonce race, expired token). We know nothing about the
         // Pod's location, so reuse the last known one and otherwise give up —
         // callers report "no pod" and retry on the next sync.
         console.warn('getPrimaryPodUrl: could not read the WebID profile', err)
-        return readCachedPodUrl(webId)
+        return { podUrl: readCachedPodUrl(webId), authoritative: false }
     }
 
     if (podUrls && podUrls.length > 0) {
         cachePodUrl(webId, podUrls[0])
-        return podUrls[0]
+        return { podUrl: podUrls[0], authoritative: true }
     }
 
     // Profile was readable but declares no pim:storage — the case for CSS v7,
@@ -516,10 +579,10 @@ export async function getPrimaryPodUrl(session: Session | null): Promise<string 
     const derivedPodUrl = derivePodUrlFromWebId(webId)
     if (derivedPodUrl) {
         cachePodUrl(webId, derivedPodUrl)
-        return derivedPodUrl
+        return { podUrl: derivedPodUrl, authoritative: true }
     }
 
-    return readCachedPodUrl(webId)
+    return { podUrl: readCachedPodUrl(webId), authoritative: false }
 }
 
 /**
@@ -678,8 +741,8 @@ export async function loadRdfFromPod<T>(
         })
     }
     try {
-        const dataset = await getSolidDataset(fileUrl, { fetch: conditionalFetch })
-        const result = deserializer(dataset, fileUrl)
+        const dataset = await profile('pod.load.fetch', () => getSolidDataset(fileUrl, { fetch: conditionalFetch }), { fileUrl })
+        const result = profile('pod.load.deserialize', () => deserializer(dataset, fileUrl), { fileUrl })
         if (observedEtag) lastSeenByUrl.set(fileUrl, { etag: observedEtag, result })
         else lastSeenByUrl.delete(fileUrl)
         return result
@@ -702,12 +765,12 @@ export async function saveRdfToPod<T>(options: SaveRdfToPodOptions<T>): Promise<
     try {
         if (session) {
             const containerUrl = fileUrl.substring(0, fileUrl.lastIndexOf('/') + 1)
-            await ensureContainerExists(session, containerUrl)
+            await profile('pod.save.ensureContainer', () => ensureContainerExists(session, containerUrl), { containerUrl })
         }
-        const newDataset = serializer(data, fileUrl)
-        const turtleContent = await solidDatasetAsTurtle(newDataset)
+        const newDataset = profile('pod.save.serialize', () => serializer(data, fileUrl))
+        const turtleContent = await profile('pod.save.turtle', () => solidDatasetAsTurtle(newDataset))
         const blob = new Blob([turtleContent], { type: 'text/turtle' })
-        await overwriteFile(fileUrl, blob, { fetch: fetchFn, contentType: 'text/turtle' })
+        await profile('pod.save.put', () => overwriteFile(fileUrl, blob, { fetch: fetchFn, contentType: 'text/turtle' }), { fileUrl, bytes: turtleContent.length })
     } catch (error: unknown) {
         if (session && isAuthenticationError(error)) handlePodError(error)
         throw error
@@ -1169,9 +1232,36 @@ export async function syncAllDataFromPod(
         }
     }
 
-    // Save the surviving pod lists to local DB in parallel (pod wins for conflicting IDs)
+    // Save the surviving pod lists to local DB in parallel.
+    //
+    // Where both sides have a copy they are merged rather than the pod simply
+    // winning: the push to the pod is best effort and deliberately off the
+    // critical path, so the last edit before a reload can still be local-only
+    // when the app comes back. Merging is what the live sync does with the same
+    // pair, and it means neither side's edit is dropped. A local copy that came
+    // out ahead goes straight back up, so the next device to sync sees it.
+    const localListsById = new Map((await db.getAllPackingLists()).map(list => [list.id, list]))
+
     const saveResults = await Promise.allSettled(
-        listsToSaveLocally.map(podList => db.savePackingList({ ...podList, _rev: undefined }))
+        listsToSaveLocally.map(async podList => {
+            const localList = localListsById.get(podList.id)
+            const resolved = localList ? mergePackingLists(localList, podList) : podList
+            await db.savePackingList({ ...resolved, _rev: undefined })
+
+            if (resolved.lastModified !== podList.lastModified) {
+                try {
+                    await saveRdfToPod({
+                        session,
+                        fileUrl: `${containerUrl}${podList.id}.ttl`,
+                        data: resolved,
+                        serializer: packingListToDataset,
+                    })
+                } catch (err) {
+                    if (err instanceof AuthenticationError) throw err
+                    console.error(`syncAllDataFromPod: error pushing merged list ${podList.id} back to pod`, err)
+                }
+            }
+        })
     )
     for (let i = 0; i < saveResults.length; i++) {
         if (saveResults[i].status === 'fulfilled') {

--- a/src/utils/profiling.test.ts
+++ b/src/utils/profiling.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { profile, profileEvent, isProfilingEnabled, resetProfilingCache, getProfileEntries, clearProfileEntries } from './profiling'
+
+const enable = () => {
+    localStorage.setItem('packMeUp.profiling', '1')
+    resetProfilingCache()
+}
+
+describe('profiling', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        resetProfilingCache()
+        clearProfileEntries()
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('is off unless switched on', () => {
+        expect(isProfilingEnabled()).toBe(false)
+
+        profile('save', () => 'result')
+        profileEvent('click')
+
+        expect(getProfileEntries()).toEqual([])
+    })
+
+    it('returns the value of the measured function either way', async () => {
+        expect(profile('sync', () => 41 + 1)).toBe(42)
+        enable()
+        expect(profile('sync', () => 41 + 1)).toBe(42)
+        await expect(profile('async', async () => 'done')).resolves.toBe('done')
+    })
+
+    it('records a completed measurement once enabled', () => {
+        enable()
+
+        profile('save.localDb', () => 'saved', { listId: 'l1' })
+
+        const [entry] = getProfileEntries()
+        expect(entry.label).toBe('save.localDb')
+        expect(entry.durationMs).toBeGreaterThanOrEqual(0)
+        expect(entry.detail).toEqual({ listId: 'l1' })
+    })
+
+    it('waits for an async function to settle before recording it', async () => {
+        enable()
+        let release!: () => void
+        const pending = new Promise<void>(resolve => { release = resolve })
+
+        const measured = profile('pod.put', () => pending)
+        expect(getProfileEntries()).toHaveLength(0)
+
+        release()
+        await measured
+
+        expect(getProfileEntries().map(e => e.label)).toEqual(['pod.put'])
+    })
+
+    it('records a failure and lets the error through', async () => {
+        enable()
+
+        await expect(profile('pod.put', () => Promise.reject(new Error('offline')))).rejects.toThrow('offline')
+        expect(() => profile('serialize', () => { throw new Error('bad data') })).toThrow('bad data')
+
+        expect(getProfileEntries().map(e => e.detail)).toEqual([
+            { failed: true },
+            { failed: true },
+        ])
+    })
+})

--- a/src/utils/profiling.ts
+++ b/src/utils/profiling.ts
@@ -1,0 +1,121 @@
+/**
+ * Opt-in timing instrumentation for the slow paths (saving a list to the pod,
+ * polling it back, deleting an item).
+ *
+ * Off unless someone turns it on, so the cost in normal use is one boolean
+ * check per call. Turn it on from the console — or from a Playwright harness —
+ * with:
+ *
+ *   localStorage.setItem('packMeUp.profiling', '1')  // then reload
+ *
+ * Completed measurements are pushed to `window.__packMeUpProfile__` and logged
+ * to the console, so a profiling run can be read either by eye or by a script.
+ */
+
+const STORAGE_KEY = 'packMeUp.profiling'
+const WINDOW_KEY = '__packMeUpProfile__'
+
+export interface ProfileEntry {
+    label: string
+    /** performance.now() at the start of the measured work */
+    startMs: number
+    durationMs: number
+    detail?: Record<string, unknown>
+}
+
+interface ProfileWindow {
+    [WINDOW_KEY]?: ProfileEntry[]
+}
+
+let enabled: boolean | null = null
+
+function readEnabled(): boolean {
+    try {
+        return typeof localStorage !== 'undefined' && localStorage.getItem(STORAGE_KEY) === '1'
+    } catch {
+        // Private mode / SSR — treat as off
+        return false
+    }
+}
+
+/** Cached so the hot paths don't hit localStorage on every measurement. */
+export function isProfilingEnabled(): boolean {
+    if (enabled === null) enabled = readEnabled()
+    return enabled
+}
+
+/** Test seam: forget the cached flag so the next check re-reads localStorage. */
+export function resetProfilingCache(): void {
+    enabled = null
+}
+
+function buffer(): ProfileEntry[] {
+    const w = globalThis as ProfileWindow
+    if (!w[WINDOW_KEY]) w[WINDOW_KEY] = []
+    return w[WINDOW_KEY]!
+}
+
+function record(entry: ProfileEntry): void {
+    buffer().push(entry)
+    console.log(
+        `[profile] ${entry.label} ${entry.durationMs.toFixed(1)}ms`,
+        entry.detail ?? ''
+    )
+}
+
+export function getProfileEntries(): ProfileEntry[] {
+    return isProfilingEnabled() ? [...buffer()] : []
+}
+
+export function clearProfileEntries(): void {
+    buffer().length = 0
+}
+
+/**
+ * Time `fn`. Returns whatever `fn` returns, so a call can be wrapped in place:
+ * `await profile('save', () => save(data))`.
+ *
+ * An async `fn` is timed to its settled promise; a throwing `fn` is still
+ * recorded (labelled as failed) before the error propagates.
+ */
+export function profile<T>(
+    label: string,
+    fn: () => T,
+    detail?: Record<string, unknown>
+): T {
+    if (!isProfilingEnabled()) return fn()
+
+    const startMs = performance.now()
+    const finish = (extra?: Record<string, unknown>) => {
+        record({
+            label,
+            startMs,
+            durationMs: performance.now() - startMs,
+            detail: extra ? { ...detail, ...extra } : detail,
+        })
+    }
+
+    let result: T
+    try {
+        result = fn()
+    } catch (err) {
+        finish({ failed: true })
+        throw err
+    }
+
+    if (result instanceof Promise) {
+        return result.then(
+            value => { finish(); return value },
+            err => { finish({ failed: true }); throw err }
+        ) as T
+    }
+
+    finish()
+    return result
+}
+
+/** Record a zero-duration event — useful for marking when a poll fired. */
+export function profileEvent(label: string, detail?: Record<string, unknown>): void {
+    if (!isProfilingEnabled()) return
+    record({ label, startMs: performance.now(), durationMs: 0, detail })
+}


### PR DESCRIPTION
Deleting an item from a packing list took nearly a second to leave the screen, with a freeze partway through.

## What the profiling showed

New opt-in timing marks (`src/utils/profiling.ts` — off unless `localStorage['packMeUp.profiling'] = '1'`), driven by a new repro harness (`scripts/perf/delete-item-repro.mjs`), timing from the app's own `delete.click` mark to the frame the row actually leaves the DOM. One delete, before, at 4x CPU throttle with 150ms of pod latency:

```
     0ms  delete.click
    11ms  save.localDb              99   ← main thread
   112ms  pod.getPrimaryPodUrl     188   ← network
   303ms  pod.save.ensureContainer 191   ← network
   495ms  pod.save.serialize        83   ← main thread
   579ms  pod.save.turtle           53   ← main thread
   639ms  pod.save.put             187   ← network
   833ms  delete.done
```

The row was on screen for all of it: `persistPackingList` awaited `saveWithSyncPrevention`, which awaited the pod write, and only then updated React state. And that write was three sequential round trips — resolve the pod URL from the WebID profile, ask whether the container exists, then PUT. 379ms of the 705ms was those first two, for answers that cannot change while the app is open.

Attribution, median perceived latency:

| | podLatency 0 | podLatency 150 |
|---|---:|---:|
| cpu 1x | — | 593ms |
| cpu 4x | 334ms | **884ms** |

Network round trips are the bulk of the wait; the main-thread work is what makes it a freeze rather than a lag.

## Changes

- **`saveWithSyncPrevention` resolves once the local database has the data** and pushes to the pod in the background. Pod failures already surfaced independently of that await, via `usePodSync`'s `onSaveError`. The save stays counted as in-flight until the push settles so a poll can't apply a stale copy over the edit; the in-flight boolean became a counter so two quick edits can't clear the guard out from under each other.
- **The push waits for the paint.** Serialising the list to RDF is ~100ms of main-thread work, and running it in the same task as the state update was what held up the deletion appearing. An animation frame plus a task, with a 100ms timer as a floor so a hidden tab (no animation frames) still reaches the pod. This one change: 299ms → 148ms perceived, 151ms → 78ms frozen frame.
- **`getPrimaryPodUrl` and `ensureContainerExists` cache per session**, cleared by `resetPodSessionCaches()` on logout and after a pod-data deletion. Two round trips off every pod write and every poll.
- **`persistPackingList` renders the change before persisting it.**

### Two data-loss holes this exposed

Making the pod write best-effort made a state reachable that the blocking write had been hiding — the local copy being ahead of the pod's. Both were reachable before this change too (edit offline, reopen the list); they just needed the pod to be behind.

- **`syncAllDataFromPod` overwrote local packing lists with pod copies unconditionally** — "pod wins for conflicting IDs", with no timestamp comparison, unlike the question set beside it. An edit whose pod write hadn't landed before a reload was silently lost. It now merges with `mergePackingLists` (the same function the live sync uses) and pushes the result back up when the local copy came out ahead.
- **A pod poll could land before the view page had read its local copy**, where `shouldApplyPodData`'s fresh-load fallback let the pod copy win and then overwrite the newer local copy in the database. Pod syncing on that page now waits until the local database has been consulted.

Both were caught by the e2e suite (F5, then C8 once the list started updating before the modal closed — the "update from questions" preview now closes before the save rather than after it).

## Measured result

Same harness, same seeded 150-item list, `--cpu=4 --podLatency=150`, four deletes, medians:

| | perceived latency | longest frozen frame |
|---|---:|---:|
| before | 984ms | 153ms |
| after | **79ms** | **107ms** |

The row now leaves before the local database write has even finished. Everything expensive happens after the user has seen their edit.

## Testing

- `npm test` — 1521 passing, including new unit tests for the background push and its guards, the two session caches, the login-sync merge, and the pod-sync gating.
- `npx playwright test` — 74 passing.
- Manual measurement against a local Community Solid Server via the new harness, before and after, as above.

Full write-up, including what is still on the table (the local database write and RDF serialisation both still re-serialise the whole list for a one-item change; rapid deletes still upload once each), in `docs/packing-list-delete-performance.md`.