### PR TITLE
Collect last minute items in a section of their own

### DIFF
--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -3363,6 +3363,22 @@ describe('ViewPackingList last minute items', () => {
         expect(within(card).getByRole('button', { name: /Collapse Shared$/i })).toBeTruthy()
     })
 
+    it('stays where the user is reading when an item is marked', async () => {
+        const scrollIntoView = vi.fn()
+        Element.prototype.scrollIntoView = scrollIntoView
+        renderLastMinuteList()
+
+        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: /mark passport as .*last minute/i }))
+
+        // The card is at the far end of a list being read down; the highlight
+        // says where the item went without taking the page with it.
+        await waitFor(() => expect(within(sectionCard('Last Minute')).getByText('Passport')).toBeTruthy())
+        expect(scrollIntoView).not.toHaveBeenCalled()
+        const row = within(sectionCard('Last Minute')).getByText('Passport').closest('div.rounded-lg')
+        expect(row?.className).toContain('ring-green-400')
+    })
+
     it('marks items added inside the last minute section as last minute', async () => {
         const db = renderLastMinuteList([{ ...lastMinuteBaseItems[0], lastMinute: true }])
 

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -281,7 +281,10 @@ export function ViewPackingList() {
     const [renamingGuestId, setRenamingGuestId] = useState<string | null>(null)
     const [renamingGuestName, setRenamingGuestName] = useState('')
     const [guestToRemove, setGuestToRemove] = useState<string | null>(null)
-    const [recentlyAddedItemId, setRecentlyAddedItemId] = useState<string | null>(null)
+    // The row worth pointing out for a moment because it has just landed
+    // somewhere: typed into a composer, or moved to the last minute card.
+    // `bringIntoView` separates the two — see the effect below.
+    const [highlightedItem, setHighlightedItem] = useState<{ id: string; bringIntoView: boolean } | null>(null)
     const itemRowRefs = useRef<Map<string, HTMLDivElement>>(new Map())
     // One-off confetti when the final item is ticked
     const [showConfetti, setShowConfetti] = useState(false)
@@ -423,13 +426,18 @@ export function ViewPackingList() {
             .catch(() => {})
     }, [packingList?.id, foreignPodUrl, ownerWebIdFromUrl, db])
 
+    // An item typed into a composer is worth following to wherever it landed.
+    // An item *moved* is not: marking things last minute happens while reading
+    // down the list, and scrolling to the card at the far end of it takes the
+    // rows being worked through out from under the user. The highlight alone
+    // says where the item went, for whoever is looking that way.
     useEffect(() => {
-        if (!recentlyAddedItemId) return
+        if (!highlightedItem?.bringIntoView) return
         // 'nearest' rather than 'center': items are usually added in runs, and
         // centring a row that is already on screen drags the composer being
         // typed into out from under the cursor.
-        itemRowRefs.current.get(recentlyAddedItemId)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-    }, [recentlyAddedItemId])
+        itemRowRefs.current.get(highlightedItem.id)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }, [highlightedItem])
 
     // Everything the add-item composers need, derived once per list rather than
     // per composer: there is one on every card, and they re-render whenever an
@@ -874,8 +882,8 @@ export function ViewPackingList() {
             })
 
             // The item has just moved to the other end of the list, so open the
-            // card it landed in and mark the row — otherwise ticking the box
-            // reads as the item having been deleted.
+            // card it landed in and mark the row — but stay where the user is
+            // reading: they are working down the list, not following the item.
             if (nowLastMinute) {
                 setCollapsedSections(prev => {
                     if (!prev.has(LAST_MINUTE_SECTION_KEY)) return prev
@@ -884,8 +892,8 @@ export function ViewPackingList() {
                     return next
                 })
             }
-            setRecentlyAddedItemId(item.id)
-            setTimeout(() => setRecentlyAddedItemId(null), 2000)
+            setHighlightedItem({ id: item.id, bringIntoView: false })
+            setTimeout(() => setHighlightedItem(null), 2000)
 
             await persistPackingList({ ...packingList, items: updatedItems })
 
@@ -1004,8 +1012,8 @@ export function ViewPackingList() {
             setAutoSaveStatus('saved')
             setTimeout(() => setAutoSaveStatus('idle'), 2000)
 
-            setRecentlyAddedItemId(newItem.id)
-            setTimeout(() => setRecentlyAddedItemId(null), 2000)
+            setHighlightedItem({ id: newItem.id, bringIntoView: true })
+            setTimeout(() => setHighlightedItem(null), 2000)
         } catch (err) {
             reportError(err, 'Error adding item')
             setAutoSaveStatus('error')
@@ -1928,7 +1936,7 @@ export function ViewPackingList() {
                                                                     if (el) itemRowRefs.current.set(item.id, el)
                                                                     else itemRowRefs.current.delete(item.id)
                                                                 }}
-                                                                className={`relative rounded-lg p-3 transition-colors duration-1000 ${item.id === recentlyAddedItemId ? 'bg-green-100 ring-2 ring-green-400' : 'bg-gray-50'} ${item.id === flourish?.itemId ? 'item-row-packed' : ''}`}
+                                                                className={`relative rounded-lg p-3 transition-colors duration-1000 ${item.id === highlightedItem?.id ? 'bg-green-100 ring-2 ring-green-400' : 'bg-gray-50'} ${item.id === flourish?.itemId ? 'item-row-packed' : ''}`}
                                                             >
                                                                 {item.id === flourish?.itemId && (
                                                                     <span


### PR DESCRIPTION
Some things can't go in the bag until you're walking out of the door — the phone charger, the toothbrush, the keys. Until now they sat in the list alongside everything that could be packed there and then, so the end of the evening was a list that couldn't be finished and no way to tell what was left on purpose.

## What changed

Every item row now carries a clock button. Marking an item lifts it out of whoever's (or whatever section's) card it was in and collects it in one amber **Last Minute** card at the end of the list, headed "Pack these just before you go." Unmarking sends it straight back where it came from.

- The card appears only once something is marked, and is the last card in **both** view modes — an item you can't pack yet doesn't belong among the ones you can, however the list happens to be grouped.
- Inside, it groups by person (shared group first), the way a category card does, so a family list still reads as "Alice's / Bob's / Shared".
- Its composers add last minute items directly: the card knows *when*, so it asks who for.
- Counts, progress, auto-folding and the all-packed celebration treat it as an ordinary section, so the totals stay honest.

Marking an item highlights the row it landed in but deliberately does **not** scroll the page there (second commit): marking happens while reading down the list, and following the item to the far end of it takes the rows being worked through out from under you. An item typed into a composer is still followed — that is where the behaviour came from, and where it belongs.

## Persistence

`lastMinute` rides on the item: stored locally, written to the pod under a new `pmu:lastMinute` predicate, and merged like any other item field. It is deleted rather than set to `false` when unmarked, so an item that was never marked and one that was unmarked stay the same item.

## Testing

- 10 new unit tests in `view-packing-list.test.tsx`, written before the implementation (both views, communal items, add-in-place, persistence of the flag, and no-scroll-on-mark).
- The `Required<...>` fixtures did their job: adding the field broke the type check, and then the RDF round-trip test, until serialisation carried it.
- New e2e `C14` (mark → reload → unmark); the full C suite passes, 14/14.
- Driven by hand in a browser at desktop and 390px: marking, unmarking, both view modes, reload, and finishing a list that still has a last minute item in it.

`npm test` green: 1539 tests, type check included. `npm run lint` reports no new problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UokHjoWQY9kJDeZq1d2f5x

---
_Generated by [Claude Code](https://claude.ai/code/session_01UokHjoWQY9kJDeZq1d2f5x)_