### PR TITLE
Lay category view out as an item × person grid

### DIFF
--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -222,7 +222,7 @@ test.describe('C – Packing Lists', () => {
     // A name both of them need is written once and ticked twice
     const shared = firstCard.getByRole('checkbox', { name: /for Alice$/ }).first()
     const label = (await shared.getAttribute('aria-label'))!.replace(/ for Alice$/, '')
-    await expect(firstCard.getByText(label, { exact: true })).toHaveCount(1)
+    await expect(firstCard.getByRole('button', { name: `Edit ${label}` })).toHaveCount(1)
 
     // Ticking one person's cell leaves the other's alone, and it survives a reload
     await shared.click()
@@ -254,7 +254,7 @@ test.describe('C – Packing Lists', () => {
     await expect(bobsCell).toBeVisible({ timeout: 8_000 })
     const label = (await bobsCell.getAttribute('aria-label'))!.replace(/ for Bob$/, '')
 
-    await card.getByRole('button', { name: `${label} — who needs this?` }).click()
+    await card.getByRole('button', { name: `Edit ${label}` }).click()
     const panel = page.getByRole('dialog')
     await expect(panel).toBeVisible()
 

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -214,10 +214,11 @@ test.describe('C – Packing Lists', () => {
 
     await page.getByRole('button', { name: 'Category View' }).click()
 
-    // Both of them named on every card, whoever has something in it
+    // One key for the page, naming whose initial is whose
+    const key = page.getByTestId('people-key')
+    await expect(key.getByText('Alice')).toBeVisible()
+    await expect(key.getByText('Bob')).toBeVisible()
     const firstCard = page.getByTestId('list-section').first()
-    await expect(firstCard.getByRole('button', { name: /everything left for Alice/i })).toBeVisible()
-    await expect(firstCard.getByRole('button', { name: /everything left for Bob/i })).toBeVisible()
 
     // A name both of them need is written once and ticked twice
     const shared = firstCard.getByRole('checkbox', { name: /for Alice$/ }).first()

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -214,18 +214,20 @@ test.describe('C – Packing Lists', () => {
 
     await page.getByRole('button', { name: 'Category View' }).click()
 
-    // A column each, in every card
+    // Both of them named on every card, whoever has something in it
     const firstCard = page.getByTestId('list-section').first()
-    await expect(firstCard.getByRole('columnheader', { name: /Alice/ })).toBeVisible()
-    await expect(firstCard.getByRole('columnheader', { name: /Bob/ })).toBeVisible()
+    await expect(firstCard.getByRole('button', { name: /everything left for Alice/i })).toBeVisible()
+    await expect(firstCard.getByRole('button', { name: /everything left for Bob/i })).toBeVisible()
 
     // A name both of them need is written once and ticked twice
     const shared = firstCard.getByRole('checkbox', { name: /for Alice$/ }).first()
     const label = (await shared.getAttribute('aria-label'))!.replace(/ for Alice$/, '')
     await expect(firstCard.getByRole('button', { name: `Edit ${label}` })).toHaveCount(1)
 
-    // Ticking one person's cell leaves the other's alone, and it survives a reload
-    await shared.click()
+    // Ticking one person's chip leaves the other's alone, and it survives a
+    // reload. The checkbox itself is behind the chip, so the chip is what gets
+    // clicked — same as a finger would.
+    await firstCard.getByTitle(`${label} for Alice`).click()
     await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
     await page.reload()
     await page.getByRole('button', { name: 'Show Packed' }).click()
@@ -261,15 +263,15 @@ test.describe('C – Packing Lists', () => {
     // Off: Bob's cell goes, Alice's stays
     await panel.getByRole('checkbox', { name: `Bob needs ${label}` }).uncheck()
     await expect(page.getByRole('checkbox', { name: `${label} for Bob` })).toHaveCount(0, { timeout: 8_000 })
-    await expect(page.getByRole('checkbox', { name: `${label} for Alice` }).first()).toBeVisible()
+    await expect(page.getByTitle(`${label} for Alice`).first()).toBeVisible()
 
     // And back on, where it stays put across a reload
     await panel.getByRole('checkbox', { name: `Bob needs ${label}` }).check()
     await panel.getByRole('button', { name: 'Done' }).click()
-    await expect(page.getByRole('checkbox', { name: `${label} for Bob` }).first()).toBeVisible({ timeout: 8_000 })
+    await expect(page.getByTitle(`${label} for Bob`).first()).toBeVisible({ timeout: 8_000 })
     await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
     await page.reload()
-    await expect(page.getByRole('checkbox', { name: `${label} for Bob` }).first()).toBeVisible({ timeout: 8_000 })
+    await expect(page.getByTitle(`${label} for Bob`).first()).toBeVisible({ timeout: 8_000 })
   })
 })
 

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -198,6 +198,79 @@ test.describe('C – Packing Lists', () => {
     await expect(card.getByTestId('person-avatar')).toHaveClass(/bg-fuchsia-500/)
     await expect(card).toHaveClass(/border-fuchsia-300/)
   })
+  test('C15: category view writes each item once, with a checkbox per person', async ({ freshPage: page }) => {
+    // Two people, because a grid with one column is just a list
+    await page.goto('/#/wizard')
+    await page.fill('[name="people.0.name"]', 'Alice')
+    await fillPersonRequiredFields(page, 0)
+    await page.getByRole('button', { name: /Add Another Person/i }).click()
+    await page.fill('[name="people.1.name"]', 'Bob')
+    await fillPersonRequiredFields(page, 1)
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: /Create My First Packing List/i }).click()
+    await page.waitForURL(/#\/create-packing-list/, { timeout: 5_000 })
+    await createList(page, 'Grid Trip')
+
+    await page.getByRole('button', { name: 'Category View' }).click()
+
+    // A column each, in every card
+    const firstCard = page.getByTestId('list-section').first()
+    await expect(firstCard.getByRole('columnheader', { name: /Alice/ })).toBeVisible()
+    await expect(firstCard.getByRole('columnheader', { name: /Bob/ })).toBeVisible()
+
+    // A name both of them need is written once and ticked twice
+    const shared = firstCard.getByRole('checkbox', { name: /for Alice$/ }).first()
+    const label = (await shared.getAttribute('aria-label'))!.replace(/ for Alice$/, '')
+    await expect(firstCard.getByText(label, { exact: true })).toHaveCount(1)
+
+    // Ticking one person's cell leaves the other's alone, and it survives a reload
+    await shared.click()
+    await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
+    await page.reload()
+    await page.getByRole('button', { name: 'Show Packed' }).click()
+    await expect(page.getByRole('checkbox', { name: `${label} for Alice` })).toBeChecked()
+    const bobs = page.getByRole('checkbox', { name: `${label} for Bob` })
+    if (await bobs.count() > 0) await expect(bobs.first()).not.toBeChecked()
+  })
+
+  test('C16: the row panel takes an item off one person and gives it back', async ({ freshPage: page }) => {
+    await page.goto('/#/wizard')
+    await page.fill('[name="people.0.name"]', 'Alice')
+    await fillPersonRequiredFields(page, 0)
+    await page.getByRole('button', { name: /Add Another Person/i }).click()
+    await page.fill('[name="people.1.name"]', 'Bob')
+    await fillPersonRequiredFields(page, 1)
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: /Create My First Packing List/i }).click()
+    await page.waitForURL(/#\/create-packing-list/, { timeout: 5_000 })
+    await createList(page, 'Panel Trip')
+    await page.getByRole('button', { name: 'Category View' }).click()
+
+    // A row both of them are on, so it can lose one and get them back
+    const card = page.getByTestId('list-section').first()
+    const bobsCell = card.getByRole('checkbox', { name: /for Bob$/ }).first()
+    await expect(bobsCell).toBeVisible({ timeout: 8_000 })
+    const label = (await bobsCell.getAttribute('aria-label'))!.replace(/ for Bob$/, '')
+
+    await card.getByRole('button', { name: `${label} — who needs this?` }).click()
+    const panel = page.getByRole('dialog')
+    await expect(panel).toBeVisible()
+
+    // Off: Bob's cell goes, Alice's stays
+    await panel.getByRole('checkbox', { name: `Bob needs ${label}` }).uncheck()
+    await expect(page.getByRole('checkbox', { name: `${label} for Bob` })).toHaveCount(0, { timeout: 8_000 })
+    await expect(page.getByRole('checkbox', { name: `${label} for Alice` }).first()).toBeVisible()
+
+    // And back on, where it stays put across a reload
+    await panel.getByRole('checkbox', { name: `Bob needs ${label}` }).check()
+    await panel.getByRole('button', { name: 'Done' }).click()
+    await expect(page.getByRole('checkbox', { name: `${label} for Bob` }).first()).toBeVisible({ timeout: 8_000 })
+    await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
+    await page.reload()
+    await expect(page.getByRole('checkbox', { name: `${label} for Bob` }).first()).toBeVisible({ timeout: 8_000 })
+  })
 })
 
 test.describe('C – Contextual sign-in prompts (logged out)', () => {

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -1,0 +1,281 @@
+/**
+ * A category's items as a grid: the item down the side, the people across the
+ * top, a checkbox where they meet.
+ *
+ * Category view used to give each person their own folded heading inside a
+ * category, so one toothbrush was three rows in three places. The question the
+ * view exists to answer — "who still needs one?" — was the one thing it made
+ * hard. Here the name is written once and the people are read across it, and
+ * the gaps in a column are as much of an answer as the ticks.
+ *
+ * One table on every screen rather than a table and a phone-shaped
+ * substitute: wrapping the people into chips would put each person somewhere
+ * different on every row, which is precisely the reading the grid exists to
+ * make possible. What gives on a narrow screen is the *names* — the header
+ * keeps the coloured initial and the card carries a legend — not the columns.
+ *
+ * Three cell weights, because two of them would lie: a filled tick (packed),
+ * an empty box (still to pack), and a flat dot (not for this person). With
+ * packed items hidden a row leaves only when every cell on it is packed, so
+ * "already done" is never dressed up as "never needed".
+ */
+import type { PackingListItem } from '../create-packing-list/types'
+import type { GridColumn, GridRow } from '../utils/categoryItemGrid'
+import type { PersonColorLookup } from '../hooks/usePersonColors'
+import { PersonAvatar } from './PersonAvatar'
+
+export interface CategoryItemGridProps {
+    /** Names the table for screen readers, e.g. "Toiletries". */
+    sectionTitle: string
+    columns: readonly GridColumn[]
+    rows: readonly GridRow[]
+    personColor: PersonColorLookup
+    packedById: Record<string, boolean>
+    /** Whether a name is on screen beside each column's avatar. */
+    showColumnNames: boolean
+    /** Packed items are hidden, so a row with nothing left on it is on its way out. */
+    hidePacked: boolean
+    /** The item taking its bow; the nonce replays the tick when the same one is re-checked. */
+    flourish: { itemId: string; nonce: number } | null
+    /** Just added or just moved — worth pointing out for a moment. */
+    highlightedItemId?: string
+    onToggleItem: (item: PackingListItem, checked: boolean) => void
+    /** Hands the page a handle on each cell, so an added item can be scrolled to. */
+    registerCellRef: (itemId: string, element: HTMLElement | null) => void
+    /** Opens the row's "who needs this?" panel — rename, quantities, who it is for. */
+    onOpenRow: (row: GridRow) => void
+    onCheckColumn: (column: GridColumn, columnIndex: number) => void
+}
+
+interface ColumnStat { packed: number; total: number }
+
+export function CategoryItemGrid({
+    sectionTitle,
+    columns,
+    rows,
+    personColor,
+    packedById,
+    showColumnNames,
+    hidePacked,
+    flourish,
+    highlightedItemId,
+    onToggleItem,
+    registerCellRef,
+    onOpenRow,
+    onCheckColumn,
+}: CategoryItemGridProps) {
+    const rowComplete = (row: GridRow) =>
+        row.items.length > 0 && row.items.every(item => packedById[item.id])
+
+    // A finished row leaves when packed items are hidden — but not in the same
+    // frame as the tick that finished it: it stays for the flourish, wearing the
+    // leaving animation, and goes when the flourish ends.
+    const visibleRows = rows.filter(row =>
+        !hidePacked || !rowComplete(row) || row.items.some(item => item.id === flourish?.itemId)
+    )
+
+    if (visibleRows.length === 0) {
+        return <p className="text-sm font-medium text-emerald-700">Nothing left to pack 🎒</p>
+    }
+
+    // Counted over every item in the category rather than the visible rows: with
+    // packed items hidden, "1" under a person two thirds done reads as a person
+    // who has barely started.
+    const columnStats: ColumnStat[] = columns.map((_column, index) => {
+        let packed = 0
+        let total = 0
+        for (const row of rows) {
+            const item = row.cells[index]
+            if (!item) continue
+            total++
+            if (packedById[item.id]) packed++
+        }
+        return { packed, total }
+    })
+
+    const renderFlourish = (item: PackingListItem) => (
+        item.id === flourish?.itemId
+            ? (
+                <span
+                    key={flourish.nonce}
+                    data-testid={`item-tick-${item.id}`}
+                    aria-hidden="true"
+                    className="item-packed-tick pointer-events-none absolute left-1/2 top-1/2 z-10 text-xl font-bold text-success-600"
+                >
+                    ✓
+                </span>
+            )
+            : null
+    )
+
+    const renderCell = (row: GridRow, column: GridColumn, item: PackingListItem | undefined) => {
+        if (!item) {
+            // Flat and untouchable. An empty cell is the most common thing on
+            // the grid and the least worth pressing — putting an "add this for
+            // them" button in every one of them would surround each checkbox
+            // with taps that create data instead of ticking it off. Filling a
+            // gap in is a job for the row's panel, where it can be undone.
+            return (
+                <span aria-hidden="true" className="mx-auto block h-1 w-1 rounded-full bg-gray-200" />
+            )
+        }
+        const packed = !!packedById[item.id]
+        const quantity = item.quantity !== undefined && item.quantity > 1 ? item.quantity : undefined
+        return (
+            <label
+                data-testid={`grid-cell-${item.id}`}
+                ref={(element) => registerCellRef(item.id, element)}
+                className={`relative mx-auto flex h-10 w-10 cursor-pointer items-center justify-center rounded-md transition-colors ${packed ? 'bg-emerald-100' : 'hover:bg-blue-50'} ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
+            >
+                <input
+                    type="checkbox"
+                    checked={packed}
+                    onChange={(e) => onToggleItem(item, e.target.checked)}
+                    aria-label={`${row.label} for ${column.name}`}
+                    className={`h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${packed ? 'accent-emerald-600' : ''}`}
+                />
+                {row.mixedQuantities && quantity && (
+                    <span className="pointer-events-none absolute -bottom-1 -right-1 rounded-full bg-blue-100 px-1 text-[10px] font-semibold text-blue-700">
+                        ×{quantity}
+                    </span>
+                )}
+                {renderFlourish(item)}
+            </label>
+        )
+    }
+
+    const renderSharedCell = (row: GridRow) => {
+        const item = row.items[0]
+        const packed = !!packedById[item.id]
+        return (
+            <label
+                data-testid={`grid-cell-${item.id}`}
+                ref={(element) => registerCellRef(item.id, element)}
+                className={`relative inline-flex h-10 cursor-pointer items-center gap-2 rounded-md px-3 transition-colors ${packed ? 'bg-emerald-100' : 'bg-blue-50 hover:bg-blue-100'} ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
+            >
+                <input
+                    type="checkbox"
+                    checked={packed}
+                    onChange={(e) => onToggleItem(item, e.target.checked)}
+                    aria-label={`${row.label} for the whole group`}
+                    className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="whitespace-nowrap text-xs font-medium text-blue-800">
+                    👥{showColumnNames && ' For everyone'}
+                </span>
+                {renderFlourish(item)}
+            </label>
+        )
+    }
+
+    return (
+        <div className="-mx-1 overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+                <caption className="sr-only">{sectionTitle}: what to pack, by person</caption>
+                <thead>
+                    <tr>
+                        {/* Takes the slack, so the person columns stay as narrow
+                            as they need to be — which is what lets four of them
+                            fit beside an item name on a phone. */}
+                        <th scope="col" className="w-full px-1 pb-2 text-left text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+                            Item
+                        </th>
+                        {columns.map((column, index) => {
+                            const { packed, total } = columnStats[index]
+                            const done = total > 0 && packed === total
+                            return (
+                                <th key={column.key} scope="col" className="px-1 pb-2 align-bottom sm:px-2">
+                                    <span className="flex flex-col items-center gap-0.5">
+                                        <span className="flex items-center gap-1.5">
+                                            {!column.unassigned && (
+                                                <PersonAvatar
+                                                    name={column.name}
+                                                    color={personColor({ id: column.personId, name: column.name })}
+                                                    size="sm"
+                                                />
+                                            )}
+                                            {showColumnNames && (
+                                                <span className={`text-sm font-semibold ${done ? 'text-emerald-700' : 'text-gray-700'}`}>
+                                                    {column.name}
+                                                </span>
+                                            )}
+                                        </span>
+                                        {/* Persistent rather than revealed on hover:
+                                            "I've just done all of Cara's toiletries"
+                                            is how people pack, and a phone has no
+                                            hover to reveal it with. */}
+                                        <button
+                                            type="button"
+                                            onClick={() => onCheckColumn(column, index)}
+                                            disabled={done}
+                                            aria-label={`Check off everything left for ${column.name} in ${sectionTitle}`}
+                                            title={done ? `${column.name} is done here` : `Check off everything ${column.name} still has in ${sectionTitle}`}
+                                            className={`rounded-full px-1.5 text-[11px] font-medium tabular-nums transition-colors ${done ? 'text-emerald-600' : 'text-gray-400 hover:bg-blue-50 hover:text-blue-700'}`}
+                                        >
+                                            {packed}/{total}
+                                        </button>
+                                    </span>
+                                </th>
+                            )
+                        })}
+                    </tr>
+                </thead>
+                <tbody>
+                    {visibleRows.map(row => {
+                        const complete = rowComplete(row)
+                        return (
+                            <tr
+                                key={row.key}
+                                data-testid="grid-row"
+                                className={`border-t border-gray-100 transition-colors ${complete ? 'bg-emerald-50' : 'hover:bg-gray-50'} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
+                            >
+                                <th scope="row" className="px-1 py-1 text-left align-middle font-medium">
+                                    {/* The name is the biggest target on the row,
+                                        so it is the way in to everything that
+                                        isn't ticking a box: renaming, quantities,
+                                        and who the item is for. */}
+                                    <button
+                                        type="button"
+                                        onClick={() => onOpenRow(row)}
+                                        aria-label={`${row.label} — who needs this?`}
+                                        title="Who needs this?"
+                                        className="group flex w-full items-center gap-1.5 rounded-md py-1.5 pr-2 text-left transition-colors hover:bg-blue-50"
+                                    >
+                                        <span className={complete ? 'text-gray-400 line-through' : 'text-gray-800'}>
+                                            {row.label}
+                                        </span>
+                                        {row.quantity !== undefined && (
+                                            <span className="shrink-0 rounded-full bg-blue-100 px-1.5 py-0.5 text-xs font-semibold text-blue-700">
+                                                ×{row.quantity}
+                                            </span>
+                                        )}
+                                        {/* Sits with the name rather than out at
+                                            the far edge of the column, where it
+                                            would read as another cell. */}
+                                        <span
+                                            aria-hidden="true"
+                                            className="shrink-0 text-xs text-gray-300 transition-colors group-hover:text-blue-500"
+                                        >
+                                            ⋯
+                                        </span>
+                                    </button>
+                                </th>
+                                {row.communal ? (
+                                    <td colSpan={Math.max(columns.length, 1)} className="px-1 py-1 text-center align-middle sm:px-2">
+                                        {renderSharedCell(row)}
+                                    </td>
+                                ) : (
+                                    columns.map((column, index) => (
+                                        <td key={column.key} className="px-1 py-1 text-center align-middle sm:px-2">
+                                            {renderCell(row, column, row.cells[index])}
+                                        </td>
+                                    ))
+                                )}
+                            </tr>
+                        )
+                    })}
+                </tbody>
+            </table>
+        </div>
+    )
+}

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -33,6 +33,8 @@ export interface CategoryItemGridProps {
     packedById: Record<string, boolean>
     /** Whether a name is on screen beside each column's avatar. */
     showColumnNames: boolean
+    /** The card's own background, which the frozen name column sits on. */
+    surfaceClass: string
     /** Packed items are hidden, so a row with nothing left on it is on its way out. */
     hidePacked: boolean
     /** The item taking its bow; the nonce replays the tick when the same one is re-checked. */
@@ -48,6 +50,29 @@ export interface CategoryItemGridProps {
 }
 
 interface ColumnStat { packed: number; total: number }
+
+/**
+ * How much of a phone's width one person's column takes.
+ *
+ * A checkbox is 20px and wants a target around it; 40 is what leaves a name
+ * column worth reading once four or five people are on the list. Below that the
+ * grid stops being readable before it stops fitting — see the scroll fallback.
+ */
+const PHONE_COLUMN_WIDTH = 40
+
+/**
+ * How little room the names may be left with before the grid gives up on
+ * fitting and scrolls instead.
+ *
+ * At 390px a card has ~348px to spend, so six people (240px) still leave a
+ * readable 108px of name. A seventh cannot be fitted at any width worth
+ * reading, and squeezing the names to 28px to avoid a scrollbar would be
+ * choosing the wrong thing to break — so past that the table keeps a wider
+ * name column and scrolls sideways under a frozen first column.
+ */
+function nameFloor(peopleCount: number): number {
+    return peopleCount <= 6 ? 104 : 136
+}
 
 /**
  * The name, split so that its last word and the chevron can be held together.
@@ -75,6 +100,7 @@ export function CategoryItemGrid({
     personColor,
     packedById,
     showColumnNames,
+    surfaceClass,
     hidePacked,
     flourish,
     highlightedItemId,
@@ -143,7 +169,7 @@ export function CategoryItemGrid({
                     aria-hidden="true"
                     onClick={() => onOpenRow(row)}
                     title={`${column.name} doesn't need this — open to change`}
-                    className="mx-auto flex h-10 w-10 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-blue-50"
+                    className="mx-auto flex h-9 w-9 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-blue-50 sm:h-10 sm:w-10"
                 >
                     <span className="block h-1 w-1 rounded-full bg-gray-200" />
                 </button>
@@ -155,7 +181,7 @@ export function CategoryItemGrid({
             <label
                 data-testid={`grid-cell-${item.id}`}
                 ref={(element) => registerCellRef(item.id, element)}
-                className={`relative mx-auto flex h-10 w-10 cursor-pointer items-center justify-center rounded-md transition-colors ${packed ? 'bg-emerald-100' : 'hover:bg-blue-50'} ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
+                className={`relative mx-auto flex h-9 w-9 cursor-pointer items-center justify-center rounded-md transition-colors sm:h-10 sm:w-10 ${packed ? 'bg-emerald-100' : 'hover:bg-blue-50'} ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
             >
                 <input
                     type="checkbox"
@@ -199,22 +225,39 @@ export function CategoryItemGrid({
     }
 
     return (
-        <div className="-mx-1 overflow-x-auto">
-            <table className="w-full border-collapse text-sm">
+        <div className="-mx-2 overflow-x-auto sm:-mx-1">
+            <table
+                className={`w-full border-collapse text-sm ${showColumnNames ? '' : 'table-fixed'}`}
+                style={showColumnNames
+                    ? undefined
+                    : { minWidth: `${nameFloor(columns.length) + columns.length * PHONE_COLUMN_WIDTH}px` }}
+            >
                 <caption className="sr-only">{sectionTitle}: what to pack, by person</caption>
+                {/* On a phone the people are told how much room they get and the
+                    name takes what is left, so a fifth person makes the names
+                    narrower instead of pushing the grid off the side of the
+                    screen. On a desktop there is room to let the names ask. */}
+                {!showColumnNames && (
+                    <colgroup>
+                        <col />
+                        {columns.map(column => (
+                            <col key={column.key} style={{ width: `${PHONE_COLUMN_WIDTH}px` }} />
+                        ))}
+                    </colgroup>
+                )}
                 <thead>
-                    <tr>
+                    <tr className={surfaceClass}>
                         {/* Takes the slack, so the person columns stay as narrow
                             as they need to be — which is what lets four of them
                             fit beside an item name on a phone. */}
-                        <th scope="col" className="w-full px-1 pb-2 text-left text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+                        <th scope="col" className="sticky left-0 z-20 w-full bg-inherit px-1 pb-2 text-left text-[11px] font-semibold uppercase tracking-wide text-gray-400">
                             Item
                         </th>
                         {columns.map((column, index) => {
                             const { packed, total } = columnStats[index]
                             const done = total > 0 && packed === total
                             return (
-                                <th key={column.key} scope="col" className="px-1 pb-2 align-bottom sm:px-2">
+                                <th key={column.key} scope="col" className="px-0 pb-2 align-bottom sm:px-2">
                                     <span className="flex flex-col items-center gap-0.5">
                                         <span className="flex items-center gap-1.5">
                                             {!column.unassigned && (
@@ -258,9 +301,13 @@ export function CategoryItemGrid({
                             <tr
                                 key={row.key}
                                 data-testid="grid-row"
-                                className={`border-t border-gray-100 transition-colors ${complete ? 'bg-emerald-50' : 'hover:bg-gray-50'} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
+                                // An opaque background of its own, because the
+                                // name cell inherits it to sit over the columns
+                                // sliding underneath when the grid is wider than
+                                // the screen.
+                                className={`border-t border-gray-100 transition-colors ${complete ? 'bg-emerald-50' : `${surfaceClass} hover:bg-gray-50`} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
                             >
-                                <th scope="row" className="px-1 py-1 text-left align-middle font-medium">
+                                <th scope="row" className="sticky left-0 z-10 bg-inherit px-1 py-1 text-left align-middle font-medium shadow-[2px_0_3px_-1px_rgba(15,23,42,0.08)] sm:shadow-none">
                                     {/* The name is the biggest target on the row,
                                         so it is the way in to everything that
                                         isn't ticking a box: renaming, quantities,
@@ -279,7 +326,7 @@ export function CategoryItemGrid({
                                         title="Rename, quantities, and who needs it"
                                         className="group block w-full cursor-pointer rounded-md px-1 py-2.5 text-left transition-colors active:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
                                     >
-                                        <span className={complete ? 'text-gray-400 line-through' : 'text-gray-800 group-hover:text-blue-800'}>
+                                        <span className={`break-words ${complete ? 'text-gray-400 line-through' : 'text-gray-800 group-hover:text-blue-800'}`}>
                                             {head && `${head} `}
                                             {/* The last word, the quantity and the
                                                 chevron travel together, so the chevron
@@ -320,7 +367,7 @@ export function CategoryItemGrid({
                                     </td>
                                 ) : (
                                     columns.map((column, index) => (
-                                        <td key={column.key} className="px-1 py-1 text-center align-middle sm:px-2">
+                                        <td key={column.key} className="px-0 py-1 text-center align-middle sm:px-2">
                                             {renderCell(row, column, row.cells[index])}
                                         </td>
                                     ))

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -1,28 +1,31 @@
 /**
- * A category's items as a grid: the item down the side, the people across the
- * top, a checkbox where they meet.
+ * A category's items as a grid: the item down the side, the people across it,
+ * a checkbox where they meet.
  *
  * Category view used to give each person their own folded heading inside a
  * category, so one toothbrush was three rows in three places. The question the
  * view exists to answer — "who still needs one?" — was the one thing it made
  * hard. Here the name is written once and the people are read across it, and
- * the gaps in a column are as much of an answer as the ticks.
+ * the gaps are as much of an answer as the ticks.
  *
- * Columns for as long as they fit. What gives on a narrow screen is first the
- * column *names* — the header keeps the coloured initial and the card carries a
- * legend — and then, once the people no longer fit beside a name worth reading,
- * the columns themselves: the item moves to a line of its own and the people
- * wrap underneath it as chips.
+ * The people are chips rather than columns under a header, and there is no
+ * header row at all: each chip carries its own colour and initial, so it says
+ * whose it is from wherever it has ended up on the screen. That is what lets
+ * the grid work at any width. A header naming the columns has to be *visible*
+ * to be any use, and the moment you scroll into a long category it isn't —
+ * whereas identity that travels with the control can't scroll away from it.
  *
  * Wrapping only works because a chip is a fixed size. Pills carrying names are
  * all different widths, so they put each person somewhere different on every
- * row and destroy the one reading the grid exists for; identical 36px discs
- * wrap into a grid that happens to have more than one line, and person five is
- * under person one on every single item.
+ * row and destroy the one reading the grid exists for; identical 32px discs sit
+ * in a block of fixed width, so person five is under person one on every item,
+ * whether the block takes one line or three. The block hands back whatever it
+ * doesn't need to the name, which is why three people still read as a tidy
+ * two-column table and twelve still fit on a phone.
  *
- * Three cell weights, because two of them would lie: a filled tick (packed),
- * an empty box (still to pack), and a flat dot (not for this person). With
- * packed items hidden a row leaves only when every cell on it is packed, so
+ * Three weights, because two of them would lie: a filled disc (packed), an
+ * outlined one (still to pack), and a flat dot (not for this person). With
+ * packed items hidden a row leaves only when every chip on it is packed, so
  * "already done" is never dressed up as "never needed".
  */
 import type { PackingListItem } from '../create-packing-list/types'
@@ -32,16 +35,12 @@ import { PersonAvatar } from './PersonAvatar'
 import { useMeasuredWidth } from '../hooks/useMeasuredWidth'
 
 export interface CategoryItemGridProps {
-    /** Names the table for screen readers, e.g. "Toiletries". */
+    /** Names the grid for screen readers, e.g. "Toiletries". */
     sectionTitle: string
     columns: readonly GridColumn[]
     rows: readonly GridRow[]
     personColor: PersonColorLookup
     packedById: Record<string, boolean>
-    /** Whether a name is on screen beside each column's avatar. */
-    showColumnNames: boolean
-    /** The card's own background, which the frozen name column sits on. */
-    surfaceClass: string
     /** Packed items are hidden, so a row with nothing left on it is on its way out. */
     hidePacked: boolean
     /** The item taking its bow; the nonce replays the tick when the same one is re-checked. */
@@ -49,7 +48,7 @@ export interface CategoryItemGridProps {
     /** Just added or just moved — worth pointing out for a moment. */
     highlightedItemId?: string
     onToggleItem: (item: PackingListItem, checked: boolean) => void
-    /** Hands the page a handle on each cell, so an added item can be scrolled to. */
+    /** Hands the page a handle on each chip, so an added item can be scrolled to. */
     registerCellRef: (itemId: string, element: HTMLElement | null) => void
     /** Opens the row's "who needs this?" panel — rename, quantities, who it is for. */
     onOpenRow: (row: GridRow) => void
@@ -58,38 +57,38 @@ export interface CategoryItemGridProps {
 
 interface ColumnStat { packed: number; total: number }
 
-/**
- * How much of a phone's width one person's column takes.
- *
- * A checkbox is 20px and wants a target around it; 40 is what leaves a name
- * column worth reading once four or five people are on the list. Below that the
- * grid stops being readable before it stops fitting — see the scroll fallback.
- */
-const PHONE_COLUMN_WIDTH = 40
+/** A 32px disc and the 4px after it. */
+const CHIP_PITCH = 36
 
 /**
- * How much room the names need before the columns stop paying for themselves.
+ * The most room a name is given on a wide card.
  *
- * Not the least they can survive on — the least they are worth having. A
- * column layout earns its extra density by keeping each item to one line; once
- * the names are wrapping to three, the table is no shorter than chips under a
- * full-width name and it is harder to read. At 390px a card has ~348px, so
- * five people leave 148px of name and six leave 108px and start wrapping —
- * which is where the item moves to a line of its own and the people wrap
- * underneath it.
+ * Past this the chips would be so far from the name that reading across the
+ * row becomes a job of its own; the leftover is left empty instead, and the two
+ * halves of a row stay next to each other.
  */
-const NAME_COMFORT = 132
+const NAME_MAX_WIDTH = 420
 
 /**
- * Whether the people still fit beside the names.
+ * The least room the names are left with, whatever the headcount.
+ *
+ * The chips take what they need up to this line and no further; past it they
+ * wrap onto a second line rather than squeezing the names away. A name is the
+ * only thing on the row that can't be recovered from context.
+ */
+const NAME_MIN_WIDTH = 128
+
+/**
+ * How many people fit on one line of chips.
  *
  * `width` is 0 until the card has been measured (and wherever there is no
- * ResizeObserver, which includes the tests), so the count alone decides until
- * a real width arrives: five is what fits on the phone this was designed for.
+ * ResizeObserver, which includes the tests), where everyone is assumed to fit —
+ * one line is what the layout looks like at rest.
  */
-function columnsFit(peopleCount: number, width: number): boolean {
-    if (width === 0) return peopleCount <= 5
-    return NAME_COMFORT + peopleCount * PHONE_COLUMN_WIDTH <= width
+function chipsPerLine(peopleCount: number, width: number): number {
+    if (width === 0) return peopleCount
+    const room = Math.floor((width - NAME_MIN_WIDTH) / CHIP_PITCH)
+    return Math.max(1, Math.min(peopleCount, room))
 }
 
 /**
@@ -97,9 +96,9 @@ function columnsFit(peopleCount: number, width: number): boolean {
  *
  * A line can break in front of an inline-block whether or not there is a space
  * there, and neither `white-space: nowrap` on the button nor a non-breaking
- * space in front of the chevron stops it — so on a phone any name that fills
- * its line drops the chevron onto a line of its own, pointing at nothing. Only
- * putting the two inside one `whitespace-nowrap` box holds them together.
+ * space in front of the chevron stops it — so any name that fills its line
+ * drops the chevron onto a line of its own, pointing at nothing. Only putting
+ * the two inside one `whitespace-nowrap` box holds them together.
  *
  * The cost is that the name is two text nodes, so `getByText('Water bottle')`
  * will not find it — query the row by its button instead (`Edit Water bottle`).
@@ -110,15 +109,12 @@ function splitLastWord(label: string): { head: string; lastWord: string } {
     return { head: parts.join(' '), lastWord }
 }
 
-
 export function CategoryItemGrid({
     sectionTitle,
     columns,
     rows,
     personColor,
     packedById,
-    showColumnNames,
-    surfaceClass,
     hidePacked,
     flourish,
     highlightedItemId,
@@ -128,9 +124,6 @@ export function CategoryItemGrid({
     onCheckColumn,
 }: CategoryItemGridProps) {
     const { ref: containerRef, width } = useMeasuredWidth<HTMLDivElement>()
-    // Columns while they fit; chips under the name once they don't. Desktop
-    // always has the room, and its names in the header are worth keeping.
-    const stacked = !showColumnNames && !columnsFit(columns.length, width)
 
     const rowComplete = (row: GridRow) =>
         row.items.length > 0 && row.items.every(item => packedById[item.id])
@@ -147,7 +140,7 @@ export function CategoryItemGrid({
     }
 
     // Counted over every item in the category rather than the visible rows: with
-    // packed items hidden, "1" under a person two thirds done reads as a person
+    // packed items hidden, "1" beside a person two thirds done reads as a person
     // who has barely started.
     const columnStats: ColumnStat[] = columns.map((_column, index) => {
         let packed = 0
@@ -160,6 +153,10 @@ export function CategoryItemGrid({
         }
         return { packed, total }
     })
+
+    // One width for every row in the card, so the chips land in the same places
+    // on all of them — which is the whole of what makes this a grid.
+    const chipBlockWidth = chipsPerLine(columns.length, width) * CHIP_PITCH
 
     const renderFlourish = (item: PackingListItem) => (
         item.id === flourish?.itemId
@@ -181,11 +178,10 @@ export function CategoryItemGrid({
      * ticking a box: renaming, quantities, and who it is for.
      *
      * Laid out as text rather than as a row of boxes, so the chevron follows the
-     * last word wherever the name wraps instead of floating at the edge of the
-     * column between two lines, belonging to neither. The padding is what makes
-     * a one-line row a 44px target.
+     * last word wherever the name wraps instead of floating out at the edge,
+     * between two lines, belonging to neither.
      */
-    const renderName = (row: GridRow, complete: boolean, padding = 'py-2.5') => {
+    const renderName = (row: GridRow, complete: boolean) => {
         const { head, lastWord } = splitLastWord(row.label)
         return (
             <button
@@ -193,7 +189,7 @@ export function CategoryItemGrid({
                 onClick={() => onOpenRow(row)}
                 aria-label={`Edit ${row.label}`}
                 title="Rename, quantities, and who needs it"
-                className={`group block w-full cursor-pointer rounded-md px-1 text-left transition-colors active:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${padding}`}
+                className="group block w-full cursor-pointer rounded-md px-1 py-2 text-left transition-colors active:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
             >
                 <span className={`break-words ${complete ? 'text-gray-400 line-through' : 'text-gray-800 group-hover:text-blue-800'}`}>
                     {head && `${head} `}
@@ -208,9 +204,9 @@ export function CategoryItemGrid({
                             </span>
                         )}
                         {/* Points, which is the whole message: there is somewhere
-                            to go from here. Grey enough to stay behind the
-                            checkboxes, dark enough to be seen without hovering —
-                            which is all a phone ever gets. */}
+                            to go from here. Grey enough to stay behind the chips,
+                            dark enough to be seen without hovering — which is all
+                            a phone ever gets. */}
                         <svg
                             aria-hidden="true"
                             viewBox="0 0 20 20"
@@ -229,58 +225,11 @@ export function CategoryItemGrid({
         )
     }
 
-    const renderCell = (row: GridRow, column: GridColumn, item: PackingListItem | undefined) => {
-        if (!item) {
-            // Flat, and it creates nothing when pressed — an "add one for them"
-            // button in every empty cell would ring each checkbox with taps that
-            // write data instead of ticking something off. But "Cara needs one
-            // too" is exactly the thought this cell provokes, and a dot that
-            // swallows the tap is worse than one that opens the panel where that
-            // can be said. Pointer only: the row's name button is the same door,
-            // and it is the one in the tab order.
-            return (
-                <button
-                    type="button"
-                    tabIndex={-1}
-                    aria-hidden="true"
-                    onClick={() => onOpenRow(row)}
-                    title={`${column.name} doesn't need this — open to change`}
-                    className="mx-auto flex h-9 w-9 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-blue-50 sm:h-10 sm:w-10"
-                >
-                    <span className="block h-1 w-1 rounded-full bg-gray-200" />
-                </button>
-            )
-        }
-        const packed = !!packedById[item.id]
-        const quantity = item.quantity !== undefined && item.quantity > 1 ? item.quantity : undefined
-        return (
-            <label
-                data-testid={`grid-cell-${item.id}`}
-                ref={(element) => registerCellRef(item.id, element)}
-                className={`relative mx-auto flex h-9 w-9 cursor-pointer items-center justify-center rounded-md transition-colors sm:h-10 sm:w-10 ${packed ? 'bg-emerald-100' : 'hover:bg-blue-50'} ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
-            >
-                <input
-                    type="checkbox"
-                    checked={packed}
-                    onChange={(e) => onToggleItem(item, e.target.checked)}
-                    aria-label={`${row.label} for ${column.name}`}
-                    className={`h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${packed ? 'accent-emerald-600' : ''}`}
-                />
-                {row.mixedQuantities && quantity && (
-                    <span className="pointer-events-none absolute -bottom-1 -right-1 rounded-full bg-blue-100 px-1 text-[10px] font-semibold text-blue-700">
-                        ×{quantity}
-                    </span>
-                )}
-                {renderFlourish(item)}
-            </label>
-        )
-    }
-
     /**
-     * One person's cell, wrapped: their own coloured disc, which is also the
-     * checkbox. Filled with a tick once it is packed, outlined and carrying
-     * their initial until then — so the colour says whose it is in both states,
-     * which is what makes a wrapped grid readable at a glance.
+     * One person's cell: their own coloured disc, which is also the checkbox.
+     * Filled with a tick once it is packed, outlined and carrying their initial
+     * until then — so the colour says whose it is in both states, which is what
+     * lets the grid do without a header.
      */
     const renderChip = (row: GridRow, column: GridColumn, item: PackingListItem) => {
         const packed = !!packedById[item.id]
@@ -317,8 +266,15 @@ export function CategoryItemGrid({
     }
 
     /**
-     * The same 36px of space, held empty. The chips only line up between one
-     * item and the next because nobody's place is ever skipped.
+     * The same 32px of space, held empty.
+     *
+     * The chips only line up between one item and the next because nobody's
+     * place is ever skipped. It creates nothing when pressed — an "add one for
+     * them" button in every gap would ring each chip with taps that write data
+     * instead of ticking something off — but "Cara needs one too" is exactly the
+     * thought a gap provokes, so it opens the panel where that can be said.
+     * Pointer only: the row's name button is the same door, and it is the one in
+     * the tab order.
      */
     const renderChipGap = (row: GridRow, column: GridColumn) => (
         <button
@@ -334,6 +290,7 @@ export function CategoryItemGrid({
         </button>
     )
 
+    /** An item nobody owns: one checkbox for the whole group, not one each. */
     const renderSharedChip = (row: GridRow) => {
         const item = row.items[0]
         const packed = !!packedById[item.id]
@@ -358,11 +315,18 @@ export function CategoryItemGrid({
 
     /**
      * Who is on the list, how far each of them has got, and a way to finish one
-     * of them off here. In the table this lives in the column headers; with the
-     * columns gone it is the only place the initials get decoded.
+     * of them off here.
+     *
+     * Not a legend the chips depend on — they carry their own colour and
+     * initial — so it can scroll away without taking the reading with it. What
+     * it is for is the progress, and the "I've just done all of Cara's
+     * toiletries" that used to live in a column header.
      */
     const renderPeopleStrip = () => (
-        <div className="mb-2 flex flex-wrap items-center gap-1 border-b border-gray-100 pb-2">
+        <div
+            data-testid="grid-people-legend"
+            className="mb-2 flex flex-wrap items-center gap-1 border-b border-gray-100 pb-2"
+        >
             {columns.map((column, index) => {
                 const { packed, total } = columnStats[index]
                 const done = total > 0 && packed === total
@@ -391,166 +355,45 @@ export function CategoryItemGrid({
         </div>
     )
 
-    const renderSharedCell = (row: GridRow) => {
-        const item = row.items[0]
-        const packed = !!packedById[item.id]
-        return (
-            <label
-                data-testid={`grid-cell-${item.id}`}
-                ref={(element) => registerCellRef(item.id, element)}
-                className={`relative inline-flex h-10 cursor-pointer items-center gap-2 rounded-md px-3 transition-colors ${packed ? 'bg-emerald-100' : 'bg-blue-50 hover:bg-blue-100'} ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
-            >
-                <input
-                    type="checkbox"
-                    checked={packed}
-                    onChange={(e) => onToggleItem(item, e.target.checked)}
-                    aria-label={`${row.label} for the whole group`}
-                    className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                />
-                <span className="whitespace-nowrap text-xs font-medium text-blue-800">
-                    👥{showColumnNames && ' For everyone'}
-                </span>
-                {renderFlourish(item)}
-            </label>
-        )
-    }
-
-    if (stacked) {
-        return (
-            <div ref={containerRef}>
-                {renderPeopleStrip()}
-                <ul className="divide-y divide-gray-100">
-                    {visibleRows.map(row => {
-                        const complete = rowComplete(row)
-                        return (
-                            <li
-                                key={row.key}
-                                data-testid="grid-row"
-                                className={`-mx-1 rounded-md px-1 py-1 transition-colors ${complete ? 'bg-emerald-50' : ''} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
-                            >
-                                {renderName(row, complete, 'py-1.5')}
-                                {/* Fixed-size chips in a fixed order, so person
-                                    five sits under person one on every item and
-                                    the wrap is still a grid to read down. */}
-                                <div role="group" aria-label={row.label} className="flex flex-wrap gap-1 pb-1 pl-1">
-                                    {row.communal
-                                        ? renderSharedChip(row)
-                                        : columns.map((column, index) => {
-                                            const item = row.cells[index]
-                                            return item
-                                                ? renderChip(row, column, item)
-                                                : renderChipGap(row, column)
-                                        })}
-                                </div>
-                            </li>
-                        )
-                    })}
-                </ul>
-            </div>
-        )
-    }
-
     return (
-        <div ref={containerRef} className="-mx-2 overflow-x-auto sm:-mx-1">
-            <table
-                className={`w-full border-collapse text-sm ${showColumnNames ? '' : 'table-fixed'}`}
-                style={showColumnNames
-                    ? undefined
-                    : { minWidth: `${NAME_COMFORT + columns.length * PHONE_COLUMN_WIDTH}px` }}
-            >
-                <caption className="sr-only">{sectionTitle}: what to pack, by person</caption>
-                {/* On a phone the people are told how much room they get and the
-                    name takes what is left, so a fifth person makes the names
-                    narrower instead of pushing the grid off the side of the
-                    screen. On a desktop there is room to let the names ask. */}
-                {!showColumnNames && (
-                    <colgroup>
-                        <col />
-                        {columns.map(column => (
-                            <col key={column.key} style={{ width: `${PHONE_COLUMN_WIDTH}px` }} />
-                        ))}
-                    </colgroup>
-                )}
-                <thead>
-                    <tr className={surfaceClass}>
-                        {/* Takes the slack, so the person columns stay as narrow
-                            as they need to be — which is what lets four of them
-                            fit beside an item name on a phone. */}
-                        <th scope="col" className="sticky left-0 z-20 w-full bg-inherit px-1 pb-2 text-left text-[11px] font-semibold uppercase tracking-wide text-gray-400">
-                            Item
-                        </th>
-                        {columns.map((column, index) => {
-                            const { packed, total } = columnStats[index]
-                            const done = total > 0 && packed === total
-                            return (
-                                <th key={column.key} scope="col" className="px-0 pb-2 align-bottom sm:px-2">
-                                    <span className="flex flex-col items-center gap-0.5">
-                                        <span className="flex items-center gap-1.5">
-                                            {!column.unassigned && (
-                                                <PersonAvatar
-                                                    name={column.name}
-                                                    color={personColor({ id: column.personId, name: column.name })}
-                                                    size="sm"
-                                                />
-                                            )}
-                                            {showColumnNames && (
-                                                <span className={`text-sm font-semibold ${done ? 'text-emerald-700' : 'text-gray-700'}`}>
-                                                    {column.name}
-                                                </span>
-                                            )}
-                                        </span>
-                                        {/* Persistent rather than revealed on hover:
-                                            "I've just done all of Cara's toiletries"
-                                            is how people pack, and a phone has no
-                                            hover to reveal it with. */}
-                                        <button
-                                            type="button"
-                                            onClick={() => onCheckColumn(column, index)}
-                                            disabled={done}
-                                            aria-label={`Check off everything left for ${column.name} in ${sectionTitle}`}
-                                            title={done ? `${column.name} is done here` : `Check off everything ${column.name} still has in ${sectionTitle}`}
-                                            className={`rounded-full px-1.5 text-[11px] font-medium tabular-nums transition-colors ${done ? 'text-emerald-600' : 'text-gray-400 hover:bg-blue-50 hover:text-blue-700'}`}
-                                        >
-                                            {packed}/{total}
-                                        </button>
-                                    </span>
-                                </th>
-                            )
-                        })}
-                    </tr>
-                </thead>
-                <tbody>
-                    {visibleRows.map(row => {
-                        const complete = rowComplete(row)
-                        return (
-                            <tr
-                                key={row.key}
-                                data-testid="grid-row"
-                                // An opaque background of its own, because the
-                                // name cell inherits it to sit over the columns
-                                // sliding underneath when the grid is wider than
-                                // the screen.
-                                className={`border-t border-gray-100 transition-colors ${complete ? 'bg-emerald-50' : `${surfaceClass} hover:bg-gray-50`} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
+        <div ref={containerRef}>
+            {renderPeopleStrip()}
+            <ul className="divide-y divide-gray-100">
+                {visibleRows.map(row => {
+                    const complete = rowComplete(row)
+                    return (
+                        <li
+                            key={row.key}
+                            data-testid="grid-row"
+                            className={`flex items-start gap-1 rounded-md transition-colors ${complete ? 'bg-emerald-50' : 'hover:bg-gray-50'} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
+                        >
+                            {/* Capped, so a wide card doesn't strand the chips
+                                an inch and a half from the name they belong to. */}
+                            <span className="min-w-0 flex-1" style={{ maxWidth: `${NAME_MAX_WIDTH}px` }}>
+                                {renderName(row, complete)}
+                            </span>
+                            {/* A block of the same width on every row, so a
+                                person keeps their place down the whole card
+                                however many lines the chips take. */}
+                            <div
+                                role="group"
+                                aria-label={row.label}
+                                className="flex shrink-0 flex-wrap gap-1 py-2"
+                                style={{ width: `${chipBlockWidth}px` }}
                             >
-                                <th scope="row" className="sticky left-0 z-10 bg-inherit px-1 py-1 text-left align-middle font-medium shadow-[2px_0_3px_-1px_rgba(15,23,42,0.08)] sm:shadow-none">
-                                    {renderName(row, complete)}
-                                </th>
-                                {row.communal ? (
-                                    <td colSpan={Math.max(columns.length, 1)} className="px-1 py-1 text-center align-middle sm:px-2">
-                                        {renderSharedCell(row)}
-                                    </td>
-                                ) : (
-                                    columns.map((column, index) => (
-                                        <td key={column.key} className="px-0 py-1 text-center align-middle sm:px-2">
-                                            {renderCell(row, column, row.cells[index])}
-                                        </td>
-                                    ))
-                                )}
-                            </tr>
-                        )
-                    })}
-                </tbody>
-            </table>
+                                {row.communal
+                                    ? renderSharedChip(row)
+                                    : columns.map((column, index) => {
+                                        const item = row.cells[index]
+                                        return item
+                                            ? renderChip(row, column, item)
+                                            : renderChipGap(row, column)
+                                    })}
+                            </div>
+                        </li>
+                    )
+                })}
+            </ul>
         </div>
     )
 }

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -8,11 +8,17 @@
  * hard. Here the name is written once and the people are read across it, and
  * the gaps in a column are as much of an answer as the ticks.
  *
- * One table on every screen rather than a table and a phone-shaped
- * substitute: wrapping the people into chips would put each person somewhere
- * different on every row, which is precisely the reading the grid exists to
- * make possible. What gives on a narrow screen is the *names* — the header
- * keeps the coloured initial and the card carries a legend — not the columns.
+ * Columns for as long as they fit. What gives on a narrow screen is first the
+ * column *names* — the header keeps the coloured initial and the card carries a
+ * legend — and then, once the people no longer fit beside a name worth reading,
+ * the columns themselves: the item moves to a line of its own and the people
+ * wrap underneath it as chips.
+ *
+ * Wrapping only works because a chip is a fixed size. Pills carrying names are
+ * all different widths, so they put each person somewhere different on every
+ * row and destroy the one reading the grid exists for; identical 36px discs
+ * wrap into a grid that happens to have more than one line, and person five is
+ * under person one on every single item.
  *
  * Three cell weights, because two of them would lie: a filled tick (packed),
  * an empty box (still to pack), and a flat dot (not for this person). With
@@ -23,6 +29,7 @@ import type { PackingListItem } from '../create-packing-list/types'
 import type { GridColumn, GridRow } from '../utils/categoryItemGrid'
 import type { PersonColorLookup } from '../hooks/usePersonColors'
 import { PersonAvatar } from './PersonAvatar'
+import { useMeasuredWidth } from '../hooks/useMeasuredWidth'
 
 export interface CategoryItemGridProps {
     /** Names the table for screen readers, e.g. "Toiletries". */
@@ -61,17 +68,28 @@ interface ColumnStat { packed: number; total: number }
 const PHONE_COLUMN_WIDTH = 40
 
 /**
- * How little room the names may be left with before the grid gives up on
- * fitting and scrolls instead.
+ * How much room the names need before the columns stop paying for themselves.
  *
- * At 390px a card has ~348px to spend, so six people (240px) still leave a
- * readable 108px of name. A seventh cannot be fitted at any width worth
- * reading, and squeezing the names to 28px to avoid a scrollbar would be
- * choosing the wrong thing to break — so past that the table keeps a wider
- * name column and scrolls sideways under a frozen first column.
+ * Not the least they can survive on — the least they are worth having. A
+ * column layout earns its extra density by keeping each item to one line; once
+ * the names are wrapping to three, the table is no shorter than chips under a
+ * full-width name and it is harder to read. At 390px a card has ~348px, so
+ * five people leave 148px of name and six leave 108px and start wrapping —
+ * which is where the item moves to a line of its own and the people wrap
+ * underneath it.
  */
-function nameFloor(peopleCount: number): number {
-    return peopleCount <= 6 ? 104 : 136
+const NAME_COMFORT = 132
+
+/**
+ * Whether the people still fit beside the names.
+ *
+ * `width` is 0 until the card has been measured (and wherever there is no
+ * ResizeObserver, which includes the tests), so the count alone decides until
+ * a real width arrives: five is what fits on the phone this was designed for.
+ */
+function columnsFit(peopleCount: number, width: number): boolean {
+    if (width === 0) return peopleCount <= 5
+    return NAME_COMFORT + peopleCount * PHONE_COLUMN_WIDTH <= width
 }
 
 /**
@@ -109,6 +127,11 @@ export function CategoryItemGrid({
     onOpenRow,
     onCheckColumn,
 }: CategoryItemGridProps) {
+    const { ref: containerRef, width } = useMeasuredWidth<HTMLDivElement>()
+    // Columns while they fit; chips under the name once they don't. Desktop
+    // always has the room, and its names in the header are worth keeping.
+    const stacked = !showColumnNames && !columnsFit(columns.length, width)
+
     const rowComplete = (row: GridRow) =>
         row.items.length > 0 && row.items.every(item => packedById[item.id])
 
@@ -152,6 +175,59 @@ export function CategoryItemGrid({
             )
             : null
     )
+
+    /**
+     * The item's name, and the way in to everything about the row that isn't
+     * ticking a box: renaming, quantities, and who it is for.
+     *
+     * Laid out as text rather than as a row of boxes, so the chevron follows the
+     * last word wherever the name wraps instead of floating at the edge of the
+     * column between two lines, belonging to neither. The padding is what makes
+     * a one-line row a 44px target.
+     */
+    const renderName = (row: GridRow, complete: boolean, padding = 'py-2.5') => {
+        const { head, lastWord } = splitLastWord(row.label)
+        return (
+            <button
+                type="button"
+                onClick={() => onOpenRow(row)}
+                aria-label={`Edit ${row.label}`}
+                title="Rename, quantities, and who needs it"
+                className={`group block w-full cursor-pointer rounded-md px-1 text-left transition-colors active:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${padding}`}
+            >
+                <span className={`break-words ${complete ? 'text-gray-400 line-through' : 'text-gray-800 group-hover:text-blue-800'}`}>
+                    {head && `${head} `}
+                    {/* The last word, the quantity and the chevron travel
+                        together, so the chevron is never left pointing at
+                        nothing from a line of its own. */}
+                    <span className="whitespace-nowrap">
+                        {lastWord}
+                        {row.quantity !== undefined && (
+                            <span className="ml-1.5 inline-block rounded-full bg-blue-100 px-1.5 py-0.5 align-middle text-xs font-semibold text-blue-700">
+                                ×{row.quantity}
+                            </span>
+                        )}
+                        {/* Points, which is the whole message: there is somewhere
+                            to go from here. Grey enough to stay behind the
+                            checkboxes, dark enough to be seen without hovering —
+                            which is all a phone ever gets. */}
+                        <svg
+                            aria-hidden="true"
+                            viewBox="0 0 20 20"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth={2.5}
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            className="ml-1.5 inline-block h-3.5 w-3.5 align-[-0.15em] text-gray-500 transition-transform group-hover:translate-x-0.5 group-hover:text-blue-600"
+                        >
+                            <path d="M7.5 4.5 13 10l-5.5 5.5" />
+                        </svg>
+                    </span>
+                </span>
+            </button>
+        )
+    }
 
     const renderCell = (row: GridRow, column: GridColumn, item: PackingListItem | undefined) => {
         if (!item) {
@@ -200,6 +276,121 @@ export function CategoryItemGrid({
         )
     }
 
+    /**
+     * One person's cell, wrapped: their own coloured disc, which is also the
+     * checkbox. Filled with a tick once it is packed, outlined and carrying
+     * their initial until then — so the colour says whose it is in both states,
+     * which is what makes a wrapped grid readable at a glance.
+     */
+    const renderChip = (row: GridRow, column: GridColumn, item: PackingListItem) => {
+        const packed = !!packedById[item.id]
+        const color = personColor({ id: column.personId, name: column.name })
+        const quantity = item.quantity !== undefined && item.quantity > 1 ? item.quantity : undefined
+        return (
+            <label
+                key={column.key}
+                data-testid={`grid-cell-${item.id}`}
+                ref={(element) => registerCellRef(item.id, element)}
+                title={`${row.label} for ${column.name}`}
+                className={`relative flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full text-xs font-bold transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 has-[:focus-visible]:ring-offset-1 ${
+                    packed ? color.avatar : `border-2 bg-white ${color.border} ${color.text}`
+                } ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
+            >
+                <input
+                    type="checkbox"
+                    checked={packed}
+                    onChange={(e) => onToggleItem(item, e.target.checked)}
+                    aria-label={`${row.label} for ${column.name}`}
+                    className="sr-only"
+                />
+                <span aria-hidden="true">
+                    {packed ? '✓' : (column.unassigned ? '?' : column.name.charAt(0).toUpperCase())}
+                </span>
+                {row.mixedQuantities && quantity && (
+                    <span className="pointer-events-none absolute -bottom-1 -right-1 rounded-full bg-blue-100 px-1 text-[10px] font-semibold text-blue-700">
+                        ×{quantity}
+                    </span>
+                )}
+                {renderFlourish(item)}
+            </label>
+        )
+    }
+
+    /**
+     * The same 36px of space, held empty. The chips only line up between one
+     * item and the next because nobody's place is ever skipped.
+     */
+    const renderChipGap = (row: GridRow, column: GridColumn) => (
+        <button
+            key={column.key}
+            type="button"
+            tabIndex={-1}
+            aria-hidden="true"
+            onClick={() => onOpenRow(row)}
+            title={`${column.name} doesn't need this — open to change`}
+            className="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-blue-50"
+        >
+            <span className="block h-1 w-1 rounded-full bg-gray-200" />
+        </button>
+    )
+
+    const renderSharedChip = (row: GridRow) => {
+        const item = row.items[0]
+        const packed = !!packedById[item.id]
+        return (
+            <label
+                data-testid={`grid-cell-${item.id}`}
+                ref={(element) => registerCellRef(item.id, element)}
+                className={`relative flex h-8 cursor-pointer items-center gap-2 rounded-full px-3 text-xs font-medium transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 ${packed ? 'bg-emerald-100 text-emerald-800' : 'bg-blue-50 text-blue-800 hover:bg-blue-100'} ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
+            >
+                <input
+                    type="checkbox"
+                    checked={packed}
+                    onChange={(e) => onToggleItem(item, e.target.checked)}
+                    aria-label={`${row.label} for the whole group`}
+                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="whitespace-nowrap">👥 Everyone</span>
+                {renderFlourish(item)}
+            </label>
+        )
+    }
+
+    /**
+     * Who is on the list, how far each of them has got, and a way to finish one
+     * of them off here. In the table this lives in the column headers; with the
+     * columns gone it is the only place the initials get decoded.
+     */
+    const renderPeopleStrip = () => (
+        <div className="mb-2 flex flex-wrap items-center gap-1 border-b border-gray-100 pb-2">
+            {columns.map((column, index) => {
+                const { packed, total } = columnStats[index]
+                const done = total > 0 && packed === total
+                return (
+                    <button
+                        key={column.key}
+                        type="button"
+                        onClick={() => onCheckColumn(column, index)}
+                        disabled={done || total === 0}
+                        aria-label={`Check off everything left for ${column.name} in ${sectionTitle}`}
+                        title={done ? `${column.name} is done here` : `Check off everything ${column.name} still has in ${sectionTitle}`}
+                        className={`flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[11px] font-medium transition-colors ${done ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-gray-200 text-gray-600 hover:bg-blue-50'}`}
+                    >
+                        {!column.unassigned && (
+                            <PersonAvatar
+                                name={column.name}
+                                color={personColor({ id: column.personId, name: column.name })}
+                                size="sm"
+                            />
+                        )}
+                        <span>{column.name}</span>
+                        <span className="tabular-nums text-gray-400">{packed}/{total}</span>
+                    </button>
+                )
+            })}
+        </div>
+    )
+
     const renderSharedCell = (row: GridRow) => {
         const item = row.items[0]
         const packed = !!packedById[item.id]
@@ -224,13 +415,48 @@ export function CategoryItemGrid({
         )
     }
 
+    if (stacked) {
+        return (
+            <div ref={containerRef}>
+                {renderPeopleStrip()}
+                <ul className="divide-y divide-gray-100">
+                    {visibleRows.map(row => {
+                        const complete = rowComplete(row)
+                        return (
+                            <li
+                                key={row.key}
+                                data-testid="grid-row"
+                                className={`-mx-1 rounded-md px-1 py-1 transition-colors ${complete ? 'bg-emerald-50' : ''} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
+                            >
+                                {renderName(row, complete, 'py-1.5')}
+                                {/* Fixed-size chips in a fixed order, so person
+                                    five sits under person one on every item and
+                                    the wrap is still a grid to read down. */}
+                                <div role="group" aria-label={row.label} className="flex flex-wrap gap-1 pb-1 pl-1">
+                                    {row.communal
+                                        ? renderSharedChip(row)
+                                        : columns.map((column, index) => {
+                                            const item = row.cells[index]
+                                            return item
+                                                ? renderChip(row, column, item)
+                                                : renderChipGap(row, column)
+                                        })}
+                                </div>
+                            </li>
+                        )
+                    })}
+                </ul>
+            </div>
+        )
+    }
+
     return (
-        <div className="-mx-2 overflow-x-auto sm:-mx-1">
+        <div ref={containerRef} className="-mx-2 overflow-x-auto sm:-mx-1">
             <table
                 className={`w-full border-collapse text-sm ${showColumnNames ? '' : 'table-fixed'}`}
                 style={showColumnNames
                     ? undefined
-                    : { minWidth: `${nameFloor(columns.length) + columns.length * PHONE_COLUMN_WIDTH}px` }}
+                    : { minWidth: `${NAME_COMFORT + columns.length * PHONE_COLUMN_WIDTH}px` }}
             >
                 <caption className="sr-only">{sectionTitle}: what to pack, by person</caption>
                 {/* On a phone the people are told how much room they get and the
@@ -296,7 +522,6 @@ export function CategoryItemGrid({
                 <tbody>
                     {visibleRows.map(row => {
                         const complete = rowComplete(row)
-                        const { head, lastWord } = splitLastWord(row.label)
                         return (
                             <tr
                                 key={row.key}
@@ -308,58 +533,7 @@ export function CategoryItemGrid({
                                 className={`border-t border-gray-100 transition-colors ${complete ? 'bg-emerald-50' : `${surfaceClass} hover:bg-gray-50`} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
                             >
                                 <th scope="row" className="sticky left-0 z-10 bg-inherit px-1 py-1 text-left align-middle font-medium shadow-[2px_0_3px_-1px_rgba(15,23,42,0.08)] sm:shadow-none">
-                                    {/* The name is the biggest target on the row,
-                                        so it is the way in to everything that
-                                        isn't ticking a box: renaming, quantities,
-                                        and who the item is for.
-
-                                        Laid out as text rather than as a row of
-                                        boxes, so the chevron follows the last word
-                                        wherever the name wraps instead of floating
-                                        at the edge of the column between two lines,
-                                        belonging to neither. The padding is what
-                                        makes a one-line row a 44px target. */}
-                                    <button
-                                        type="button"
-                                        onClick={() => onOpenRow(row)}
-                                        aria-label={`Edit ${row.label}`}
-                                        title="Rename, quantities, and who needs it"
-                                        className="group block w-full cursor-pointer rounded-md px-1 py-2.5 text-left transition-colors active:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
-                                    >
-                                        <span className={`break-words ${complete ? 'text-gray-400 line-through' : 'text-gray-800 group-hover:text-blue-800'}`}>
-                                            {head && `${head} `}
-                                            {/* The last word, the quantity and the
-                                                chevron travel together, so the chevron
-                                                is never left pointing at nothing from
-                                                a line of its own. */}
-                                            <span className="whitespace-nowrap">
-                                                {lastWord}
-                                                {row.quantity !== undefined && (
-                                                    <span className="ml-1.5 inline-block rounded-full bg-blue-100 px-1.5 py-0.5 align-middle text-xs font-semibold text-blue-700">
-                                                        ×{row.quantity}
-                                                    </span>
-                                                )}
-                                                {/* Points, which is the whole message:
-                                                    there is somewhere to go from here.
-                                                    Grey enough to stay behind the
-                                                    checkboxes, dark enough to be seen
-                                                    without hovering — which is all a
-                                                    phone ever gets. */}
-                                                <svg
-                                                    aria-hidden="true"
-                                                    viewBox="0 0 20 20"
-                                                    fill="none"
-                                                    stroke="currentColor"
-                                                    strokeWidth={2.5}
-                                                    strokeLinecap="round"
-                                                    strokeLinejoin="round"
-                                                    className="ml-1.5 inline-block h-3.5 w-3.5 align-[-0.15em] text-gray-500 transition-transform group-hover:translate-x-0.5 group-hover:text-blue-600"
-                                                >
-                                                    <path d="M7.5 4.5 13 10l-5.5 5.5" />
-                                                </svg>
-                                            </span>
-                                        </span>
-                                    </button>
+                                    {renderName(row, complete)}
                                 </th>
                                 {row.communal ? (
                                     <td colSpan={Math.max(columns.length, 1)} className="px-1 py-1 text-center align-middle sm:px-2">

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -49,6 +49,25 @@ export interface CategoryItemGridProps {
 
 interface ColumnStat { packed: number; total: number }
 
+/**
+ * The name, split so that its last word and the chevron can be held together.
+ *
+ * A line can break in front of an inline-block whether or not there is a space
+ * there, and neither `white-space: nowrap` on the button nor a non-breaking
+ * space in front of the chevron stops it — so on a phone any name that fills
+ * its line drops the chevron onto a line of its own, pointing at nothing. Only
+ * putting the two inside one `whitespace-nowrap` box holds them together.
+ *
+ * The cost is that the name is two text nodes, so `getByText('Water bottle')`
+ * will not find it — query the row by its button instead (`Edit Water bottle`).
+ */
+function splitLastWord(label: string): { head: string; lastWord: string } {
+    const parts = label.trim().split(/\s+/)
+    const lastWord = parts.pop() ?? ''
+    return { head: parts.join(' '), lastWord }
+}
+
+
 export function CategoryItemGrid({
     sectionTitle,
     columns,
@@ -110,13 +129,24 @@ export function CategoryItemGrid({
 
     const renderCell = (row: GridRow, column: GridColumn, item: PackingListItem | undefined) => {
         if (!item) {
-            // Flat and untouchable. An empty cell is the most common thing on
-            // the grid and the least worth pressing — putting an "add this for
-            // them" button in every one of them would surround each checkbox
-            // with taps that create data instead of ticking it off. Filling a
-            // gap in is a job for the row's panel, where it can be undone.
+            // Flat, and it creates nothing when pressed — an "add one for them"
+            // button in every empty cell would ring each checkbox with taps that
+            // write data instead of ticking something off. But "Cara needs one
+            // too" is exactly the thought this cell provokes, and a dot that
+            // swallows the tap is worse than one that opens the panel where that
+            // can be said. Pointer only: the row's name button is the same door,
+            // and it is the one in the tab order.
             return (
-                <span aria-hidden="true" className="mx-auto block h-1 w-1 rounded-full bg-gray-200" />
+                <button
+                    type="button"
+                    tabIndex={-1}
+                    aria-hidden="true"
+                    onClick={() => onOpenRow(row)}
+                    title={`${column.name} doesn't need this — open to change`}
+                    className="mx-auto flex h-10 w-10 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-blue-50"
+                >
+                    <span className="block h-1 w-1 rounded-full bg-gray-200" />
+                </button>
             )
         }
         const packed = !!packedById[item.id]
@@ -223,6 +253,7 @@ export function CategoryItemGrid({
                 <tbody>
                     {visibleRows.map(row => {
                         const complete = rowComplete(row)
+                        const { head, lastWord } = splitLastWord(row.label)
                         return (
                             <tr
                                 key={row.key}
@@ -233,30 +264,53 @@ export function CategoryItemGrid({
                                     {/* The name is the biggest target on the row,
                                         so it is the way in to everything that
                                         isn't ticking a box: renaming, quantities,
-                                        and who the item is for. */}
+                                        and who the item is for.
+
+                                        Laid out as text rather than as a row of
+                                        boxes, so the chevron follows the last word
+                                        wherever the name wraps instead of floating
+                                        at the edge of the column between two lines,
+                                        belonging to neither. The padding is what
+                                        makes a one-line row a 44px target. */}
                                     <button
                                         type="button"
                                         onClick={() => onOpenRow(row)}
-                                        aria-label={`${row.label} — who needs this?`}
-                                        title="Who needs this?"
-                                        className="group flex w-full items-center gap-1.5 rounded-md py-1.5 pr-2 text-left transition-colors hover:bg-blue-50"
+                                        aria-label={`Edit ${row.label}`}
+                                        title="Rename, quantities, and who needs it"
+                                        className="group block w-full cursor-pointer rounded-md px-1 py-2.5 text-left transition-colors active:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
                                     >
-                                        <span className={complete ? 'text-gray-400 line-through' : 'text-gray-800'}>
-                                            {row.label}
-                                        </span>
-                                        {row.quantity !== undefined && (
-                                            <span className="shrink-0 rounded-full bg-blue-100 px-1.5 py-0.5 text-xs font-semibold text-blue-700">
-                                                ×{row.quantity}
+                                        <span className={complete ? 'text-gray-400 line-through' : 'text-gray-800 group-hover:text-blue-800'}>
+                                            {head && `${head} `}
+                                            {/* The last word, the quantity and the
+                                                chevron travel together, so the chevron
+                                                is never left pointing at nothing from
+                                                a line of its own. */}
+                                            <span className="whitespace-nowrap">
+                                                {lastWord}
+                                                {row.quantity !== undefined && (
+                                                    <span className="ml-1.5 inline-block rounded-full bg-blue-100 px-1.5 py-0.5 align-middle text-xs font-semibold text-blue-700">
+                                                        ×{row.quantity}
+                                                    </span>
+                                                )}
+                                                {/* Points, which is the whole message:
+                                                    there is somewhere to go from here.
+                                                    Grey enough to stay behind the
+                                                    checkboxes, dark enough to be seen
+                                                    without hovering — which is all a
+                                                    phone ever gets. */}
+                                                <svg
+                                                    aria-hidden="true"
+                                                    viewBox="0 0 20 20"
+                                                    fill="none"
+                                                    stroke="currentColor"
+                                                    strokeWidth={2.5}
+                                                    strokeLinecap="round"
+                                                    strokeLinejoin="round"
+                                                    className="ml-1.5 inline-block h-3.5 w-3.5 align-[-0.15em] text-gray-500 transition-transform group-hover:translate-x-0.5 group-hover:text-blue-600"
+                                                >
+                                                    <path d="M7.5 4.5 13 10l-5.5 5.5" />
+                                                </svg>
                                             </span>
-                                        )}
-                                        {/* Sits with the name rather than out at
-                                            the far edge of the column, where it
-                                            would read as another cell. */}
-                                        <span
-                                            aria-hidden="true"
-                                            className="shrink-0 text-xs text-gray-300 transition-colors group-hover:text-blue-500"
-                                        >
-                                            ⋯
                                         </span>
                                     </button>
                                 </th>

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -15,6 +15,12 @@
  * to be any use, and the moment you scroll into a long category it isn't —
  * whereas identity that travels with the control can't scroll away from it.
  *
+ * Which initial is whose is written once, in the page's sticky strip, where it
+ * stays in view for every card. It is a key and nothing else: nothing in it can
+ * be pressed, because the only thing a key could plausibly *do* — pack
+ * everything of one person's — is nine items changed by one stray tap, with no
+ * undo. That job has a home in person view, on a button that says so.
+ *
  * Wrapping only works because a chip is a fixed size. Pills carrying names are
  * all different widths, so they put each person somewhere different on every
  * row and destroy the one reading the grid exists for; identical 32px discs sit
@@ -31,12 +37,9 @@
 import type { PackingListItem } from '../create-packing-list/types'
 import type { GridColumn, GridRow } from '../utils/categoryItemGrid'
 import type { PersonColorLookup } from '../hooks/usePersonColors'
-import { PersonAvatar } from './PersonAvatar'
 import { useMeasuredWidth } from '../hooks/useMeasuredWidth'
 
 export interface CategoryItemGridProps {
-    /** Names the grid for screen readers, e.g. "Toiletries". */
-    sectionTitle: string
     columns: readonly GridColumn[]
     rows: readonly GridRow[]
     personColor: PersonColorLookup
@@ -52,10 +55,7 @@ export interface CategoryItemGridProps {
     registerCellRef: (itemId: string, element: HTMLElement | null) => void
     /** Opens the row's "who needs this?" panel — rename, quantities, who it is for. */
     onOpenRow: (row: GridRow) => void
-    onCheckColumn: (column: GridColumn, columnIndex: number) => void
 }
-
-interface ColumnStat { packed: number; total: number }
 
 /** A 32px disc and the 4px after it. */
 const CHIP_PITCH = 36
@@ -110,7 +110,6 @@ function splitLastWord(label: string): { head: string; lastWord: string } {
 }
 
 export function CategoryItemGrid({
-    sectionTitle,
     columns,
     rows,
     personColor,
@@ -121,7 +120,6 @@ export function CategoryItemGrid({
     onToggleItem,
     registerCellRef,
     onOpenRow,
-    onCheckColumn,
 }: CategoryItemGridProps) {
     const { ref: containerRef, width } = useMeasuredWidth<HTMLDivElement>()
 
@@ -138,21 +136,6 @@ export function CategoryItemGrid({
     if (visibleRows.length === 0) {
         return <p className="text-sm font-medium text-emerald-700">Nothing left to pack 🎒</p>
     }
-
-    // Counted over every item in the category rather than the visible rows: with
-    // packed items hidden, "1" beside a person two thirds done reads as a person
-    // who has barely started.
-    const columnStats: ColumnStat[] = columns.map((_column, index) => {
-        let packed = 0
-        let total = 0
-        for (const row of rows) {
-            const item = row.cells[index]
-            if (!item) continue
-            total++
-            if (packedById[item.id]) packed++
-        }
-        return { packed, total }
-    })
 
     // One width for every row in the card, so the chips land in the same places
     // on all of them — which is the whole of what makes this a grid.
@@ -313,51 +296,8 @@ export function CategoryItemGrid({
         )
     }
 
-    /**
-     * Who is on the list, how far each of them has got, and a way to finish one
-     * of them off here.
-     *
-     * Not a legend the chips depend on — they carry their own colour and
-     * initial — so it can scroll away without taking the reading with it. What
-     * it is for is the progress, and the "I've just done all of Cara's
-     * toiletries" that used to live in a column header.
-     */
-    const renderPeopleStrip = () => (
-        <div
-            data-testid="grid-people-legend"
-            className="mb-2 flex flex-wrap items-center gap-1 border-b border-gray-100 pb-2"
-        >
-            {columns.map((column, index) => {
-                const { packed, total } = columnStats[index]
-                const done = total > 0 && packed === total
-                return (
-                    <button
-                        key={column.key}
-                        type="button"
-                        onClick={() => onCheckColumn(column, index)}
-                        disabled={done || total === 0}
-                        aria-label={`Check off everything left for ${column.name} in ${sectionTitle}`}
-                        title={done ? `${column.name} is done here` : `Check off everything ${column.name} still has in ${sectionTitle}`}
-                        className={`flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[11px] font-medium transition-colors ${done ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-gray-200 text-gray-600 hover:bg-blue-50'}`}
-                    >
-                        {!column.unassigned && (
-                            <PersonAvatar
-                                name={column.name}
-                                color={personColor({ id: column.personId, name: column.name })}
-                                size="sm"
-                            />
-                        )}
-                        <span>{column.name}</span>
-                        <span className="tabular-nums text-gray-400">{packed}/{total}</span>
-                    </button>
-                )
-            })}
-        </div>
-    )
-
     return (
         <div ref={containerRef}>
-            {renderPeopleStrip()}
             <ul className="divide-y divide-gray-100">
                 {visibleRows.map(row => {
                     const complete = rowComplete(row)

--- a/src/components/ItemRowPanel.tsx
+++ b/src/components/ItemRowPanel.tsx
@@ -1,0 +1,243 @@
+/**
+ * "Who needs this?" — everything about one row of the category grid that isn't
+ * ticking a box.
+ *
+ * The grid answers a question by being read; this is where it gets *changed*.
+ * Adding an item for someone, taking it off their list, giving one person three
+ * of them and another one, marking somebody's charger as a last-minute job:
+ * each of those is per-person, and none of them belongs in a cell the user is
+ * aiming a thumb at to tick something off. Putting them together behind the
+ * item's name means one affordance instead of a hover control the phone can't
+ * reach and a mode the desktop has to be taught.
+ *
+ * Checking a person on and off is the same gesture in both directions: on adds
+ * them a copy, off takes theirs away. The name, alone among these, belongs to
+ * every copy at once — the same item spelled two ways is a bug, not a feature —
+ * so renaming says so and applies to the row.
+ */
+import { useEffect, useState } from 'react'
+import { Modal } from './Modal'
+import { PersonAvatar } from './PersonAvatar'
+import type { PackingListItem } from '../create-packing-list/types'
+import type { GridColumn, GridRow } from '../utils/categoryItemGrid'
+import type { PersonColorLookup } from '../hooks/usePersonColors'
+
+export interface ItemRowPanelProps {
+    isOpen: boolean
+    onClose: () => void
+    /** The row being looked at; null between openings. */
+    row: GridRow | null
+    /** Everyone on the list, so somebody with nothing here can still be given one. */
+    columns: readonly GridColumn[]
+    /** Where the item lives, shown under its name. */
+    sectionTitle: string
+    personColor: PersonColorLookup
+    packedById: Record<string, boolean>
+    /** Applies to every copy on the row. */
+    onRename: (row: GridRow, text: string) => void
+    onSetQuantity: (item: PackingListItem, quantity: number | undefined) => void
+    onToggleLastMinute: (item: PackingListItem) => void
+    onAddFor: (row: GridRow, column: GridColumn) => void
+    onRemove: (item: PackingListItem) => void
+    onDeleteRow: (row: GridRow) => void
+}
+
+export function ItemRowPanel({
+    isOpen,
+    onClose,
+    row,
+    columns,
+    sectionTitle,
+    personColor,
+    packedById,
+    onRename,
+    onSetQuantity,
+    onToggleLastMinute,
+    onAddFor,
+    onRemove,
+    onDeleteRow,
+}: ItemRowPanelProps) {
+    const [draftName, setDraftName] = useState('')
+
+    // The row object is rebuilt on every save — a new quantity, a person added —
+    // so the draft follows the row's identity rather than the row itself, or
+    // typing a name would be undone by the first change made underneath it.
+    useEffect(() => {
+        if (row) setDraftName(row.label)
+    }, [row?.key, isOpen]) // eslint-disable-line react-hooks/exhaustive-deps -- the label is a starting value, not a binding
+
+    if (!isOpen || !row) return null
+
+    const commitName = () => {
+        const trimmed = draftName.trim()
+        if (!trimmed || trimmed === row.label) {
+            setDraftName(row.label)
+            return
+        }
+        onRename(row, trimmed)
+    }
+
+    const renderItemControls = (item: PackingListItem, who: string) => (
+        <>
+            <QuantityField
+                key={`${item.id}-${item.quantity ?? ''}`}
+                item={item}
+                label={`Quantity for ${who}`}
+                onCommit={(quantity) => onSetQuantity(item, quantity)}
+            />
+            <button
+                type="button"
+                onClick={() => onToggleLastMinute(item)}
+                aria-pressed={item.lastMinute === true}
+                aria-label={item.lastMinute
+                    ? `Pack ${who}'s ${row.label} with everything else`
+                    : `Mark ${who}'s ${row.label} as a last minute item`}
+                title={item.lastMinute
+                    ? 'Packed with everything else after all'
+                    : "Can't be packed until just before you go"}
+                className={`rounded-md p-1.5 transition-colors hover:bg-amber-50 hover:text-amber-600 ${item.lastMinute ? 'text-amber-600' : 'text-gray-400'}`}
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.5 2.5a1 1 0 101.414-1.414L11 9.586V6z" clipRule="evenodd" />
+                </svg>
+            </button>
+        </>
+    )
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title="Who needs this?">
+            <div className="space-y-4">
+                <div>
+                    <label htmlFor="item-row-name" className="block text-sm font-medium text-gray-700">
+                        Item
+                    </label>
+                    <input
+                        id="item-row-name"
+                        type="text"
+                        value={draftName}
+                        onChange={(e) => setDraftName(e.target.value)}
+                        onBlur={commitName}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') { e.preventDefault(); commitName() }
+                            if (e.key === 'Escape') { e.preventDefault(); setDraftName(row.label) }
+                        }}
+                        className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    <p className="mt-1 text-xs text-gray-500">
+                        In {sectionTitle}
+                        {row.items.length > 1 && ' · renaming changes it for everyone below'}
+                    </p>
+                </div>
+
+                {row.communal ? (
+                    <div className="flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2">
+                        <span aria-hidden="true">👥</span>
+                        <span className="flex-1 text-sm font-medium text-blue-900">
+                            Everyone — packed once for the whole group
+                        </span>
+                        {renderItemControls(row.items[0], 'the group')}
+                    </div>
+                ) : (
+                    <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200">
+                        {columns.map((column, index) => {
+                            const item = row.cells[index]
+                            const packed = item !== undefined && packedById[item.id]
+                            return (
+                                <li key={column.key} className="flex items-center gap-2 px-3 py-2">
+                                    <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
+                                        <input
+                                            type="checkbox"
+                                            checked={item !== undefined}
+                                            onChange={(e) => {
+                                                if (e.target.checked) onAddFor(row, column)
+                                                else if (item) onRemove(item)
+                                            }}
+                                            // Not "Toothbrush for Alice" — that
+                                            // is the grid cell, which packs it.
+                                            // This one decides whether she has
+                                            // one at all.
+                                            aria-label={`${column.name} needs ${row.label}`}
+                                            className="h-5 w-5 shrink-0 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                                        />
+                                        {!column.unassigned && (
+                                            <PersonAvatar
+                                                name={column.name}
+                                                color={personColor({ id: column.personId, name: column.name })}
+                                                size="sm"
+                                            />
+                                        )}
+                                        <span className={`truncate text-sm font-medium ${item ? 'text-gray-800' : 'text-gray-400'}`}>
+                                            {column.name}
+                                        </span>
+                                        {packed && (
+                                            <span className="shrink-0 rounded-full bg-emerald-100 px-1.5 py-0.5 text-[11px] font-medium text-emerald-700">
+                                                packed
+                                            </span>
+                                        )}
+                                    </label>
+                                    {item && renderItemControls(item, column.name)}
+                                </li>
+                            )
+                        })}
+                    </ul>
+                )}
+
+                <div className="flex justify-between gap-2 pt-1">
+                    <button
+                        type="button"
+                        onClick={() => onDeleteRow(row)}
+                        className="rounded-md px-3 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50"
+                    >
+                        {row.items.length > 1 ? `Remove for all ${row.items.length}` : 'Remove item'}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                    >
+                        Done
+                    </button>
+                </div>
+            </div>
+        </Modal>
+    )
+}
+
+/**
+ * How many of a thing one person is packing. Committed on blur or Enter rather
+ * than on every keystroke: each save is a write to the pod, and "12" typed a
+ * digit at a time would be two of them.
+ */
+function QuantityField({ item, label, onCommit }: {
+    item: PackingListItem
+    label: string
+    onCommit: (quantity: number | undefined) => void
+}) {
+    const [draft, setDraft] = useState(item.quantity !== undefined ? String(item.quantity) : '')
+
+    const commit = () => {
+        const parsed = parseInt(draft, 10)
+        const quantity = Number.isFinite(parsed) && parsed > 1 ? parsed : undefined
+        // A quantity of one is what no quantity already means, so both settle
+        // the field back to empty rather than leaving a "1" that means nothing.
+        setDraft(quantity !== undefined ? String(quantity) : '')
+        if (quantity !== item.quantity) onCommit(quantity)
+    }
+
+    return (
+        <input
+            type="number"
+            min={1}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur() }
+            }}
+            placeholder="Qty"
+            aria-label={label}
+            title="How many to pack (leave blank for one)"
+            className="w-14 shrink-0 rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+    )
+}

--- a/src/components/ItemRowPanel.tsx
+++ b/src/components/ItemRowPanel.tsx
@@ -105,11 +105,20 @@ export function ItemRowPanel({
     )
 
     return (
-        <Modal isOpen={isOpen} onClose={onClose} title="Who needs this?">
-            <div className="space-y-4">
+        // Titled by the item, and told plainly what is in here. Someone who
+        // opens this once by accident should come away knowing where renaming,
+        // quantities and deleting live — that one accident is the cheapest
+        // lesson the grid will ever get to teach.
+        <Modal isOpen={isOpen} onClose={onClose} title={row.label}>
+            {/* The modal centres its content on a phone, which is right for a
+                message and wrong for a form. */}
+            <div className="space-y-4 text-left">
+                <p className="-mt-2 text-sm text-gray-500">
+                    In {sectionTitle} · rename it, choose who needs one and how many, or remove it.
+                </p>
                 <div>
                     <label htmlFor="item-row-name" className="block text-sm font-medium text-gray-700">
-                        Item
+                        Name
                     </label>
                     <input
                         id="item-row-name"
@@ -123,10 +132,11 @@ export function ItemRowPanel({
                         }}
                         className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     />
-                    <p className="mt-1 text-xs text-gray-500">
-                        In {sectionTitle}
-                        {row.items.length > 1 && ' · renaming changes it for everyone below'}
-                    </p>
+                    {row.items.length > 1 && (
+                        <p className="mt-1 text-xs text-gray-500">
+                            Renaming changes it for everyone below
+                        </p>
+                    )}
                 </div>
 
                 {row.communal ? (

--- a/src/hooks/useMeasuredWidth.ts
+++ b/src/hooks/useMeasuredWidth.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * How wide an element actually is, watched.
+ *
+ * Used where a layout decision depends on the room available rather than on
+ * the screen size: a card in a two-up desktop grid and a card on a phone are
+ * different widths at the same breakpoint, and rotating a phone changes the
+ * answer without changing anything a media query can see.
+ *
+ * Reports 0 until it has measured (and where there is no ResizeObserver, such
+ * as in tests), so callers need a sensible answer for "not known yet".
+ */
+export function useMeasuredWidth<T extends HTMLElement>() {
+    const ref = useRef<T | null>(null)
+    const [width, setWidth] = useState(0)
+
+    useEffect(() => {
+        const element = ref.current
+        if (!element) return
+        const measure = () => setWidth(element.clientWidth)
+        measure()
+        if (typeof ResizeObserver === 'undefined') return
+        const observer = new ResizeObserver(measure)
+        observer.observe(element)
+        return () => observer.disconnect()
+    }, [])
+
+    return { ref, width }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -297,6 +297,37 @@ body {
   animation: item-packed-tick 0.45s ease-out;
 }
 
+/* ── Category view's item x person grid ─────────────────────────────────────
+   The grid's rewards are the same as the list's, moved from a row to a cell:
+   the swell happens where the finger landed rather than across the whole row,
+   which at grid density is the difference between "that one" and "one of
+   those". Kept in step with ITEM_FLOURISH_MS. */
+@keyframes grid-cell-packed {
+  0% { transform: scale(1); background-color: transparent; }
+  30% { transform: scale(1.06); background-color: rgb(220 252 231); }
+  70% { transform: scale(1); background-color: rgb(220 252 231); }
+  100% { transform: scale(1); background-color: transparent; }
+}
+
+.grid-cell-packed {
+  animation: grid-cell-packed 0.45s ease-out;
+}
+
+/* With packed items hidden a finished row has to go, but not before the tick
+   that finished it has been seen — so it fades rather than blinking out from
+   under the finger. Opacity only: a table row is not a box you can move or
+   clip, and transforming one is a different shape in every browser. Kept in
+   step with ITEM_FLOURISH_MS. */
+@keyframes grid-row-leaving {
+  0% { opacity: 1; }
+  60% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+.grid-row-leaving {
+  animation: grid-row-leaving 0.45s ease-in forwards;
+}
+
 /* Celebrations and waiting states are decorative — hold still for anyone who
    asked us to. */
 @media (prefers-reduced-motion: reduce) {
@@ -338,8 +369,15 @@ body {
   /* The check-off flourish is pure decoration. The component skips rendering the
      tick entirely in this mode; this is the belt to that pair of braces. */
   .item-row-packed,
-  .item-packed-tick {
+  .item-packed-tick,
+  .grid-cell-packed {
     animation: none;
+  }
+
+  /* The row still has to leave — it just doesn't make a show of going */
+  .grid-row-leaving {
+    animation: none;
+    opacity: 0;
   }
 }
 

--- a/src/pages/view-packing-list.person-colors.test.tsx
+++ b/src/pages/view-packing-list.person-colors.test.tsx
@@ -135,10 +135,11 @@ describe('ViewPackingList person colours', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
 
-        // Everyone is marked the same way here as on their own card
-        const bob = (await screen.findAllByRole('button', { name: /everything left for Bob/i }))[0]
+        // Everyone is marked the same way in the key as on their own card
+        const key = within(await screen.findByTestId('people-key'))
+        const bob = key.getByText('Bob').closest('span')!
         await waitFor(() => expect(within(bob).getByTestId('person-avatar').className).toContain(pink.avatar))
-        const alice = screen.getAllByRole('button', { name: /everything left for Alice/i })[0]
+        const alice = key.getByText('Alice').closest('span')!
         expect(within(alice).getByTestId('person-avatar').className).toContain(personColorAt(0).avatar)
     })
 

--- a/src/pages/view-packing-list.person-colors.test.tsx
+++ b/src/pages/view-packing-list.person-colors.test.tsx
@@ -129,17 +129,17 @@ describe('ViewPackingList person colours', () => {
             .not.toContain(pink.avatar)
     })
 
-    it('carries the colours into the category grid\'s columns', async () => {
+    it('carries the colours into the category grid', async () => {
         renderList()
         await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
 
         fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
 
-        // Each column is headed by the same mark that person's card carries
-        const bobColumn = (await screen.findAllByRole('columnheader', { name: /Bob/ }))[0]
-        await waitFor(() => expect(within(bobColumn).getByTestId('person-avatar').className).toContain(pink.avatar))
-        const aliceColumn = screen.getAllByRole('columnheader', { name: /Alice/ })[0]
-        expect(within(aliceColumn).getByTestId('person-avatar').className).toContain(personColorAt(0).avatar)
+        // Everyone is marked the same way here as on their own card
+        const bob = (await screen.findAllByRole('button', { name: /everything left for Bob/i }))[0]
+        await waitFor(() => expect(within(bob).getByTestId('person-avatar').className).toContain(pink.avatar))
+        const alice = screen.getAllByRole('button', { name: /everything left for Alice/i })[0]
+        expect(within(alice).getByTestId('person-avatar').className).toContain(personColorAt(0).avatar)
     })
 
     it('leaves the shared card unmarked — it belongs to nobody in particular', async () => {

--- a/src/pages/view-packing-list.person-colors.test.tsx
+++ b/src/pages/view-packing-list.person-colors.test.tsx
@@ -129,17 +129,17 @@ describe('ViewPackingList person colours', () => {
             .not.toContain(pink.avatar)
     })
 
-    it('carries the colours into the section-grouped view', async () => {
+    it('carries the colours into the category grid\'s columns', async () => {
         renderList()
         await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
 
-        fireEvent.click(screen.getByRole('button', { name: 'Question View' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
 
-        // Each person's group inside a section card is marked the same way
-        const bobGroup = await screen.findByRole('button', { name: /Collapse Bob/ })
-        await waitFor(() => expect(within(bobGroup).getByTestId('person-avatar').className).toContain(pink.avatar))
-        const aliceGroup = screen.getByRole('button', { name: /Collapse Alice/ })
-        expect(within(aliceGroup).getByTestId('person-avatar').className).toContain(personColorAt(0).avatar)
+        // Each column is headed by the same mark that person's card carries
+        const bobColumn = (await screen.findAllByRole('columnheader', { name: /Bob/ }))[0]
+        await waitFor(() => expect(within(bobColumn).getByTestId('person-avatar').className).toContain(pink.avatar))
+        const aliceColumn = screen.getAllByRole('columnheader', { name: /Alice/ })[0]
+        expect(within(aliceColumn).getByTestId('person-avatar').className).toContain(personColorAt(0).avatar)
     })
 
     it('leaves the shared card unmarked — it belongs to nobody in particular', async () => {

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -372,21 +372,24 @@ describe('ViewPackingList person/category view toggle', () => {
         expect(screen.getByText('Nappies')).toBeTruthy()
     })
 
-    it('writes each item once, with a column of checkboxes for the people', async () => {
+    it('writes each item once, with a chip per person', async () => {
         renderComponentMultiCategory()
         await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
 
         fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
 
-        // Every card carries the same columns, in the same places, whoever has
+        // Every card names the same people, in the same order, whoever has
         // something in it — the grid is only readable if a person stays put.
         const essentials = screen.getAllByTestId('list-section')[0]
-        expect(within(essentials).getAllByRole('columnheader').map(header => header.textContent))
-            .toEqual(['Item', expect.stringContaining('Alice'), expect.stringContaining('Bob')])
+        expect(within(within(essentials).getByTestId('grid-people-legend'))
+            .getAllByRole('button')
+            .map(person => person.textContent))
+            .toEqual([expect.stringContaining('Alice'), expect.stringContaining('Bob')])
 
-        // Toothbrush is Alice's alone: she has a checkbox, Bob has a gap
+        // Toothbrush is Alice's alone: she has a chip, Bob has a gap
         expect(within(essentials).getByRole('checkbox', { name: 'Toothbrush for Alice' })).toBeTruthy()
         expect(within(essentials).queryByRole('checkbox', { name: 'Toothbrush for Bob' })).toBeNull()
+        expect(within(essentials).getByTitle("Bob doesn't need this — open to change")).toBeTruthy()
         expect(within(essentials).getByRole('checkbox', { name: 'Nappies for Bob' })).toBeTruthy()
     })
 
@@ -652,7 +655,7 @@ describe('ViewPackingList category grid', () => {
         })
     })
 
-    it('gives the unassigned items a column of their own, last', async () => {
+    it('gives the unassigned items a place of their own, last', async () => {
         await renderGrid({
             ...gridList,
             items: [
@@ -661,8 +664,14 @@ describe('ViewPackingList category grid', () => {
             ],
         })
 
-        expect(screen.getAllByRole('columnheader').map(header => header.textContent))
-            .toEqual(['Item', expect.stringContaining('Alice'), expect.stringContaining('Bob'), expect.stringContaining('Unassigned')])
+        expect(within(screen.getByTestId('grid-people-legend'))
+            .getAllByRole('button')
+            .map(person => person.textContent))
+            .toEqual([
+                expect.stringContaining('Alice'),
+                expect.stringContaining('Bob'),
+                expect.stringContaining('Unassigned'),
+            ])
         expect(checkbox('Torch for Unassigned')).toBeTruthy()
     })
 
@@ -755,7 +764,7 @@ describe('ViewPackingList category grid', () => {
         })
     })
 
-    describe('on a phone', () => {
+    describe('however wide the screen', () => {
         beforeEach(() => {
             vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
                 // Narrower than the sm breakpoint, and no reduced-motion preference
@@ -770,11 +779,11 @@ describe('ViewPackingList category grid', () => {
             }) as unknown as MediaQueryList)
         })
 
-        it('keeps the columns and drops the names, decoding them once in a legend', async () => {
+        it('names everyone in the strip, since the chips themselves carry initials', async () => {
             await renderGrid()
 
-            // The checkboxes still name their person, so nothing is lost to a
-            // screen reader by the header being an initial
+            // The chips still name their person, so nothing is lost to a screen
+            // reader by their showing an initial
             expect(checkbox('Toothbrush for Alice')).toBeTruthy()
             const legend = within(screen.getByTestId('grid-people-legend'))
             expect(legend.getByText('Alice')).toBeTruthy()
@@ -2067,7 +2076,7 @@ describe('ViewPackingList shared (communal) items in category view', () => {
         // No column belongs to it, and it comes first — the shared card's place
         // in person view, kept
         expect(camping.getAllByTestId('grid-row')[0].textContent).toContain('Tent')
-        expect(camping.getByText('👥 For everyone')).toBeTruthy()
+        expect(camping.getByText('👥 Everyone')).toBeTruthy()
     })
 
     it('counts shared items in the section total', async () => {

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -326,7 +326,7 @@ describe('ViewPackingList category grouping', () => {
     })
 })
 
-describe('ViewPackingList person/question view toggle', () => {
+describe('ViewPackingList person/category view toggle', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({
             isLoggedIn: false,
@@ -357,35 +357,340 @@ describe('ViewPackingList person/question view toggle', () => {
         expect(screen.getByText("Bob's Items")).toBeTruthy()
     })
 
-    it('switches to question view, showing category section titles grouped by person within', async () => {
+    it('switches to category view, showing category section titles', async () => {
         renderComponentMultiCategory()
         await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
 
-        fireEvent.click(screen.getByRole('button', { name: 'Question View' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
 
         // Top-level sections are now categories, not people
         expect(screen.queryByText("Alice's Items")).toBeNull()
         expect(screen.queryByText("Bob's Items")).toBeNull()
         expect(screen.getAllByText('Essentials').length).toBeGreaterThan(0)
         expect(screen.getByText('Hiking')).toBeTruthy()
-
-        // Within each category, items are grouped by person
-        expect(screen.getAllByRole('button', { name: /Collapse Alice/i }).length).toBeGreaterThan(0)
-        expect(screen.getByRole('button', { name: /Collapse Bob/i })).toBeTruthy()
         expect(screen.getByText('Toothbrush')).toBeTruthy()
         expect(screen.getByText('Nappies')).toBeTruthy()
+    })
+
+    it('writes each item once, with a column of checkboxes for the people', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
+
+        // Every card carries the same columns, in the same places, whoever has
+        // something in it — the grid is only readable if a person stays put.
+        const essentials = screen.getAllByTestId('list-section')[0]
+        expect(within(essentials).getAllByRole('columnheader').map(header => header.textContent))
+            .toEqual(['Item', expect.stringContaining('Alice'), expect.stringContaining('Bob')])
+
+        // Toothbrush is Alice's alone: she has a checkbox, Bob has a gap
+        expect(within(essentials).getByRole('checkbox', { name: 'Toothbrush for Alice' })).toBeTruthy()
+        expect(within(essentials).queryByRole('checkbox', { name: 'Toothbrush for Bob' })).toBeNull()
+        expect(within(essentials).getByRole('checkbox', { name: 'Nappies for Bob' })).toBeTruthy()
+    })
+
+    it('packs an item from its cell', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
+
+        const cell = screen.getByRole('checkbox', { name: 'Toothbrush for Alice' }) as HTMLInputElement
+        fireEvent.click(cell)
+
+        await waitFor(() => expect(
+            (screen.getByRole('checkbox', { name: 'Toothbrush for Alice' }) as HTMLInputElement).checked,
+        ).toBe(true))
+    })
+
+    it('checks off everything one person has left in a category', async () => {
+        renderComponentMultiCategory()
+        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
+
+        fireEvent.click(screen.getByRole('button', { name: /Check off everything left for Alice in Essentials/i }))
+
+        // Alice's row is done, so with packed items hidden it goes; Bob's stays
+        await waitFor(() => expect(screen.queryByRole('checkbox', { name: 'Toothbrush for Alice' })).toBeNull())
+        expect((screen.getByRole('checkbox', { name: 'Nappies for Bob' }) as HTMLInputElement).checked).toBe(false)
     })
 
     it('switches back to person view', async () => {
         renderComponentMultiCategory()
         await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
 
-        fireEvent.click(screen.getByRole('button', { name: 'Question View' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
         await waitFor(() => expect(screen.getByText('Hiking')).toBeTruthy())
 
         fireEvent.click(screen.getByRole('button', { name: 'Person View' }))
         expect(screen.getByText("Alice's Items")).toBeTruthy()
         expect(screen.getByText("Bob's Items")).toBeTruthy()
+    })
+})
+
+// ─── The category grid: an item down the side, the people across the top ────
+
+describe('ViewPackingList category grid', () => {
+    // Alice and Bob both need a toothbrush; only Bob has nappies. One name, two
+    // people, is the whole reason the grid exists.
+    const gridList = {
+        id: 'test-list-grid',
+        name: 'Grid Trip',
+        createdAt: '2026-01-01T00:00:00Z',
+        items: [
+            { id: 'tb-a', itemText: 'Toothbrush', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', packed: false, category: 'Essentials', order: 0 },
+            { id: 'tb-b', itemText: 'Toothbrush', personName: 'Bob', personId: 'p2', questionId: 'q1', optionId: 'o1', packed: false, category: 'Essentials', order: 0 },
+            { id: 'np-b', itemText: 'Nappies', personName: 'Bob', personId: 'p2', questionId: 'q1', optionId: 'o1', packed: false, category: 'Essentials', order: 1 },
+        ],
+    }
+
+    let db: { getPackingList: ReturnType<typeof vi.fn>; savePackingList: ReturnType<typeof vi.fn> }
+
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn(),
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    async function renderGrid(list: typeof gridList = gridList) {
+        db = {
+            getPackingList: vi.fn().mockResolvedValue(list),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+        }
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        render(
+            <MemoryRouter initialEntries={[`/view-list/${list.id}`]}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+        await waitFor(() => expect(screen.getAllByText('Toothbrush').length).toBeGreaterThan(0))
+        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
+    }
+
+    function checkbox(name: string): HTMLInputElement {
+        return screen.getByRole('checkbox', { name }) as HTMLInputElement
+    }
+
+    async function savedList() {
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        return db.savePackingList.mock.calls.at(-1)![0] as { items: PackingListItem[]; deletedItems?: PackingListItem[] }
+    }
+
+    it('writes a name shared by two people once, with a checkbox each', async () => {
+        await renderGrid()
+
+        expect(screen.getAllByText('Toothbrush')).toHaveLength(1)
+        expect(checkbox('Toothbrush for Alice')).toBeTruthy()
+        expect(checkbox('Toothbrush for Bob')).toBeTruthy()
+    })
+
+    describe('hiding packed items', () => {
+        it('keeps a half-packed row, so a packed cell never reads as one nobody needs', async () => {
+            await renderGrid()
+
+            fireEvent.click(checkbox('Toothbrush for Alice'))
+
+            // The row stays whole: Alice's cell is ticked and still on screen,
+            // where an empty cell would have said "Alice doesn't need one".
+            await waitFor(() => expect(checkbox('Toothbrush for Alice').checked).toBe(true))
+            expect(checkbox('Toothbrush for Bob')).toBeTruthy()
+        })
+
+        it('takes the row away once everyone on it is packed', async () => {
+            await renderGrid()
+
+            fireEvent.click(checkbox('Toothbrush for Alice'))
+            fireEvent.click(checkbox('Toothbrush for Bob'))
+
+            await waitFor(() => expect(screen.queryByText('Toothbrush')).toBeNull())
+            expect(checkbox('Nappies for Bob')).toBeTruthy()
+        })
+
+        it('counts what it is actually holding back, not every packed item', async () => {
+            await renderGrid()
+
+            fireEvent.click(checkbox('Toothbrush for Alice'))
+            fireEvent.click(checkbox('Toothbrush for Bob'))
+
+            // Two items hidden — Alice's and Bob's toothbrushes — and not the
+            // three a person-view count would have claimed.
+            await waitFor(() => expect(screen.getByText(/2 packed items hidden/)).toBeTruthy())
+        })
+    })
+
+    describe('the "who needs this?" panel', () => {
+        const openPanel = async (label: string) => {
+            fireEvent.click(screen.getByRole('button', { name: `${label} — who needs this?` }))
+            await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy())
+            return within(screen.getByRole('dialog'))
+        }
+
+        it('opens from the item name and says who has it', async () => {
+            await renderGrid()
+
+            const panel = await openPanel('Nappies')
+            expect((panel.getByRole('checkbox', { name: 'Bob needs Nappies' }) as HTMLInputElement).checked).toBe(true)
+            expect((panel.getByRole('checkbox', { name: 'Alice needs Nappies' }) as HTMLInputElement).checked).toBe(false)
+        })
+
+        it('adds the item for somebody who does not have it', async () => {
+            await renderGrid()
+
+            const panel = await openPanel('Nappies')
+            fireEvent.click(panel.getByRole('checkbox', { name: 'Alice needs Nappies' }))
+
+            const saved = await savedList()
+            const added = saved.items.findLast(item => item.itemText === 'Nappies')!
+            expect(added.personName).toBe('Alice')
+            expect(added.personId).toBe('p1')
+            expect(added.category).toBe('Essentials')
+        })
+
+        it('takes it off one person without touching the others', async () => {
+            await renderGrid()
+
+            const panel = await openPanel('Toothbrush')
+            fireEvent.click(panel.getByRole('checkbox', { name: 'Bob needs Toothbrush' }))
+
+            const saved = await savedList()
+            expect(saved.items.map(item => item.id)).toEqual(['tb-a', 'np-b'])
+            // Deleting an item the question set put there is remembered, so the
+            // user can be asked about it next time
+            expect(saved.deletedItems?.map(item => item.id)).toEqual(['tb-b'])
+        })
+
+        it('renames every copy at once, because one item spelled two ways is a bug', async () => {
+            await renderGrid()
+
+            const panel = await openPanel('Toothbrush')
+            const field = panel.getByLabelText('Item') as HTMLInputElement
+            fireEvent.change(field, { target: { value: 'Tooth brush' } })
+            fireEvent.keyDown(field, { key: 'Enter' })
+
+            const saved = await savedList()
+            expect(saved.items.filter(item => item.itemText === 'Tooth brush').map(item => item.id))
+                .toEqual(['tb-a', 'tb-b'])
+        })
+
+        it('stays open on the row it was opened on after a rename', async () => {
+            await renderGrid()
+
+            const panel = await openPanel('Toothbrush')
+            const field = panel.getByLabelText('Item') as HTMLInputElement
+            fireEvent.change(field, { target: { value: 'Tooth brush' } })
+            fireEvent.keyDown(field, { key: 'Enter' })
+
+            await waitFor(() => expect(
+                within(screen.getByRole('dialog')).getByRole('checkbox', { name: 'Alice needs Tooth brush' }),
+            ).toBeTruthy())
+        })
+
+        it('sets a quantity for one person only', async () => {
+            await renderGrid()
+
+            const panel = await openPanel('Toothbrush')
+            const quantity = panel.getByLabelText('Quantity for Alice')
+            fireEvent.change(quantity, { target: { value: '3' } })
+            fireEvent.blur(quantity)
+
+            const saved = await savedList()
+            expect(saved.items.find(item => item.id === 'tb-a')!.quantity).toBe(3)
+            expect(saved.items.find(item => item.id === 'tb-b')!.quantity).toBeUndefined()
+        })
+
+        it('marks one person\'s copy as last minute, leaving the other where it is', async () => {
+            await renderGrid()
+
+            const panel = await openPanel('Toothbrush')
+            fireEvent.click(panel.getByRole('button', { name: /Mark Alice's Toothbrush as a last minute item/i }))
+
+            const saved = await savedList()
+            expect(saved.items.find(item => item.id === 'tb-a')!.lastMinute).toBe(true)
+            expect(saved.items.find(item => item.id === 'tb-b')!.lastMinute).toBeUndefined()
+        })
+
+        it('removes the whole row once the removal is confirmed, naming who it covers', async () => {
+            await renderGrid()
+
+            const panel = await openPanel('Toothbrush')
+            fireEvent.click(panel.getByRole('button', { name: 'Remove for all 2' }))
+
+            await waitFor(() => expect(screen.getByText('Remove Toothbrush for Alice, Bob?')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /^remove$/i }))
+
+            const saved = await savedList()
+            expect(saved.items.map(item => item.id)).toEqual(['np-b'])
+        })
+    })
+
+    it('gives the unassigned items a column of their own, last', async () => {
+        await renderGrid({
+            ...gridList,
+            items: [
+                ...gridList.items,
+                { id: 'tr-x', itemText: 'Torch', personName: '', personId: '', questionId: '', optionId: '', packed: false, category: 'Essentials', order: 2 },
+            ],
+        })
+
+        expect(screen.getAllByRole('columnheader').map(header => header.textContent))
+            .toEqual(['Item', expect.stringContaining('Alice'), expect.stringContaining('Bob'), expect.stringContaining('Unassigned')])
+        expect(checkbox('Torch for Unassigned')).toBeTruthy()
+    })
+
+    it('lays the last minute card out as a grid too', async () => {
+        await renderGrid({
+            ...gridList,
+            items: gridList.items.map(item => item.id === 'tb-a' ? { ...item, lastMinute: true } : item),
+        })
+
+        const lastMinute = screen.getAllByTestId('list-section').find(section =>
+            within(section).queryByRole('button', { name: /Collapse the last minute items list/i }))!
+        expect(within(lastMinute).getByRole('checkbox', { name: 'Toothbrush for Alice' })).toBeTruthy()
+    })
+
+    describe('on a phone', () => {
+        beforeEach(() => {
+            vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+                // Narrower than the sm breakpoint, and no reduced-motion preference
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+            }) as unknown as MediaQueryList)
+        })
+
+        it('keeps the columns and drops the names, decoding them once in a legend', async () => {
+            await renderGrid()
+
+            // The checkboxes still name their person, so nothing is lost to a
+            // screen reader by the header being an initial
+            expect(checkbox('Toothbrush for Alice')).toBeTruthy()
+            const legend = within(screen.getByTestId('grid-people-legend'))
+            expect(legend.getByText('Alice')).toBeTruthy()
+            expect(legend.getByText('Bob')).toBeTruthy()
+        })
     })
 })
 
@@ -1604,7 +1909,7 @@ describe('ViewPackingList shared (communal) section', () => {
     })
 })
 
-describe('ViewPackingList shared (communal) items in question view', () => {
+describe('ViewPackingList shared (communal) items in category view', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({
             isLoggedIn: false,
@@ -1641,7 +1946,7 @@ describe('ViewPackingList shared (communal) items in question view', () => {
             </MemoryRouter>
         )
         await waitFor(() => expect(screen.getByText('Sleeping bag')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: 'Question View' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
         return db
     }
 
@@ -1663,42 +1968,36 @@ describe('ViewPackingList shared (communal) items in question view', () => {
         expect(within(card('Essentials')).getByText('First aid kit')).toBeTruthy()
     })
 
-    it('groups shared items under Shared, ahead of the people', async () => {
+    it('gives a shared item one checkbox for the whole group, ahead of the rest', async () => {
         await renderInQuestionView()
 
-        const headings = within(card('Camping'))
-            .getAllByRole('button', { name: /^Collapse / })
-            .map(button => button.getAttribute('aria-label'))
-        expect(headings).toEqual(['Collapse Camping list', 'Collapse Shared', 'Collapse Alice'])
+        const camping = within(card('Camping'))
+        expect(camping.getByRole('checkbox', { name: 'Tent for the whole group' })).toBeTruthy()
+        // No column belongs to it, and it comes first — the shared card's place
+        // in person view, kept
+        expect(camping.getAllByTestId('grid-row')[0].textContent).toContain('Tent')
+        expect(camping.getByText('👥 For everyone')).toBeTruthy()
     })
 
-    it('counts shared items in the section and group totals', async () => {
+    it('counts shared items in the section total', async () => {
         await renderInQuestionView()
 
         const camping = within(card('Camping'))
         expect(camping.getByRole('button', { name: /collapse camping list/i }).textContent).toContain('0 / 2')
-        expect(camping.getByRole('button', { name: 'Collapse Shared' }).textContent).toContain('0 / 1')
     })
 
-    it('adds a shared item from the shared group of a section', async () => {
-        const db = await renderInQuestionView()
+    it('keeps a shared item apart from someone\'s own copy of the same thing', async () => {
+        await renderInQuestionView({
+            ...communalPackingList,
+            items: [
+                ...communalPackingList.items,
+                { id: 'item-a2', itemText: 'Tent', personName: 'Alice', personId: 'p1', questionId: 'q2', optionId: 'o2', packed: false, category: 'Camping' },
+            ],
+        })
 
         const camping = within(card('Camping'))
-        fireEvent.click(camping.getByRole('button', { name: /add item to camping for shared items/i }))
-        const composer = camping.getAllByTestId('add-item-composer')
-            .find(node => within(node).queryByLabelText(/add an item to camping for shared items/i))
-        expect(composer).toBeTruthy()
-        fireEvent.change(within(composer!).getByLabelText(/add an item to camping for shared items/i), {
-            target: { value: 'Camping stove' },
-        })
-        fireEvent.click(within(composer!).getByRole('button', { name: 'Add' }))
-
-        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
-        const saved = db.savePackingList.mock.calls[0][0]
-        const added = saved.items.find((i: { itemText: string }) => i.itemText === 'Camping stove')
-        expect(added.communal).toBe(true)
-        expect(added.category).toBe('Camping')
-        expect(added.personName).toBe('')
+        expect(camping.getByRole('checkbox', { name: 'Tent for the whole group' })).toBeTruthy()
+        expect(camping.getByRole('checkbox', { name: 'Tent for Alice' })).toBeTruthy()
     })
 
     it('offers Shared in a section\'s who-for picker, so shared items can be added without a shared card', async () => {
@@ -2080,11 +2379,11 @@ describe('ViewPackingList section completion celebration', () => {
         await waitFor(() => expect(screen.getByLabelText(/all packed for bob/i)).toBeTruthy())
     })
 
-    it('celebrates a fully packed category in question view', async () => {
+    it('celebrates a fully packed category in category view', async () => {
         renderList()
         await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
 
-        fireEvent.click(screen.getByRole('button', { name: /question view/i }))
+        fireEvent.click(screen.getByRole('button', { name: /category view/i }))
 
         // Documents (Passport) is fully packed; Toiletries (Toothbrush) is not
         expect(screen.getByText('Documents')).toBeTruthy()
@@ -2620,10 +2919,10 @@ describe('ViewPackingList adding items', () => {
         expect(screen.getByLabelText('Add an item to Other for Alice')).toBeTruthy()
     })
 
-    it('adds for someone with nothing in a section yet, from question view', async () => {
+    it('adds for someone with nothing in a section yet, from category view', async () => {
         renderComponentMultiCategory()
         await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: 'Question View' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
 
         const { input, fields } = composerFor('Hiking')
         fireEvent.change(input, { target: { value: 'Walking poles' } })
@@ -2885,13 +3184,13 @@ describe('ViewPackingList folding sections away', () => {
         it('reopens in the view mode the user chose', async () => {
             const { unmount } = renderList()
             await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-            fireEvent.click(screen.getByRole('button', { name: /question view/i }))
+            fireEvent.click(screen.getByRole('button', { name: /category view/i }))
             unmount()
 
             renderList()
             await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
 
-            expect(screen.getByRole('button', { name: /question view/i }).getAttribute('aria-pressed')).toBe('true')
+            expect(screen.getByRole('button', { name: /category view/i }).getAttribute('aria-pressed')).toBe('true')
         })
 
         it('reopens still showing packed items', async () => {
@@ -3337,14 +3636,14 @@ describe('ViewPackingList last minute items', () => {
         expect(screen.queryByText('Shared Items')).toBeNull()
     })
 
-    it('keeps a marked item out of its category card in question view', async () => {
+    it('keeps a marked item out of its category card in category view', async () => {
         renderLastMinuteList([
             { ...lastMinuteBaseItems[0], lastMinute: true },
             lastMinuteBaseItems[1],
         ])
 
         await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: 'Question View' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
 
         expect(within(sectionCard('Last Minute')).getByText('Passport')).toBeTruthy()
         expect(screen.queryByText('Documents')).toBeNull()

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -677,6 +677,84 @@ describe('ViewPackingList category grid', () => {
         expect(within(lastMinute).getByRole('checkbox', { name: 'Toothbrush for Alice' })).toBeTruthy()
     })
 
+    describe('when there are more people than fit beside the names', () => {
+        // Seven people: the columns stop paying for themselves, so the item
+        // takes a line of its own and the people wrap underneath it.
+        const crowd = ['Ann', 'Ben', 'Cass', 'Dev', 'Eve', 'Fin', 'Gil']
+        const crowdedList = {
+            id: 'test-list-crowd',
+            name: 'Big Family',
+            createdAt: '2026-01-01T00:00:00Z',
+            items: [
+                ...crowd.map((name, index) => ({
+                    id: `tb-${index}`,
+                    itemText: 'Toothbrush',
+                    personName: name,
+                    personId: `p${index}`,
+                    questionId: 'q1',
+                    optionId: 'o1',
+                    packed: false,
+                    category: 'Essentials',
+                    order: 0,
+                })),
+                { id: 'np-1', itemText: 'Nappies', personName: 'Ben', personId: 'p1', questionId: 'q1', optionId: 'o1', packed: false, category: 'Essentials', order: 1 },
+            ],
+        }
+
+        beforeEach(() => {
+            // The columns only give way where there is no room for them, and
+            // the test environment is a desktop unless it is told otherwise.
+            vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+            }) as unknown as MediaQueryList)
+        })
+
+        const renderCrowd = () => renderGrid(crowdedList as typeof gridList)
+
+        it('drops the columns and gives every person a chip', async () => {
+            await renderCrowd()
+
+            expect(screen.queryByRole('columnheader')).toBeNull()
+            for (const name of crowd) {
+                expect(checkbox(`Toothbrush for ${name}`)).toBeTruthy()
+            }
+        })
+
+        it('keeps a place for someone who does not need it, so the chips still line up', async () => {
+            await renderCrowd()
+
+            // Ben is the only one with nappies; the other six keep their place
+            expect(checkbox('Nappies for Ben')).toBeTruthy()
+            expect(screen.queryByRole('checkbox', { name: 'Nappies for Ann' })).toBeNull()
+            expect(screen.getByTitle("Ann doesn't need this — open to change")).toBeTruthy()
+        })
+
+        it('packs from a chip', async () => {
+            await renderCrowd()
+
+            fireEvent.click(checkbox('Toothbrush for Cass'))
+
+            await waitFor(() => expect(checkbox('Toothbrush for Cass').checked).toBe(true))
+            expect(checkbox('Toothbrush for Dev').checked).toBe(false)
+        })
+
+        it('still offers each person their own check-all, in the strip above', async () => {
+            await renderCrowd()
+
+            fireEvent.click(screen.getByRole('button', { name: /Check off everything left for Gil in Essentials/i }))
+
+            await waitFor(() => expect(checkbox('Toothbrush for Gil').checked).toBe(true))
+            expect(checkbox('Toothbrush for Ann').checked).toBe(false)
+        })
+    })
+
     describe('on a phone', () => {
         beforeEach(() => {
             vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -538,7 +538,7 @@ describe('ViewPackingList category grid', () => {
 
     describe('the "who needs this?" panel', () => {
         const openPanel = async (label: string) => {
-            fireEvent.click(screen.getByRole('button', { name: `${label} — who needs this?` }))
+            fireEvent.click(screen.getByRole('button', { name: `Edit ${label}` }))
             await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy())
             return within(screen.getByRole('dialog'))
         }
@@ -549,6 +549,17 @@ describe('ViewPackingList category grid', () => {
             const panel = await openPanel('Nappies')
             expect((panel.getByRole('checkbox', { name: 'Bob needs Nappies' }) as HTMLInputElement).checked).toBe(true)
             expect((panel.getByRole('checkbox', { name: 'Alice needs Nappies' }) as HTMLInputElement).checked).toBe(false)
+        })
+
+        it('opens from a gap in the row, where "Cara needs one too" is thought', async () => {
+            await renderGrid()
+
+            // Pointer-only, and hidden from screen readers: the row's own button
+            // is the same door and it is the one in the tab order.
+            fireEvent.click(screen.getByTitle("Alice doesn't need this — open to change"))
+
+            await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy())
+            expect(within(screen.getByRole('dialog')).getByRole('checkbox', { name: 'Alice needs Nappies' })).toBeTruthy()
         })
 
         it('adds the item for somebody who does not have it', async () => {
@@ -581,7 +592,7 @@ describe('ViewPackingList category grid', () => {
             await renderGrid()
 
             const panel = await openPanel('Toothbrush')
-            const field = panel.getByLabelText('Item') as HTMLInputElement
+            const field = panel.getByLabelText('Name') as HTMLInputElement
             fireEvent.change(field, { target: { value: 'Tooth brush' } })
             fireEvent.keyDown(field, { key: 'Enter' })
 
@@ -594,7 +605,7 @@ describe('ViewPackingList category grid', () => {
             await renderGrid()
 
             const panel = await openPanel('Toothbrush')
-            const field = panel.getByLabelText('Item') as HTMLInputElement
+            const field = panel.getByLabelText('Name') as HTMLInputElement
             fireEvent.change(field, { target: { value: 'Tooth brush' } })
             fireEvent.keyDown(field, { key: 'Enter' })
 
@@ -1962,10 +1973,12 @@ describe('ViewPackingList shared (communal) items in category view', () => {
     it('files shared items into their section rather than a Shared Items card', async () => {
         await renderInQuestionView()
 
+        // By the row's button rather than by its text: a row's name is split so
+        // its last word can hold on to the chevron — see `splitLastWord`.
         expect(screen.queryByText('Shared Items')).toBeNull()
-        expect(within(card('Camping')).getByText('Tent')).toBeTruthy()
-        expect(within(card('Camping')).getByText('Sleeping bag')).toBeTruthy()
-        expect(within(card('Essentials')).getByText('First aid kit')).toBeTruthy()
+        expect(within(card('Camping')).getByRole('button', { name: 'Edit Tent' })).toBeTruthy()
+        expect(within(card('Camping')).getByRole('button', { name: 'Edit Sleeping bag' })).toBeTruthy()
+        expect(within(card('Essentials')).getByRole('button', { name: 'Edit First aid kit' })).toBeTruthy()
     })
 
     it('gives a shared item one checkbox for the whole group, ahead of the rest', async () => {

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -378,15 +378,13 @@ describe('ViewPackingList person/category view toggle', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
 
-        // Every card names the same people, in the same order, whoever has
-        // something in it — the grid is only readable if a person stays put.
-        const essentials = screen.getAllByTestId('list-section')[0]
-        expect(within(within(essentials).getByTestId('grid-people-legend'))
-            .getAllByRole('button')
-            .map(person => person.textContent))
-            .toEqual([expect.stringContaining('Alice'), expect.stringContaining('Bob')])
+        // One key for the page, naming everyone in the order the chips sit in
+        const key = within(screen.getByTestId('people-key'))
+        expect(key.getByText('Alice')).toBeTruthy()
+        expect(key.getByText('Bob')).toBeTruthy()
 
         // Toothbrush is Alice's alone: she has a chip, Bob has a gap
+        const essentials = screen.getAllByTestId('list-section')[0]
         expect(within(essentials).getByRole('checkbox', { name: 'Toothbrush for Alice' })).toBeTruthy()
         expect(within(essentials).queryByRole('checkbox', { name: 'Toothbrush for Bob' })).toBeNull()
         expect(within(essentials).getByTitle("Bob doesn't need this — open to change")).toBeTruthy()
@@ -406,16 +404,15 @@ describe('ViewPackingList person/category view toggle', () => {
         ).toBe(true))
     })
 
-    it('checks off everything one person has left in a category', async () => {
+    it('keeps the key to itself — nothing in it can be pressed', async () => {
         renderComponentMultiCategory()
         await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
         fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
 
-        fireEvent.click(screen.getByRole('button', { name: /Check off everything left for Alice in Essentials/i }))
-
-        // Alice's row is done, so with packed items hidden it goes; Bob's stays
-        await waitFor(() => expect(screen.queryByRole('checkbox', { name: 'Toothbrush for Alice' })).toBeNull())
-        expect((screen.getByRole('checkbox', { name: 'Nappies for Bob' }) as HTMLInputElement).checked).toBe(false)
+        // A key that packs a person's whole category on a stray tap is a
+        // hazard, not a shortcut; person view has a labelled button for that.
+        expect(within(screen.getByTestId('people-key')).queryAllByRole('button')).toEqual([])
+        expect(within(screen.getByTestId('people-key')).queryAllByRole('checkbox')).toEqual([])
     })
 
     it('switches back to person view', async () => {
@@ -664,14 +661,9 @@ describe('ViewPackingList category grid', () => {
             ],
         })
 
-        expect(within(screen.getByTestId('grid-people-legend'))
-            .getAllByRole('button')
-            .map(person => person.textContent))
-            .toEqual([
-                expect.stringContaining('Alice'),
-                expect.stringContaining('Bob'),
-                expect.stringContaining('Unassigned'),
-            ])
+        const key = within(screen.getByTestId('people-key'))
+        expect(['Alice', 'Bob', 'Unassigned'].map(name => !!key.queryByText(name)))
+            .toEqual([true, true, true])
         expect(checkbox('Torch for Unassigned')).toBeTruthy()
     })
 
@@ -754,13 +746,11 @@ describe('ViewPackingList category grid', () => {
             expect(checkbox('Toothbrush for Dev').checked).toBe(false)
         })
 
-        it('still offers each person their own check-all, in the strip above', async () => {
+        it('names all seven in the key, however the chips wrap', async () => {
             await renderCrowd()
 
-            fireEvent.click(screen.getByRole('button', { name: /Check off everything left for Gil in Essentials/i }))
-
-            await waitFor(() => expect(checkbox('Toothbrush for Gil').checked).toBe(true))
-            expect(checkbox('Toothbrush for Ann').checked).toBe(false)
+            const key = within(screen.getByTestId('people-key'))
+            expect(crowd.map(name => !!key.queryByText(name))).toEqual(crowd.map(() => true))
         })
     })
 
@@ -779,15 +769,15 @@ describe('ViewPackingList category grid', () => {
             }) as unknown as MediaQueryList)
         })
 
-        it('names everyone in the strip, since the chips themselves carry initials', async () => {
+        it('names everyone in the key, since the chips themselves carry initials', async () => {
             await renderGrid()
 
             // The chips still name their person, so nothing is lost to a screen
             // reader by their showing an initial
             expect(checkbox('Toothbrush for Alice')).toBeTruthy()
-            const legend = within(screen.getByTestId('grid-people-legend'))
-            expect(legend.getByText('Alice')).toBeTruthy()
-            expect(legend.getByText('Bob')).toBeTruthy()
+            const key = within(screen.getByTestId('people-key'))
+            expect(key.getByText('Alice')).toBeTruthy()
+            expect(key.getByText('Bob')).toBeTruthy()
         })
     })
 })

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -523,14 +523,6 @@ export function ViewPackingList() {
         handleItemToggle(item.id, checked)
     }, [setValue, handleItemToggle])
 
-    /** Everything one person still has to pack in one category, ticked off at once. */
-    const handleCheckColumn = useCallback((rows: readonly GridRow[], columnIndex: number) => {
-        for (const row of rows) {
-            const item = row.cells[columnIndex]
-            if (item) setValue(`items.${item.id}`, true)
-        }
-    }, [setValue])
-
     const registerCellRef = useCallback((itemId: string, element: HTMLElement | null) => {
         if (element) itemRowRefs.current.set(itemId, element)
         else itemRowRefs.current.delete(itemId)
@@ -1761,6 +1753,31 @@ export function ViewPackingList() {
                                 </Button>
                             </div>
                         </div>
+                        {/* Which coloured initial is whose, written once and kept
+                            in view rather than repeated on every card — a key is
+                            only any use while you are looking at the thing it
+                            explains. Nothing here is pressable: the one thing it
+                            could do is pack somebody's whole category on a stray
+                            tap, and person view has a button that says so. */}
+                        {viewMode === 'category' && gridColumns.length > 0 && (
+                            <div
+                                data-testid="people-key"
+                                className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-gray-100 pt-1.5"
+                            >
+                                {gridColumns.map(column => (
+                                    <span key={column.key} className="flex items-center gap-1 text-[11px] font-medium text-gray-600">
+                                        {!column.unassigned && (
+                                            <PersonAvatar
+                                                name={column.name}
+                                                color={personColor({ id: column.personId, name: column.name })}
+                                                size="sm"
+                                            />
+                                        )}
+                                        {column.name}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>
@@ -2019,7 +2036,6 @@ export function ViewPackingList() {
                                     )}
                                     {isGridSection && (
                                         <CategoryItemGrid
-                                            sectionTitle={title}
                                             columns={gridColumns}
                                             rows={section.rows ?? []}
                                             personColor={personColor}
@@ -2033,7 +2049,6 @@ export function ViewPackingList() {
                                             onToggleItem={handleGridToggle}
                                             registerCellRef={registerCellRef}
                                             onOpenRow={(row) => setOpenRowKeys({ sectionKey, rowKey: row.key, anchorItemId: row.items[0]?.id })}
-                                            onCheckColumn={(_column, index) => handleCheckColumn(section.rows ?? [], index)}
                                         />
                                     )}
                                     {!isGridSection && innerGroups.map(({ key: groupKey, label, items: catItems, communal: isSharedGroup }) => {

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1587,7 +1587,7 @@ export function ViewPackingList() {
 
     return (
         <>
-        <div className="w-full flex flex-col items-center py-8 px-4">
+        <div className="w-full flex flex-col items-center py-8 px-0 sm:px-4">
             {/* Non-sticky header: name, actions */}
             <div className="w-full max-w-screen-2xl mb-3">
                 <div className="flex flex-wrap items-center justify-between gap-3">
@@ -1929,7 +1929,7 @@ export function ViewPackingList() {
                                     ? 'border-amber-300 bg-amber-50'
                                     : `bg-white ${sectionPersonColor?.border ?? (isShared ? 'border-blue-200' : 'border-gray-200')}`
                             return (
-                            <div key={sectionKey} data-testid="list-section" className={`border rounded-lg p-4 shadow-sm transition-colors duration-300 ${viewMode === 'category' ? '' : 'mb-4'} ${sectionBorder}`} style={{ breakInside: 'avoid' }}>
+                            <div key={sectionKey} data-testid="list-section" className={`border rounded-lg p-3 shadow-sm transition-colors duration-300 sm:p-4 ${viewMode === 'category' ? '' : 'mb-4'} ${sectionBorder}`} style={{ breakInside: 'avoid' }}>
                                 {/* The rule under the heading separates it from the items
                                     below; a folded card has none, so it would just be a
                                     line ruling off empty space. */}
@@ -2048,6 +2048,9 @@ export function ViewPackingList() {
                                             // for them; the legend above the
                                             // cards decodes the initials instead.
                                             showColumnNames={isDesktop}
+                                            // What the frozen name column sits on
+                                            // when the grid scrolls sideways.
+                                            surfaceClass={isComplete ? 'bg-emerald-50' : isLastMinute ? 'bg-amber-50' : 'bg-white'}
                                             hidePacked={!showPacked}
                                             flourish={flourish}
                                             highlightedItemId={highlightedItem?.id}

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1813,26 +1813,6 @@ export function ViewPackingList() {
                 </div>
             )}
 
-            {/* On a narrow screen the grid's columns are initials, because four
-                names across a phone leaves no room for the items. They are
-                decoded once here rather than card by card. */}
-            {viewMode === 'category' && !isDesktop && gridColumns.length > 0 && (
-                <div data-testid="grid-people-legend" className="w-full max-w-screen-2xl mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
-                    {gridColumns.map(column => (
-                        <span key={column.key} className="flex items-center gap-1 text-xs font-medium text-gray-600">
-                            {!column.unassigned && (
-                                <PersonAvatar
-                                    name={column.name}
-                                    color={personColor({ id: column.personId, name: column.name })}
-                                    size="sm"
-                                />
-                            )}
-                            {column.name}
-                        </span>
-                    ))}
-                </div>
-            )}
-
             {/* Hidden packed items banner — at 100% it's just noise next to the
                 celebration, and the Show Packed button is right there anyway */}
             {hiddenPackedCount > 0 && !allPacked && (
@@ -2047,10 +2027,6 @@ export function ViewPackingList() {
                                             // The names go when there isn't room
                                             // for them; the legend above the
                                             // cards decodes the initials instead.
-                                            showColumnNames={isDesktop}
-                                            // What the frozen name column sits on
-                                            // when the grid scrolls sideways.
-                                            surfaceClass={isComplete ? 'bg-emerald-50' : isLastMinute ? 'bg-amber-50' : 'bg-white'}
                                             hidePacked={!showPacked}
                                             flourish={flourish}
                                             highlightedItemId={highlightedItem?.id}

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -33,6 +33,9 @@ import { clearPendingSignInAction, getPendingSignInAction, setPendingSignInActio
 import { usePersonColors } from '../hooks/usePersonColors'
 import { PersonAvatar } from '../components/PersonAvatar'
 import { AddItemComposer, UNCATEGORISED_LABEL, type AddItemTarget, type PersonOption } from '../components/AddItemComposer'
+import { CategoryItemGrid } from '../components/CategoryItemGrid'
+import { ItemRowPanel } from '../components/ItemRowPanel'
+import { buildCategoryRows, buildGridColumns, type GridRow } from '../utils/categoryItemGrid'
 import { buildSuggestionIndex } from '../utils/itemSuggestions'
 import { useIsDesktop } from '../hooks/useIsDesktop'
 import { loadListViewPreferences, saveListViewPreferences, hasStoredListViewPreferences, type ListViewMode } from '../utils/listViewPreferences'
@@ -111,8 +114,12 @@ interface ListSection {
     name: string
     guestId?: string
     communal?: boolean
-    // True for question-centric top-level sections (grouped by category rather than person)
+    // True for category-centric top-level sections (grouped by category rather than person)
     isCategory?: boolean
+    // Category view's arrangement of this section: a row per item, a column per
+    // person. Built from every item in the section, packed ones included — see
+    // `buildCategoryRows`.
+    rows?: GridRow[]
     // True for the one section holding the items that can only be packed on the
     // way out of the door. Grouped by person, like a category section.
     lastMinute?: boolean
@@ -257,6 +264,14 @@ export function ViewPackingList() {
     // heading on the page, which is what the list already pays for in item rows.
     const [openComposerKey, setOpenComposerKey] = useState<string | null>(null)
     const [itemToDelete, setItemToDelete] = useState<string | null>(null)
+    // Which row of the category grid has its "who needs this?" panel open, held
+    // as keys rather than as the row itself: the row is rebuilt whenever the
+    // list changes, and a panel holding the old one would keep showing the state
+    // before the change it was used to make.
+    const [openRowKeys, setOpenRowKeys] = useState<{ sectionKey: string; rowKey: string; anchorItemId?: string } | null>(null)
+    // A row can hold one item or one each for four people; removing the second
+    // kind is worth naming who it affects.
+    const [rowToDelete, setRowToDelete] = useState<{ label: string; items: PackingListItem[]; who: string } | null>(null)
     const [editingItemId, setEditingItemId] = useState<string | null>(null)
     const [editingItemText, setEditingItemText] = useState<string>('')
     const [editingItemQuantity, setEditingItemQuantity] = useState<string>('')
@@ -285,7 +300,7 @@ export function ViewPackingList() {
     // somewhere: typed into a composer, or moved to the last minute card.
     // `bringIntoView` separates the two — see the effect below.
     const [highlightedItem, setHighlightedItem] = useState<{ id: string; bringIntoView: boolean } | null>(null)
-    const itemRowRefs = useRef<Map<string, HTMLDivElement>>(new Map())
+    const itemRowRefs = useRef<Map<string, HTMLElement>>(new Map())
     // One-off confetti when the final item is ticked
     const [showConfetti, setShowConfetti] = useState(false)
     // 'exiting' plays the fold-away animation, 'packed-away' has removed the cards
@@ -473,6 +488,15 @@ export function ViewPackingList() {
     // nobody else here is wearing.
     const personColor = usePersonColors(db, peopleOptions)
 
+    // The columns every category card uses — the whole list's people, not the
+    // ones a particular category happens to mention, so a person is in the same
+    // place on every card and a column of gaps is an answer rather than an
+    // absence: nobody has packed a thing for the baby in here.
+    const gridColumns = useMemo(
+        () => buildGridColumns(peopleOptions, packingList?.items ?? []),
+        [peopleOptions, packingList?.items],
+    )
+
 
     const { register, setValue, getValues, control, reset } = useForm<FormData>({
         defaultValues: {
@@ -482,6 +506,35 @@ export function ViewPackingList() {
 
     // Use useWatch instead of watch() for proper re-renders on form changes
     const watchedItems = useWatch({ control, name: 'items', defaultValue: {} })
+
+    /**
+     * The grid's checkboxes are driven from the form's values rather than
+     * registered against it.
+     *
+     * A registered checkbox reads its initial state from the form's *default*
+     * values, which `setValue` doesn't update — so a registered box that
+     * unmounts and comes back renders unchecked while the form still says
+     * packed, and the next save writes the lie down. The grid mounts and
+     * unmounts cells constantly (a row leaves when it is finished, columns
+     * change with the list), so it reads `watchedItems` instead and can't drift.
+     */
+    const handleGridToggle = useCallback((item: PackingListItem, checked: boolean) => {
+        setValue(`items.${item.id}`, checked)
+        handleItemToggle(item.id, checked)
+    }, [setValue, handleItemToggle])
+
+    /** Everything one person still has to pack in one category, ticked off at once. */
+    const handleCheckColumn = useCallback((rows: readonly GridRow[], columnIndex: number) => {
+        for (const row of rows) {
+            const item = row.cells[columnIndex]
+            if (item) setValue(`items.${item.id}`, true)
+        }
+    }, [setValue])
+
+    const registerCellRef = useCallback((itemId: string, element: HTMLElement | null) => {
+        if (element) itemRowRefs.current.set(itemId, element)
+        else itemRowRefs.current.delete(itemId)
+    }, [])
 
     // The finale belongs to the *moment* the list is finished, so it fires on the
     // transition into "everything packed" and is anchored to the viewport rather
@@ -951,6 +1004,92 @@ export function ViewPackingList() {
         }
     }
 
+    /**
+     * Everything a row of the category grid can be asked to do, in one place.
+     *
+     * Each of these rewrites the whole list once. Calling the single-item
+     * handlers in a loop would not: they each close over `packingList` and each
+     * persist a fresh copy of it, so three calls in one tick all start from the
+     * same snapshot and the last one to land is the only one that survives.
+     */
+    const persistItemChanges = async (
+        change: (list: PackingList) => PackingList,
+        errorContext: string,
+    ) => {
+        if (!packingList) return
+        try {
+            setAutoSaveStatus('saving')
+            await persistPackingList(change(packingList))
+            setAutoSaveStatus('saved')
+            setTimeout(() => setAutoSaveStatus('idle'), 2000)
+        } catch (err) {
+            reportError(err, errorContext)
+            setAutoSaveStatus('error')
+        }
+    }
+
+    /**
+     * The name belongs to the row rather than to any one copy of it: the same
+     * item spelled two ways for two people is a mistake, not a distinction.
+     * Quantities are the opposite — they're per person by construction — so this
+     * touches nothing but the text.
+     */
+    const handleRenameRow = (row: GridRow, text: string) => {
+        const trimmed = text.trim()
+        if (!trimmed || trimmed === row.label) return
+        const ids = new Set(row.items.map(item => item.id))
+        const now = new Date().toISOString()
+        return persistItemChanges(
+            list => ({
+                ...list,
+                items: list.items.map(item => ids.has(item.id) ? { ...item, itemText: trimmed, lastModified: now } : item),
+            }),
+            'Error renaming item',
+        )
+    }
+
+    const handleSetItemQuantity = (target: PackingListItem, quantity: number | undefined) => {
+        const now = new Date().toISOString()
+        return persistItemChanges(
+            list => ({
+                ...list,
+                items: list.items.map(item => {
+                    if (item.id !== target.id) return item
+                    // Absent rather than 1: an explicit 1 says nothing the default
+                    // doesn't, and it would travel to the pod saying it.
+                    const { quantity: _previous, ...rest } = item
+                    return { ...rest, ...(quantity !== undefined && quantity > 1 ? { quantity } : {}), lastModified: now }
+                }),
+            }),
+            'Error saving quantity',
+        )
+    }
+
+    /** Removing every copy on a row, which is one write however many people it covers. */
+    const handleDeleteRowItems = (rowItems: PackingListItem[]) => {
+        const ids = new Set(rowItems.map(item => item.id))
+        const deletedAt = new Date().toISOString()
+        const currentFormValues = getValues('items')
+        for (const id of ids) delete currentFormValues[id]
+        setValue('items', currentFormValues)
+        return persistItemChanges(
+            list => ({
+                ...list,
+                items: list.items.filter(item => !ids.has(item.id)),
+                // Same bookkeeping as deleting one: items that came from the
+                // question set are remembered, so the user can be asked about
+                // them the next time the list is updated from their questions.
+                deletedItems: [
+                    ...(list.deletedItems ?? []),
+                    ...rowItems
+                        .filter(item => item.questionId !== '')
+                        .map(item => ({ ...item, reviewed: false, lastModified: deletedAt })),
+                ],
+            }),
+            'Error removing items',
+        )
+    }
+
     const handleAddItem = async (target: AddItemTarget, itemText: string, quantity?: number) => {
         if (!packingList) return
 
@@ -1165,9 +1304,16 @@ export function ViewPackingList() {
         if (listSeenBefore || hasSeededFoldRef.current || !listItems) return
         if (listItems.length <= FOLD_ON_OPEN_MIN_ITEMS) return
 
-        const sectionKeys = new Set(listItems.map(personViewSectionKey))
+        // Keyed the way the view the list is about to open in keys them —
+        // folding people away while the page is showing categories folds
+        // nothing at all.
+        const sectionKeys = new Set(listItems.map(item => viewMode === 'category'
+            ? (item.lastMinute ? LAST_MINUTE_SECTION_KEY : (item.category ?? UNCATEGORISED_LABEL))
+            : personViewSectionKey(item)))
         // Guests with nothing in them yet still have a card to fold
-        for (const guest of packingList?.guests ?? []) sectionKeys.add(guest.name)
+        if (viewMode === 'person') {
+            for (const guest of packingList?.guests ?? []) sectionKeys.add(guest.name)
+        }
         // Nothing to fold *into* — one long section stays open, since folding it
         // would leave the user looking at a single closed box.
         if (sectionKeys.size < 2) return
@@ -1175,6 +1321,7 @@ export function ViewPackingList() {
         hasSeededFoldRef.current = true
         setCollapsedSections(prev => new Set([...prev, ...sectionKeys]))
         setFoldedOnOpen(true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- viewMode is read once, when the list first opens
     }, [listSeenBefore, listItems, packingList?.guests])
 
     // Showing packed items is a request to see everything, so it hands back the
@@ -1258,10 +1405,6 @@ export function ViewPackingList() {
         return !watchedItems[item.id]
     })
 
-    const hiddenPackedCount = !showPacked
-        ? packingList.items.filter(item => watchedItems[item.id]).length
-        : 0
-
     const percentComplete = totalCount > 0 ? Math.round((packedCount / totalCount) * 100) : 0
     // A sliver of fill so the first item packed is visibly worth something, but
     // nothing at all while the list is untouched
@@ -1335,7 +1478,12 @@ export function ViewPackingList() {
             title: LAST_MINUTE_TITLE,
             name: '',
             lastMinute: true,
+            // Person view reads the filtered items directly; the grid takes all
+            // of them and decides row by row what to show — see below.
             items: filteredItems.filter(i => i.lastMinute),
+            ...(viewMode === 'category'
+                ? { rows: buildCategoryRows(lastMinuteItems, gridColumns) }
+                : {}),
         }]
         : []
 
@@ -1357,24 +1505,57 @@ export function ViewPackingList() {
         listSections = [...sharedSections, ...regularSections, ...guestSections, ...lastMinuteSections]
     } else {
         // Communal items are filed by category here, same as everyone else's —
-        // they sit in a shared group inside the section they belong to rather
-        // than in a card of their own.
-        const visibleByCategory = new Map(
-            groupByCategory(filteredItems.filter(i => !i.lastMinute), sectionOrder).map(({ label, items }) => [label, items])
-        )
-        // Categories come from every item, not just the visible ones, so a fully
-        // packed category keeps its celebratory card instead of disappearing.
+        // they sit among the rows of the section they belong to rather than in a
+        // card of their own.
+        //
+        // Every item goes into the grid, packed ones included: a cell that
+        // disappeared when it was ticked would leave a gap indistinguishable
+        // from a person who never needed the item, and telling those two apart
+        // is the whole of what the grid is for. Hiding what's packed is decided
+        // a row at a time, inside the grid.
         const categorySections: ListSection[] = groupByCategory(packingList.items.filter(i => !i.lastMinute), sectionOrder)
-            .filter(({ label }) => visibleByCategory.has(label) || isSectionComplete(categoryStats[label]))
-            .map(({ label }) => ({
+            .map(({ label, items }) => ({
                 key: label,
                 title: label,
                 name: '',
-                items: visibleByCategory.get(label) ?? [],
+                items,
                 isCategory: true,
+                rows: buildCategoryRows(items, gridColumns),
             }))
         listSections = [...categorySections, ...lastMinuteSections]
     }
+
+    // How much of the list the grid is holding back: the items on rows where
+    // every cell is already packed, which are the only ones it hides.
+    const hiddenGridItemCount = showPacked || viewMode === 'person'
+        ? 0
+        : listSections.reduce((count, section) => count + (section.rows ?? []).reduce(
+            (rowCount, row) =>
+                rowCount + (row.items.length > 0 && row.items.every(item => watchedItems[item.id]) ? row.items.length : 0),
+            0,
+        ), 0)
+
+    // What the banner offers to bring back has to be what is actually missing.
+    // Person view hides every packed item; category view hides a row only once
+    // every cell on it is packed, so most of a half-packed list is still on
+    // screen and counting all of it would send the user looking for items that
+    // are right in front of them.
+    const hiddenPackedCount = showPacked
+        ? 0
+        : viewMode === 'person'
+            ? packingList.items.filter(item => watchedItems[item.id]).length
+            : hiddenGridItemCount
+
+    // The panel shows a row that is rebuilt from the list on every render, so it
+    // has to be found again each time rather than held. By key first; by one of
+    // the items it opened on when the key has moved under it — renaming a row
+    // changes its key, and the panel is where renaming happens.
+    const openRowSection = openRowKeys ? listSections.find(section => section.key === openRowKeys.sectionKey) : undefined
+    const openRow = openRowKeys
+        ? openRowSection?.rows?.find(row => row.key === openRowKeys.rowKey)
+            ?? openRowSection?.rows?.find(row => row.items.some(item => item.id === openRowKeys.anchorItemId))
+            ?? null
+        : null
 
     const tripDates = formatTripDates(packingList.startDate, packingList.endDate)
 
@@ -1428,7 +1609,7 @@ export function ViewPackingList() {
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
                         {/* The reveal opens an empty shared *card*, which only
-                            person view has — question view offers "Shared" in
+                            person view has — category view offers "Shared" in
                             each section's who-for picker instead. */}
                         {!foreignPodUrl && viewMode === 'person' && !hasCommunalItems && !showSharedSection && (
                             <Button
@@ -1563,12 +1744,12 @@ export function ViewPackingList() {
                                     </button>
                                     <button
                                         type="button"
-                                        aria-pressed={viewMode === 'question'}
-                                        aria-label="Question View"
-                                        onClick={() => setViewMode('question')}
-                                        className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors border-l border-gray-300 ${viewMode === 'question' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                                        aria-pressed={viewMode === 'category'}
+                                        aria-label="Category View"
+                                        onClick={() => setViewMode('category')}
+                                        className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors border-l border-gray-300 ${viewMode === 'category' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
                                     >
-                                        {isDesktop ? 'Question View' : 'Question'}
+                                        {isDesktop ? 'Category View' : 'Category'}
                                     </button>
                                 </div>
                                 <Button
@@ -1632,6 +1813,26 @@ export function ViewPackingList() {
                 </div>
             )}
 
+            {/* On a narrow screen the grid's columns are initials, because four
+                names across a phone leaves no room for the items. They are
+                decoded once here rather than card by card. */}
+            {viewMode === 'category' && !isDesktop && gridColumns.length > 0 && (
+                <div data-testid="grid-people-legend" className="w-full max-w-screen-2xl mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
+                    {gridColumns.map(column => (
+                        <span key={column.key} className="flex items-center gap-1 text-xs font-medium text-gray-600">
+                            {!column.unassigned && (
+                                <PersonAvatar
+                                    name={column.name}
+                                    color={personColor({ id: column.personId, name: column.name })}
+                                    size="sm"
+                                />
+                            )}
+                            {column.name}
+                        </span>
+                    ))}
+                </div>
+            )}
+
             {/* Hidden packed items banner — at 100% it's just noise next to the
                 celebration, and the Show Packed button is right there anyway */}
             {hiddenPackedCount > 0 && !allPacked && (
@@ -1682,9 +1883,13 @@ export function ViewPackingList() {
                         celebrations, so they fold away and leave the banner as the
                         last thing standing — the fold itself is the celebration.
                         Showing packed items brings them straight back. */}
+                    {/* Person view's cards are narrow and ragged, so they flow
+                        into masonry columns. A grid card is a table that has to
+                        be read across, so category view stacks them instead —
+                        two abreast once there is room for two tables. */}
                     {!sectionsPackedAway && <div
-                        className={sectionsExiting ? 'sections-packing-away' : undefined}
-                        style={{ columnWidth: '300px', columnGap: '1rem' }}
+                        className={`${sectionsExiting ? 'sections-packing-away' : ''} ${viewMode === 'category' ? 'grid grid-cols-1 items-start gap-4 xl:grid-cols-2' : ''}`}
+                        style={viewMode === 'category' ? undefined : { columnWidth: '300px', columnGap: '1rem' }}
                     >
                         {listSections.map((section) => {
                             const { key: sectionKey, title, items, guestId } = section
@@ -1700,9 +1905,16 @@ export function ViewPackingList() {
                             const collapseLabelTarget = isShared ? 'the shared items' : isLastMinute ? 'the last minute items' : isCategorySection ? title : `${section.name}'s`
                             // The last minute card holds everybody's, so it groups
                             // by person the way a category card does.
-                            const innerGroups: ItemGroup[] = (isCategorySection || isLastMinute)
-                                ? groupByPerson(items)
-                                : groupByCategory(items, sectionOrder).map(({ label, items: groupItems }) => ({ key: label, label, items: groupItems }))
+                            // Category view arranges a section as a grid; person
+                            // view still folds each card into groups, and so does
+                            // the last minute card while it is being read by
+                            // person.
+                            const isGridSection = viewMode === 'category' && (isCategorySection || isLastMinute)
+                            const innerGroups: ItemGroup[] = isGridSection
+                                ? []
+                                : (isCategorySection || isLastMinute)
+                                    ? groupByPerson(items)
+                                    : groupByCategory(items, sectionOrder).map(({ label, items: groupItems }) => ({ key: label, label, items: groupItems }))
                             const isSectionCollapsed = collapsedSections.has(sectionKey)
                             // Only a card that belongs to one person can wear
                             // their colour: a category card holds everybody's.
@@ -1717,7 +1929,7 @@ export function ViewPackingList() {
                                     ? 'border-amber-300 bg-amber-50'
                                     : `bg-white ${sectionPersonColor?.border ?? (isShared ? 'border-blue-200' : 'border-gray-200')}`
                             return (
-                            <div key={sectionKey} data-testid="list-section" className={`border rounded-lg p-4 shadow-sm mb-4 transition-colors duration-300 ${sectionBorder}`} style={{ breakInside: 'avoid' }}>
+                            <div key={sectionKey} data-testid="list-section" className={`border rounded-lg p-4 shadow-sm transition-colors duration-300 ${viewMode === 'category' ? '' : 'mb-4'} ${sectionBorder}`} style={{ breakInside: 'avoid' }}>
                                 {/* The rule under the heading separates it from the items
                                     below; a folded card has none, so it would just be a
                                     line ruling off empty space. */}
@@ -1820,12 +2032,32 @@ export function ViewPackingList() {
                                             onAdd={handleComposerAdd}
                                         />
                                     </div>
-                                    {isComplete && items.length === 0 && (
+                                    {isComplete && items.length === 0 && !isGridSection && (
                                         <p className="text-sm font-medium text-emerald-700">
                                             Nothing left to pack 🎒
                                         </p>
                                     )}
-                                    {innerGroups.map(({ key: groupKey, label, items: catItems, communal: isSharedGroup }) => {
+                                    {isGridSection && (
+                                        <CategoryItemGrid
+                                            sectionTitle={title}
+                                            columns={gridColumns}
+                                            rows={section.rows ?? []}
+                                            personColor={personColor}
+                                            packedById={watchedItems}
+                                            // The names go when there isn't room
+                                            // for them; the legend above the
+                                            // cards decodes the initials instead.
+                                            showColumnNames={isDesktop}
+                                            hidePacked={!showPacked}
+                                            flourish={flourish}
+                                            highlightedItemId={highlightedItem?.id}
+                                            onToggleItem={handleGridToggle}
+                                            registerCellRef={registerCellRef}
+                                            onOpenRow={(row) => setOpenRowKeys({ sectionKey, rowKey: row.key, anchorItemId: row.items[0]?.id })}
+                                            onCheckColumn={(_column, index) => handleCheckColumn(section.rows ?? [], index)}
+                                        />
+                                    )}
+                                    {!isGridSection && innerGroups.map(({ key: groupKey, label, items: catItems, communal: isSharedGroup }) => {
                                         const categoryKey = `${sectionKey}::${groupKey}`
                                         const isCollapsed = collapsedGroups.has(categoryKey)
                                         // Counted over every item in the group, not the ones on
@@ -2092,6 +2324,50 @@ export function ViewPackingList() {
             onConfirm={() => { handleDeleteItem(itemToDelete!); setItemToDelete(null) }}
             title="Remove item"
             message="Are you sure you want to remove this item?"
+            confirmText="Remove"
+            confirmVariant="danger"
+        />
+        <ItemRowPanel
+            isOpen={openRow !== null}
+            onClose={() => setOpenRowKeys(null)}
+            row={openRow}
+            columns={gridColumns}
+            sectionTitle={openRowSection?.title ?? ''}
+            personColor={personColor}
+            packedById={watchedItems}
+            onRename={handleRenameRow}
+            onSetQuantity={handleSetItemQuantity}
+            onToggleLastMinute={handleToggleLastMinute}
+            onAddFor={(row, column) => handleAddItem({
+                personName: column.unassigned ? '' : column.name,
+                personId: column.unassigned ? '' : column.personId,
+                // A category card's section *is* the category. The last minute
+                // card's isn't: its items keep the section they came from, so a
+                // copy made there takes it from the item beside it.
+                category: openRowSection?.isCategory
+                    ? categoryFromLabel(openRowSection.title)
+                    : row.items[0]?.category,
+                lastMinute: openRowSection?.lastMinute,
+            }, row.label, row.quantity)}
+            onRemove={(item) => handleDeleteItem(item.id)}
+            onDeleteRow={(row) => {
+                setOpenRowKeys(null)
+                if (row.items.length === 1) { setItemToDelete(row.items[0].id); return }
+                setRowToDelete({
+                    label: row.label,
+                    items: row.items,
+                    who: row.items.map(item => item.personName || UNASSIGNED_LABEL).join(', '),
+                })
+            }}
+        />
+        <ConfirmationDialog
+            isOpen={rowToDelete !== null}
+            onClose={() => setRowToDelete(null)}
+            onConfirm={() => { if (rowToDelete) handleDeleteRowItems(rowToDelete.items); setRowToDelete(null) }}
+            title="Remove item"
+            message={rowToDelete
+                ? `Remove ${rowToDelete.label} for ${rowToDelete.who}?`
+                : ''}
             confirmText="Remove"
             confirmVariant="danger"
         />

--- a/src/utils/categoryItemGrid.test.ts
+++ b/src/utils/categoryItemGrid.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest'
+import {
+    buildCategoryRows,
+    buildGridColumns,
+    SHARED_ROW_SUFFIX,
+    UNASSIGNED_COLUMN_KEY,
+} from './categoryItemGrid'
+import type { PackingListItem } from '../create-packing-list/types'
+
+function item(overrides: Partial<PackingListItem> & { id: string; itemText: string }): PackingListItem {
+    return {
+        personId: '',
+        personName: '',
+        questionId: 'q1',
+        optionId: 'o1',
+        packed: false,
+        ...overrides,
+    }
+}
+
+const alice = { name: 'Alice', id: 'p1' }
+const bob = { name: 'Bob', id: 'p2' }
+
+/** The columns a two-person list has, which is what most of these rows sit on. */
+const twoColumns = buildGridColumns([alice, bob], [])
+
+describe('buildGridColumns', () => {
+    it('gives every person on the list a column, whatever is in this category', () => {
+        expect(buildGridColumns([alice, bob], []).map(column => column.name)).toEqual(['Alice', 'Bob'])
+    })
+
+    it('keeps the order the list puts its people in', () => {
+        expect(buildGridColumns([bob, alice], []).map(column => column.name)).toEqual(['Bob', 'Alice'])
+    })
+
+    it('gives someone the list does not name a column of their own, after the rest', () => {
+        const columns = buildGridColumns([alice], [
+            item({ id: '1', itemText: 'Toothbrush', personName: 'Zoe', personId: 'p9' }),
+        ])
+
+        expect(columns.map(column => column.name)).toEqual(['Alice', 'Zoe'])
+        expect(columns[1].personId).toBe('p9')
+    })
+
+    it('adds an unassigned column, last, only when something is unassigned', () => {
+        expect(buildGridColumns([alice], []).map(column => column.key)).toEqual(['Alice'])
+
+        const columns = buildGridColumns([alice], [item({ id: '1', itemText: 'Torch' })])
+        expect(columns.map(column => column.key)).toEqual(['Alice', UNASSIGNED_COLUMN_KEY])
+        expect(columns[1].unassigned).toBe(true)
+    })
+
+    it('does not mistake a shared item for an unassigned one', () => {
+        const columns = buildGridColumns([alice], [item({ id: '1', itemText: 'Tent', communal: true })])
+
+        expect(columns.map(column => column.key)).toEqual(['Alice'])
+    })
+})
+
+describe('buildCategoryRows', () => {
+    describe('rows', () => {
+        it('gives an item one row however many people need it', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Toothbrush', personName: 'Alice', personId: 'p1' }),
+                item({ id: '2', itemText: 'Toothbrush', personName: 'Bob', personId: 'p2' }),
+            ], twoColumns)
+
+            expect(rows.map(row => row.label)).toEqual(['Toothbrush'])
+            expect(rows[0].items.map(i => i.id)).toEqual(['1', '2'])
+        })
+
+        it('lines each person up with their own copy, and leaves a gap where there is none', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Toothbrush', personName: 'Alice', personId: 'p1' }),
+                item({ id: '2', itemText: 'Sunhat', personName: 'Bob', personId: 'p2' }),
+            ], twoColumns)
+
+            expect(rows.find(row => row.label === 'Toothbrush')!.cells.map(cell => cell?.id)).toEqual(['1', undefined])
+            expect(rows.find(row => row.label === 'Sunhat')!.cells.map(cell => cell?.id)).toEqual([undefined, '2'])
+        })
+
+        it('keeps a cell for every column, including people with nothing in this category', () => {
+            const rows = buildCategoryRows(
+                [item({ id: '1', itemText: 'Toothbrush', personName: 'Alice', personId: 'p1' })],
+                twoColumns,
+            )
+
+            expect(rows[0].cells).toHaveLength(2)
+        })
+
+        it('matches names that differ only in case or spacing, keeping the first spelling', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Toothbrush', personName: 'Alice', personId: 'p1' }),
+                item({ id: '2', itemText: ' toothbrush ', personName: 'Bob', personId: 'p2' }),
+            ], twoColumns)
+
+            expect(rows.map(row => row.label)).toEqual(['Toothbrush'])
+            expect(rows[0].items).toHaveLength(2)
+        })
+
+        it('gives a second copy for the same person a row of its own, so neither loses its checkbox', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Socks', personName: 'Alice', personId: 'p1' }),
+                item({ id: '2', itemText: 'Socks', personName: 'Alice', personId: 'p1' }),
+                item({ id: '3', itemText: 'Socks', personName: 'Bob', personId: 'p2' }),
+            ], twoColumns)
+
+            expect(rows).toHaveLength(2)
+            expect(rows[0].cells.map(cell => cell?.id)).toEqual(['1', '3'])
+            expect(rows[1].cells.map(cell => cell?.id)).toEqual(['2', undefined])
+            // Two rows for one name need two keys, or React sees one row
+            expect(rows[0].key).not.toEqual(rows[1].key)
+        })
+
+        it('orders rows by the question set order, then alphabetically', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Zebra socks', personName: 'Alice', personId: 'p1', order: 2 }),
+                item({ id: '2', itemText: 'Anorak', personName: 'Alice', personId: 'p1', order: 5 }),
+                item({ id: '3', itemText: 'Boots', personName: 'Alice', personId: 'p1' }),
+                item({ id: '4', itemText: 'Anorak', personName: 'Bob', personId: 'p2', order: 1 }),
+            ], twoColumns)
+
+            // Anorak ranks by the earliest order among its copies
+            expect(rows.map(row => row.label)).toEqual(['Anorak', 'Zebra socks', 'Boots'])
+        })
+
+        it('files an item belonging to nobody in the unassigned column', () => {
+            const columns = buildGridColumns([alice], [item({ id: '1', itemText: 'Torch' })])
+            const rows = buildCategoryRows([item({ id: '1', itemText: 'Torch' })], columns)
+
+            expect(rows[0].cells.map(cell => cell?.id)).toEqual([undefined, '1'])
+        })
+
+        it('keeps packed items, so a ticked cell never looks like one nobody needs', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Toothbrush', personName: 'Alice', personId: 'p1', packed: true }),
+            ], twoColumns)
+
+            expect(rows[0].items.map(i => i.id)).toEqual(['1'])
+        })
+    })
+
+    describe('shared items', () => {
+        it('gives a shared item a row that belongs to no column', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Tent', communal: true }),
+                item({ id: '2', itemText: 'Toothbrush', personName: 'Alice', personId: 'p1' }),
+            ], twoColumns)
+
+            const tent = rows.find(row => row.label === 'Tent')!
+            expect(tent.communal).toBe(true)
+            expect(tent.items.map(i => i.id)).toEqual(['1'])
+            expect(tent.cells).toEqual([])
+        })
+
+        it('puts shared rows ahead of the rest, the way the shared card comes first', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Anorak', personName: 'Alice', personId: 'p1', order: 1 }),
+                item({ id: '2', itemText: 'Tent', communal: true, order: 9 }),
+            ], twoColumns)
+
+            expect(rows.map(row => row.label)).toEqual(['Tent', 'Anorak'])
+        })
+
+        it('keeps a shared item apart from a personal item of the same name', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Tent', communal: true }),
+                item({ id: '2', itemText: 'Tent', personName: 'Alice', personId: 'p1' }),
+            ], twoColumns)
+
+            expect(rows).toHaveLength(2)
+            expect(rows.filter(row => row.communal)).toHaveLength(1)
+            expect(rows.some(row => row.key.includes(SHARED_ROW_SUFFIX))).toBe(true)
+        })
+    })
+
+    describe('quantities', () => {
+        it('reports a quantity every copy shares', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Socks', personName: 'Alice', personId: 'p1', quantity: 3 }),
+                item({ id: '2', itemText: 'Socks', personName: 'Bob', personId: 'p2', quantity: 3 }),
+            ], twoColumns)
+
+            expect(rows[0].quantity).toBe(3)
+            expect(rows[0].mixedQuantities).toBe(false)
+        })
+
+        it('reports quantities that differ as mixed, so each cell can say its own', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Socks', personName: 'Alice', personId: 'p1', quantity: 3 }),
+                item({ id: '2', itemText: 'Socks', personName: 'Bob', personId: 'p2', quantity: 5 }),
+            ], twoColumns)
+
+            expect(rows[0].quantity).toBeUndefined()
+            expect(rows[0].mixedQuantities).toBe(true)
+        })
+
+        it('treats an absent quantity as one', () => {
+            const rows = buildCategoryRows([
+                item({ id: '1', itemText: 'Socks', personName: 'Alice', personId: 'p1' }),
+                item({ id: '2', itemText: 'Socks', personName: 'Bob', personId: 'p2', quantity: 1 }),
+            ], twoColumns)
+
+            expect(rows[0].quantity).toBeUndefined()
+            expect(rows[0].mixedQuantities).toBe(false)
+        })
+    })
+})

--- a/src/utils/categoryItemGrid.ts
+++ b/src/utils/categoryItemGrid.ts
@@ -1,0 +1,196 @@
+/**
+ * The shape of a category card in category view: one row per item, one column
+ * per person, a checkbox where the two meet.
+ *
+ * Category view used to repeat an item's name once per person — "Toothbrush"
+ * three times in Toiletries, under three folded headings — which made the one
+ * question the view exists to answer ("who still needs a toothbrush?") a matter
+ * of reading three lists and holding them in your head. Turning it on its side
+ * gives the name once and the people across it: the same information in a
+ * quarter of the height, and the gaps become the answer.
+ *
+ * Columns are the whole list's people rather than the people this category
+ * happens to mention, so a person is in the same place on every card and an
+ * empty column is a finding rather than a missing one — nobody has packed
+ * anything for the baby in here.
+ *
+ * Kept apart from the page so the arrangement can be tested on its own: nearly
+ * everything awkward here (duplicate names, shared items, quantities that
+ * differ between people) is arithmetic, not rendering.
+ */
+import type { PackingListItem } from '../create-packing-list/types'
+
+/** Column for items typed in without saying whose they are. */
+export const UNASSIGNED_COLUMN_KEY = '__unassigned__'
+
+/** What that column is called where it has to be read as a name. */
+export const UNASSIGNED_COLUMN_LABEL = 'Unassigned'
+
+/**
+ * Distinguishes the shared row for "Tent" from the row for the tent Alice is
+ * carrying herself. A person can't be in both, so the two are different items
+ * that happen to share a name.
+ */
+export const SHARED_ROW_SUFFIX = '::__shared__'
+
+export interface GridColumn {
+    /** Identifies the column; a person's name, or the unassigned key. */
+    key: string
+    /** Shown in the header, and in every label naming the person. */
+    name: string
+    personId: string
+    /** Nobody's in particular — items added without a person. */
+    unassigned?: boolean
+}
+
+export interface GridRow {
+    /** Stable across renders and unique even when two rows share a name. */
+    key: string
+    /** The first spelling of the name seen, since it is the same item either way. */
+    label: string
+    /** Every copy on this row, in column order. */
+    items: PackingListItem[]
+    /** One entry per column, in the same order; undefined where nobody needs it. */
+    cells: (PackingListItem | undefined)[]
+    /** A row for an item packed once for the whole group: no columns, one checkbox. */
+    communal?: boolean
+    /** The quantity every copy agrees on, when it is worth showing (> 1). */
+    quantity?: number
+    /** Copies disagree about how many, so each cell has to say its own. */
+    mixedQuantities: boolean
+}
+
+export interface GridPerson {
+    name: string
+    id: string
+}
+
+/** Names that differ only in case or padding are the same item. */
+function nameKey(itemText: string): string {
+    return itemText.trim().toLowerCase()
+}
+
+function columnKeyFor(item: PackingListItem): string {
+    return item.personName || UNASSIGNED_COLUMN_KEY
+}
+
+/**
+ * The columns every category card in this list uses.
+ *
+ * `people` is the order the list puts its people in. Anyone the list doesn't
+ * name — someone whose items came from a pod, a person since deleted from the
+ * question set — still gets a column, after the known ones, because their items
+ * have to be somewhere.
+ */
+export function buildGridColumns(
+    people: readonly GridPerson[],
+    items: readonly PackingListItem[],
+): GridColumn[] {
+    const personal = items.filter(item => !item.communal)
+    const knownNames = new Set(people.map(person => person.name))
+
+    const strangers = new Map<string, string>()
+    let anyUnassigned = false
+    for (const item of personal) {
+        if (!item.personName) { anyUnassigned = true; continue }
+        if (!knownNames.has(item.personName) && !strangers.has(item.personName)) {
+            strangers.set(item.personName, item.personId)
+        }
+    }
+
+    const columns: GridColumn[] = [
+        ...people.map(person => ({ key: person.name, name: person.name, personId: person.id })),
+        ...[...strangers.entries()]
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([name, personId]) => ({ key: name, name, personId })),
+    ]
+    // Last, because it is where the eye should end up rather than start.
+    if (anyUnassigned) {
+        columns.push({ key: UNASSIGNED_COLUMN_KEY, name: UNASSIGNED_COLUMN_LABEL, personId: '', unassigned: true })
+    }
+    return columns
+}
+
+/**
+ * One category's items, arranged against those columns.
+ *
+ * Takes every item in the category, packed ones included: which cells exist is
+ * a fact about the list, not about what is on screen, and a cell that vanished
+ * when it was ticked would be indistinguishable from a person who never needed
+ * the item. Hiding packed things is a decision for the row, made where it is
+ * rendered.
+ */
+export function buildCategoryRows(
+    items: readonly PackingListItem[],
+    columns: readonly GridColumn[],
+): GridRow[] {
+    const columnKeys = columns.map(column => column.key)
+
+    // Every copy the same person has of one name gets its own row, so no item
+    // ever has to share a checkbox with another: two pairs of socks are two
+    // things to pack, and ticking one can't mean ticking both.
+    interface RowDraft { label: string; order: number; byColumn: Map<string, PackingListItem> }
+    const drafts = new Map<string, RowDraft[]>()
+
+    for (const item of items) {
+        if (item.communal) continue
+        const key = nameKey(item.itemText)
+        let rows = drafts.get(key)
+        if (!rows) { rows = []; drafts.set(key, rows) }
+        const column = columnKeyFor(item)
+        let row = rows.find(candidate => !candidate.byColumn.has(column))
+        if (!row) {
+            row = { label: item.itemText.trim(), order: Infinity, byColumn: new Map() }
+            rows.push(row)
+        }
+        row.byColumn.set(column, item)
+        row.order = Math.min(row.order, item.order ?? Infinity)
+    }
+
+    const personalRows = [...drafts.entries()]
+        .flatMap(([key, rows]) => rows.map((row, index) => {
+            const cells = columnKeys.map(columnKey => row.byColumn.get(columnKey))
+            const rowItems = cells.filter((item): item is PackingListItem => item !== undefined)
+            return {
+                key: index === 0 ? key : `${key}#${index}`,
+                label: row.label,
+                items: rowItems,
+                cells,
+                ...quantityOf(rowItems),
+                sortOrder: row.order,
+            }
+        }))
+
+    // Shared items sit among the rest rather than in a card of their own — a
+    // tent belongs to Camping as much as anyone's sleeping bag does — but each
+    // is one item, so it never shares a row with a person's copy of the name.
+    // First, the way the shared card comes first in person view.
+    const sharedRows = items
+        .filter(item => item.communal)
+        .map(item => ({
+            key: `${nameKey(item.itemText)}${SHARED_ROW_SUFFIX}${item.id}`,
+            label: item.itemText.trim(),
+            items: [item],
+            cells: [] as (PackingListItem | undefined)[],
+            communal: true,
+            ...quantityOf([item]),
+            sortOrder: item.order ?? Infinity,
+        }))
+
+    return [...byOrderThenName(sharedRows), ...byOrderThenName(personalRows)]
+}
+
+/** Items carry the order they had in the question set; rows inherit it. */
+function byOrderThenName<T extends GridRow & { sortOrder: number }>(rows: T[]): GridRow[] {
+    return rows
+        .sort((a, b) => (a.sortOrder - b.sortOrder) || a.label.localeCompare(b.label))
+        .map(({ sortOrder: _sortOrder, ...row }) => row)
+}
+
+/** A quantity is only worth showing when it is more than the one it means by default. */
+function quantityOf(items: PackingListItem[]): { quantity?: number; mixedQuantities: boolean } {
+    const quantities = new Set(items.map(item => item.quantity ?? 1))
+    if (quantities.size > 1) return { mixedQuantities: true }
+    const [only] = [...quantities]
+    return { mixedQuantities: false, ...(only !== undefined && only > 1 ? { quantity: only } : {}) }
+}

--- a/src/utils/listViewPreferences.test.ts
+++ b/src/utils/listViewPreferences.test.ts
@@ -27,14 +27,14 @@ describe('listViewPreferences', () => {
 
         it('reads back what was saved', () => {
             saveListViewPreferences('list-1', {
-                viewMode: 'question',
+                viewMode: 'category',
                 showPacked: true,
                 collapsedSections: ['Alice', '__shared__'],
                 collapsedGroups: ['Alice::Clothes'],
             })
 
             expect(loadListViewPreferences('list-1')).toEqual({
-                viewMode: 'question',
+                viewMode: 'category',
                 showPacked: true,
                 collapsedSections: ['Alice', '__shared__'],
                 collapsedGroups: ['Alice::Clothes'],
@@ -59,6 +59,12 @@ describe('listViewPreferences', () => {
             localStorage.setItem(listViewPreferencesKey('list-1'), '"just a string"')
 
             expect(loadListViewPreferences('list-1')).toEqual(DEFAULT_LIST_VIEW_PREFERENCES)
+        })
+
+        it('reads a list left in the old "question" view as the category view', () => {
+            localStorage.setItem(listViewPreferencesKey('list-1'), JSON.stringify({ viewMode: 'question' }))
+
+            expect(loadListViewPreferences('list-1').viewMode).toBe('category')
         })
 
         it('ignores a view mode it does not recognise', () => {

--- a/src/utils/listViewPreferences.ts
+++ b/src/utils/listViewPreferences.ts
@@ -14,7 +14,7 @@
  * different bag.
  */
 
-export type ListViewMode = 'person' | 'question'
+export type ListViewMode = 'person' | 'category'
 
 export interface ListViewPreferences {
     viewMode: ListViewMode
@@ -88,7 +88,9 @@ export function loadListViewPreferences(listId: string | undefined): ListViewPre
 
     const stored = parsed as Partial<Record<keyof ListViewPreferences, unknown>>
     return {
-        viewMode: stored.viewMode === 'question' ? 'question' : 'person',
+        // 'question' is what the category view was called before it was named
+        // after what it groups by. Lists left in it stay in it.
+        viewMode: stored.viewMode === 'category' || stored.viewMode === 'question' ? 'category' : 'person',
         showPacked: stored.showPacked === true,
         collapsedSections: stringsOnly(stored.collapsedSections),
         collapsedGroups: stringsOnly(stored.collapsedGroups),


### PR DESCRIPTION
"Question view" was named after where its sections came from rather than
what they are, and inside a category it gave every person a folded
heading of their own — so one toothbrush was three rows in three places,
and the question the view exists to answer ("who still needs one?") was
the one thing it made hard.

The view is now called Category, and a category card is a grid: the item
written once down the side, the people across the top, a checkbox where
they meet. Columns are the whole list's people rather than the ones a
category happens to mention, so a person stays in the same place on every
card and a column of gaps is an answer rather than an absence.

One table on every screen, not a table and a phone-shaped substitute:
wrapping people into chips would put each person somewhere different on
every row, which is exactly the reading the grid exists to make possible.
What gives on a narrow screen is the names — the header keeps the
coloured initial and a legend above the cards decodes them once.

Three cell weights, because two would lie: a ticked box, an empty box,
and a flat dot for "not for this person". That is also why hiding packed
items now hides a *row* only once every cell on it is packed — a cell
that vanished when it was ticked would be indistinguishable from a person
who never needed the item — and why the hidden-items count is worked out
per view rather than shared.

Everything about a row that isn't ticking a box lives behind its name, in
a "who needs this?" panel: check a person on to give them one, off to take
it away, with their own quantity and their own last-minute mark beside
them. Renaming is the one thing that belongs to the row, since the same
item spelled two ways for two people is a mistake rather than a
distinction. Each of those rewrites the list once — the single-item
handlers each close over the list and persist a whole copy of it, so
fanning one out in a loop would keep only the last write.

Two smaller fixes fall out of the change: the grid's checkboxes are driven
from the form's values rather than registered against it, since a
registered box that unmounts and returns renders unchecked while the form
still says packed; and the fold-on-open now keys sections the way the view
it is opening in keys them, so a list left in category view no longer
folds a set of people it isn't showing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EotPeKJ2eY9ByT1NkFJYpJ