### PR TITLE
Stop E2E runs reporting into the production Sentry project

### DIFF
--- a/src/sentry.test.ts
+++ b/src/sentry.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const init = vi.fn()
+const mockIsNativePlatform = vi.fn(() => false)
+vi.mock('@capacitor/core', () => ({
+    Capacitor: { isNativePlatform: () => mockIsNativePlatform() },
+}))
 vi.mock('@sentry/capacitor', () => ({ init: (...args: unknown[]) => init(...args) }))
 vi.mock('@sentry/react', () => ({
     init: vi.fn(),
@@ -66,13 +70,26 @@ describe('isThirdPartyScriptError', () => {
 })
 
 describe('initSentry', () => {
+    let originalLocation: Location
+
     beforeEach(() => {
         init.mockClear()
+        mockIsNativePlatform.mockReturnValue(false)
+        originalLocation = window.location
+        servedFrom('packmeup.app')
     })
 
     afterEach(() => {
         vi.unstubAllEnvs()
+        Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
     })
+
+    function servedFrom(hostname: string) {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { ...originalLocation, hostname },
+        })
+    }
 
     it('does not initialise Sentry in local dev', () => {
         vi.stubEnv('MODE', 'development')
@@ -102,6 +119,42 @@ describe('initSentry', () => {
     it('initialises Sentry in local dev when explicitly opted in', () => {
         vi.stubEnv('MODE', 'development')
         vi.stubEnv('VITE_SENTRY_ENABLED', 'true')
+
+        initSentry()
+
+        expect(init).toHaveBeenCalledOnce()
+    })
+
+    it.each(['localhost', '127.0.0.1', '[::1]'])(
+        'does not initialise Sentry for a production build served from %s',
+        hostname => {
+            // `npm run test:e2e` builds in production mode and serves the result with
+            // `vite preview`, so the E2E suite used to report its own failures — a stream
+            // of "Failed to fetch" from the test Solid server on localhost:4001 — into the
+            // production project, on every run and every PR in CI.
+            vi.stubEnv('MODE', 'production')
+            servedFrom(hostname)
+
+            initSentry()
+
+            expect(init).not.toHaveBeenCalled()
+        },
+    )
+
+    it('initialises Sentry in the native app, which also serves the bundle from localhost', () => {
+        vi.stubEnv('MODE', 'production')
+        mockIsNativePlatform.mockReturnValue(true)
+        servedFrom('localhost')
+
+        initSentry()
+
+        expect(init).toHaveBeenCalledOnce()
+    })
+
+    it('initialises Sentry on a local web server when explicitly opted in', () => {
+        vi.stubEnv('MODE', 'production')
+        vi.stubEnv('VITE_SENTRY_ENABLED', 'true')
+        servedFrom('localhost')
 
         initSentry()
 

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,17 +1,44 @@
 import * as Sentry from '@sentry/capacitor'
 import * as SentryReact from '@sentry/react'
 import type { ErrorEvent, Exception } from '@sentry/react'
+import { Capacitor } from '@capacitor/core'
 
 // Sentry DSNs are public identifiers, safe to ship in client-side code.
 const SENTRY_DSN = 'https://a331ffe142776c6dd8d5fcecfb2a4a97@o4511757730578432.ingest.de.sentry.io/4511757737525328'
 
-// Local dev and test runs report to the console instead of Sentry, so day-to-day
-// development doesn't fill the project's error quota with noise from work in progress.
-// Set VITE_SENTRY_ENABLED=true to opt a local dev build back in (e.g. to verify a
-// Sentry change end to end).
+/**
+ * Is this bundle being served by a developer machine's own web server?
+ *
+ * The build mode alone doesn't answer that: `npm run test:e2e` runs
+ * `npm run build` and serves the result with `vite preview`, so the E2E suite
+ * drives a *production* build — DSN, `environment: 'production'` and all. Every
+ * run, local and on every PR in CI, reported the suite's own failures into the
+ * live project; the Community Solid Server the tests talk to lives on
+ * localhost:4001 and is stopped between suites, which is where the stream of
+ * "Failed to fetch (localhost:4001)" issues came from.
+ *
+ * The native shell serves the bundle from localhost too (capacitor.config.ts
+ * sets an https scheme for both platforms), and those are real users' sessions —
+ * so a loopback origin only means "local" when we're not inside the native app.
+ */
+function isLocalWebServer() {
+  if (Capacitor.isNativePlatform()) return false
+  const { hostname } = window.location
+  return hostname === 'localhost'
+    || hostname.endsWith('.localhost')
+    || hostname === '::1'
+    || hostname === '[::1]'
+    || /^127\./.test(hostname)
+}
+
+// Local dev, test runs and E2E runs report to the console instead of Sentry, so
+// day-to-day development doesn't fill the project's error quota with noise from work
+// in progress. Set VITE_SENTRY_ENABLED=true to opt a local build back in (e.g. to
+// verify a Sentry change end to end, including against a preview build).
 function isSentryEnabled() {
   if (import.meta.env.VITE_SENTRY_ENABLED === 'true') return true
-  return import.meta.env.MODE !== 'development' && import.meta.env.MODE !== 'test'
+  if (import.meta.env.MODE === 'development' || import.meta.env.MODE === 'test') return false
+  return !isLocalWebServer()
 }
 
 /**


### PR DESCRIPTION
`npm run test:e2e` builds with `npm run build` and serves the result with
`vite preview`, so the suite drives a production build: real DSN, real
`environment: 'production'`. Every run — local and on every PR in CI —
posted its own failures to the live project, which is where the stream of
"Failed to fetch (localhost:4001)" issues came from. Port 4001 is the
Community Solid Server the E2E suite starts and stops around itself, so
those events were the tests watching their own server go away.

Gate init on where the bundle is served from rather than on the build mode
alone: a loopback origin means a developer's own web server. The native
shell also serves from localhost (capacitor.config.ts sets an https scheme
for both platforms) and those are real sessions, so that case is exempt,
and VITE_SENTRY_ENABLED=true still opts a local build back in.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015HfUyxt79fWTFqabMgY3Hf