### PR TITLE
Reorganise shared items in question view

### DIFF
--- a/src/components/AddItemComposer.tsx
+++ b/src/components/AddItemComposer.tsx
@@ -38,6 +38,8 @@ export interface AddItemTarget {
 export interface PersonOption {
     name: string
     id: string
+    /** An option standing for the whole group rather than a person. */
+    communal?: boolean
 }
 
 interface AddItemComposerProps {
@@ -87,10 +89,14 @@ export const AddItemComposer = memo(function AddItemComposer({
         ?? peopleOptions?.[0]
         ?? { name: personName, id: personId }
 
+    // Either the composer belongs to a shared card, or the picker was pointed at
+    // the whole group — the item is the group's, and nobody's, both ways round.
+    const isCommunal = communal || person.communal === true
+
     const target: AddItemTarget = {
-        personName: communal ? '' : person.name,
-        personId: communal ? '' : person.id,
-        communal,
+        personName: isCommunal ? '' : person.name,
+        personId: isCommunal ? '' : person.id,
+        communal: isCommunal ? true : communal,
         category: categoryOptions
             ? (chosenCategory === UNCATEGORISED_LABEL ? undefined : chosenCategory)
             : category,

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1604,6 +1604,151 @@ describe('ViewPackingList shared (communal) section', () => {
     })
 })
 
+describe('ViewPackingList shared (communal) items in question view', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...communalPackingList, _rev: '2' }),
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    async function renderInQuestionView(list = communalPackingList) {
+        const db = {
+            getPackingList: vi.fn().mockResolvedValue(list),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+        }
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        render(
+            <MemoryRouter initialEntries={[`/view-list/${list.id}`]}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+        await waitFor(() => expect(screen.getByText('Sleeping bag')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: 'Question View' }))
+        return db
+    }
+
+    /** The card for a category section, found by its own collapse control. */
+    function card(title: string): HTMLElement {
+        const match = screen.getAllByTestId('list-section').find(section =>
+            within(section).queryByRole('button', { name: new RegExp(`(Collapse|Expand) ${title} list`, 'i') })
+        )
+        if (!match) throw new Error(`No "${title}" card on the page`)
+        return match
+    }
+
+    it('files shared items into their section rather than a Shared Items card', async () => {
+        await renderInQuestionView()
+
+        expect(screen.queryByText('Shared Items')).toBeNull()
+        expect(within(card('Camping')).getByText('Tent')).toBeTruthy()
+        expect(within(card('Camping')).getByText('Sleeping bag')).toBeTruthy()
+        expect(within(card('Essentials')).getByText('First aid kit')).toBeTruthy()
+    })
+
+    it('groups shared items under Shared, ahead of the people', async () => {
+        await renderInQuestionView()
+
+        const headings = within(card('Camping'))
+            .getAllByRole('button', { name: /^Collapse / })
+            .map(button => button.getAttribute('aria-label'))
+        expect(headings).toEqual(['Collapse Camping list', 'Collapse Shared', 'Collapse Alice'])
+    })
+
+    it('counts shared items in the section and group totals', async () => {
+        await renderInQuestionView()
+
+        const camping = within(card('Camping'))
+        expect(camping.getByRole('button', { name: /collapse camping list/i }).textContent).toContain('0 / 2')
+        expect(camping.getByRole('button', { name: 'Collapse Shared' }).textContent).toContain('0 / 1')
+    })
+
+    it('adds a shared item from the shared group of a section', async () => {
+        const db = await renderInQuestionView()
+
+        const camping = within(card('Camping'))
+        fireEvent.click(camping.getByRole('button', { name: /add item to camping for shared items/i }))
+        const composer = camping.getAllByTestId('add-item-composer')
+            .find(node => within(node).queryByLabelText(/add an item to camping for shared items/i))
+        expect(composer).toBeTruthy()
+        fireEvent.change(within(composer!).getByLabelText(/add an item to camping for shared items/i), {
+            target: { value: 'Camping stove' },
+        })
+        fireEvent.click(within(composer!).getByRole('button', { name: 'Add' }))
+
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        const saved = db.savePackingList.mock.calls[0][0]
+        const added = saved.items.find((i: { itemText: string }) => i.itemText === 'Camping stove')
+        expect(added.communal).toBe(true)
+        expect(added.category).toBe('Camping')
+        expect(added.personName).toBe('')
+    })
+
+    it('offers Shared in a section\'s who-for picker, so shared items can be added without a shared card', async () => {
+        const listWithoutCommunal = { ...communalPackingList, items: communalPackingList.items.filter(i => !i.communal) }
+        const db = await renderInQuestionView(listWithoutCommunal)
+
+        const composer = within(card('Camping')).getByTestId('add-item-composer')
+        fireEvent.change(within(composer).getByLabelText(/add an item to camping/i), { target: { value: 'Camping stove' } })
+        fireEvent.change(within(composer).getByLabelText('Who for'), { target: { value: 'Shared' } })
+        fireEvent.click(within(composer).getByRole('button', { name: 'Add' }))
+
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        const saved = db.savePackingList.mock.calls[0][0]
+        const added = saved.items.find((i: { itemText: string }) => i.itemText === 'Camping stove')
+        expect(added.communal).toBe(true)
+        expect(added.category).toBe('Camping')
+        expect(added.personName).toBe('')
+    })
+
+    it('leaves the who-for picker on a person by default', async () => {
+        const db = await renderInQuestionView()
+
+        const composer = within(card('Camping')).getAllByTestId('add-item-composer')[0]
+        fireEvent.change(within(composer).getByLabelText(/add an item to camping/i), { target: { value: 'Head torch' } })
+        fireEvent.click(within(composer).getByRole('button', { name: 'Add' }))
+
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        const saved = db.savePackingList.mock.calls[0][0]
+        const added = saved.items.find((i: { itemText: string }) => i.itemText === 'Head torch')
+        expect(added.personName).toBe('Alice')
+        expect(added.communal).toBeUndefined()
+    })
+
+    it('hides the "+ Add Shared Items" reveal, which belongs to person view', async () => {
+        const listWithoutCommunal = { ...communalPackingList, items: communalPackingList.items.filter(i => !i.communal) }
+        await renderInQuestionView(listWithoutCommunal)
+
+        expect(screen.queryByRole('button', { name: /add shared items/i })).toBeNull()
+    })
+
+    it('keeps the Shared Items card in person view', async () => {
+        await renderInQuestionView()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Person View' }))
+
+        expect(screen.getByText('Shared Items')).toBeTruthy()
+        expect(screen.getByText('Tent')).toBeTruthy()
+    })
+})
+
 describe('grouping honours generated item order', () => {
     const mk = (over: Partial<PackingListItem>): PackingListItem => ({
         id: Math.random().toString(36).slice(2),

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -42,9 +42,14 @@ type FormData = {
     items: Record<string, boolean>
 }
 
-// Reserved section key for communal items — cannot collide with a person's
-// name used as a key for the other sections.
+// Reserved key for communal items — cannot collide with a person's name, which
+// is what keys the other sections (and, in question view, the groups inside a
+// section).
 const SHARED_SECTION_KEY = '__shared__'
+
+// What the shared group is called where it sits among people: inside a
+// section's card in question view, and in the "who for" picker.
+const SHARED_GROUP_LABEL = 'Shared'
 
 // Long enough for the last (delayed) confetti piece to finish falling
 const CONFETTI_DURATION_MS = 4000
@@ -145,18 +150,38 @@ function isSectionComplete(stats?: SectionStats): boolean {
 /** Where a custom item was added without saying whose it is. */
 export const UNASSIGNED_LABEL = 'Unassigned'
 
-export function groupByPerson(items: PackingListItem[]) {
+/** One group of items inside a section's card: a category, or a person, or the shared group. */
+interface ItemGroup {
+    /** Identifies the group in collapse state and stats; not shown to the user. */
+    key: string
+    label: string
+    items: PackingListItem[]
+    /** The group holding communal items — nobody's in particular, so everybody's. */
+    communal?: boolean
+}
+
+/**
+ * The people a section's items belong to, plus — since communal items belong to
+ * the section as much as anyone's do — a shared group, first, the way the shared
+ * card comes first in person view. Keyed rather than labelled so a person
+ * actually called "Shared" keeps their own group.
+ */
+export function groupByPerson(items: PackingListItem[]): ItemGroup[] {
     const map = new Map<string, PackingListItem[]>()
     for (const item of items) {
-        const person = item.personName || UNASSIGNED_LABEL
-        if (!map.has(person)) map.set(person, [])
-        map.get(person)!.push(item)
+        const key = item.communal ? SHARED_SECTION_KEY : (item.personName || UNASSIGNED_LABEL)
+        if (!map.has(key)) map.set(key, [])
+        map.get(key)!.push(item)
     }
     return [...map.entries()]
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([person, personItems]) => ({
-            label: person,
-            items: sortByItemOrder(personItems),
+        .sort(([a], [b]) => (
+            a === SHARED_SECTION_KEY ? -1 : b === SHARED_SECTION_KEY ? 1 : a.localeCompare(b)
+        ))
+        .map(([key, groupItems]) => ({
+            key,
+            label: key === SHARED_SECTION_KEY ? SHARED_GROUP_LABEL : key,
+            items: sortByItemOrder(groupItems),
+            ...(key === SHARED_SECTION_KEY ? { communal: true } : {}),
         }))
 }
 
@@ -880,8 +905,9 @@ export function ViewPackingList() {
             // views key the same group the opposite way round.
             const sectionKey = target.communal ? SHARED_SECTION_KEY : target.personName
             const categoryLabel = target.category ?? UNCATEGORISED_LABEL
+            const groupKey = target.communal ? SHARED_SECTION_KEY : (target.personName || UNASSIGNED_LABEL)
             setCollapsedGroups(prev => {
-                const keysToExpand = [`${sectionKey}::${categoryLabel}`, `${categoryLabel}::${target.personName}`]
+                const keysToExpand = [`${sectionKey}::${categoryLabel}`, `${categoryLabel}::${groupKey}`]
                 if (!keysToExpand.some(k => prev.has(k))) return prev
                 const next = new Set(prev)
                 for (const k of keysToExpand) next.delete(k)
@@ -982,11 +1008,12 @@ export function ViewPackingList() {
         return stats
     }, [listItems, watchedItems])
 
-    // Stats per category, used by question-centric top-level sections
+    // Stats per category, used by question-centric top-level sections. Communal
+    // items count here too: question view files them under their category
+    // alongside everyone else's, so a section's total has to include them.
     const categoryStats = useMemo(() => {
         const stats: Record<string, SectionStats> = {}
         for (const item of listItems ?? []) {
-            if (item.communal) continue
             const key = item.category ?? UNCATEGORISED_LABEL
             stats[key] ??= { packed: 0, total: 0 }
             stats[key].total++
@@ -997,8 +1024,8 @@ export function ViewPackingList() {
 
     // Stats for the groups *inside* a section. Both views are keyed here because
     // both are one toggle away: person view groups a person's items by category,
-    // question view groups a category's items by person, and the shared section
-    // groups by category whichever view is on.
+    // question view groups a category's items by person (communal items under
+    // the shared key), and the person-view shared card groups by category.
     const groupStats = useMemo(() => {
         const stats: Record<string, SectionStats> = {}
         const count = (key: string, packed: boolean) => {
@@ -1011,10 +1038,11 @@ export function ViewPackingList() {
             const packed = !!watchedItems[item.id]
             if (item.communal) {
                 count(`${SHARED_SECTION_KEY}::${category}`, packed)
+                count(`${category}::${SHARED_SECTION_KEY}`, packed)
                 continue
             }
             count(`${item.personName}::${category}`, packed)
-            count(`${category}::${item.personName || 'Unassigned'}`, packed)
+            count(`${category}::${item.personName || UNASSIGNED_LABEL}`, packed)
         }
         return stats
     }, [listItems, watchedItems])
@@ -1022,9 +1050,7 @@ export function ViewPackingList() {
     // Which top-level sections have nothing left to pack, keyed the way the
     // active view keys them. Sorted so the value is stable enough to compare.
     const completeSectionKeys = useMemo(() => {
-        const stats = viewMode === 'person'
-            ? sectionStats
-            : { ...categoryStats, [SHARED_SECTION_KEY]: sectionStats[SHARED_SECTION_KEY] }
+        const stats = viewMode === 'person' ? sectionStats : categoryStats
         return Object.entries(stats)
             .filter(([, sectionStat]) => isSectionComplete(sectionStat))
             .map(([key]) => key)
@@ -1167,6 +1193,11 @@ export function ViewPackingList() {
     const personIdByName = new Map(peopleOptions.map(person => [person.name, person.id]))
     // Only worth offering a section picker once the list has sections to pick.
     const sectionChoices = categoryOptions.length > 1 ? categoryOptions : undefined
+    // A section's card asks who an item is for, and "the whole group" is one of
+    // the answers — it is how a shared item gets added in question view, where
+    // there is no shared card to type into. Last, so the picker still opens on a
+    // person: most items are somebody's.
+    const sectionPeopleChoices: PersonOption[] = [...peopleOptions, { name: SHARED_GROUP_LABEL, id: '', communal: true }]
 
     // Build grouped item map, seeding guest names so their sections exist even when empty
     const groupedItems: Record<string, PackingListItem[]> = {}
@@ -1182,12 +1213,14 @@ export function ViewPackingList() {
         groupedItems[item.personName].push(item)
     }
 
-    // Shared section first (when the list has visible communal items), then
-    // either people (person-centric) or categories (question-centric). Like
-    // person sections, the shared section disappears when all its items are
-    // packed and packed items are hidden.
+    // Person view gives communal items a card of their own, first, because they
+    // are the one part of the list that is nobody's. Question view has no use
+    // for it: there the sections are the question set's, and a shared item
+    // belongs to its section as much as anyone's does — see below.
     const hasCommunalItems = packingList.items.some(i => i.communal)
     const visibleCommunalItems = filteredItems.filter(i => i.communal)
+    // Like person sections, the shared section disappears when all its items are
+    // packed and packed items are hidden.
     const sharedSections: ListSection[] = (visibleCommunalItems.length > 0 || showSharedSection || isSectionComplete(sectionStats[SHARED_SECTION_KEY]))
         ? [{
             key: SHARED_SECTION_KEY,
@@ -1215,12 +1248,15 @@ export function ViewPackingList() {
             }))
         listSections = [...sharedSections, ...regularSections, ...guestSections]
     } else {
+        // Communal items are filed by category here, same as everyone else's —
+        // they sit in a shared group inside the section they belong to rather
+        // than in a card of their own.
         const visibleByCategory = new Map(
-            groupByCategory(filteredItems.filter(i => !i.communal), sectionOrder).map(({ label, items }) => [label, items])
+            groupByCategory(filteredItems, sectionOrder).map(({ label, items }) => [label, items])
         )
         // Categories come from every item, not just the visible ones, so a fully
         // packed category keeps its celebratory card instead of disappearing.
-        const categorySections: ListSection[] = groupByCategory(packingList.items.filter(i => !i.communal), sectionOrder)
+        const categorySections: ListSection[] = groupByCategory(packingList.items, sectionOrder)
             .filter(({ label }) => visibleByCategory.has(label) || isSectionComplete(categoryStats[label]))
             .map(({ label }) => ({
                 key: label,
@@ -1229,7 +1265,7 @@ export function ViewPackingList() {
                 items: visibleByCategory.get(label) ?? [],
                 isCategory: true,
             }))
-        listSections = [...sharedSections, ...categorySections]
+        listSections = categorySections
     }
 
     const tripDates = formatTripDates(packingList.startDate, packingList.endDate)
@@ -1283,7 +1319,10 @@ export function ViewPackingList() {
                         </div>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
-                        {!foreignPodUrl && !hasCommunalItems && !showSharedSection && (
+                        {/* The reveal opens an empty shared *card*, which only
+                            person view has — question view offers "Shared" in
+                            each section's who-for picker instead. */}
+                        {!foreignPodUrl && viewMode === 'person' && !hasCommunalItems && !showSharedSection && (
                             <Button
                                 type="button"
                                 variant="secondary"
@@ -1550,8 +1589,8 @@ export function ViewPackingList() {
                             const isComplete = isSectionComplete(stats)
                             const completeLabel = isShared ? 'shared items' : isCategorySection ? title : section.name
                             const collapseLabelTarget = isShared ? 'the shared items' : isCategorySection ? title : `${section.name}'s`
-                            const innerGroups = (isShared || !isCategorySection)
-                                ? groupByCategory(items, sectionOrder)
+                            const innerGroups: ItemGroup[] = (isShared || !isCategorySection)
+                                ? groupByCategory(items, sectionOrder).map(({ label, items: groupItems }) => ({ key: label, label, items: groupItems }))
                                 : groupByPerson(items)
                             const isSectionCollapsed = collapsedSections.has(sectionKey)
                             // Only a card that belongs to one person can wear
@@ -1654,7 +1693,7 @@ export function ViewPackingList() {
                                             communal={section.communal}
                                             category={isCategorySection ? categoryFromLabel(title) : undefined}
                                             categoryOptions={isCategorySection ? undefined : sectionChoices}
-                                            peopleOptions={isCategorySection && peopleOptions.length > 0 ? peopleOptions : undefined}
+                                            peopleOptions={isCategorySection ? sectionPeopleChoices : undefined}
                                             suggestions={suggestionIndex}
                                             targetLabel={isShared ? 'shared items' : isCategorySection ? title : `${section.name}'s items`}
                                             onAdd={handleComposerAdd}
@@ -1665,8 +1704,8 @@ export function ViewPackingList() {
                                             Nothing left to pack 🎒
                                         </p>
                                     )}
-                                    {innerGroups.map(({ label, items: catItems }) => {
-                                        const categoryKey = `${sectionKey}::${label}`
+                                    {innerGroups.map(({ key: groupKey, label, items: catItems, communal: isSharedGroup }) => {
+                                        const categoryKey = `${sectionKey}::${groupKey}`
                                         const isCollapsed = collapsedGroups.has(categoryKey)
                                         // Counted over every item in the group, not the ones on
                                         // screen: with packed items hidden, "2" next to a group
@@ -1675,12 +1714,13 @@ export function ViewPackingList() {
                                         // Both views end up describing the same place; only which
                                         // half the card supplies changes.
                                         const groupLabel = isCategorySection
-                                            ? `${title} for ${label}`
+                                            ? `${title} for ${isSharedGroup ? 'shared items' : label}`
                                             : `${label} for ${isShared ? 'shared items' : section.name}`
                                         const groupTarget = isCategorySection
                                             ? {
-                                                personName: label,
-                                                personId: personIdByName.get(label) ?? '',
+                                                personName: isSharedGroup ? '' : label,
+                                                personId: isSharedGroup ? '' : (personIdByName.get(label) ?? ''),
+                                                communal: isSharedGroup,
                                                 category: categoryFromLabel(title),
                                             }
                                             : {
@@ -1702,8 +1742,12 @@ export function ViewPackingList() {
                                                         <span>{isCollapsed ? '▶' : '▼'}</span>
                                                         {/* A category card's groups are people, so each one
                                                             gets the same mark its owner's card would have.
-                                                            The catch-all group is nobody's. */}
-                                                        {isCategorySection && label !== UNASSIGNED_LABEL && (
+                                                            The catch-all and shared groups are nobody's —
+                                                            the shared one says so instead. */}
+                                                        {isSharedGroup && (
+                                                            <span aria-hidden title="Packed once for the whole group">👥</span>
+                                                        )}
+                                                        {isCategorySection && !isSharedGroup && label !== UNASSIGNED_LABEL && (
                                                             <PersonAvatar
                                                                 name={label}
                                                                 color={personColor({ id: personIdByName.get(label) ?? '', name: label })}


### PR DESCRIPTION
Question view rearranged everyone's items into the question set's sections
but left communal items sitting in their own "Shared Items" card at the top,
so the one view that is meant to be organised by section still had a card
that wasn't.

Shared items are now filed by category like everybody else's, in a group of
their own inside each section's card — first, the way the shared card comes
first in person view — and the section's counts include them. Person view is
unchanged.

Adding still works both ways round: the shared group has its own ＋ Add, and
a section's composer offers "Shared" in its who-for picker, which is how a
shared item gets added in question view now that there is no shared card to
type into. The "+ Add Shared Items" reveal opens that card, so it is person
view's alone.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014D78Y1NZ1mxMa2uSZ24e8s