### PR TITLE
Render stored data before the pod, not after it

### DIFF
--- a/src/components/PodSyncIndicator.test.tsx
+++ b/src/components/PodSyncIndicator.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { PodSyncIndicator } from './PodSyncIndicator'
+
+describe('PodSyncIndicator', () => {
+    it('says what is being waited for without taking over the page', () => {
+        render(<PodSyncIndicator />)
+
+        const indicator = screen.getByTestId('pod-sync-indicator')
+        expect(indicator.textContent).toContain('Checking your Pod for changes')
+        expect(indicator.getAttribute('aria-live')).toBe('polite')
+    })
+
+    it('names what is being checked when the page shows one thing', () => {
+        render(<PodSyncIndicator subject="this list" />)
+
+        expect(screen.getByTestId('pod-sync-indicator').textContent).toContain('Checking your Pod for changes to this list')
+    })
+})

--- a/src/components/PodSyncIndicator.tsx
+++ b/src/components/PodSyncIndicator.tsx
@@ -1,0 +1,31 @@
+interface PodSyncIndicatorProps {
+    /**
+     * What is being checked, when the page is showing one thing rather than
+     * everything — "this list", say. Omitted, the note stays general.
+     */
+    subject?: string
+}
+
+/**
+ * A quiet note that what's on screen is the device's copy and the pod is still
+ * being read.
+ *
+ * Pages render their local data immediately (see `useLocalFirstLoad`) rather
+ * than waiting on the pod, so anything that appears or changes a moment later
+ * needs to make sense. Deliberately a line of text rather than a spinner or an
+ * overlay: nothing here is blocked on the pod, and the page must stay usable
+ * while it answers.
+ */
+export function PodSyncIndicator({ subject }: PodSyncIndicatorProps) {
+    return (
+        <div
+            data-testid="pod-sync-indicator"
+            role="status"
+            aria-live="polite"
+            className="mb-4 flex items-center gap-2 text-sm font-medium text-gray-600"
+        >
+            <span aria-hidden="true" className="loading-suitcase text-base leading-none">🧳</span>
+            Checking your Pod for changes{subject ? ` to ${subject}` : ''}...
+        </div>
+    )
+}

--- a/src/hooks/useLocalFirstLoad.test.ts
+++ b/src/hooks/useLocalFirstLoad.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useLocalFirstLoad } from './useLocalFirstLoad'
+import { useDatabase } from '../components/DatabaseContext'
+
+vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
+
+const mockUseDatabase = vi.mocked(useDatabase)
+
+function databaseContext(loginSyncVersion: number, loginSyncInProgress: boolean) {
+    mockUseDatabase.mockReturnValue({
+        db: {} as never,
+        loginSyncVersion,
+        loginSyncInProgress,
+    })
+}
+
+describe('useLocalFirstLoad', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('reads without waiting for the pod sync to finish', async () => {
+        databaseContext(0, true)
+        const read = vi.fn()
+
+        renderHook(() => useLocalFirstLoad(read, []))
+
+        await waitFor(() => expect(read).toHaveBeenCalledTimes(1))
+    })
+
+    it('reports that the pod is still being checked', () => {
+        databaseContext(0, true)
+
+        const { result } = renderHook(() => useLocalFirstLoad(vi.fn(), []))
+
+        expect(result.current.isCheckingPod).toBe(true)
+    })
+
+    it('stops reporting once the pod sync has finished', () => {
+        databaseContext(1, false)
+
+        const { result } = renderHook(() => useLocalFirstLoad(vi.fn(), []))
+
+        expect(result.current.isCheckingPod).toBe(false)
+    })
+
+    it('does not claim to be checking a pod when there is none', () => {
+        databaseContext(0, false)
+
+        const { result } = renderHook(() => useLocalFirstLoad(vi.fn(), []))
+
+        expect(result.current.isCheckingPod).toBe(false)
+    })
+
+    // Otherwise a page with nothing to show paints its empty state for a frame
+    // between the sync finishing and the read it triggered coming back.
+    it('keeps reporting the check until the read the sync triggered comes back', async () => {
+        databaseContext(0, true)
+        let finishRead: () => void = () => {}
+        const read = vi.fn(() => new Promise<void>(resolve => { finishRead = resolve }))
+
+        const { result, rerender } = renderHook(() => useLocalFirstLoad(read, []))
+        await waitFor(() => expect(read).toHaveBeenCalledTimes(1))
+        act(() => finishRead())
+
+        databaseContext(1, false)
+        rerender()
+
+        expect(result.current.isCheckingPod).toBe(true)
+
+        await act(async () => { finishRead() })
+        expect(result.current.isCheckingPod).toBe(false)
+    })
+
+    it('reads again when the login sync lands, in case the pod brought something new', async () => {
+        databaseContext(0, true)
+        const read = vi.fn()
+
+        const { rerender } = renderHook(() => useLocalFirstLoad(read, []))
+        await waitFor(() => expect(read).toHaveBeenCalledTimes(1))
+
+        databaseContext(1, false)
+        rerender()
+
+        await waitFor(() => expect(read).toHaveBeenCalledTimes(2))
+    })
+
+    it('reads again when the caller\'s own dependencies change', async () => {
+        databaseContext(1, false)
+        const read = vi.fn()
+
+        const { rerender } = renderHook(({ id }: { id: string }) => useLocalFirstLoad(read, [id]), {
+            initialProps: { id: 'list-1' },
+        })
+        await waitFor(() => expect(read).toHaveBeenCalledTimes(1))
+
+        rerender({ id: 'list-2' })
+
+        await waitFor(() => expect(read).toHaveBeenCalledTimes(2))
+    })
+
+    it('does not re-read when nothing it depends on has changed', async () => {
+        databaseContext(1, false)
+        const read = vi.fn()
+
+        const { rerender } = renderHook(() => useLocalFirstLoad(read, ['stable']))
+        await waitFor(() => expect(read).toHaveBeenCalledTimes(1))
+
+        rerender()
+        rerender()
+
+        expect(read).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses the latest read function without re-running for it', async () => {
+        databaseContext(1, false)
+        const first = vi.fn()
+        const second = vi.fn()
+
+        const { rerender } = renderHook(({ read }: { read: () => void }) => useLocalFirstLoad(read, ['stable']), {
+            initialProps: { read: first },
+        })
+        await waitFor(() => expect(first).toHaveBeenCalledTimes(1))
+
+        rerender({ read: second })
+
+        expect(second).not.toHaveBeenCalled()
+    })
+})

--- a/src/hooks/useLocalFirstLoad.ts
+++ b/src/hooks/useLocalFirstLoad.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState, type DependencyList } from 'react'
+import { useDatabase } from '../components/DatabaseContext'
+
+export interface LocalFirstLoad {
+    /**
+     * True while the pod → local sync started at login could still turn
+     * "there's nothing here" into "here it is": the sync is running, or it has
+     * just landed and the follow-up read hasn't come back yet.
+     *
+     * A page that found what it needed locally only uses this to say the pod is
+     * still being read (see `PodSyncIndicator`). A page that found nothing keeps
+     * its loading treatment up until it clears, rather than showing an empty
+     * state that is about to be wrong.
+     */
+    isCheckingPod: boolean
+}
+
+/**
+ * Reads local data straight away and lets the pod catch up afterwards.
+ *
+ * Everything this app shows is stored on the device as well as in the pod, so
+ * there is nearly always something to render immediately: the PouchDB read
+ * resolves in milliseconds. The pod → local sync that runs at login walks the
+ * whole pod — the question set, every packing list, the tombstones — and takes
+ * as long as the pod takes to answer, which on a slow connection is seconds.
+ * Blocking the first paint on it turns opening a list the device already holds
+ * into a wait for data the page isn't going to use.
+ *
+ * So `read` runs on mount, and again when the login sync finishes in case it
+ * brought something this device had never seen. A page whose data is already on
+ * screen by then, and that reconciles pod changes some other way — a
+ * per-resource `usePodSync` poll, say — should skip that second read itself
+ * rather than overwrite what the user is looking at.
+ *
+ * `read` is always called through its latest closure, so it does not need to be
+ * memoized and does not belong in `deps`. Put in `deps` only what changes *which
+ * data to read* — the database, a list id — the way you would for `useEffect`.
+ */
+export function useLocalFirstLoad(read: () => void | Promise<void>, deps: DependencyList): LocalFirstLoad {
+    const { loginSyncVersion, loginSyncInProgress } = useDatabase()
+
+    const readRef = useRef(read)
+    readRef.current = read
+
+    // Which login sync the last completed read saw. Seeded with the version at
+    // mount so a page that opens after the sync — or with no pod at all — never
+    // claims to be checking one. It falls behind only when a sync lands, and
+    // catches up when the read it triggered comes back. Comparing the two during
+    // render is what stops an empty state painting for a frame between the sync
+    // finishing and its read returning.
+    const [readSyncVersion, setReadSyncVersion] = useState(loginSyncVersion)
+
+    useEffect(() => {
+        let cancelled = false
+        Promise.resolve(readRef.current())
+            .catch(() => {})
+            .finally(() => {
+                if (!cancelled) setReadSyncVersion(loginSyncVersion)
+            })
+        return () => { cancelled = true }
+    // The caller's deps are spread in deliberately; `read` is reached through a
+    // ref so a fresh closure on every render can't turn this into a read loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [...deps, loginSyncVersion])
+
+    return { isCheckingPod: loginSyncInProgress || readSyncVersion !== loginSyncVersion }
+}

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -1524,6 +1524,51 @@ describe('CreatePackingList – loading state', () => {
         await waitFor(() => screen.getByText(/Answer the questions below/i))
         expect(screen.queryByRole('status')).toBeNull()
     })
+
+    // The pod → local sync at login walks the whole pod. Waiting for it before
+    // reading the device's own copy is seconds of skeleton for questions the
+    // page already has.
+    it('shows the stored questions without waiting for the pod sync', async () => {
+        mockUseDatabase.mockReturnValue({
+            db: makeDb(),
+            loginSyncVersion: 0,
+            loginSyncInProgress: true,
+        } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+        expect(screen.getByTestId('pod-sync-indicator')).toBeTruthy()
+    })
+
+    // Otherwise a device the sync hasn't reached invites the user to redo a
+    // setup they have already done.
+    it('keeps waiting rather than claiming there are no questions while the pod is still being read', async () => {
+        mockUseDatabase.mockReturnValue({
+            db: makeDb({ getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }) }),
+            loginSyncVersion: 0,
+            loginSyncInProgress: true,
+        } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+
+        await waitFor(() => {
+            expect(screen.getByRole('status').textContent).toContain('Loading questions...')
+        })
+        expect(screen.queryByText(/No Questions Found/i)).toBeNull()
+    })
+
+    it('says there are no questions once the pod has been read', async () => {
+        mockUseDatabase.mockReturnValue({
+            db: makeDb({ getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }) }),
+            loginSyncVersion: 0,
+            loginSyncInProgress: false,
+        } as ReturnType<typeof useDatabase>)
+
+        renderCreatePackingList()
+
+        await waitFor(() => expect(screen.getByText(/No Questions Found/i)).toBeTruthy())
+    })
 })
 
 // ─── CreatePackingList – landing on the new list ──────────────────────────────

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useRef } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { Link, useNavigate } from 'react-router-dom'
 import { PackingListQuestionSet } from '../edit-questions/types'
@@ -12,11 +12,13 @@ import { reportError } from '../errorReporting'
 import { SolidProviderSelector } from '../components/SolidProviderSelector'
 import { getPrimaryPodUrl, saveRdfToPod, POD_CONTAINERS, loadMultipleRdfFromPod } from '../services/solidPod'
 import { usePodSync } from '../hooks/usePodSync'
+import { useLocalFirstLoad } from '../hooks/useLocalFirstLoad'
 import { questionSetToDataset, datasetToQuestionSet, packingListToDataset, datasetToPackingList } from '../services/rdfSerialization'
 import { useForeignPod } from '../components/ForeignPodContext'
 import { generateQuestionBasedItems, generateAlwaysNeededItems, withItemOrder } from '../create-packing-list/generatePackingListItems'
 import { AgePromotionCard } from '../components/AgePromotionCard'
 import { LoadingState } from '../components/LoadingState'
+import { PodSyncIndicator } from '../components/PodSyncIndicator'
 import { tripDatesOutOfOrder } from '../create-packing-list/tripDetails'
 import { deduplicateItems } from '../create-packing-list/deduplicate'
 import { PersonAvatar } from '../components/PersonAvatar'
@@ -307,13 +309,16 @@ export function CreatePackingList() {
     const [allPackingLists, setAllPackingLists] = useState<PackingList[]>([])
     const [isLoading, setIsLoading] = useState(true)
     const [noQuestionsFound, setNoQuestionsFound] = useState(false)
+    // Whether a question set was actually read off this device. A device that
+    // has none keeps looking each time the login sync lands something.
+    const hasStoredSetRef = useRef(false)
     const [selectedPeopleIds, setSelectedPeopleIds] = useState<string[]>([])
     const [isSuggestionDismissed, setIsSuggestionDismissed] = useState(false)
     const [isDeletionSuggestionDismissed, setIsDeletionSuggestionDismissed] = useState(false)
     const { showToast } = useToast()
     const { isLoggedIn, login, session } = useSolidPod()
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
-    const { db, loginSyncInProgress } = useDatabase()
+    const { db } = useDatabase()
     const navigate = useNavigate()
     const foreignPodCtx = useForeignPod()
     const foreignPodUrl = foreignPodCtx?.foreignPodUrl ?? null
@@ -360,17 +365,22 @@ export function CreatePackingList() {
         onSyncSuccess: handleQuestionSetPodSync,
     })
 
-    useEffect(() => {
+    // Local first: the question set stored on this device goes up straight away
+    // and the pod catches up afterwards — see useLocalFirstLoad.
+    const { isCheckingPod } = useLocalFirstLoad(() => {
         if (foreignPodUrl) {
             // Questions come from usePodSync onSyncSuccess; just load past lists from the foreign pod.
             if (!session) return
-            loadMultipleRdfFromPod(session, `${foreignPodUrl}${POD_CONTAINERS.PACKING_LISTS}`, datasetToPackingList)
+            return loadMultipleRdfFromPod(session, `${foreignPodUrl}${POD_CONTAINERS.PACKING_LISTS}`, datasetToPackingList)
                 .then(({ data }) => setAllPackingLists(data))
                 .catch(err => console.error('Error loading foreign packing lists for suggestions:', err))
-            return
         }
 
-        if (loginSyncInProgress) return
+        // Once a stored set is on screen, re-reading it when the login sync
+        // lands would throw away the people the user has since picked. The read
+        // the sync triggers is only of use to a device that had nothing of its
+        // own to show.
+        if (hasStoredSetRef.current) return
 
         const fetchQuestionSet = async () => {
             if (!db) {
@@ -384,6 +394,7 @@ export function CreatePackingList() {
                     db.getQuestionSet(),
                     db.getAllPackingLists(),
                 ])
+                hasStoredSetRef.current = true
                 setQuestionSet(doc)
                 setAllPackingLists(lists)
                 setNoQuestionsFound(false)
@@ -401,8 +412,8 @@ export function CreatePackingList() {
                 setIsLoading(false)
             }
         }
-        fetchQuestionSet()
-    }, [db, showToast, loginSyncInProgress, foreignPodUrl, session])
+        return fetchQuestionSet()
+    }, [db, foreignPodUrl, session])
 
     const suggestions = useMemo(
         () => questionSet ? getUnreviewedCustomItems(allPackingLists, questionSet) : [],
@@ -659,7 +670,10 @@ export function CreatePackingList() {
         }
     }
 
-    if (isLoading) {
+    // "No Questions Found" on a device the login sync hasn't reached yet is a
+    // lie the page has to take back — and one that invites the user to redo a
+    // setup they have already done. Keep waiting until the pod has been read.
+    if (isLoading || (noQuestionsFound && isCheckingPod)) {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
                 <LoadingState message="Loading questions..." rows={3} />
@@ -746,6 +760,10 @@ export function CreatePackingList() {
                 <h1 className="text-2xl font-bold text-gray-900">Create New Packing List</h1>
                 <p className="mt-2 text-gray-600">Answer the questions below to create your packing list.</p>
             </div>
+
+            {/* The questions below are this device's copy; say so while the pod
+                is still being read, so anything that changes makes sense. */}
+            {isCheckingPod && <PodSyncIndicator />}
 
             {!foreignPodUrl && (
                 <div className="mb-6 empty:hidden">

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -6,12 +6,14 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { LoadingState } from '../components/LoadingState'
+import { PodSyncIndicator } from '../components/PodSyncIndicator'
 import { Modal } from '../components/Modal'
 import { SyncAcrossDevicesPrompt } from '../components/SyncAcrossDevicesPrompt'
 import { getPrimaryPodUrl, saveRdfToPod, deleteFileFromPod, POD_CONTAINERS, POD_ERROR_MESSAGES, getCollaborators, isPubliclyAccessible, resolveOwnerDisplayName, buildSharedListPath } from '../services/solidPod'
 import { useOwnerDisplayNames } from '../hooks/useOwnerDisplayName'
 import { packingListToDataset, deletedPackingListsToDataset } from '../services/rdfSerialization'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
+import { useLocalFirstLoad } from '../hooks/useLocalFirstLoad'
 import { generateUUID } from '../utils/uuid'
 import { formatTripDates } from '../create-packing-list/tripDetails'
 
@@ -32,7 +34,7 @@ export function PackingLists() {
             .map(l => ({ id: l.id, podUrl: l.sharedFromPodUrl!, ownerWebId: l.ownerWebId })),
         session
     )
-    const { db, loginSyncVersion, loginSyncInProgress } = useDatabase()
+    const { db } = useDatabase()
     const handlePodError = usePodErrorHandler()
 
     const requestDeletePackingList = (id: string, name: string, event: React.MouseEvent) => {
@@ -134,7 +136,9 @@ export function PackingLists() {
         }
     }
 
-    useEffect(() => {
+    // Local first: the lists on this device go up straight away and the pod
+    // catches up afterwards — see useLocalFirstLoad.
+    const { isCheckingPod } = useLocalFirstLoad(() => {
         const fetchPackingLists = async () => {
             try {
                 const lists = await db.getAllPackingLists()
@@ -145,8 +149,8 @@ export function PackingLists() {
                 setIsLoading(false)
             }
         }
-        fetchPackingLists()
-    }, [db, isLoggedIn, loginSyncVersion])
+        return fetchPackingLists()
+    }, [db, isLoggedIn])
 
     // Lazy-load sharing status badges for own lists only
     useEffect(() => {
@@ -169,13 +173,11 @@ export function PackingLists() {
         }).catch(() => {})
     }, [packingLists, isLoggedIn, session])
 
-    // The local PouchDB read is the only thing worth blocking on — it resolves in
-    // milliseconds. The pod sync runs for as long as the pod takes to answer, and
-    // the effect above re-fetches when loginSyncVersion bumps, so local lists can
-    // be shown straight away and quietly refreshed when the pod catches up. The
-    // one case that still has to wait is an empty device on first login: there is
-    // nothing local to show and "No packing lists found" would be a lie.
-    if (isLoading || (packingLists.length === 0 && loginSyncInProgress)) {
+    // The local read is the only thing worth blocking on — it resolves in
+    // milliseconds. The one case that still has to wait is an empty device on
+    // first login: there is nothing local to show and "No packing lists found"
+    // would be a lie until the pod has been read.
+    if (isLoading || (packingLists.length === 0 && isCheckingPod)) {
         // Keep the real header in place so only the list area changes when the
         // lists land.
         return (
@@ -204,17 +206,7 @@ export function PackingLists() {
 
             {/* The lists below are the local copy; say so while the pod is still
                 being read, so anything that appears or changes makes sense. */}
-            {loginSyncInProgress && (
-                <div
-                    data-testid="pod-sync-indicator"
-                    role="status"
-                    aria-live="polite"
-                    className="mb-4 flex items-center gap-2 text-sm font-medium text-gray-600"
-                >
-                    <span aria-hidden="true" className="loading-suitcase text-base leading-none">🧳</span>
-                    Checking your Pod for changes...
-                </div>
-            )}
+            {isCheckingPod && <PodSyncIndicator />}
 
             {/* Only worth asking once there is something to sync */}
             {packingLists.length > 0 && <SyncAcrossDevicesPrompt />}

--- a/src/pages/questions-page.loading.test.tsx
+++ b/src/pages/questions-page.loading.test.tsx
@@ -47,9 +47,18 @@ const mockUseForeignPod = vi.mocked(useForeignPod)
 
 const emptyQuestionSet = { _id: '1', _rev: '1', questions: [], people: [], alwaysNeededItems: [] }
 
-function renderQuestionsPage(getQuestionSet: () => Promise<unknown>) {
+const storedQuestionSet = {
+    _id: '1',
+    _rev: '1',
+    questions: [],
+    people: [{ id: 'p1', name: 'Alice', personSelections: [] }],
+    alwaysNeededItems: [],
+}
+
+function renderQuestionsPage(getQuestionSet: () => Promise<unknown>, databaseContext: Record<string, unknown> = {}) {
     mockUseDatabase.mockReturnValue({
         db: { getQuestionSet, saveQuestionSet: vi.fn() } as unknown as PackingAppDatabase,
+        ...databaseContext,
     })
     return render(
         <MemoryRouter>
@@ -90,5 +99,44 @@ describe('QuestionsPage loading state', () => {
 
         await waitFor(() => expect(screen.getByText('My Questions & Items')).toBeTruthy())
         expect(screen.queryByRole('status')).toBeNull()
+    })
+
+    // The pod → local sync at login walks the whole pod. Waiting for it before
+    // reading the device's own copy is seconds of skeleton for data the page
+    // already has.
+    it('shows the stored question set without waiting for the pod sync', async () => {
+        renderQuestionsPage(() => Promise.resolve(storedQuestionSet), { loginSyncInProgress: true, loginSyncVersion: 0 })
+
+        expect(await screen.findByText('My Questions & Items')).toBeTruthy()
+    })
+
+    it('flags that the pod is still being read', async () => {
+        renderQuestionsPage(() => Promise.resolve(storedQuestionSet), { loginSyncInProgress: true, loginSyncVersion: 0 })
+
+        await screen.findByText('My Questions & Items')
+        expect(screen.getByTestId('pod-sync-indicator')).toBeTruthy()
+    })
+
+    // Otherwise a fresh device tells the user their questions are gone, and
+    // invites them to redo a setup they have already done.
+    it('keeps waiting rather than showing an empty set while the pod is still being read', async () => {
+        renderQuestionsPage(
+            () => Promise.reject({ name: 'not_found' }),
+            { loginSyncInProgress: true, loginSyncVersion: 0 },
+        )
+
+        await waitFor(() => {
+            expect(screen.getByRole('status').textContent).toContain('Loading questions & items...')
+        })
+        expect(screen.queryByText('My Questions & Items')).toBeNull()
+    })
+
+    it('shows the empty set once the pod has been read', async () => {
+        renderQuestionsPage(
+            () => Promise.reject({ name: 'not_found' }),
+            { loginSyncInProgress: false, loginSyncVersion: 0 },
+        )
+
+        await waitFor(() => expect(screen.getByText('My Questions & Items')).toBeTruthy())
     })
 })

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -12,6 +12,7 @@ import { PackingListQuestionSet, Person, Item, Option, Question, QuestionType, n
 import { Link } from 'react-router-dom'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 import { usePodSync } from '../hooks/usePodSync'
+import { useLocalFirstLoad } from '../hooks/useLocalFirstLoad'
 import { mergeQuestionSets } from '../utils/mergeQuestionSets'
 import { POD_CONTAINERS } from '../services/solidPod'
 import { questionSetToDataset, datasetToQuestionSet } from '../services/rdfSerialization'
@@ -20,6 +21,7 @@ import { useForeignPod } from '../components/ForeignPodContext'
 import { AgePromotionCard } from '../components/AgePromotionCard'
 import { TemplateUpdatesCard } from '../components/TemplateUpdatesCard'
 import { LoadingState } from '../components/LoadingState'
+import { PodSyncIndicator } from '../components/PodSyncIndicator'
 import { AgeTransition } from '../edit-questions/age-derivation'
 import { appendItemToSection, applyItemEdit, tombstoneRemovedItems, withQuestionOptions } from '../edit-questions/item-edits'
 import { ItemInlineEditor } from '../components/ItemInlineEditor'
@@ -1485,7 +1487,7 @@ function QuestionModal({ question, onSave, onClose }: {
 }
 
 export function QuestionsPage() {
-    const { db, loginSyncInProgress } = useDatabase()
+    const { db } = useDatabase()
     const { isLoggedIn } = useSolidPod()
     const foreignPodCtx = useForeignPod()
     const foreignPodUrl = foreignPodCtx?.foreignPodUrl
@@ -1497,6 +1499,9 @@ export function QuestionsPage() {
     // changes, which is what lets the memoized QuestionSections skip renders.
     const dataRef = useRef<PackingListQuestionSet | null>(null)
     dataRef.current = data
+    // Whether a question set was actually read off this device, as opposed to
+    // the empty one stood up when there is nothing stored yet.
+    const hasStoredSetRef = useRef(false)
     const [rev, setRev] = useState<string | undefined>(undefined)
     const [error, setError] = useState<string | null>(null)
     const [questionModal, setQuestionModal] = useState<{ question: Question | null } | null>(null)
@@ -1533,26 +1538,36 @@ export function QuestionsPage() {
     // Keep saveToPodRef in sync so useSyncCoordinator can push merge results back to pod
     useEffect(() => { saveToPodRef.current = saveToPod }, [saveToPod])
 
-    useEffect(() => {
-        if (loginSyncInProgress) return
+    // Local first: the question set stored on this device goes up straight away
+    // and the pod catches up afterwards — see useLocalFirstLoad.
+    const { isCheckingPod } = useLocalFirstLoad(() => {
+        // Once a stored set is on screen the pod poll owns reconciliation: it
+        // merges through useSyncCoordinator rather than replacing what the user
+        // may be part-way through editing. The read the login sync triggers is
+        // only of use to a device that had nothing of its own to show.
+        if (hasStoredSetRef.current) return
+
         const load = async () => {
             try {
                 const migration = await DatabaseMigration.checkMigrationNeeded(db)
                 if (migration.needed) await DatabaseMigration.performMigration(db)
                 const d = await db.getQuestionSet()
+                hasStoredSetRef.current = true
                 setData(d)
                 setRev(d._rev)
             } catch (err: unknown) {
                 if (typeof err === 'object' && err !== null && 'name' in err && (err as { name: string }).name === 'not_found') {
+                    // Nothing stored here yet. An empty set is something to work
+                    // with, but it is not this device's answer — leave the ref
+                    // alone so the login sync's read still gets its turn.
                     setData({ _id: '1', questions: [], people: [], alwaysNeededItems: [] })
                 } else {
                     setError(String(err))
                 }
             }
         }
-        load()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [loginSyncInProgress])
+        return load()
+    }, [db])
 
     const saveData = useCallback(async (updated: PackingListQuestionSet) => {
         const previous = dataRef.current
@@ -1899,7 +1914,12 @@ export function QuestionsPage() {
     const activeAlwaysNeededItems = useMemo(() => (data?.alwaysNeededItems ?? []).filter(i => !i.deletedAt), [data])
 
     if (error) return <div className="p-8 text-red-600">Error: {error}</div>
-    if (!data) return (
+    // An empty set on a device that has never synced isn't an answer yet: the
+    // login sync may be about to bring the user's real questions. Showing them
+    // "you have no questions" first, and a full set a moment later, would read
+    // as their questions having been lost.
+    const nothingStoredYet = people.length === 0 && activeQuestions.length === 0 && activeAlwaysNeededItems.length === 0
+    if (!data || (nothingStoredYet && isCheckingPod)) return (
         <div className="w-full flex flex-col items-center py-8 px-4">
             <div className="w-full max-w-3xl">
                 <LoadingState message="Loading questions & items..." rows={3} />
@@ -1910,6 +1930,9 @@ export function QuestionsPage() {
     return (
         <div className="w-full flex flex-col items-center py-8 px-4">
             <div className="w-full max-w-3xl space-y-4">
+                {/* What's below is this device's copy; say so while the pod is
+                    still being read, so anything that changes makes sense. */}
+                {isCheckingPod && <PodSyncIndicator />}
                 <div className="mb-2">
                     <h1 className="text-2xl font-bold text-gray-900">{isForeign ? 'Questions & Items' : 'My Questions & Items'}</h1>
                     <p className="mt-1 text-gray-600 text-sm">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react'
 import React from 'react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom'
 import { ViewPackingList, groupByCategory, groupByPerson } from './view-packing-list'
 import type { PackingAppDatabase } from '../services/database'
 import type { PackingListItem } from '../create-packing-list/types'
@@ -1396,18 +1396,25 @@ describe('ViewPackingList when an own-pod list is not in local storage yet', () 
         expect(mockCaptureException).not.toHaveBeenCalled()
     })
 
-    it('does not read from local storage while the login sync is still running', async () => {
+    it('says the list is still on its way rather than missing while the login sync runs', async () => {
         const { getPackingList } = renderMissingLocally({ loginSyncInProgress: true })
 
-        await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Loading packing list...'))
-        expect(getPackingList).not.toHaveBeenCalled()
+        await waitFor(() => expect(getPackingList).toHaveBeenCalledWith('test-list-1'))
+        expect(screen.getByRole('status').textContent).toContain('Loading packing list...')
         expect(screen.queryByText('Packing list not found')).toBeNull()
     })
 
-    it('reads local storage once the login sync finishes', async () => {
+    it('says the list is not there once the login sync has finished', async () => {
+        const { getPackingList } = renderMissingLocally({ loginSyncInProgress: false })
+
+        await waitFor(() => expect(getPackingList).toHaveBeenCalled())
+        await waitFor(() => expect(screen.getByText('Packing list not found')).toBeTruthy())
+    })
+
+    it('looks again when the login sync lands something it had not seen', async () => {
         const getPackingList = vi.fn().mockRejectedValue({ name: 'not_found', message: 'Packing list not found' })
         const db = { ...makeDb(), getPackingList } as unknown as PackingAppDatabase
-        mockUseDatabase.mockReturnValue({ db, loginSyncInProgress: true })
+        mockUseDatabase.mockReturnValue({ db, loginSyncVersion: 0, loginSyncInProgress: true })
 
         const { rerender } = render(
             <MemoryRouter initialEntries={['/view-list/test-list-1']}>
@@ -1416,9 +1423,10 @@ describe('ViewPackingList when an own-pod list is not in local storage yet', () 
                 </Routes>
             </MemoryRouter>
         )
-        expect(getPackingList).not.toHaveBeenCalled()
+        await waitFor(() => expect(getPackingList).toHaveBeenCalledTimes(1))
 
-        mockUseDatabase.mockReturnValue({ db, loginSyncInProgress: false })
+        getPackingList.mockResolvedValue(testPackingList)
+        mockUseDatabase.mockReturnValue({ db, loginSyncVersion: 1, loginSyncInProgress: false })
         rerender(
             <MemoryRouter initialEntries={['/view-list/test-list-1']}>
                 <Routes>
@@ -1427,7 +1435,7 @@ describe('ViewPackingList when an own-pod list is not in local storage yet', () 
             </MemoryRouter>
         )
 
-        await waitFor(() => expect(getPackingList).toHaveBeenCalledWith('test-list-1'))
+        await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
         expect(mockCaptureException).not.toHaveBeenCalled()
     })
 
@@ -1458,6 +1466,121 @@ describe('ViewPackingList when an own-pod list is not in local storage yet', () 
         )
 
         await waitFor(() => expect(mockCaptureException).toHaveBeenCalledWith(failure))
+    })
+})
+
+// Opening a list the device already holds must not wait on the pod. The login
+// sync walks the whole pod — every list, the question set, the tombstones — and
+// on a slow connection that is seconds of staring at a skeleton for data the
+// page already has locally.
+
+describe('ViewPackingList while the pod sync is still running', () => {
+    function renderWithSync(loginSyncInProgress: boolean, db = makeDb()) {
+        mockUseDatabase.mockReturnValue({
+            db: db as unknown as PackingAppDatabase,
+            loginSyncVersion: 0,
+            loginSyncInProgress,
+        })
+        return { ...renderComponent(), db }
+    }
+
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: { info: { isLoggedIn: true, webId: 'https://own.solidcommunity.net/profile/card#me' }, fetch: vi.fn() },
+            webId: 'https://own.solidcommunity.net/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
+        })
+    })
+
+    it('shows a locally stored list without waiting for the pod', async () => {
+        renderWithSync(true)
+
+        expect(await screen.findByText('Test Trip')).toBeTruthy()
+        expect(screen.queryByText('Loading packing list...')).toBeNull()
+    })
+
+    it('flags that the pod is still being read', async () => {
+        renderWithSync(true)
+
+        await screen.findByText('Test Trip')
+        expect(screen.getByTestId('pod-sync-indicator')).toBeTruthy()
+    })
+
+    it('drops the flag once the pod has been read', async () => {
+        renderWithSync(false)
+
+        await screen.findByText('Test Trip')
+        expect(screen.queryByTestId('pod-sync-indicator')).toBeNull()
+    })
+
+    // The guard above must not turn into "this page has loaded something":
+    // moving between two lists keeps the same component mounted, and the second
+    // one has to be read.
+    it('reads the next list when the route moves to a different one', async () => {
+        const secondList = { ...testPackingList, id: 'test-list-2', name: 'Second Trip' }
+        const getPackingList = vi.fn(async (listId: string) => (
+            listId === 'test-list-2' ? secondList : testPackingList
+        ))
+        mockUseDatabase.mockReturnValue({
+            db: { ...makeDb(), getPackingList } as unknown as PackingAppDatabase,
+            loginSyncVersion: 0,
+            loginSyncInProgress: false,
+        })
+
+        function GoToSecondList() {
+            const navigate = useNavigate()
+            return <button onClick={() => navigate('/view-list/test-list-2')}>go to second</button>
+        }
+
+        render(
+            <MemoryRouter initialEntries={['/view-list/test-list-1']}>
+                <GoToSecondList />
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+        await screen.findByText('Test Trip')
+
+        fireEvent.click(screen.getByText('go to second'))
+
+        expect(await screen.findByText('Second Trip')).toBeTruthy()
+    })
+
+    // Once the list is on screen the per-list pod poll owns reconciliation: it
+    // merges through useSyncCoordinator, which preserves focus and in-flight
+    // edits. A raw re-read would reset the form under the user's fingers.
+    it('leaves the list on screen alone when the login sync lands', async () => {
+        const db = makeDb()
+        const { rerender } = renderWithSync(true, db)
+        await screen.findByText('Test Trip')
+        expect(db.getPackingList).toHaveBeenCalledTimes(1)
+
+        mockUseDatabase.mockReturnValue({
+            db: db as unknown as PackingAppDatabase,
+            loginSyncVersion: 1,
+            loginSyncInProgress: false,
+        })
+        rerender(
+            <MemoryRouter initialEntries={['/view-list/test-list-1']}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+
+        await waitFor(() => expect(screen.queryByTestId('pod-sync-indicator')).toBeNull())
+        expect(db.getPackingList).toHaveBeenCalledTimes(1)
     })
 })
 

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -6,11 +6,13 @@ import { useDatabase } from '../components/DatabaseContext'
 import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { LoadingState } from '../components/LoadingState'
+import { PodSyncIndicator } from '../components/PodSyncIndicator'
 import { useForm, useWatch } from 'react-hook-form'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useToast } from '../components/ToastContext'
 import { reportError } from '../errorReporting'
 import { usePodSync } from '../hooks/usePodSync'
+import { useLocalFirstLoad } from '../hooks/useLocalFirstLoad'
 import { useSyncCoordinator } from '../hooks/useSyncCoordinator'
 import { POD_CONTAINERS, getPrimaryPodUrl, saveRdfToPod, resolveOwnerDisplayName, deriveWebIdFromPodUrl } from '../services/solidPod'
 import { useOwnerDisplayName } from '../hooks/useOwnerDisplayName'
@@ -356,7 +358,7 @@ export function ViewPackingList() {
     const isDesktop = useIsDesktop()
     const { isLoggedIn, session } = useSolidPod()
     const { showToast } = useToast()
-    const { db, loginSyncInProgress } = useDatabase()
+    const { db } = useDatabase()
     // Read from the question set on every visit, not copied onto the list when
     // it was generated — the order is one global setting, so changing it has to
     // reach the lists that already exist. See `useSectionOrder`.
@@ -617,14 +619,17 @@ export function ViewPackingList() {
         saveToPodRef.current = saveToPod
     }, [saveToPod])
 
-    useEffect(() => {
-        // The login sync (pod -> local) runs in the background while the app is
-        // already rendering, so reading local storage before it finishes would
-        // miss any list this device hasn't seen yet — a fresh browser, or a link
-        // to a list created on another device. Wait for it and keep the spinner
-        // up; the effect re-runs when the sync finishes. Same guard as
-        // create-packing-list and questions-page.
-        if (loginSyncInProgress) return
+    // The list is read from this device first and the pod catches up afterwards
+    // — see useLocalFirstLoad. A list already stored here is on screen in
+    // milliseconds instead of waiting on a sync that walks the whole pod.
+    const { isCheckingPod } = useLocalFirstLoad(() => {
+        // Once this list is on screen the per-list pod poll owns reconciliation:
+        // it merges through useSyncCoordinator, which preserves focus and
+        // in-flight edits. Re-reading here would reset the form under the
+        // user's fingers. The read the login sync triggers is only of use while
+        // there is still nothing to show — or while what is showing is another
+        // list, which is why this checks the id rather than a "have loaded" flag.
+        if (packingList?.id === id) return
 
         const fetchPackingList = async () => {
             try {
@@ -646,12 +651,14 @@ export function ViewPackingList() {
                 setLocalCopyChecked(true)
                 const isNotFound = typeof err === 'object' && err !== null && (err as { name?: string }).name === 'not_found'
                 if (isNotFound) {
-                    // Not an error: the list simply isn't on this device. On a
-                    // foreign pod the first poll hydrates it via
-                    // handleSyncSuccess, so hold the spinner. Otherwise the
-                    // login sync has already had its turn and the list really is
-                    // gone, so fall through to "Packing list not found" — but
-                    // never report it, a missing list is a normal outcome.
+                    // Not an error: the list simply isn't on this device — a
+                    // fresh browser, or a link to a list made on another one.
+                    // On a foreign pod the first poll is the only place it can
+                    // come from, so hold the spinner and let that poll (or its
+                    // error handler) end the wait. On our own pod the local read
+                    // is done, which is all isLoading tracks; whether that means
+                    // "gone" or "not here yet" is settled at render time. Never
+                    // reported either way — a missing list is a normal outcome.
                     if (!foreignPodUrl) setIsLoading(false)
                     return
                 }
@@ -660,8 +667,8 @@ export function ViewPackingList() {
             }
         }
 
-        fetchPackingList()
-    }, [db, id, setValue, foreignPodUrl, loginSyncInProgress])
+        return fetchPackingList()
+    }, [db, id, foreignPodUrl])
 
     const handleItemChange = useDebouncedCallback(async () => {
         if (!packingList) {
@@ -1235,7 +1242,12 @@ export function ViewPackingList() {
         return () => clearTimeout(timer)
     }, [completeSectionSignature, formHydrated, showPacked, allPacked])
 
-    if (isLoading) {
+    // Nothing to show yet, but somewhere still to hear from: the pod sync may
+    // be about to write this list locally. Calling it missing before then would
+    // be a lie the page has to take back a moment later.
+    const listStillOnItsWay = !packingList && isCheckingPod
+
+    if (isLoading || listStillOnItsWay) {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
                 <LoadingState message="Loading packing list..." rows={3} />
@@ -1486,6 +1498,15 @@ export function ViewPackingList() {
                     </div>
                 )}
             </div>
+
+            {/* What's below is this device's copy of the list. Say so while
+                the pod is still being read, so anything that changes under the
+                user a moment later makes sense. */}
+            {isCheckingPod && (
+                <div className="w-full max-w-screen-2xl">
+                    <PodSyncIndicator subject="this list" />
+                </div>
+            )}
 
             {/* Persistent "viewing someone else's list" indicator */}
             {foreignPodUrl && !foreignPodCtx && (


### PR DESCRIPTION
Opening a packing list waited on the background login sync before it
would even look in local storage. That sync walks the whole pod — the
question set, every list, the tombstones — so on a slow connection the
page sat on a skeleton for seconds while the data it was going to render
was already on the device. The list page, the create page and the
questions page all had the same guard.

Local first instead: read the device's copy straight away, render it,
and let the pod catch up. Reconciliation was already handled — each page
polls its own pod resource through usePodSync and merges via
useSyncCoordinator — so the only thing the whole-pod sync is still
needed for is a device that has nothing of its own to show.

The shared piece is useLocalFirstLoad: it runs the read on mount and
again when the login sync lands, and reports isCheckingPod so a page
that found nothing keeps waiting rather than claiming the data doesn't
exist. That last part matters — "Packing list not found" or "No
Questions Found" on a fresh device is a lie the page has to take back,
and one that invites the user to redo a setup they've already done. The
view-lists page had worked this way already; it now uses the same hook,
and the "Checking your Pod for changes..." note it grew is now a shared
PodSyncIndicator on all four pages, so data appearing or changing a
moment after the first paint makes sense.

Pages that reconcile through their own pod poll skip the follow-up read
rather than resetting a form under the user's fingers — the list page
keys that on the id it has on screen, so moving between lists still
reads the next one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VWd6Yxydoz7emkdKJzbuS1