### PR TITLE
Replace the person/category view toggle with a people filter

### DIFF
--- a/e2e/helpers/packing-list.ts
+++ b/e2e/helpers/packing-list.ts
@@ -1,0 +1,67 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+/**
+ * An item's checkbox on the view-list page.
+ *
+ * Every personal item is a coloured chip, and the `input` inside it is
+ * screen-reader-only — so the chip is what gets clicked, which is the same
+ * thing a finger hits. A shared item carries a visible box inside the same
+ * wrapper, so one locator serves both.
+ *
+ * Reaching for `input[type="checkbox"]` instead finds an element Playwright
+ * cannot click, and waits the full timeout before saying so.
+ */
+export function itemChips(page: Page): Locator {
+    return page.locator('[data-testid^="grid-cell-"]')
+}
+
+export function firstItemChip(page: Page): Locator {
+    return itemChips(page).first()
+}
+
+/** The input behind a chip. Checked state needs no visibility, so this is safe. */
+export function chipInput(chip: Locator): Locator {
+    return chip.locator('input[type="checkbox"]')
+}
+
+/**
+ * A chip found again after a reload.
+ *
+ * The grid's inputs are driven by the form rather than registered against it,
+ * so they carry no `name` to hold on to — the item's id in the chip's test id
+ * is what survives.
+ */
+export function chipByTestId(page: Page, testId: string): Locator {
+    return page.locator(`[data-testid="${testId}"]`)
+}
+
+/** Any chip whose item is packed. */
+export function packedChips(page: Page): Locator {
+    return page.locator('[data-testid^="grid-cell-"]:has(input:checked)')
+}
+
+/**
+ * The chips belonging to one person, by the title their label carries.
+ *
+ * Assert on these rather than on the `input` inside them: the input is
+ * screen-reader-only, so `toBeVisible` is false of it even where the control
+ * is plainly on screen.
+ */
+export function chipsForPerson(page: Page, name: string): Locator {
+    return page.locator(`[data-testid^="grid-cell-"][title$="for ${name}"]`)
+}
+
+/**
+ * Open every card on a freshly created list.
+ *
+ * A long list arrives folded on its first open. That used to need several
+ * people to trigger, because the cards were people; now the cards are
+ * categories, so a list with one person and a handful of categories folds
+ * too — and a folded card has no chips in it at all.
+ */
+export async function expandAllSections(page: Page): Promise<void> {
+    // Waits for a control that is there whether the list arrived folded or not
+    await expect(page.getByRole('button', { name: /Show Packed/i })).toBeVisible({ timeout: 15_000 })
+    const expandAll = page.getByRole('button', { name: /^Expand all$/ }).first()
+    if (await expandAll.count() > 0) await expandAll.click()
+}

--- a/e2e/tests/a-onboarding.spec.ts
+++ b/e2e/tests/a-onboarding.spec.ts
@@ -94,7 +94,10 @@ test.describe('A – Onboarding & Wizard', () => {
     await waitForWizardSuccess(page)
     await page.getByRole('button', { name: /Refine My Packing List Questions/i }).click()
     await page.waitForURL(/#\/manage-questions/, { timeout: 8_000 })
-    await page.waitForLoadState('networkidle')
+    // Wait for the saved group to be readable, not merely for the network to go
+    // quiet: the question set is written to IndexedDB, so "no requests in
+    // flight" says nothing about whether the wizard's next read will find it.
+    await expect(page.getByText('Alice', { exact: false }).first()).toBeVisible({ timeout: 10_000 })
 
     // Second run: the wizard starts from the family set up the first time
     await page.goto('/#/wizard')

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -212,9 +212,8 @@ test.describe('C – Packing Lists', () => {
     await page.waitForURL(/#\/create-packing-list/, { timeout: 5_000 })
     await createList(page, 'Grid Trip')
 
-    await page.getByRole('button', { name: 'Category View' }).click()
-
-    // One key for the page, naming whose initial is whose
+    // One strip for the page, naming whose initial is whose — and the control
+    // for narrowing the cards to one of them
     const key = page.getByTestId('people-key')
     await expect(key.getByText('Alice')).toBeVisible()
     await expect(key.getByText('Bob')).toBeVisible()
@@ -237,6 +236,44 @@ test.describe('C – Packing Lists', () => {
     if (await bobs.count() > 0) await expect(bobs.first()).not.toBeChecked()
   })
 
+  test('C15b: the people strip narrows the whole list to one person', async ({ freshPage: page }) => {
+    await page.goto('/#/wizard')
+    await page.fill('[name="people.0.name"]', 'Alice')
+    await fillPersonRequiredFields(page, 0)
+    await page.getByRole('button', { name: /Add Another Person/i }).click()
+    await page.fill('[name="people.1.name"]', 'Bob')
+    await fillPersonRequiredFields(page, 1)
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: /Create My First Packing List/i }).click()
+    await page.waitForURL(/#\/create-packing-list/, { timeout: 5_000 })
+    await createList(page, 'Filter Trip')
+
+    const alice = page.getByTestId('people-key').getByRole('button', { name: /^Alice/ })
+    await expect(alice).toBeVisible({ timeout: 8_000 })
+    await expect(page.getByRole('checkbox', { name: /for Bob$/ }).first()).toBeVisible()
+
+    // Packing Alice's bag: Bob leaves the page entirely, chips and all
+    await alice.click()
+    await expect(alice).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.getByRole('checkbox', { name: /for Bob$/ })).toHaveCount(0)
+    await expect(page.getByRole('checkbox', { name: /for Alice$/ }).first()).toBeVisible()
+
+    // Her own progress rides on her chip while she is the one being packed for
+    await expect(alice).toContainText('/')
+
+    // And Clear puts the list back — a filter is something you are doing, not
+    // how this list is kept, so it is never restored on the next visit either
+    await page.getByRole('button', { name: 'Clear' }).click()
+    await expect(page.getByRole('checkbox', { name: /for Bob$/ }).first()).toBeVisible()
+
+    await alice.click()
+    await page.reload()
+    await expect(page.getByRole('checkbox', { name: /for Bob$/ }).first()).toBeVisible({ timeout: 8_000 })
+    await expect(page.getByTestId('people-key').getByRole('button', { name: /^Alice/ }))
+      .toHaveAttribute('aria-pressed', 'false')
+  })
+
   test('C16: the row panel takes an item off one person and gives it back', async ({ freshPage: page }) => {
     await page.goto('/#/wizard')
     await page.fill('[name="people.0.name"]', 'Alice')
@@ -249,7 +286,6 @@ test.describe('C – Packing Lists', () => {
     await page.getByRole('button', { name: /Create My First Packing List/i }).click()
     await page.waitForURL(/#\/create-packing-list/, { timeout: 5_000 })
     await createList(page, 'Panel Trip')
-    await page.getByRole('button', { name: 'Category View' }).click()
 
     // A row both of them are on, so it can lose one and get them back
     const card = page.getByTestId('list-section').first()

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures'
 import { fillPersonRequiredFields } from '../helpers/wizard'
+import { chipInput, chipsForPerson, expandAllSections, firstItemChip } from '../helpers/packing-list'
 
 async function runWizard(page: import('@playwright/test').Page) {
   await page.goto('/#/wizard')
@@ -17,6 +18,8 @@ async function createList(page: import('@playwright/test').Page, name: string) {
   await page.getByRole('button', { name: 'Create Packing List' }).click()
   // Navigates to /view-lists/:id
   await page.waitForURL(/#\/view-lists\//, { timeout: 8_000 })
+  // A list long enough to arrive as a wall of cards opens folded
+  await expandAllSections(page)
 }
 
 test.describe('C – Packing Lists', () => {
@@ -60,32 +63,32 @@ test.describe('C – Packing Lists', () => {
   test('C2: check item as packed persists on reload', async ({ freshPage: page }) => {
     await runWizard(page)
     await createList(page, 'Test Trip')
-    // Click the first checkbox (use click() not check() - item hides after packing, making check() stale)
-    await page.locator('input[type="checkbox"]').first().click()
+    // Click the chip, not the input inside it: the input is screen-reader-only
+    await firstItemChip(page).click()
     // Wait for auto-save indicator
     await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
     // Reload and show packed items to verify the item is still checked
     await page.reload()
     await page.getByRole('button', { name: 'Show Packed' }).click()
-    await expect(page.locator('input[type="checkbox"]').first()).toBeChecked()
+    await expect(chipInput(firstItemChip(page))).toBeChecked()
   })
 
   test('C3: uncheck a packed item', async ({ freshPage: page }) => {
     await runWizard(page)
     await createList(page, 'Test Trip 2')
-    // Click the first checkbox to pack the item
-    await page.locator('input[type="checkbox"]').first().click()
+    // Click the chip to pack the item
+    await firstItemChip(page).click()
     // Wait for auto-save to complete and indicator to disappear
     await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
     await expect(page.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 5_000 })
     // Show packed items, then uncheck
     await page.getByRole('button', { name: 'Show Packed' }).click()
-    await page.locator('input[type="checkbox"]').first().click()
+    await firstItemChip(page).click()
     // Wait for the unpack auto-save to complete
     await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
     await expect(page.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 5_000 })
     await page.reload()
-    await expect(page.locator('input[type="checkbox"]').first()).not.toBeChecked()
+    await expect(chipInput(firstItemChip(page))).not.toBeChecked()
   })
 
   test('C4: rename a packing list', async ({ freshPage: page }) => {
@@ -161,11 +164,10 @@ test.describe('C – Packing Lists', () => {
     // The item now appears on the list
     await expect(page.getByText('GadgetTest')).toBeVisible({ timeout: 5_000 })
 
-    // Delete it, then update again — it must not be re-suggested
-    await page.getByText('GadgetTest', { exact: true })
-      .locator('xpath=ancestor::label[1]/..')
-      .getByTitle('Delete item')
-      .click()
+    // Delete it, then update again — it must not be re-suggested. Removing an
+    // item is the row panel's job, reached through the row's own name.
+    await page.getByRole('button', { name: 'Edit GadgetTest' }).click()
+    await page.getByRole('dialog').getByRole('button', { name: /^Remove item$/ }).click()
     await page.getByRole('button', { name: /^Remove$/ }).click()
     await expect(page.getByText('GadgetTest')).not.toBeVisible({ timeout: 5_000 })
 
@@ -191,12 +193,15 @@ test.describe('C – Packing Lists', () => {
     // Give the async IndexedDB write time to commit
     await page.waitForTimeout(800)
 
-    // A list made afterwards shows that colour on their card
+    // A list made afterwards wears that colour on their cells. There is one
+    // person on this list, so there is no filter strip to wear it in — the
+    // grid's chips are where the colour has to show.
     await page.goto('/#/create-packing-list')
     await createList(page, 'Colourful Trip')
-    const card = page.locator('[data-testid="list-section"]').filter({ hasText: "Me's Items" })
-    await expect(card.getByTestId('person-avatar')).toHaveClass(/bg-fuchsia-500/)
-    await expect(card).toHaveClass(/border-fuchsia-300/)
+    const cell = page.locator('[data-testid^="grid-cell-"]').first()
+    await expect(cell).toBeVisible({ timeout: 8_000 })
+    // Unpacked, so the disc is outlined in their colour rather than filled
+    await expect(cell).toHaveClass(/border-fuchsia-300/)
   })
   test('C15: category view writes each item once, with a checkbox per person', async ({ freshPage: page }) => {
     // Two people, because a grid with one column is just a list
@@ -251,13 +256,13 @@ test.describe('C – Packing Lists', () => {
 
     const alice = page.getByTestId('people-key').getByRole('button', { name: /^Alice/ })
     await expect(alice).toBeVisible({ timeout: 8_000 })
-    await expect(page.getByRole('checkbox', { name: /for Bob$/ }).first()).toBeVisible()
+    await expect(chipsForPerson(page, 'Bob').first()).toBeVisible()
 
     // Packing Alice's bag: Bob leaves the page entirely, chips and all
     await alice.click()
     await expect(alice).toHaveAttribute('aria-pressed', 'true')
-    await expect(page.getByRole('checkbox', { name: /for Bob$/ })).toHaveCount(0)
-    await expect(page.getByRole('checkbox', { name: /for Alice$/ }).first()).toBeVisible()
+    await expect(chipsForPerson(page, 'Bob')).toHaveCount(0)
+    await expect(chipsForPerson(page, 'Alice').first()).toBeVisible()
 
     // Her own progress rides on her chip while she is the one being packed for
     await expect(alice).toContainText('/')
@@ -265,11 +270,11 @@ test.describe('C – Packing Lists', () => {
     // And Clear puts the list back — a filter is something you are doing, not
     // how this list is kept, so it is never restored on the next visit either
     await page.getByRole('button', { name: 'Clear' }).click()
-    await expect(page.getByRole('checkbox', { name: /for Bob$/ }).first()).toBeVisible()
+    await expect(chipsForPerson(page, 'Bob').first()).toBeVisible()
 
     await alice.click()
     await page.reload()
-    await expect(page.getByRole('checkbox', { name: /for Bob$/ }).first()).toBeVisible({ timeout: 8_000 })
+    await expect(chipsForPerson(page, 'Bob').first()).toBeVisible({ timeout: 8_000 })
     await expect(page.getByTestId('people-key').getByRole('button', { name: /^Alice/ }))
       .toHaveAttribute('aria-pressed', 'false')
   })
@@ -289,9 +294,9 @@ test.describe('C – Packing Lists', () => {
 
     // A row both of them are on, so it can lose one and get them back
     const card = page.getByTestId('list-section').first()
-    const bobsCell = card.getByRole('checkbox', { name: /for Bob$/ }).first()
+    const bobsCell = card.locator('[data-testid^="grid-cell-"][title$="for Bob"]').first()
     await expect(bobsCell).toBeVisible({ timeout: 8_000 })
-    const label = (await bobsCell.getAttribute('aria-label'))!.replace(/ for Bob$/, '')
+    const label = (await bobsCell.getAttribute('title'))!.replace(/ for Bob$/, '')
 
     await card.getByRole('button', { name: `Edit ${label}` }).click()
     const panel = page.getByRole('dialog')
@@ -382,26 +387,33 @@ test.describe('C – Contextual sign-in prompts (logged out)', () => {
     await createList(page, 'Doorstep Trip')
 
     const lastMinuteCard = page.getByTestId('list-section').filter({ hasText: 'Last Minute' })
-    const mark = page.getByRole('button', { name: /Mark .* as a last minute item/ }).first()
-    await expect(mark).toBeVisible({ timeout: 8_000 })
+    // Marking lives in the row's panel, reached through the row's own name
+    const firstRow = page.getByRole('button', { name: /^Edit / }).first()
+    await expect(firstRow).toBeVisible({ timeout: 8_000 })
+    const itemName = (await firstRow.getAttribute('aria-label'))!.replace(/^Edit /, '')
+    const rowFor = (name: string) => page.getByRole('button', { name: `Edit ${name}` })
+
     // Nothing is last minute yet, so there is no card for it
     await expect(lastMinuteCard).toHaveCount(0)
 
-    const itemName = (await mark.getAttribute('aria-label'))!
-      .replace(/^Mark /, '').replace(/ as a last minute item$/, '')
-    await mark.click()
+    await firstRow.click()
+    const panel = page.getByRole('dialog')
+    await panel.getByRole('button', { name: /as a last minute item$/ }).click()
+    await panel.getByRole('button', { name: 'Close' }).click()
 
-    await expect(lastMinuteCard.getByText(itemName, { exact: true })).toBeVisible({ timeout: 8_000 })
+    await expect(lastMinuteCard.getByRole('button', { name: `Edit ${itemName}` })).toBeVisible({ timeout: 8_000 })
     await expect(page.getByText('Pack these just before you go.')).toBeVisible()
 
     // The mark is saved, not just shown
     await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
     await page.reload()
-    await expect(lastMinuteCard.getByText(itemName, { exact: true })).toBeVisible({ timeout: 8_000 })
+    await expect(lastMinuteCard.getByRole('button', { name: `Edit ${itemName}` })).toBeVisible({ timeout: 8_000 })
 
     // And it goes back where it came from when unmarked
-    await page.getByRole('button', { name: `Remove ${itemName} from the last minute items` }).click()
+    await lastMinuteCard.getByRole('button', { name: `Edit ${itemName}` }).click()
+    await page.getByRole('dialog').getByRole('button', { name: /with everything else$/ }).click()
+    await page.getByRole('dialog').getByRole('button', { name: 'Close' }).click()
     await expect(lastMinuteCard).toHaveCount(0)
-    await expect(page.getByText(itemName, { exact: true })).toBeVisible()
+    await expect(rowFor(itemName)).toBeVisible()
   })
 })

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -198,7 +198,9 @@ test.describe('C – Packing Lists', () => {
     // grid's chips are where the colour has to show.
     await page.goto('/#/create-packing-list')
     await createList(page, 'Colourful Trip')
-    const cell = page.locator('[data-testid^="grid-cell-"]').first()
+    // One of theirs, not the first chip on the page: shared items lead a card
+    // and their chip belongs to nobody, so it wears nobody's colour.
+    const cell = chipsForPerson(page, 'Me').first()
     await expect(cell).toBeVisible({ timeout: 8_000 })
     // Unpacked, so the disc is outlined in their colour rather than filled
     await expect(cell).toHaveClass(/border-fuchsia-300/)
@@ -399,7 +401,8 @@ test.describe('C – Contextual sign-in prompts (logged out)', () => {
     await firstRow.click()
     const panel = page.getByRole('dialog')
     await panel.getByRole('button', { name: /as a last minute item$/ }).click()
-    await panel.getByRole('button', { name: 'Close' }).click()
+    // The item has moved to another card and the panel has gone with its row
+    await expect(panel).toBeHidden({ timeout: 8_000 })
 
     await expect(lastMinuteCard.getByRole('button', { name: `Edit ${itemName}` })).toBeVisible({ timeout: 8_000 })
     await expect(page.getByText('Pack these just before you go.')).toBeVisible()
@@ -412,7 +415,7 @@ test.describe('C – Contextual sign-in prompts (logged out)', () => {
     // And it goes back where it came from when unmarked
     await lastMinuteCard.getByRole('button', { name: `Edit ${itemName}` }).click()
     await page.getByRole('dialog').getByRole('button', { name: /with everything else$/ }).click()
-    await page.getByRole('dialog').getByRole('button', { name: 'Close' }).click()
+    await expect(page.getByRole('dialog')).toBeHidden({ timeout: 8_000 })
     await expect(lastMinuteCard).toHaveCount(0)
     await expect(rowFor(itemName)).toBeVisible()
   })

--- a/e2e/tests/f-sync.spec.ts
+++ b/e2e/tests/f-sync.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../fixtures'
 import { fillPersonRequiredFields } from '../helpers/wizard'
 import { loginToCss } from '../helpers/login'
 import { CSS_ISSUER, FUSER_EMAIL, FUSER_PASSWORD } from '../../playwright.config'
+import { chipByTestId, chipInput, firstItemChip, itemChips, packedChips } from '../helpers/packing-list'
 
 // All F tests share the same pod user and write to overlapping resources.
 // Serial mode gives each test exclusive pod access.
@@ -67,7 +68,7 @@ test.describe('F – Solid Pod Sync', () => {
   // The green indicator disappearing confirms the pod PUT completed — no extra waitForTimeout needed.
   async function syncListToPod() {
     await openAllSections()
-    await page.locator('input[type="checkbox"]').first().click()
+    await firstItemChip(page).click()
     await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
     await expect(page.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
   }
@@ -132,12 +133,14 @@ test.describe('F – Solid Pod Sync', () => {
     await openAllSections()
     await page.getByRole('button', { name: 'Show Packed' }).click()
 
-    const checkboxes = page.locator('input[type="checkbox"]')
-    await expect(checkboxes.first()).toBeVisible()
+    const chips = itemChips(page)
+    await expect(chips.first()).toBeVisible()
 
-    // Capture stable name attributes for post-reload assertions
-    const box0Name = await checkboxes.nth(0).getAttribute('name')
-    const box1Name = await checkboxes.nth(1).getAttribute('name')
+    // The grid's inputs are driven by the form rather than registered against
+    // it, so they carry no `name` to hold on to — the item's id in the chip's
+    // test id is what survives a reload.
+    const box0Id = (await chips.nth(0).getAttribute('data-testid'))!
+    const box1Id = (await chips.nth(1).getAttribute('data-testid'))!
 
     // Add artificial latency to pod PUT requests.
     // This opens the stale-_rev window: local DB save completes in <50 ms (advances _rev),
@@ -151,10 +154,10 @@ test.describe('F – Solid Pod Sync', () => {
     })
 
     try {
-      await checkboxes.nth(0).click()
+      await chips.nth(0).click()
       // Wait for first debounce + local DB save (~850ms) but not pod PUT (~2300ms)
       await page.waitForTimeout(1000)
-      await checkboxes.nth(1).click()
+      await chips.nth(1).click()
 
       await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 15_000 })
       await expect(page.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
@@ -164,8 +167,8 @@ test.describe('F – Solid Pod Sync', () => {
       // The list reopens as it was left, so packed items are already showing —
       // clicking "Show Packed" again would be clicking "Hide Packed".
       await expect(page.getByRole('button', { name: 'Hide Packed' })).toBeVisible({ timeout: 10_000 })
-      await expect(page.locator(`input[name="${box0Name}"]`)).toBeChecked({ timeout: 5_000 })
-      await expect(page.locator(`input[name="${box1Name}"]`)).toBeChecked({ timeout: 5_000 })
+      await expect(chipInput(chipByTestId(page, box0Id))).toBeChecked({ timeout: 5_000 })
+      await expect(chipInput(chipByTestId(page, box1Id))).toBeChecked({ timeout: 5_000 })
     } finally {
       await page.unrouteAll()
     }
@@ -175,7 +178,7 @@ test.describe('F – Solid Pod Sync', () => {
     await createList(`Suggestion Save Trip ${Date.now()}`)
     await openAllSections()
     // Confirm list content is loaded before interacting (waitForURL fires on URL match, not content render)
-    await expect(page.locator('input[type="checkbox"]').first()).toBeVisible({ timeout: 15_000 })
+    await expect(firstItemChip(page)).toBeVisible({ timeout: 15_000 })
 
     const customItemName = 'super special sunscreen'
     const addItemInput = page.getByPlaceholder('Add new item...').first()
@@ -224,7 +227,7 @@ test.describe('F – Solid Pod Sync', () => {
     // Fresh context, so this is a first open here too — the list arrives folded
     await openAllSections(page2)
     await page2.getByRole('button', { name: /Show Packed/i }).click()
-    await expect(page2.locator('input[type="checkbox"]:checked').first()).toBeVisible({ timeout: 10_000 })
+    await expect(packedChips(page2).first()).toBeVisible({ timeout: 10_000 })
     await context2.close()
   })
 

--- a/e2e/tests/g-cross-context.spec.ts
+++ b/e2e/tests/g-cross-context.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../fixtures'
 import { fillPersonRequiredFields } from '../helpers/wizard'
 import { loginToCss } from '../helpers/login'
 import { CSS_ISSUER, GUSER_EMAIL, GUSER_PASSWORD } from '../../playwright.config'
+import { expandAllSections, firstItemChip } from '../helpers/packing-list'
 
 // G tests share the same pod user. Serial mode gives exclusive pod access.
 test.describe.configure({ mode: 'serial' })
@@ -44,11 +45,14 @@ test.describe('G – Cross-context Pod Sync', () => {
     await page.getByPlaceholder('Enter a name for your packing list').fill(name)
     await page.getByRole('button', { name: 'Create Packing List' }).click()
     await page.waitForURL(/#\/view-lists\//, { timeout: 10_000 })
+    // The cards are categories now, so even a one-person list is long enough
+    // to arrive folded — and a folded card holds no chips to click.
+    await expandAllSections(page)
   }
 
   // Sync to Pod by checking an item. Green indicator disappearing confirms pod PUT is done.
   async function syncToPod() {
-    await page.locator('input[type="checkbox"]').first().click()
+    await firstItemChip(page).click()
     await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
     await expect(page.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
   }

--- a/e2e/tests/h-backups.spec.ts
+++ b/e2e/tests/h-backups.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../fixtures'
 import { fillPersonRequiredFields } from '../helpers/wizard'
 import { loginToCss } from '../helpers/login'
 import { CSS_ISSUER, HUSER_EMAIL, HUSER_PASSWORD } from '../../playwright.config'
+import { expandAllSections, firstItemChip } from '../helpers/packing-list'
 
 // H tests share the same user's backups pod resource; running them in parallel causes
 // concurrent creates/deletes to make counts non-deterministic.
@@ -29,8 +30,9 @@ test.describe('H – Backups', () => {
     await page.getByPlaceholder('Enter a name for your packing list').fill('Backup Test List')
     await page.getByRole('button', { name: 'Create Packing List' }).click()
     await page.waitForURL(/#\/view-lists\//, { timeout: 10_000 })
+    await expandAllSections(page)
     // Sync to pod via green-indicator cycle (same pattern as F/G/L/M).
-    await page.locator('input[type="checkbox"]').first().click()
+    await firstItemChip(page).click()
     await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
     await expect(page.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })
   })

--- a/e2e/tests/l-sharing.spec.ts
+++ b/e2e/tests/l-sharing.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../fixtures'
 import { fillPersonRequiredFields } from '../helpers/wizard'
 import { loginToCss } from '../helpers/login'
 import { CSS_ISSUER, CSS_PORT, LUSER_EMAIL, LUSER_PASSWORD, LUSER_POD_NAME, COLLAB_EMAIL, COLLAB_PASSWORD, COLLAB_POD_NAME } from '../../playwright.config'
+import { expandAllSections, firstItemChip } from '../helpers/packing-list'
 
 // L tests use two pod users. Serial mode gives exclusive pod access.
 test.describe.configure({ mode: 'serial' })
@@ -32,9 +33,10 @@ test.describe('L – Sharing a packing list', () => {
         await pageA.getByPlaceholder('Enter a name for your packing list').fill(listName)
         await pageA.getByRole('button', { name: 'Create Packing List' }).click()
         await pageA.waitForURL(/#\/view-lists\//, { timeout: 10_000 })
+        await expandAllSections(pageA)
 
         // Sync to pod: check an item, wait for green indicator cycle
-        const firstCheckbox = pageA.locator('input[type="checkbox"]').first()
+        const firstCheckbox = firstItemChip(pageA)
         await firstCheckbox.waitFor({ timeout: 10_000 })
         await firstCheckbox.click()
         await expect(pageA.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
@@ -119,7 +121,7 @@ test.describe('L – Sharing a packing list', () => {
             await expect(pageB.getByText('Shared list')).toBeVisible({ timeout: 30_000 })
 
             // User B checks the first item
-            const firstCheckbox = pageB.locator('input[type="checkbox"]').first()
+            const firstCheckbox = firstItemChip(pageB)
             await firstCheckbox.waitFor({ timeout: 10_000 })
             await firstCheckbox.click()
 
@@ -165,7 +167,7 @@ test.describe('L – Sharing a packing list', () => {
             // Wait for list items to load via pod poll.
             // Item 1 is already packed (from L3) so it's hidden with showPacked=false;
             // the first visible checkbox is item 2.
-            const firstCheckbox = pageAnon.locator('input[type="checkbox"]').first()
+            const firstCheckbox = firstItemChip(pageAnon)
             await firstCheckbox.waitFor({ timeout: 20_000 })
 
             // Check the first visible item

--- a/e2e/tests/m-collaboration.spec.ts
+++ b/e2e/tests/m-collaboration.spec.ts
@@ -12,6 +12,7 @@ import {
     COLLAB_PASSWORD,
     COLLAB_POD_NAME,
 } from '../../playwright.config'
+import { expandAllSections, firstItemChip } from '../helpers/packing-list'
 
 // M tests use two pod users. Serial mode gives exclusive pod access.
 test.describe.configure({ mode: 'serial' })
@@ -51,9 +52,10 @@ test.describe('M – Full pod collaboration', () => {
         await pageA.getByPlaceholder('Enter a name for your packing list').fill(listName)
         await pageA.getByRole('button', { name: 'Create Packing List' }).click()
         await pageA.waitForURL(/#\/view-lists\//, { timeout: 10_000 })
+        await expandAllSections(pageA)
 
         // Wait for pod sync indicator
-        const firstCheckbox = pageA.locator('input[type="checkbox"]').first()
+        const firstCheckbox = firstItemChip(pageA)
         await firstCheckbox.waitFor({ timeout: 10_000 })
         await firstCheckbox.click()
         await expect(pageA.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })

--- a/e2e/tests/z-verify-offline-share.spec.ts
+++ b/e2e/tests/z-verify-offline-share.spec.ts
@@ -52,8 +52,14 @@ test.describe('Z – Offline list → login → share (regression for 404 fix)',
         await page.getByRole('button', { name: /share publicly/i }).click()
 
         // ── 6. Assert: no error shown, link is present ─────────────────────
-        const errorText = await page.locator('.text-red-600').first().textContent().catch(() => '')
-        expect(errorText.trim(), 'No error should appear in the modal').toBe('')
+        // Scoped to the modal, and given a timeout so that "no error element at
+        // all" resolves rather than waiting for one to appear. Unscoped, the
+        // first red thing on the page used to be an item row's delete button —
+        // an icon, so its text was empty and this passed without ever looking
+        // at the modal.
+        const errorText = await page.getByRole('dialog').locator('.text-red-600').first()
+            .textContent({ timeout: 2_000 }).catch(() => '')
+        expect(errorText?.trim() ?? '', 'No error should appear in the modal').toBe('')
 
         const linkInput = page.getByRole('textbox', { name: /shareable link/i })
         await expect(linkInput).toBeVisible({ timeout: 12_000 })

--- a/src/components/AddItemComposer.tsx
+++ b/src/components/AddItemComposer.tsx
@@ -87,10 +87,17 @@ export const AddItemComposer = memo(function AddItemComposer({
     const [chosenCategory, setChosenCategory] = useState(category ?? UNCATEGORISED_LABEL)
     // Held by name, not id: custom items carry no person id, so a name is the
     // only thing that identifies a person on every list.
-    const [chosenPersonName, setChosenPersonName] = useState(personName)
+    //
+    // Null until the picker is used, so that until then the composer follows
+    // whoever the page says it is for. The list view moves that with the people
+    // filter, and a composer that had latched onto the person named at mount
+    // would file an item for the wrong one — silently, since a filtered-out item
+    // has nowhere on screen to appear.
+    const [chosenPersonName, setChosenPersonName] = useState<string | null>(null)
     const inputRef = useRef<HTMLInputElement>(null)
 
-    const person: PersonOption = peopleOptions?.find(p => p.name === chosenPersonName)
+    const wantedName = chosenPersonName ?? personName
+    const person: PersonOption = peopleOptions?.find(p => p.name === wantedName)
         ?? peopleOptions?.[0]
         ?? { name: personName, id: personId }
 

--- a/src/components/CategoryItemGrid.test.tsx
+++ b/src/components/CategoryItemGrid.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * The grid's layout rules, which a round of manual testing caught twice.
+ *
+ * Both faults were invisible to every other test: the chips still worked, the
+ * right rows still showed, and the only thing wrong was where things sat. These
+ * pin the arrangement itself.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { render, screen, within, fireEvent } from '@testing-library/react'
+import { CategoryItemGrid } from './CategoryItemGrid'
+import { buildCategoryRows, buildGridColumns } from '../utils/categoryItemGrid'
+import { PERSON_COLORS } from '../edit-questions/person-colors'
+import type { PackingListItem } from '../create-packing-list/types'
+
+function item(over: Partial<PackingListItem> & { id: string; itemText: string }): PackingListItem {
+    return { personId: '', personName: '', questionId: 'q1', optionId: 'o1', packed: false, ...over }
+}
+
+const people = [{ name: 'Alice', id: 'p1' }, { name: 'Bob', id: 'p2' }]
+const items = [
+    item({ id: 'a1', itemText: 'Sunhat', personName: 'Alice', personId: 'p1' }),
+    item({ id: 'b1', itemText: 'Sunhat', personName: 'Bob', personId: 'p2' }),
+    item({ id: 's1', itemText: 'Tent', communal: true }),
+]
+const columns = buildGridColumns(people, items)
+const rows = buildCategoryRows(items, columns)
+
+function renderGrid(visibleColumnKeys?: ReadonlySet<string>) {
+    return render(
+        <CategoryItemGrid
+            columns={columns}
+            visibleColumnKeys={visibleColumnKeys}
+            rows={rows}
+            personColor={() => PERSON_COLORS[0]}
+            packedById={{}}
+            hidePacked={false}
+            flourish={null}
+            onToggleItem={vi.fn()}
+            registerCellRef={vi.fn()}
+            onOpenRow={vi.fn()}
+        />
+    )
+}
+
+/** The chip block and the name span of the row carrying `label`. */
+function partsOf(label: string) {
+    const row = screen.getByRole('button', { name: `Edit ${label}` }).closest('[data-testid="grid-row"]')!
+    const chips = within(row as HTMLElement).getByRole('group', { name: label })
+    return { row: row as HTMLElement, chips, name: chips.parentElement!.querySelector('span')! }
+}
+
+describe('where the chips sit', () => {
+    it('keeps the columns to the right of the name when the whole list is showing', () => {
+        renderGrid()
+
+        const { chips } = partsOf('Sunhat')
+        expect(chips.className).not.toContain('order-first')
+        // A fixed width is what holds a person in the same place down the card
+        expect(chips.style.width).not.toBe('')
+    })
+
+    it('keeps them there for two people, where lining them up is still the point', () => {
+        renderGrid(new Set(['Alice', 'Bob']))
+
+        const { chips } = partsOf('Sunhat')
+        expect(chips.className).not.toContain('order-first')
+    })
+
+    it('leads with the chip for one person, where there is no grid left to line up', () => {
+        renderGrid(new Set(['Alice']))
+
+        const { chips } = partsOf('Sunhat')
+        expect(chips.className).toContain('order-first')
+        // and gives the name the room the empty column used to take
+        expect(chips.style.width).toBe('')
+    })
+
+    it('moves the chip in the picture only, never in the reading order', () => {
+        renderGrid(new Set(['Alice']))
+
+        // The name is still what a screen reader — and the tab key — reaches
+        // first, whichever side the chip is drawn on.
+        const { row } = partsOf('Sunhat')
+        const focusable = [...row.querySelectorAll('button, input')]
+        expect(focusable[0]!.getAttribute('aria-label')).toBe('Edit Sunhat')
+    })
+
+    it('reads a shared row the same way round as the rows above it', () => {
+        // One card that flips halfway down is worse than either order — and
+        // the shared rows are rendered separately, so they can drift.
+        renderGrid(new Set(['Alice']))
+        fireEvent.click(screen.getByRole('button', { name: /Shared \(1\)/ }))
+
+        expect(partsOf('Tent').chips.className).toContain('order-first')
+        expect(partsOf('Sunhat').chips.className).toContain('order-first')
+    })
+
+    it('leaves a shared row alongside the rest when the columns are showing', () => {
+        renderGrid()
+
+        expect(partsOf('Tent').chips.className).not.toContain('order-first')
+        expect(partsOf('Sunhat').chips.className).not.toContain('order-first')
+    })
+})
+
+describe('what the filter leaves on the page', () => {
+    it('drops a row nobody in the filter needs', () => {
+        renderGrid(new Set(['Bob']))
+
+        expect(screen.getByRole('checkbox', { name: 'Sunhat for Bob' })).toBeTruthy()
+        expect(screen.queryByRole('checkbox', { name: 'Sunhat for Alice' })).toBeNull()
+    })
+
+    it('folds shared items away under a filter, and leaves them inline without one', () => {
+        const { unmount } = renderGrid()
+        expect(screen.getByRole('checkbox', { name: 'Tent for the whole group' })).toBeTruthy()
+        expect(screen.queryByRole('button', { name: /Shared \(1\)/ })).toBeNull()
+        unmount()
+
+        renderGrid(new Set(['Alice']))
+        expect(screen.getByRole('button', { name: /Shared \(1\)/ })).toBeTruthy()
+    })
+})

--- a/src/components/CategoryItemGrid.test.tsx
+++ b/src/components/CategoryItemGrid.test.tsx
@@ -10,6 +10,7 @@ import React from 'react'
 import { render, screen, within, fireEvent } from '@testing-library/react'
 import { CategoryItemGrid } from './CategoryItemGrid'
 import { buildCategoryRows, buildGridColumns } from '../utils/categoryItemGrid'
+import { SHARED_FILTER_KEY } from '../utils/peopleFilter'
 import { PERSON_COLORS } from '../edit-questions/person-colors'
 import type { PackingListItem } from '../create-packing-list/types'
 
@@ -67,20 +68,16 @@ describe('where the chips sit', () => {
         expect(chips.className).not.toContain('order-first')
     })
 
-    it('leads with the chip for one person, where there is no grid left to line up', () => {
+    it('keeps them there for one person too — a row reads the same way round everywhere', () => {
         renderGrid(new Set(['Alice']))
 
         const { chips } = partsOf('Sunhat')
-        expect(chips.className).toContain('order-first')
-        // and gives the name the room the empty column used to take
-        expect(chips.style.width).toBe('')
+        expect(chips.className).not.toContain('order-first')
     })
 
-    it('moves the chip in the picture only, never in the reading order', () => {
+    it('puts the name before the chip in the reading order', () => {
         renderGrid(new Set(['Alice']))
 
-        // The name is still what a screen reader — and the tab key — reaches
-        // first, whichever side the chip is drawn on.
         const { row } = partsOf('Sunhat')
         const focusable = [...row.querySelectorAll('button, input')]
         expect(focusable[0]!.getAttribute('aria-label')).toBe('Edit Sunhat')
@@ -92,8 +89,8 @@ describe('where the chips sit', () => {
         renderGrid(new Set(['Alice']))
         fireEvent.click(screen.getByRole('button', { name: /Shared \(1\)/ }))
 
-        expect(partsOf('Tent').chips.className).toContain('order-first')
-        expect(partsOf('Sunhat').chips.className).toContain('order-first')
+        expect(partsOf('Tent').chips.className).not.toContain('order-first')
+        expect(partsOf('Sunhat').chips.className).not.toContain('order-first')
     })
 
     it('leaves a shared row alongside the rest when the columns are showing', () => {
@@ -112,7 +109,7 @@ describe('what the filter leaves on the page', () => {
         expect(screen.queryByRole('checkbox', { name: 'Sunhat for Alice' })).toBeNull()
     })
 
-    it('folds shared items away under a filter, and leaves them inline without one', () => {
+    it('folds shared items away when the filter is people, and leaves them inline without one', () => {
         const { unmount } = renderGrid()
         expect(screen.getByRole('checkbox', { name: 'Tent for the whole group' })).toBeTruthy()
         expect(screen.queryByRole('button', { name: /Shared \(1\)/ })).toBeNull()
@@ -120,5 +117,19 @@ describe('what the filter leaves on the page', () => {
 
         renderGrid(new Set(['Alice']))
         expect(screen.getByRole('button', { name: /Shared \(1\)/ })).toBeTruthy()
+    })
+
+    it('brings shared items back among the rest when the group is what was asked for', () => {
+        renderGrid(new Set(['Alice', SHARED_FILTER_KEY]))
+
+        expect(screen.getByRole('checkbox', { name: 'Tent for the whole group' })).toBeTruthy()
+        expect(screen.queryByRole('button', { name: /Shared \(1\)/ })).toBeNull()
+    })
+
+    it('shows the group alone when the group alone is selected', () => {
+        renderGrid(new Set([SHARED_FILTER_KEY]))
+
+        expect(screen.getByRole('checkbox', { name: 'Tent for the whole group' })).toBeTruthy()
+        expect(screen.queryByRole('button', { name: 'Edit Sunhat' })).toBeNull()
     })
 })

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -33,7 +33,13 @@
  * outlined one (still to pack), and a flat dot (not for this person). With
  * packed items hidden a row leaves only when every chip on it is packed, so
  * "already done" is never dressed up as "never needed".
+ *
+ * That last part describes the card with everyone on it. Filtered to some of
+ * the list's people (`visibleColumnKeys`), a row is finished when every chip
+ * still on screen is packed — the question being asked is what Alice has left,
+ * and what Bob still owes is not part of the answer.
  */
+import { useState } from 'react'
 import type { PackingListItem } from '../create-packing-list/types'
 import type { GridColumn, GridRow } from '../utils/categoryItemGrid'
 import type { PersonColorLookup } from '../hooks/usePersonColors'
@@ -41,6 +47,17 @@ import { useMeasuredWidth } from '../hooks/useMeasuredWidth'
 
 export interface CategoryItemGridProps {
     columns: readonly GridColumn[]
+    /**
+     * Whose chips to draw, when the user is packing for some of the list rather
+     * than all of it. Undefined means everyone.
+     *
+     * Narrowing happens here rather than in `columns`, and never in
+     * `buildCategoryRows`: a row's cells line up with the full column set, and
+     * the row panel — the only way to say "Bob needs one too" — walks the same
+     * set. Filter the columns upstream and that door opens onto one person.
+     * This is the layer `hidePacked` already works at, for the same reason.
+     */
+    visibleColumnKeys?: ReadonlySet<string>
     rows: readonly GridRow[]
     personColor: PersonColorLookup
     packedById: Record<string, boolean>
@@ -111,6 +128,7 @@ function splitLastWord(label: string): { head: string; lastWord: string } {
 
 export function CategoryItemGrid({
     columns,
+    visibleColumnKeys,
     rows,
     personColor,
     packedById,
@@ -122,24 +140,60 @@ export function CategoryItemGrid({
     onOpenRow,
 }: CategoryItemGridProps) {
     const { ref: containerRef, width } = useMeasuredWidth<HTMLDivElement>()
+    const [sharedOpen, setSharedOpen] = useState(false)
 
-    const rowComplete = (row: GridRow) =>
-        row.items.length > 0 && row.items.every(item => packedById[item.id])
+    // Positions in the full column set, so `row.cells[index]` still lines up
+    // after some of the people have been filtered out.
+    const shownIndices = columns
+        .map((_column, index) => index)
+        .filter(index => visibleColumnKeys === undefined || visibleColumnKeys.has(columns[index]!.key))
+
+    /**
+     * The copies of this item that the filter is actually showing.
+     *
+     * A row leaving once every *visible* chip is packed is a change of meaning
+     * under a filter, and the right one: packing for Alice, a row she has
+     * finished is done, whatever Bob still owes. Unfiltered this is every copy,
+     * which is what the note at the top of this file describes.
+     */
+    const visibleItemsOf = (row: GridRow) => (
+        row.communal
+            ? row.items
+            : shownIndices.map(index => row.cells[index]).filter((item): item is PackingListItem => item !== undefined)
+    )
+
+    const rowComplete = (row: GridRow) => {
+        const items = visibleItemsOf(row)
+        return items.length > 0 && items.every(item => packedById[item.id])
+    }
+
+    // A row nobody in the filter needs isn't hidden, it's absent: the question
+    // being asked is what Alice has left, and an item that was never hers is no
+    // part of the answer.
+    const rowsForFilter = rows.filter(row => row.communal || visibleItemsOf(row).length > 0)
 
     // A finished row leaves when packed items are hidden — but not in the same
     // frame as the tick that finished it: it stays for the flourish, wearing the
     // leaving animation, and goes when the flourish ends.
-    const visibleRows = rows.filter(row =>
+    const visible = rowsForFilter.filter(row =>
         !hidePacked || !rowComplete(row) || row.items.some(item => item.id === flourish?.itemId)
     )
 
-    if (visibleRows.length === 0) {
+    // Shared items belong to this category as much as anyone's do, so unfiltered
+    // they sit among the rest. Under a filter they would answer a question that
+    // wasn't asked — "what is left for the baby?" is not a request for the
+    // group's tent — so they fold into one line that can be opened.
+    const filtering = visibleColumnKeys !== undefined
+    const sharedRows = filtering ? visible.filter(row => row.communal) : []
+    const visibleRows = filtering ? visible.filter(row => !row.communal) : visible
+
+    if (visibleRows.length === 0 && sharedRows.length === 0) {
         return <p className="text-sm font-medium text-emerald-700">Nothing left to pack 🎒</p>
     }
 
     // One width for every row in the card, so the chips land in the same places
     // on all of them — which is the whole of what makes this a grid.
-    const chipBlockWidth = chipsPerLine(columns.length, width) * CHIP_PITCH
+    const chipBlockWidth = chipsPerLine(shownIndices.length, width) * CHIP_PITCH
 
     const renderFlourish = (item: PackingListItem) => (
         item.id === flourish?.itemId
@@ -213,6 +267,11 @@ export function CategoryItemGrid({
      * Filled with a tick once it is packed, outlined and carrying their initial
      * until then — so the colour says whose it is in both states, which is what
      * lets the grid do without a header.
+     *
+     * The initial comes from the column rather than from the first letter of
+     * the name: Alice and Amy are both "A", and with person view gone there is
+     * no other place in the app where their chips are told apart by anything
+     * but colour. `buildGridColumns` grows the label until it separates them.
      */
     const renderChip = (row: GridRow, column: GridColumn, item: PackingListItem) => {
         const packed = !!packedById[item.id]
@@ -236,7 +295,7 @@ export function CategoryItemGrid({
                     className="sr-only"
                 />
                 <span aria-hidden="true">
-                    {packed ? '✓' : (column.unassigned ? '?' : column.name.charAt(0).toUpperCase())}
+                    {packed ? '✓' : column.initial}
                 </span>
                 {row.mixedQuantities && quantity && (
                     <span className="pointer-events-none absolute -bottom-1 -right-1 rounded-full bg-blue-100 px-1 text-[10px] font-semibold text-blue-700">
@@ -323,7 +382,8 @@ export function CategoryItemGrid({
                             >
                                 {row.communal
                                     ? renderSharedChip(row)
-                                    : columns.map((column, index) => {
+                                    : shownIndices.map(index => {
+                                        const column = columns[index]!
                                         const item = row.cells[index]
                                         return item
                                             ? renderChip(row, column, item)
@@ -334,6 +394,41 @@ export function CategoryItemGrid({
                     )
                 })}
             </ul>
+            {/* Not hidden, just not in the way: the group's tent is still this
+                category's business, and a line saying how many there are is
+                enough to remember that while packing one person's bag. */}
+            {sharedRows.length > 0 && (
+                <div className="mt-1 border-t border-gray-100 pt-1">
+                    <button
+                        type="button"
+                        aria-expanded={sharedOpen}
+                        onClick={() => setSharedOpen(open => !open)}
+                        className="flex w-full items-center gap-1.5 rounded-md px-1 py-2 text-left text-xs font-semibold text-blue-800 transition-colors hover:bg-blue-50"
+                    >
+                        <span aria-hidden="true" className="text-gray-400">{sharedOpen ? '▼' : '▶'}</span>
+                        <span aria-hidden="true">👥</span>
+                        Shared ({sharedRows.length})
+                    </button>
+                    {sharedOpen && (
+                        <ul className="divide-y divide-gray-100">
+                            {sharedRows.map(row => (
+                                <li
+                                    key={row.key}
+                                    data-testid="grid-row"
+                                    className="flex items-start gap-1 rounded-md transition-colors hover:bg-gray-50"
+                                >
+                                    <span className="min-w-0 flex-1" style={{ maxWidth: `${NAME_MAX_WIDTH}px` }}>
+                                        {renderName(row, rowComplete(row))}
+                                    </span>
+                                    <div role="group" aria-label={row.label} className="flex shrink-0 flex-wrap gap-1 py-2">
+                                        {renderSharedChip(row)}
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            )}
         </div>
     )
 }

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -40,6 +40,7 @@
  * and what Bob still owes is not part of the answer.
  */
 import { useState } from 'react'
+import { SHARED_FILTER_KEY } from '../utils/peopleFilter'
 import type { PackingListItem } from '../create-packing-list/types'
 import type { GridColumn, GridRow } from '../utils/categoryItemGrid'
 import type { PersonColorLookup } from '../hooks/usePersonColors'
@@ -151,6 +152,11 @@ export function CategoryItemGrid({
 
     // Positions in the full column set, so `row.cells[index]` still lines up
     // after some of the people have been filtered out.
+    const filtering = visibleColumnKeys !== undefined
+    // With only the Shared chip pressed there are no people left to show, and
+    // the card is the group's items alone.
+    const anyPersonSelected = !filtering || [...visibleColumnKeys].some(key => key !== SHARED_FILTER_KEY)
+
     const shownIndices = columns
         .map((_column, index) => index)
         .filter(index => visibleColumnKeys === undefined || visibleColumnKeys.has(columns[index]!.key))
@@ -177,7 +183,11 @@ export function CategoryItemGrid({
     // A row nobody in the filter needs isn't hidden, it's absent: the question
     // being asked is what Alice has left, and an item that was never hers is no
     // part of the answer.
-    const rowsForFilter = rows.filter(row => row.communal || visibleItemsOf(row).length > 0)
+    // A row nobody in the filter needs is absent rather than hidden — and with
+    // the Shared chip alone, the people's rows are what nobody asked for.
+    const rowsForFilter = rows.filter(row => (
+        row.communal ? true : anyPersonSelected && visibleItemsOf(row).length > 0
+    ))
 
     // A finished row leaves when packed items are hidden — but not in the same
     // frame as the tick that finished it: it stays for the flourish, wearing the
@@ -187,12 +197,13 @@ export function CategoryItemGrid({
     )
 
     // Shared items belong to this category as much as anyone's do, so unfiltered
-    // they sit among the rest. Under a filter they would answer a question that
-    // wasn't asked — "what is left for the baby?" is not a request for the
-    // group's tent — so they fold into one line that can be opened.
-    const filtering = visibleColumnKeys !== undefined
-    const sharedRows = filtering ? visible.filter(row => row.communal) : []
-    const visibleRows = filtering ? visible.filter(row => !row.communal) : visible
+    // they sit among the rest. Filtered to people they would answer a question
+    // that wasn't asked — "what is left for the baby?" is not a request for the
+    // group's tent — so they fold into one line that can be opened. Asked for by
+    // name, on the Shared chip, they come back out among the rest.
+    const foldShared = filtering && !visibleColumnKeys.has(SHARED_FILTER_KEY)
+    const sharedRows = foldShared ? visible.filter(row => row.communal) : []
+    const visibleRows = foldShared ? visible.filter(row => !row.communal) : visible
 
     if (visibleRows.length === 0 && sharedRows.length === 0) {
         return <p className="text-sm font-medium text-emerald-700">Nothing left to pack 🎒</p>
@@ -201,17 +212,6 @@ export function CategoryItemGrid({
     // One width for every row in the card, so the chips land in the same places
     // on all of them — which is the whole of what makes this a grid.
     const chipBlockWidth = chipsPerLine(shownIndices.length, width) * CHIP_PITCH
-
-    /**
-     * Filtered to one person there is no grid left to line up — one chip a row,
-     * and the column it used to hold its place in is now a hand's width of empty
-     * paper between the name and the only control on the row.
-     *
-     * So it stops being a table: the chip leads, the name follows it, and the
-     * card reads as the checklist it now is. Two or more people and the columns
-     * come back, because then the alignment is the point again.
-     */
-    const asChecklist = shownIndices.length === 1
 
     const renderFlourish = (item: PackingListItem) => (
         item.id === flourish?.itemId
@@ -367,7 +367,7 @@ export function CategoryItemGrid({
                     aria-label={`${row.label} for the whole group`}
                     className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                 />
-                <span className="whitespace-nowrap">👥 Everyone</span>
+                <span className="whitespace-nowrap">👥 Shared</span>
                 {renderFlourish(item)}
             </label>
         )
@@ -386,20 +386,19 @@ export function CategoryItemGrid({
                         >
                             {/* Capped, so a wide card doesn't strand the chips
                                 an inch and a half from the name they belong to. */}
-                            <span className="min-w-0 flex-1" style={asChecklist ? undefined : { maxWidth: `${NAME_MAX_WIDTH}px` }}>
+                            <span className="min-w-0 flex-1" style={{ maxWidth: `${NAME_MAX_WIDTH}px` }}>
                                 {renderName(row, complete)}
                             </span>
                             {/* A block of the same width on every row, so a
                                 person keeps their place down the whole card
-                                however many lines the chips take. Leading and
-                                unpadded when there is only one of them — see
-                                `asChecklist`. The flip is visual only: the name
-                                is still what a screen reader reaches first. */}
+                                however many lines the chips take — and the same
+                                side of the name on every row of every card,
+                                filtered or not. */}
                             <div
                                 role="group"
                                 aria-label={row.label}
-                                className={`flex shrink-0 flex-wrap gap-3 py-2 ${asChecklist ? 'order-first' : ''}`}
-                                style={asChecklist ? undefined : { width: `${chipBlockWidth}px` }}
+                                className="flex shrink-0 flex-wrap gap-3 py-2"
+                                style={{ width: `${chipBlockWidth}px` }}
                             >
                                 {row.communal
                                     ? renderSharedChip(row)
@@ -438,14 +437,10 @@ export function CategoryItemGrid({
                                     data-testid="grid-row"
                                     className="flex items-start gap-1 rounded-md transition-colors hover:bg-gray-50"
                                 >
-                                    <span className="min-w-0 flex-1" style={asChecklist ? undefined : { maxWidth: `${NAME_MAX_WIDTH}px` }}>
+                                    <span className="min-w-0 flex-1" style={{ maxWidth: `${NAME_MAX_WIDTH}px` }}>
                                         {renderName(row, rowComplete(row))}
                                     </span>
-                                    <div
-                                        role="group"
-                                        aria-label={row.label}
-                                        className={`flex shrink-0 flex-wrap gap-3 py-2 ${asChecklist ? 'order-first' : ''}`}
-                                    >
+                                    <div role="group" aria-label={row.label} className="flex shrink-0 flex-wrap gap-3 py-2">
                                         {renderSharedChip(row)}
                                     </div>
                                 </li>

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -195,6 +195,17 @@ export function CategoryItemGrid({
     // on all of them — which is the whole of what makes this a grid.
     const chipBlockWidth = chipsPerLine(shownIndices.length, width) * CHIP_PITCH
 
+    /**
+     * Filtered to one person there is no grid left to line up — one chip a row,
+     * and the column it used to hold its place in is now a hand's width of empty
+     * paper between the name and the only control on the row.
+     *
+     * So it stops being a table: the chip leads, the name follows it, and the
+     * card reads as the checklist it now is. Two or more people and the columns
+     * come back, because then the alignment is the point again.
+     */
+    const asChecklist = shownIndices.length === 1
+
     const renderFlourish = (item: PackingListItem) => (
         item.id === flourish?.itemId
             ? (
@@ -283,7 +294,7 @@ export function CategoryItemGrid({
                 data-testid={`grid-cell-${item.id}`}
                 ref={(element) => registerCellRef(item.id, element)}
                 title={`${row.label} for ${column.name}`}
-                className={`relative flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full text-xs font-bold transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 has-[:focus-visible]:ring-offset-1 ${
+                className={`relative flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full text-xs font-bold transition-colors before:absolute before:-inset-1.5 before:content-[''] has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 has-[:focus-visible]:ring-offset-1 ${
                     packed ? color.avatar : `border-2 bg-white ${color.border} ${color.text}`
                 } ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
             >
@@ -366,19 +377,16 @@ export function CategoryItemGrid({
                             data-testid="grid-row"
                             className={`flex items-start gap-1 rounded-md transition-colors ${complete ? 'bg-emerald-50' : 'hover:bg-gray-50'} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
                         >
-                            {/* Capped, so a wide card doesn't strand the chips
-                                an inch and a half from the name they belong to. */}
-                            <span className="min-w-0 flex-1" style={{ maxWidth: `${NAME_MAX_WIDTH}px` }}>
-                                {renderName(row, complete)}
-                            </span>
                             {/* A block of the same width on every row, so a
                                 person keeps their place down the whole card
-                                however many lines the chips take. */}
+                                however many lines the chips take. Leading and
+                                unpadded when there is only one of them — see
+                                `asChecklist`. */}
                             <div
                                 role="group"
                                 aria-label={row.label}
-                                className="flex shrink-0 flex-wrap gap-1 py-2"
-                                style={{ width: `${chipBlockWidth}px` }}
+                                className={`flex shrink-0 flex-wrap gap-1 py-2 ${asChecklist ? 'order-first' : ''}`}
+                                style={asChecklist ? undefined : { width: `${chipBlockWidth}px` }}
                             >
                                 {row.communal
                                     ? renderSharedChip(row)
@@ -390,6 +398,11 @@ export function CategoryItemGrid({
                                             : renderChipGap(row, column)
                                     })}
                             </div>
+                            {/* Capped, so a wide card doesn't strand the chips
+                                an inch and a half from the name they belong to. */}
+                            <span className="min-w-0 flex-1" style={asChecklist ? undefined : { maxWidth: `${NAME_MAX_WIDTH}px` }}>
+                                {renderName(row, complete)}
+                            </span>
                         </li>
                     )
                 })}

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -74,8 +74,15 @@ export interface CategoryItemGridProps {
     onOpenRow: (row: GridRow) => void
 }
 
-/** A 32px disc and the 4px after it. */
-const CHIP_PITCH = 36
+/**
+ * A 32px disc and the 12px after it.
+ *
+ * The gap is what the disc's tap target grows into. At 4px a 44px target
+ * overlapped its neighbour's *visible* edge, so the right rim of one person's
+ * circle packed the next person's item; 12px is the room the target needs to
+ * reach 44px and stop there.
+ */
+const CHIP_PITCH = 44
 
 /**
  * The most room a name is given on a wide card.
@@ -351,7 +358,7 @@ export function CategoryItemGrid({
             <label
                 data-testid={`grid-cell-${item.id}`}
                 ref={(element) => registerCellRef(item.id, element)}
-                className={`relative flex h-8 cursor-pointer items-center gap-2 rounded-full px-3 text-xs font-medium transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 ${packed ? 'bg-emerald-100 text-emerald-800' : 'bg-blue-50 text-blue-800 hover:bg-blue-100'} ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
+                className={`relative flex h-8 cursor-pointer items-center gap-2 rounded-full px-3 text-xs font-medium transition-colors before:absolute before:-inset-y-1.5 before:inset-x-0 before:content-[''] has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 ${packed ? 'bg-emerald-100 text-emerald-800' : 'bg-blue-50 text-blue-800 hover:bg-blue-100'} ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
             >
                 <input
                     type="checkbox"
@@ -377,15 +384,21 @@ export function CategoryItemGrid({
                             data-testid="grid-row"
                             className={`flex items-start gap-1 rounded-md transition-colors ${complete ? 'bg-emerald-50' : 'hover:bg-gray-50'} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
                         >
+                            {/* Capped, so a wide card doesn't strand the chips
+                                an inch and a half from the name they belong to. */}
+                            <span className="min-w-0 flex-1" style={asChecklist ? undefined : { maxWidth: `${NAME_MAX_WIDTH}px` }}>
+                                {renderName(row, complete)}
+                            </span>
                             {/* A block of the same width on every row, so a
                                 person keeps their place down the whole card
                                 however many lines the chips take. Leading and
                                 unpadded when there is only one of them — see
-                                `asChecklist`. */}
+                                `asChecklist`. The flip is visual only: the name
+                                is still what a screen reader reaches first. */}
                             <div
                                 role="group"
                                 aria-label={row.label}
-                                className={`flex shrink-0 flex-wrap gap-1 py-2 ${asChecklist ? 'order-first' : ''}`}
+                                className={`flex shrink-0 flex-wrap gap-3 py-2 ${asChecklist ? 'order-first' : ''}`}
                                 style={asChecklist ? undefined : { width: `${chipBlockWidth}px` }}
                             >
                                 {row.communal
@@ -398,11 +411,6 @@ export function CategoryItemGrid({
                                             : renderChipGap(row, column)
                                     })}
                             </div>
-                            {/* Capped, so a wide card doesn't strand the chips
-                                an inch and a half from the name they belong to. */}
-                            <span className="min-w-0 flex-1" style={asChecklist ? undefined : { maxWidth: `${NAME_MAX_WIDTH}px` }}>
-                                {renderName(row, complete)}
-                            </span>
                         </li>
                     )
                 })}
@@ -430,10 +438,14 @@ export function CategoryItemGrid({
                                     data-testid="grid-row"
                                     className="flex items-start gap-1 rounded-md transition-colors hover:bg-gray-50"
                                 >
-                                    <span className="min-w-0 flex-1" style={{ maxWidth: `${NAME_MAX_WIDTH}px` }}>
+                                    <span className="min-w-0 flex-1" style={asChecklist ? undefined : { maxWidth: `${NAME_MAX_WIDTH}px` }}>
                                         {renderName(row, rowComplete(row))}
                                     </span>
-                                    <div role="group" aria-label={row.label} className="flex shrink-0 flex-wrap gap-1 py-2">
+                                    <div
+                                        role="group"
+                                        aria-label={row.label}
+                                        className={`flex shrink-0 flex-wrap gap-3 py-2 ${asChecklist ? 'order-first' : ''}`}
+                                    >
                                         {renderSharedChip(row)}
                                     </div>
                                 </li>

--- a/src/components/ItemRowPanel.tsx
+++ b/src/components/ItemRowPanel.tsx
@@ -172,6 +172,7 @@ export function ItemRowPanel({
                                         {!column.unassigned && (
                                             <PersonAvatar
                                                 name={column.name}
+                                                initial={column.initial}
                                                 color={personColor({ id: column.personId, name: column.name })}
                                                 size="sm"
                                             />

--- a/src/components/ItemRowPanel.tsx
+++ b/src/components/ItemRowPanel.tsx
@@ -143,7 +143,7 @@ export function ItemRowPanel({
                     <div className="flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2">
                         <span aria-hidden="true">👥</span>
                         <span className="flex-1 text-sm font-medium text-blue-900">
-                            Everyone — packed once for the whole group
+                            Shared — packed once for the whole group
                         </span>
                         {renderItemControls(row.items[0], 'the group')}
                     </div>

--- a/src/components/PeopleFilterBar.test.tsx
+++ b/src/components/PeopleFilterBar.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * The strip drops the names on a phone, so the ways of getting them back are
+ * the part worth pinning.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { PeopleFilterBar } from './PeopleFilterBar'
+import { buildGridColumns } from '../utils/categoryItemGrid'
+import { SHARED_FILTER_KEY } from '../utils/peopleFilter'
+import { PERSON_COLORS } from '../edit-questions/person-colors'
+
+const columns = buildGridColumns([{ name: 'Alice', id: 'p1' }, { name: 'Amy', id: 'p2' }], [])
+const totals = new Map([['Alice', { packed: 1, total: 2 }], ['Amy', { packed: 2, total: 2 }]])
+
+function renderBar(selected: ReadonlySet<string> = new Set(), onToggle = vi.fn()) {
+    render(
+        <PeopleFilterBar
+            columns={columns}
+            selected={selected}
+            totals={totals}
+            personColor={() => PERSON_COLORS[0]}
+            onToggle={onToggle}
+            controlsId="sections"
+        />
+    )
+    return onToggle
+}
+
+const chip = (name: string) => screen.getByRole('button', { name: new RegExp(`^${name}`) })
+
+describe('getting a name back off a face', () => {
+    it('gives a pointer the full name to hover', () => {
+        renderBar()
+
+        expect(chip('Alice').getAttribute('title')).toBe('Alice')
+    })
+
+    it('gives a finger the name on a long press, and does not also pick them', () => {
+        vi.useFakeTimers()
+        const onToggle = renderBar()
+
+        fireEvent.touchStart(chip('Amy'))
+        act(() => { vi.advanceTimersByTime(500) })
+        expect(screen.getByTestId('chip-name-reveal').textContent).toBe('Amy')
+
+        // The press asked who it was; it did not choose them
+        fireEvent.touchEnd(chip('Amy'))
+        fireEvent.click(chip('Amy'))
+        expect(onToggle).not.toHaveBeenCalled()
+
+        vi.useRealTimers()
+    })
+
+    it('picks the person on an ordinary tap', () => {
+        vi.useFakeTimers()
+        const onToggle = renderBar()
+
+        fireEvent.touchStart(chip('Amy'))
+        act(() => { vi.advanceTimersByTime(100) })
+        fireEvent.touchEnd(chip('Amy'))
+        fireEvent.click(chip('Amy'))
+
+        expect(onToggle).toHaveBeenCalledWith('Amy')
+        vi.useRealTimers()
+    })
+
+    it('lets go of the name again', () => {
+        vi.useFakeTimers()
+        renderBar()
+
+        fireEvent.touchStart(chip('Alice'))
+        act(() => { vi.advanceTimersByTime(500) })
+        expect(screen.getByTestId('chip-name-reveal')).toBeTruthy()
+
+        act(() => { vi.advanceTimersByTime(2000) })
+        expect(screen.queryByTestId('chip-name-reveal')).toBeNull()
+
+        vi.useRealTimers()
+    })
+})
+
+describe('what a chip says without being asked', () => {
+    it('tells two people who share a first letter apart', () => {
+        renderBar()
+
+        expect(chip('Alice').textContent).toContain('Al')
+        expect(chip('Amy').textContent).toContain('Am')
+    })
+
+    it('marks somebody finished without filling the chip, which means pressed', () => {
+        renderBar(new Set(['Alice']))
+
+        // Amy is done but not selected: no fill
+        expect(chip('Amy').className).toContain('bg-white')
+        expect(chip('Amy').className).not.toContain('bg-emerald')
+        // Alice is selected: filled
+        expect(chip('Alice').className).toContain('bg-blue-600')
+    })
+
+    it('offers the group its own chip when the list has shared items', () => {
+        render(
+            <PeopleFilterBar
+                columns={columns}
+                selected={new Set([SHARED_FILTER_KEY])}
+                totals={totals}
+                personColor={() => PERSON_COLORS[0]}
+                onToggle={vi.fn()}
+                sharedStat={{ packed: 0, total: 3 }}
+                controlsId="sections"
+            />
+        )
+
+        expect(screen.getByRole('button', { name: /^Shared/ }).getAttribute('aria-pressed')).toBe('true')
+    })
+})

--- a/src/components/PeopleFilterBar.test.tsx
+++ b/src/components/PeopleFilterBar.test.tsx
@@ -80,6 +80,16 @@ describe('getting a name back off a face', () => {
     })
 })
 
+describe('fitting the group in', () => {
+    it('wraps rather than scrolling, so a chip past the edge is never a person the strip hides', () => {
+        renderBar()
+
+        const group = screen.getByRole('group', { name: 'Filter by person' })
+        expect(group.className).toContain('flex-wrap')
+        expect(group.className).not.toContain('overflow-x-auto')
+    })
+})
+
 describe('what a chip says without being asked', () => {
     it('tells two people who share a first letter apart', () => {
         renderBar()

--- a/src/components/PeopleFilterBar.tsx
+++ b/src/components/PeopleFilterBar.tsx
@@ -23,6 +23,12 @@
  * part the grid below already says twice over in colour and initial. Who is
  * selected is written out in the bar underneath instead, where there is a whole
  * line for it.
+ *
+ * A filled chip means one thing and one thing only: pressed. Somebody who has
+ * finished packing used to get a chip filled green, which read as selected
+ * beside the white ones that read as not — two states competing for the same
+ * signal. Finished is a tick on the face instead, which says it without
+ * borrowing the fill.
  */
 import { useEffect, useRef } from 'react'
 import { PersonAvatar } from './PersonAvatar'
@@ -40,6 +46,19 @@ export interface PeopleFilterBarProps {
     sharedStat?: PersonStat
     /** Names the region the strip filters, for assistive tech. */
     controlsId: string
+}
+
+/** Finished packing — said on the face, so the chip's fill can stay the answer
+ *  to one question only: is this one pressed? */
+function DoneTick() {
+    return (
+        <span
+            aria-hidden="true"
+            className="absolute -bottom-0.5 -right-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full border border-white bg-emerald-500 text-[8px] font-bold leading-none text-white"
+        >
+            ✓
+        </span>
+    )
 }
 
 export function PeopleFilterBar({
@@ -114,14 +133,15 @@ export function PeopleFilterBar({
                             className={`flex min-h-[44px] shrink-0 snap-start items-center justify-center gap-1.5 rounded-full border p-2 text-xs font-medium transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 ${
                                 isSelected
                                     ? 'border-blue-500 bg-blue-600 text-white'
-                                    : done
-                                        ? 'border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100'
-                                        : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+                                    : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
                             }`}
                         >
-                            {column.unassigned
-                                ? <span aria-hidden="true" className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gray-200 text-xs font-bold text-gray-600">?</span>
-                                : <PersonAvatar name={column.name} color={color} initial={column.initial} />}
+                            <span className="relative shrink-0">
+                                {column.unassigned
+                                    ? <span aria-hidden="true" className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gray-200 text-xs font-bold text-gray-600">?</span>
+                                    : <PersonAvatar name={column.name} color={color} initial={column.initial} />}
+                                {done && <DoneTick />}
+                            </span>
                             <span className="hidden whitespace-nowrap sm:inline">{column.name}</span>
                             {/* Only the selected chip carries its numbers, and
                                 only where there is room for them. Every chip
@@ -134,7 +154,6 @@ export function PeopleFilterBar({
                                     {stat.packed}/{stat.total}
                                 </span>
                             )}
-                            {!isSelected && done && <span aria-hidden="true">✓</span>}
                         </button>
                     )
                 })}
@@ -151,19 +170,19 @@ export function PeopleFilterBar({
                             className={`flex min-h-[44px] min-w-[44px] shrink-0 snap-start items-center justify-center gap-1.5 rounded-full border p-2 text-base transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 sm:text-xs sm:font-medium ${
                                 isSelected
                                     ? 'border-blue-500 bg-blue-600 text-white'
-                                    : done
-                                        ? 'border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100'
-                                        : 'border-blue-200 bg-blue-50 text-blue-800 hover:bg-blue-100'
+                                    : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
                             }`}
                         >
-                            <span aria-hidden="true">👥</span>
+                            <span className="relative shrink-0">
+                                <span aria-hidden="true">👥</span>
+                                {done && <DoneTick />}
+                            </span>
                             <span className="hidden whitespace-nowrap sm:inline">Shared</span>
                             {isSelected && (
                                 <span className="hidden whitespace-nowrap tabular-nums opacity-90 sm:inline">
                                     {sharedStat.packed}/{sharedStat.total}
                                 </span>
                             )}
-                            {!isSelected && done && <span aria-hidden="true">✓</span>}
                         </button>
                     )
                 })()}

--- a/src/components/PeopleFilterBar.tsx
+++ b/src/components/PeopleFilterBar.tsx
@@ -9,20 +9,21 @@
  * unlike the destructive thing a key could have done (pack somebody's whole
  * category on a stray tap), filtering undoes itself.
  *
- * One line, always, scrolled rather than wrapped. It is sticky, above a
- * progress line and a row of controls that already goes to two lines on a
- * phone; a wrapping strip of six tappable chips would take a third of the
- * screen in the one situation this is for — packing a bag in a hallway,
- * one-handed. Scrolling also keeps a chip where the user last saw it, which
- * wrapping does not: a chip that changes width on selection reflows the line.
- *
  * On a phone the chips are faces and nothing else. Four names and "Shared"
- * come to about 370px of chips in about 340px of room, so a family of four
- * scrolled — and a control you have to scroll to find is one you don't know is
- * there. The names are worth roughly a third of that width, and they are the
- * part the grid below already says twice over in colour and initial. Who is
- * selected is written out in the bar underneath instead, where there is a whole
- * line for it.
+ * come to about 370px of chips in about 340px of room, so carrying the names
+ * meant the strip could not hold a family of four. The names are worth roughly
+ * a third of that width, and they are the part the grid below already says
+ * twice over in colour and initial. Who is selected is written out in the bar
+ * underneath instead, where there is a whole line for it.
+ *
+ * The strip wraps rather than scrolls. It used to scroll, on the argument that
+ * a wrapping row of tappable chips would take a third of a phone screen and
+ * that a chip changing width on selection would reflow the line — both true of
+ * chips carrying names and counts, and neither true of these. A fixed 44px
+ * circle never changes width, and six fit a line, so a family of four wraps to
+ * nothing at all and only a party of seven costs a second row. What scrolling
+ * costs is worse and certain: a chip past the edge is a person the strip does
+ * not appear to have.
  *
  * The names come back on demand: a pointer hovers, a finger holds. Whichever
  * way, the chip says who it is without the strip having to carry it.
@@ -78,9 +79,6 @@ export function PeopleFilterBar({
     sharedStat,
     controlsId,
 }: PeopleFilterBarProps) {
-    const scroller = useRef<HTMLDivElement>(null)
-    const settled = useRef(false)
-
     /**
      * Who a chip belongs to, on a screen with no room to write it beside them.
      *
@@ -88,12 +86,11 @@ export function PeopleFilterBar({
      * where the names were dropped and "the face is the only label" is fine
      * until the day somebody else packs the bag.
      *
-     * Rendered outside the scroller: `overflow-x` makes the other axis scroll
-     * too, so anything drawn above a chip is clipped by the strip it sits in.
-     * The position is measured against the scroller instead and the label is
-     * placed over it.
+     * Placed under the chip's own row rather than over it: above would take it
+     * out of the strip and into the controls above, and with the chips wrapped
+     * every row has a below to sit against.
      */
-    const [revealed, setRevealed] = useState<{ name: string; left: number } | null>(null)
+    const [revealed, setRevealed] = useState<{ name: string; left: number; top: number } | null>(null)
     const pressTimer = useRef<number | null>(null)
     const wasLongPress = useRef(false)
 
@@ -108,11 +105,12 @@ export function PeopleFilterBar({
         wasLongPress.current = false
         cancelPress()
         pressTimer.current = window.setTimeout(() => {
-            const box = scroller.current
-            if (!box) return
             wasLongPress.current = true
-            const left = chip.offsetLeft - box.scrollLeft + chip.offsetWidth / 2
-            setRevealed({ name, left })
+            setRevealed({
+                name,
+                left: chip.offsetLeft + chip.offsetWidth / 2,
+                top: chip.offsetTop + chip.offsetHeight,
+            })
         }, LONG_PRESS_MS)
     }, [cancelPress])
 
@@ -139,23 +137,6 @@ export function PeopleFilterBar({
         return true
     }
 
-    // A chip pressed off screen leaves the list filtered by a control the user
-    // can't see — which is what happens as soon as the group outgrows the strip.
-    //
-    // Never on the first render: the list opens unfiltered, and scrolling
-    // anything into view before the user has asked for it moves a page they are
-    // already reading.
-    const lastSelected = [...selected].join('\u0000')
-    useEffect(() => {
-        const box = scroller.current
-        if (!box) return
-        if (!settled.current) { settled.current = true; return }
-        const target = selected.size > 0
-            ? box.querySelector<HTMLElement>('[aria-pressed="true"]')
-            : box.firstElementChild as HTMLElement | null
-        target?.scrollIntoView({ inline: 'nearest', block: 'nearest', behavior: 'smooth' })
-    }, [lastSelected, selected.size])
-
     // One person is not a choice, and neither is nobody — unless the group's
     // own items are also on offer, which makes it a choice again.
     if (columns.length <= 1 && sharedStat === undefined) return null
@@ -172,15 +153,12 @@ export function PeopleFilterBar({
             <span className="hidden shrink-0 text-[11px] font-semibold uppercase tracking-wide text-gray-400 sm:inline">
                 Packing for
             </span>
-            {/* Faded at the trailing edge, so a group that runs off the end
-                looks like it continues rather than like it stops there. */}
             <div className="relative min-w-0 flex-1">
             <div
-                ref={scroller}
                 role="group"
                 aria-label="Filter by person"
                 aria-controls={controlsId}
-                className="flex items-center gap-1.5 overflow-x-auto scroll-pr-6 scroll-smooth pr-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                className="flex flex-wrap items-center gap-1.5"
             >
                 {columns.map(column => {
                     const isSelected = selected.has(column.key)
@@ -197,7 +175,7 @@ export function PeopleFilterBar({
                             aria-pressed={isSelected}
                             {...pressHandlers(column.name)}
                             onClick={() => { if (!swallowLongPress()) onToggle(column.key) }}
-                            className={`flex min-h-[44px] shrink-0 snap-start items-center justify-center gap-1.5 rounded-full border p-2 text-xs font-medium transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 ${
+                            className={`flex min-h-[44px] shrink-0 items-center justify-center gap-1.5 rounded-full border p-2 text-xs font-medium transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 ${
                                 isSelected
                                     ? 'border-blue-500 bg-blue-600 text-white'
                                     : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
@@ -235,7 +213,7 @@ export function PeopleFilterBar({
                             aria-pressed={isSelected}
                             {...pressHandlers('Shared items')}
                             onClick={() => { if (!swallowLongPress()) onToggle(SHARED_FILTER_KEY) }}
-                            className={`flex min-h-[44px] min-w-[44px] shrink-0 snap-start items-center justify-center gap-1.5 rounded-full border p-2 text-base transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 sm:text-xs sm:font-medium ${
+                            className={`flex min-h-[44px] min-w-[44px] shrink-0 items-center justify-center gap-1.5 rounded-full border p-2 text-base transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 sm:text-xs sm:font-medium ${
                                 isSelected
                                     ? 'border-blue-500 bg-blue-600 text-white'
                                     : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
@@ -255,16 +233,12 @@ export function PeopleFilterBar({
                     )
                 })()}
             </div>
-            <span
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-white to-transparent"
-            />
             {revealed && (
                 <span
                     aria-hidden="true"
                     data-testid="chip-name-reveal"
-                    style={{ left: `${revealed.left}px` }}
-                    className="pointer-events-none absolute -top-1 z-20 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md bg-gray-900 px-2 py-1 text-xs font-medium text-white shadow-lg"
+                    style={{ left: `${revealed.left}px`, top: `${revealed.top + 4}px` }}
+                    className="pointer-events-none absolute z-20 -translate-x-1/2 whitespace-nowrap rounded-md bg-gray-900 px-2 py-1 text-xs font-medium text-white shadow-lg"
                 >
                     {revealed.name}
                 </span>

--- a/src/components/PeopleFilterBar.tsx
+++ b/src/components/PeopleFilterBar.tsx
@@ -24,13 +24,16 @@
  * selected is written out in the bar underneath instead, where there is a whole
  * line for it.
  *
+ * The names come back on demand: a pointer hovers, a finger holds. Whichever
+ * way, the chip says who it is without the strip having to carry it.
+ *
  * A filled chip means one thing and one thing only: pressed. Somebody who has
  * finished packing used to get a chip filled green, which read as selected
  * beside the white ones that read as not — two states competing for the same
  * signal. Finished is a tick on the face instead, which says it without
  * borrowing the fill.
  */
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { PersonAvatar } from './PersonAvatar'
 import type { PersonColorLookup } from '../hooks/usePersonColors'
 import type { GridColumn } from '../utils/categoryItemGrid'
@@ -61,6 +64,11 @@ function DoneTick() {
     )
 }
 
+/** How long a press has to be held before it is asking who, not choosing. */
+const LONG_PRESS_MS = 400
+/** And how long the answer stays up afterwards. */
+const REVEAL_MS = 1800
+
 export function PeopleFilterBar({
     columns,
     selected,
@@ -72,6 +80,64 @@ export function PeopleFilterBar({
 }: PeopleFilterBarProps) {
     const scroller = useRef<HTMLDivElement>(null)
     const settled = useRef(false)
+
+    /**
+     * Who a chip belongs to, on a screen with no room to write it beside them.
+     *
+     * A pointer gets `title`. A finger gets a long press, because the phone is
+     * where the names were dropped and "the face is the only label" is fine
+     * until the day somebody else packs the bag.
+     *
+     * Rendered outside the scroller: `overflow-x` makes the other axis scroll
+     * too, so anything drawn above a chip is clipped by the strip it sits in.
+     * The position is measured against the scroller instead and the label is
+     * placed over it.
+     */
+    const [revealed, setRevealed] = useState<{ name: string; left: number } | null>(null)
+    const pressTimer = useRef<number | null>(null)
+    const wasLongPress = useRef(false)
+
+    const cancelPress = useCallback(() => {
+        if (pressTimer.current !== null) {
+            clearTimeout(pressTimer.current)
+            pressTimer.current = null
+        }
+    }, [])
+
+    const beginPress = useCallback((name: string, chip: HTMLElement) => {
+        wasLongPress.current = false
+        cancelPress()
+        pressTimer.current = window.setTimeout(() => {
+            const box = scroller.current
+            if (!box) return
+            wasLongPress.current = true
+            const left = chip.offsetLeft - box.scrollLeft + chip.offsetWidth / 2
+            setRevealed({ name, left })
+        }, LONG_PRESS_MS)
+    }, [cancelPress])
+
+    useEffect(() => {
+        if (!revealed) return
+        const timer = setTimeout(() => setRevealed(null), REVEAL_MS)
+        return () => clearTimeout(timer)
+    }, [revealed])
+
+    useEffect(() => cancelPress, [cancelPress])
+
+    /** A press held long enough to ask who was not a press to choose them. */
+    const pressHandlers = (name: string) => ({
+        title: name,
+        onTouchStart: (e: React.TouchEvent<HTMLButtonElement>) => beginPress(name, e.currentTarget),
+        onTouchEnd: cancelPress,
+        onTouchMove: cancelPress,
+        onTouchCancel: cancelPress,
+    })
+
+    const swallowLongPress = () => {
+        if (!wasLongPress.current) return false
+        wasLongPress.current = false
+        return true
+    }
 
     // A chip pressed off screen leaves the list filtered by a control the user
     // can't see — which is what happens as soon as the group outgrows the strip.
@@ -129,7 +195,8 @@ export function PeopleFilterBar({
                             key={column.key}
                             type="button"
                             aria-pressed={isSelected}
-                            onClick={() => onToggle(column.key)}
+                            {...pressHandlers(column.name)}
+                            onClick={() => { if (!swallowLongPress()) onToggle(column.key) }}
                             className={`flex min-h-[44px] shrink-0 snap-start items-center justify-center gap-1.5 rounded-full border p-2 text-xs font-medium transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 ${
                                 isSelected
                                     ? 'border-blue-500 bg-blue-600 text-white'
@@ -166,7 +233,8 @@ export function PeopleFilterBar({
                         <button
                             type="button"
                             aria-pressed={isSelected}
-                            onClick={() => onToggle(SHARED_FILTER_KEY)}
+                            {...pressHandlers('Shared items')}
+                            onClick={() => { if (!swallowLongPress()) onToggle(SHARED_FILTER_KEY) }}
                             className={`flex min-h-[44px] min-w-[44px] shrink-0 snap-start items-center justify-center gap-1.5 rounded-full border p-2 text-base transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 sm:text-xs sm:font-medium ${
                                 isSelected
                                     ? 'border-blue-500 bg-blue-600 text-white'
@@ -191,6 +259,16 @@ export function PeopleFilterBar({
                 aria-hidden="true"
                 className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-white to-transparent"
             />
+            {revealed && (
+                <span
+                    aria-hidden="true"
+                    data-testid="chip-name-reveal"
+                    style={{ left: `${revealed.left}px` }}
+                    className="pointer-events-none absolute -top-1 z-20 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md bg-gray-900 px-2 py-1 text-xs font-medium text-white shadow-lg"
+                >
+                    {revealed.name}
+                </span>
+            )}
             </div>
         </div>
     )

--- a/src/components/PeopleFilterBar.tsx
+++ b/src/components/PeopleFilterBar.tsx
@@ -20,7 +20,7 @@ import { useEffect, useRef } from 'react'
 import { PersonAvatar } from './PersonAvatar'
 import type { PersonColorLookup } from '../hooks/usePersonColors'
 import type { GridColumn } from '../utils/categoryItemGrid'
-import type { PeopleFilter, PersonStat } from '../utils/peopleFilter'
+import { SHARED_FILTER_KEY, type PeopleFilter, type PersonStat } from '../utils/peopleFilter'
 
 export interface PeopleFilterBarProps {
     columns: readonly GridColumn[]
@@ -28,6 +28,8 @@ export interface PeopleFilterBarProps {
     totals: Map<string, PersonStat>
     personColor: PersonColorLookup
     onToggle: (name: string) => void
+    /** The group's own items, when the list has any. Omitted when it has none. */
+    sharedStat?: PersonStat
     /** Names the region the strip filters, for assistive tech. */
     controlsId: string
 }
@@ -38,24 +40,32 @@ export function PeopleFilterBar({
     totals,
     personColor,
     onToggle,
+    sharedStat,
     controlsId,
 }: PeopleFilterBarProps) {
     const scroller = useRef<HTMLDivElement>(null)
+    const settled = useRef(false)
 
     // A chip pressed off screen leaves the list filtered by a control the user
     // can't see — which is what happens as soon as the group outgrows the strip.
+    //
+    // Never on the first render: the list opens unfiltered, and scrolling
+    // anything into view before the user has asked for it moves a page they are
+    // already reading.
     const lastSelected = [...selected].join('\u0000')
     useEffect(() => {
         const box = scroller.current
         if (!box) return
+        if (!settled.current) { settled.current = true; return }
         const target = selected.size > 0
             ? box.querySelector<HTMLElement>('[aria-pressed="true"]')
             : box.firstElementChild as HTMLElement | null
         target?.scrollIntoView({ inline: 'nearest', block: 'nearest', behavior: 'smooth' })
     }, [lastSelected, selected.size])
 
-    // One person is not a choice, and neither is nobody.
-    if (columns.length <= 1) return null
+    // One person is not a choice, and neither is nobody — unless the group's
+    // own items are also on offer, which makes it a choice again.
+    if (columns.length <= 1 && sharedStat === undefined) return null
 
     return (
         <div className="mt-1.5 flex items-center gap-2 border-t border-gray-100 pt-1.5">
@@ -119,6 +129,35 @@ export function PeopleFilterBar({
                         </button>
                     )
                 })}
+                {/* Last, after the people, because it is the one chip that is
+                    nobody's. Wearing the same mark a shared row wears. */}
+                {sharedStat !== undefined && (() => {
+                    const isSelected = selected.has(SHARED_FILTER_KEY)
+                    const done = sharedStat.total > 0 && sharedStat.packed === sharedStat.total
+                    return (
+                        <button
+                            type="button"
+                            aria-pressed={isSelected}
+                            onClick={() => onToggle(SHARED_FILTER_KEY)}
+                            className={`flex min-h-[44px] shrink-0 snap-start items-center gap-1.5 rounded-full border py-1.5 pl-2 pr-2.5 text-xs font-medium transition-colors ${
+                                isSelected
+                                    ? 'border-blue-500 bg-blue-600 text-white'
+                                    : done
+                                        ? 'border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100'
+                                        : 'border-blue-200 bg-blue-50 text-blue-800 hover:bg-blue-100'
+                            }`}
+                        >
+                            <span aria-hidden="true">👥</span>
+                            <span className="whitespace-nowrap">Shared</span>
+                            {isSelected && (
+                                <span className="whitespace-nowrap tabular-nums opacity-90">
+                                    {sharedStat.packed}/{sharedStat.total}
+                                </span>
+                            )}
+                            {!isSelected && done && <span aria-hidden="true">✓</span>}
+                        </button>
+                    )
+                })()}
             </div>
             <span
                 aria-hidden="true"

--- a/src/components/PeopleFilterBar.tsx
+++ b/src/components/PeopleFilterBar.tsx
@@ -28,7 +28,6 @@ export interface PeopleFilterBarProps {
     totals: Map<string, PersonStat>
     personColor: PersonColorLookup
     onToggle: (name: string) => void
-    onClear: () => void
     /** Names the region the strip filters, for assistive tech. */
     controlsId: string
 }
@@ -39,7 +38,6 @@ export function PeopleFilterBar({
     totals,
     personColor,
     onToggle,
-    onClear,
     controlsId,
 }: PeopleFilterBarProps) {
     const scroller = useRef<HTMLDivElement>(null)
@@ -79,7 +77,7 @@ export function PeopleFilterBar({
                 role="group"
                 aria-label="Filter by person"
                 aria-controls={controlsId}
-                className="flex items-center gap-1.5 overflow-x-auto scroll-smooth pr-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                className="flex items-center gap-1.5 overflow-x-auto scroll-pr-6 scroll-smooth pr-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             >
                 {columns.map(column => {
                     const isSelected = selected.has(column.key)
@@ -121,19 +119,6 @@ export function PeopleFilterBar({
                         </button>
                     )
                 })}
-                {/* Last in the scroller rather than in a gutter of its own: a
-                    reserved 56px is a chip's worth of a phone screen spent on
-                    nothing, and coming after every chip it can appear without
-                    moving one of them. */}
-                {selected.size > 0 && (
-                    <button
-                        type="button"
-                        onClick={onClear}
-                        className="ml-0.5 min-h-[44px] shrink-0 rounded-full px-2.5 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-50"
-                    >
-                        Clear
-                    </button>
-                )}
             </div>
             <span
                 aria-hidden="true"

--- a/src/components/PeopleFilterBar.tsx
+++ b/src/components/PeopleFilterBar.tsx
@@ -1,0 +1,111 @@
+/**
+ * Who the user is packing for — the strip above the cards.
+ *
+ * This used to be a key: coloured initials and their names, explaining the
+ * chips on the cards below and doing nothing. Beside it sat a toggle between
+ * two whole views of the list, one per person and one per category. The key
+ * already names every person the grid can show, so pressing it is the same
+ * question the toggle was asking, without a second layout to maintain — and
+ * unlike the destructive thing a key could have done (pack somebody's whole
+ * category on a stray tap), filtering undoes itself.
+ *
+ * One line, always, scrolled rather than wrapped. It is sticky, above a
+ * progress line and a row of controls that already goes to two lines on a
+ * phone; a wrapping strip of six tappable chips would take a third of the
+ * screen in the one situation this is for — packing a bag in a hallway,
+ * one-handed. Scrolling also keeps a chip where the user last saw it, which
+ * wrapping does not: a chip that changes width on selection reflows the line.
+ */
+import { PersonAvatar } from './PersonAvatar'
+import type { PersonColorLookup } from '../hooks/usePersonColors'
+import type { GridColumn } from '../utils/categoryItemGrid'
+import type { PeopleFilter, PersonStat } from '../utils/peopleFilter'
+
+export interface PeopleFilterBarProps {
+    columns: readonly GridColumn[]
+    selected: PeopleFilter
+    totals: Map<string, PersonStat>
+    personColor: PersonColorLookup
+    onToggle: (name: string) => void
+    onClear: () => void
+    /** Names the region the strip filters, for assistive tech. */
+    controlsId: string
+}
+
+export function PeopleFilterBar({
+    columns,
+    selected,
+    totals,
+    personColor,
+    onToggle,
+    onClear,
+    controlsId,
+}: PeopleFilterBarProps) {
+    // One person is not a choice, and neither is nobody.
+    if (columns.length <= 1) return null
+
+    return (
+        <div className="mt-1.5 flex items-center gap-2 border-t border-gray-100 pt-1.5">
+            <span className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+                Packing for
+            </span>
+            <div
+                role="group"
+                aria-label="Filter by person"
+                aria-controls={controlsId}
+                className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+                {columns.map(column => {
+                    const isSelected = selected.has(column.key)
+                    const stat = totals.get(column.key)
+                    const done = stat !== undefined && stat.total > 0 && stat.packed === stat.total
+                    const color = personColor({ id: column.personId, name: column.name })
+                    return (
+                        <button
+                            key={column.key}
+                            type="button"
+                            aria-pressed={isSelected}
+                            onClick={() => onToggle(column.key)}
+                            className={`flex shrink-0 snap-start items-center gap-1.5 rounded-full border py-1.5 pl-1.5 pr-2.5 text-xs font-medium transition-colors ${
+                                isSelected
+                                    ? 'border-blue-500 bg-blue-600 text-white'
+                                    : done
+                                        ? 'border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100'
+                                        : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+                            }`}
+                        >
+                            {column.unassigned
+                                ? <span aria-hidden="true" className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-gray-200 text-[10px] font-bold text-gray-600">?</span>
+                                : <PersonAvatar name={column.name} color={color} size="sm" initial={column.initial} />}
+                            <span className="whitespace-nowrap">{column.name}</span>
+                            {/* Only the selected chip carries its numbers. Every
+                                chip carrying them makes the strip twice as long
+                                for a figure nobody is reading, and a chip that
+                                grows when pressed moves the one beside it out
+                                from under the finger going there next. */}
+                            {isSelected && stat !== undefined && (
+                                <span className="whitespace-nowrap tabular-nums opacity-90">
+                                    {stat.packed}/{stat.total}
+                                </span>
+                            )}
+                            {!isSelected && done && <span aria-hidden="true">✓</span>}
+                        </button>
+                    )
+                })}
+            </div>
+            {/* Held open whether or not it is showing, so the chips don't shift
+                sideways the moment the first one is pressed. */}
+            <div className="w-14 shrink-0 text-right">
+                {selected.size > 0 && (
+                    <button
+                        type="button"
+                        onClick={onClear}
+                        className="rounded-md px-1.5 py-1 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-50"
+                    >
+                        Clear
+                    </button>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/src/components/PeopleFilterBar.tsx
+++ b/src/components/PeopleFilterBar.tsx
@@ -15,6 +15,14 @@
  * screen in the one situation this is for — packing a bag in a hallway,
  * one-handed. Scrolling also keeps a chip where the user last saw it, which
  * wrapping does not: a chip that changes width on selection reflows the line.
+ *
+ * On a phone the chips are faces and nothing else. Four names and "Shared"
+ * come to about 370px of chips in about 340px of room, so a family of four
+ * scrolled — and a control you have to scroll to find is one you don't know is
+ * there. The names are worth roughly a third of that width, and they are the
+ * part the grid below already says twice over in colour and initial. Who is
+ * selected is written out in the bar underneath instead, where there is a whole
+ * line for it.
  */
 import { useEffect, useRef } from 'react'
 import { PersonAvatar } from './PersonAvatar'
@@ -103,7 +111,7 @@ export function PeopleFilterBar({
                             type="button"
                             aria-pressed={isSelected}
                             onClick={() => onToggle(column.key)}
-                            className={`flex min-h-[44px] shrink-0 snap-start items-center gap-1.5 rounded-full border py-1.5 pl-1.5 pr-2.5 text-xs font-medium transition-colors ${
+                            className={`flex min-h-[44px] shrink-0 snap-start items-center justify-center gap-1.5 rounded-full border p-2 text-xs font-medium transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 ${
                                 isSelected
                                     ? 'border-blue-500 bg-blue-600 text-white'
                                     : done
@@ -112,16 +120,17 @@ export function PeopleFilterBar({
                             }`}
                         >
                             {column.unassigned
-                                ? <span aria-hidden="true" className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-gray-200 text-[10px] font-bold text-gray-600">?</span>
-                                : <PersonAvatar name={column.name} color={color} size="sm" initial={column.initial} />}
-                            <span className="whitespace-nowrap">{column.name}</span>
-                            {/* Only the selected chip carries its numbers. Every
-                                chip carrying them makes the strip twice as long
-                                for a figure nobody is reading, and a chip that
-                                grows when pressed moves the one beside it out
-                                from under the finger going there next. */}
+                                ? <span aria-hidden="true" className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gray-200 text-xs font-bold text-gray-600">?</span>
+                                : <PersonAvatar name={column.name} color={color} initial={column.initial} />}
+                            <span className="hidden whitespace-nowrap sm:inline">{column.name}</span>
+                            {/* Only the selected chip carries its numbers, and
+                                only where there is room for them. Every chip
+                                carrying them makes the strip twice as long for a
+                                figure nobody is reading, and a chip that grows
+                                when pressed moves the one beside it out from
+                                under the finger going there next. */}
                             {isSelected && (
-                                <span className="whitespace-nowrap tabular-nums opacity-90">
+                                <span className="hidden whitespace-nowrap tabular-nums opacity-90 sm:inline">
                                     {stat.packed}/{stat.total}
                                 </span>
                             )}
@@ -139,7 +148,7 @@ export function PeopleFilterBar({
                             type="button"
                             aria-pressed={isSelected}
                             onClick={() => onToggle(SHARED_FILTER_KEY)}
-                            className={`flex min-h-[44px] shrink-0 snap-start items-center gap-1.5 rounded-full border py-1.5 pl-2 pr-2.5 text-xs font-medium transition-colors ${
+                            className={`flex min-h-[44px] min-w-[44px] shrink-0 snap-start items-center justify-center gap-1.5 rounded-full border p-2 text-base transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 sm:text-xs sm:font-medium ${
                                 isSelected
                                     ? 'border-blue-500 bg-blue-600 text-white'
                                     : done
@@ -148,9 +157,9 @@ export function PeopleFilterBar({
                             }`}
                         >
                             <span aria-hidden="true">👥</span>
-                            <span className="whitespace-nowrap">Shared</span>
+                            <span className="hidden whitespace-nowrap sm:inline">Shared</span>
                             {isSelected && (
-                                <span className="whitespace-nowrap tabular-nums opacity-90">
+                                <span className="hidden whitespace-nowrap tabular-nums opacity-90 sm:inline">
                                     {sharedStat.packed}/{sharedStat.total}
                                 </span>
                             )}

--- a/src/components/PeopleFilterBar.tsx
+++ b/src/components/PeopleFilterBar.tsx
@@ -16,6 +16,7 @@
  * one-handed. Scrolling also keeps a chip where the user last saw it, which
  * wrapping does not: a chip that changes width on selection reflows the line.
  */
+import { useEffect, useRef } from 'react'
 import { PersonAvatar } from './PersonAvatar'
 import type { PersonColorLookup } from '../hooks/usePersonColors'
 import type { GridColumn } from '../utils/categoryItemGrid'
@@ -41,24 +42,52 @@ export function PeopleFilterBar({
     onClear,
     controlsId,
 }: PeopleFilterBarProps) {
+    const scroller = useRef<HTMLDivElement>(null)
+
+    // A chip pressed off screen leaves the list filtered by a control the user
+    // can't see — which is what happens as soon as the group outgrows the strip.
+    const lastSelected = [...selected].join('\u0000')
+    useEffect(() => {
+        const box = scroller.current
+        if (!box) return
+        const target = selected.size > 0
+            ? box.querySelector<HTMLElement>('[aria-pressed="true"]')
+            : box.firstElementChild as HTMLElement | null
+        target?.scrollIntoView({ inline: 'nearest', block: 'nearest', behavior: 'smooth' })
+    }, [lastSelected, selected.size])
+
     // One person is not a choice, and neither is nobody.
     if (columns.length <= 1) return null
 
     return (
         <div className="mt-1.5 flex items-center gap-2 border-t border-gray-100 pt-1.5">
-            <span className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+            {/* The words are worth 87px of a 390px screen, which is most of a
+                chip — so the phone gets the funnel and the room instead. */}
+            <span aria-hidden="true" className="shrink-0 text-gray-400 sm:hidden">
+                <svg viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                    <path fillRule="evenodd" d="M2.6 4.2A1 1 0 0 1 3.5 3.6h13a1 1 0 0 1 .77 1.64l-4.77 5.6v4.2a1 1 0 0 1-.55.9l-2.4 1.2a1 1 0 0 1-1.45-.9v-5.4L2.33 5.24a1 1 0 0 1 .27-1.04Z" clipRule="evenodd" />
+                </svg>
+            </span>
+            <span className="hidden shrink-0 text-[11px] font-semibold uppercase tracking-wide text-gray-400 sm:inline">
                 Packing for
             </span>
+            {/* Faded at the trailing edge, so a group that runs off the end
+                looks like it continues rather than like it stops there. */}
+            <div className="relative min-w-0 flex-1">
             <div
+                ref={scroller}
                 role="group"
                 aria-label="Filter by person"
                 aria-controls={controlsId}
-                className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                className="flex items-center gap-1.5 overflow-x-auto scroll-smooth pr-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             >
                 {columns.map(column => {
                     const isSelected = selected.has(column.key)
-                    const stat = totals.get(column.key)
-                    const done = stat !== undefined && stat.total > 0 && stat.packed === stat.total
+                    // Somebody with nothing of their own still has a total, and
+                    // it is worth saying: a bare chip where every other selected
+                    // chip carries numbers reads as a chip that failed to load.
+                    const stat = totals.get(column.key) ?? { packed: 0, total: 0 }
+                    const done = stat.total > 0 && stat.packed === stat.total
                     const color = personColor({ id: column.personId, name: column.name })
                     return (
                         <button
@@ -66,7 +95,7 @@ export function PeopleFilterBar({
                             type="button"
                             aria-pressed={isSelected}
                             onClick={() => onToggle(column.key)}
-                            className={`flex shrink-0 snap-start items-center gap-1.5 rounded-full border py-1.5 pl-1.5 pr-2.5 text-xs font-medium transition-colors ${
+                            className={`flex min-h-[44px] shrink-0 snap-start items-center gap-1.5 rounded-full border py-1.5 pl-1.5 pr-2.5 text-xs font-medium transition-colors ${
                                 isSelected
                                     ? 'border-blue-500 bg-blue-600 text-white'
                                     : done
@@ -83,7 +112,7 @@ export function PeopleFilterBar({
                                 for a figure nobody is reading, and a chip that
                                 grows when pressed moves the one beside it out
                                 from under the finger going there next. */}
-                            {isSelected && stat !== undefined && (
+                            {isSelected && (
                                 <span className="whitespace-nowrap tabular-nums opacity-90">
                                     {stat.packed}/{stat.total}
                                 </span>
@@ -92,19 +121,24 @@ export function PeopleFilterBar({
                         </button>
                     )
                 })}
-            </div>
-            {/* Held open whether or not it is showing, so the chips don't shift
-                sideways the moment the first one is pressed. */}
-            <div className="w-14 shrink-0 text-right">
+                {/* Last in the scroller rather than in a gutter of its own: a
+                    reserved 56px is a chip's worth of a phone screen spent on
+                    nothing, and coming after every chip it can appear without
+                    moving one of them. */}
                 {selected.size > 0 && (
                     <button
                         type="button"
                         onClick={onClear}
-                        className="rounded-md px-1.5 py-1 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-50"
+                        className="ml-0.5 min-h-[44px] shrink-0 rounded-full px-2.5 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-50"
                     >
                         Clear
                     </button>
                 )}
+            </div>
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-white to-transparent"
+            />
             </div>
         </div>
     )

--- a/src/components/PersonAvatar.tsx
+++ b/src/components/PersonAvatar.tsx
@@ -9,10 +9,16 @@ import type { PersonColor } from '../edit-questions/person-colors'
  * beside it, so announcing the initial as well would only make a screen
  * reader say "A, Alice's Items".
  */
-export function PersonAvatar({ name, color, size = 'md' }: {
+export function PersonAvatar({ name, color, size = 'md', initial }: {
     name: string
     color: PersonColor
     size?: 'sm' | 'md'
+    /**
+     * Overrides the first letter, for the places that have already worked out
+     * what tells this person apart from everyone else on the list — Alice and
+     * Amy are both "A". See `buildGridColumns`.
+     */
+    initial?: string
 }) {
     const dimensions = size === 'sm' ? 'w-5 h-5 text-[10px]' : 'w-7 h-7 text-xs'
     return (
@@ -22,7 +28,7 @@ export function PersonAvatar({ name, color, size = 'md' }: {
             aria-hidden="true"
             className={`inline-flex items-center justify-center rounded-full font-bold select-none shrink-0 ${dimensions} ${color.avatar}`}
         >
-            {name.charAt(0).toUpperCase() || '?'}
+            {initial ?? (name.charAt(0).toUpperCase() || '?')}
         </span>
     )
 }

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -9,9 +9,11 @@ interface ToastProps {
     onClose: () => void;
     duration?: number;
     details?: string;
+    /** Takes back what the toast is reporting — see `action` in ToastContext. */
+    action?: { label: string; onAction: () => void };
 }
 
-export function Toast({ message, type, onClose, duration = 3000, details }: ToastProps) {
+export function Toast({ message, type, onClose, duration = 3000, details, action }: ToastProps) {
     const [copied, setCopied] = useState(false);
 
     useEffect(() => {
@@ -37,6 +39,14 @@ export function Toast({ message, type, onClose, duration = 3000, details }: Toas
     return (
         <div className={`fixed top-4 right-4 ${styles} text-white px-6 py-4 rounded-2xl flex items-center gap-3 min-w-[250px] animate-slide-down backdrop-blur-sm`}>
             <span className="flex-1 font-semibold">{message}</span>
+            {action && (
+                <button
+                    onClick={() => { action.onAction(); onClose(); }}
+                    className="rounded-lg bg-white/20 px-3 py-1 text-sm font-bold transition-colors hover:bg-white/30"
+                >
+                    {action.label}
+                </button>
+            )}
             {details && (
                 <button
                     onClick={handleCopy}

--- a/src/components/ToastContext.tsx
+++ b/src/components/ToastContext.tsx
@@ -1,17 +1,28 @@
 import { createContext, useContext, useState, ReactNode } from 'react';
 import { Toast, ToastType } from './Toast';
 
+/**
+ * An action offered alongside the message — in practice, taking back what the
+ * message is reporting. A bulk change is safe to offer without a confirmation
+ * dialog when it can be undone afterwards; a dialog met often is a dialog
+ * dismissed without reading.
+ */
+export interface ToastAction {
+    label: string;
+    onAction: () => void;
+}
+
 interface ToastContextType {
-    showToast: (message: string, type: ToastType, details?: string) => void;
+    showToast: (message: string, type: ToastType, details?: string, action?: ToastAction) => void;
 }
 
 const ToastContext = createContext<ToastContextType | undefined>(undefined);
 
 export function ToastProvider({ children }: { children: ReactNode }) {
-    const [toast, setToast] = useState<{ message: string; type: ToastType; details?: string } | null>(null);
+    const [toast, setToast] = useState<{ message: string; type: ToastType; details?: string; action?: ToastAction } | null>(null);
 
-    const showToast = (message: string, type: ToastType, details?: string) => {
-        setToast({ message, type, details });
+    const showToast = (message: string, type: ToastType, details?: string, action?: ToastAction) => {
+        setToast({ message, type, details, action });
     };
 
     return (
@@ -22,6 +33,10 @@ export function ToastProvider({ children }: { children: ReactNode }) {
                     message={toast.message}
                     type={toast.type}
                     details={toast.details}
+                    action={toast.action}
+                    // Long enough to be noticed and taken; an undo that has gone
+                    // by the time you look up is not an undo.
+                    duration={toast.action ? 8000 : undefined}
                     onClose={() => setToast(null)}
                 />
             )}

--- a/src/pages/view-packing-list.person-colors.test.tsx
+++ b/src/pages/view-packing-list.person-colors.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor, within, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { ViewPackingList } from './view-packing-list'
@@ -75,9 +75,14 @@ function renderList() {
 }
 
 /** The card whose heading names this person. */
-function cardFor(name: string): HTMLElement {
-    const heading = screen.getByRole('button', { name: new RegExp(`Collapse ${name}'s list`) })
-    return heading.closest('[data-testid="list-section"]') as HTMLElement
+/** A person's chip in the "Packing for" strip. */
+function chipFor(name: string): HTMLElement {
+    return screen.getByRole('button', { name: new RegExp(`^${name}`) })
+}
+
+/** A row of the grid, by the button carrying its name. */
+function row(itemText: string) {
+    return screen.getByRole('button', { name: `Edit ${itemText}` })
 }
 
 const pink = PERSON_COLORS.find(c => c.id === 'pink')!
@@ -98,58 +103,46 @@ beforeEach(() => {
 })
 
 describe('ViewPackingList person colours', () => {
-    it('marks each person’s card with their coloured initial', async () => {
+    it('marks each person in the filter strip with their coloured initial', async () => {
         renderList()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
         await waitFor(() =>
-            expect(within(cardFor('Bob')).getByTestId('person-avatar').className).toContain(pink.avatar))
-        expect(within(cardFor('Alice')).getByTestId('person-avatar').className)
+            expect(within(chipFor('Bob')).getByTestId('person-avatar').className).toContain(pink.avatar))
+        expect(within(chipFor('Alice')).getByTestId('person-avatar').className)
             .toContain(personColorAt(0).avatar)
     })
 
-    it('outlines the card in the same colour', async () => {
+    it('carries the same colour onto that person’s cells in the grid', async () => {
         renderList()
-        await waitFor(() => expect(screen.getByText('Nappies')).toBeTruthy())
+        await waitFor(() => expect(row('Nappies')).toBeTruthy())
 
-        await waitFor(() => expect(cardFor('Bob').className).toContain(pink.border))
-        expect(cardFor('Alice').className).toContain(personColorAt(0).border)
+        // Unpacked, so the disc is outlined in their colour rather than filled
+        await waitFor(() => expect(screen.getByTestId('grid-cell-i2').className).toContain(pink.border))
+        expect(screen.getByTestId('grid-cell-i1').className).toContain(personColorAt(0).border)
     })
 
     it('gives a guest a colour nobody else on the list is wearing', async () => {
         renderList()
-        await waitFor(() => expect(screen.getByText('Sun hat')).toBeTruthy())
+        await waitFor(() => expect(row('Sun hat')).toBeTruthy())
 
         // Alice holds position 0 and Bob chose pink, so the first colour going
         // spare is position 1's.
         await waitFor(() =>
-            expect(within(cardFor('Zoe')).getByTestId('person-avatar').className)
+            expect(within(chipFor('Zoe')).getByTestId('person-avatar').className)
                 .toContain(personColorAt(1).avatar))
-        expect(within(cardFor('Zoe')).getByTestId('person-avatar').className)
+        expect(within(chipFor('Zoe')).getByTestId('person-avatar').className)
             .not.toContain(pink.avatar)
     })
 
-    it('carries the colours into the category grid', async () => {
+    it('tells two people who share a first letter apart by more than colour', async () => {
+        // Colour alone is no answer for someone who cannot separate two of them,
+        // and with person view gone there is no list of names to fall back to.
         renderList()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
-        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
-
-        // Everyone is marked the same way in the key as on their own card
-        const key = within(await screen.findByTestId('people-key'))
-        const bob = key.getByText('Bob').closest('span')!
-        await waitFor(() => expect(within(bob).getByTestId('person-avatar').className).toContain(pink.avatar))
-        const alice = key.getByText('Alice').closest('span')!
-        expect(within(alice).getByTestId('person-avatar').className).toContain(personColorAt(0).avatar)
-    })
-
-    it('leaves the shared card unmarked — it belongs to nobody in particular', async () => {
-        renderList()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-
-        fireEvent.click(screen.getByRole('button', { name: /Add Shared Items/i }))
-        const sharedHeading = await screen.findByRole('button', { name: /Collapse the shared items list/ })
-        const sharedCard = sharedHeading.closest('[data-testid="list-section"]') as HTMLElement
-        expect(within(sharedCard).queryByTestId('person-avatar')).toBeNull()
+        expect(within(chipFor('Alice')).getByTestId('person-avatar').textContent).toBe('A')
+        expect(within(chipFor('Bob')).getByTestId('person-avatar').textContent).toBe('B')
+        expect(within(chipFor('Zoe')).getByTestId('person-avatar').textContent).toBe('Z')
     })
 })

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -112,105 +112,27 @@ function renderComponent() {
     )
 }
 
-// The list view remembers how it was left (folded sections, view mode, whether
-// packed items are showing) per list id in localStorage. Tests reuse the same
+/**
+ * A row of the category grid, by the button carrying its name.
+ *
+ * Not `getByText`: a row's name is split so that its last word can hold on to
+ * the chevron (see `splitLastWord`), so any name of more than one word is more
+ * than one text node.
+ */
+function row(itemText: string) {
+    return screen.getByRole('button', { name: `Edit ${itemText}` })
+}
+
+/** The chip that packs one person's copy of an item — the grid's checkbox. */
+function chipFor(itemText: string, person: string) {
+    return screen.getByRole('checkbox', { name: `${itemText} for ${person}` })
+}
+
+// The list view remembers how it was left (folded sections, whether packed
+// items are showing) per list id in localStorage. Tests reuse the same
 // ids, so without this each one inherits the last one's folded sections.
 beforeEach(() => {
     localStorage.clear()
-})
-
-describe('ViewPackingList item deletion confirmation', () => {
-    beforeEach(() => {
-        mockUseSolidPod.mockReturnValue({
-            isLoggedIn: false,
-            session: null,
-            webId: undefined,
-            isLoading: false,
-            login: vi.fn(),
-            logout: vi.fn(),
-        })
-        mockUsePodSync.mockReturnValue({
-            saveToPod: vi.fn(),
-        })
-        mockUseSyncCoordinator.mockReturnValue({
-            syncingFromPod: false,
-            handleSyncSuccess: vi.fn(),
-            handleSyncError: vi.fn(),
-            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
-        })
-        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
-    })
-
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
-
-    it('does not immediately delete item when X is clicked', async () => {
-        renderComponent()
-
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-
-        fireEvent.click(screen.getByTitle('Delete item'))
-
-        expect(screen.getByText('Passport')).toBeTruthy()
-    })
-
-    it('shows confirmation dialog when X is clicked', async () => {
-        renderComponent()
-
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-
-        fireEvent.click(screen.getByTitle('Delete item'))
-
-        expect(screen.getByText('Are you sure you want to remove this item?')).toBeTruthy()
-    })
-
-    it('does not delete item when Cancel is clicked in confirmation dialog', async () => {
-        renderComponent()
-
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-
-        fireEvent.click(screen.getByTitle('Delete item'))
-        fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
-
-        expect(screen.getByText('Passport')).toBeTruthy()
-        expect(screen.queryByText('Are you sure you want to remove this item?')).toBeNull()
-    })
-
-    it('deletes item when Remove is clicked in confirmation dialog', async () => {
-        renderComponent()
-
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-
-        fireEvent.click(screen.getByTitle('Delete item'))
-        fireEvent.click(screen.getByRole('button', { name: /^remove$/i }))
-
-        await waitFor(() => {
-            expect(screen.queryByText('Passport')).toBeNull()
-        })
-    })
-
-    it('removes the row without waiting for the save to come back', async () => {
-        // A save that never settles — stands in for a slow phone, or a pod on
-        // the end of a bad connection. The row still has to go straight away.
-        mockUseDatabase.mockReturnValue({
-            db: {
-                ...makeDb(),
-                savePackingList: vi.fn(() => new Promise(() => {})),
-            } as unknown as PackingAppDatabase,
-        })
-
-        renderComponent()
-
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-
-        fireEvent.click(screen.getByTitle('Delete item'))
-        fireEvent.click(screen.getByRole('button', { name: /^remove$/i }))
-
-        await waitFor(() => {
-            expect(screen.queryByText('Passport')).toBeNull()
-        })
-    })
 })
 
 const multiCategoryPackingList = {
@@ -268,14 +190,14 @@ describe('ViewPackingList category grouping', () => {
 
     it('renders category headings within a person card', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
         expect(screen.getAllByRole('button', { name: /Collapse Essentials/i }).length).toBeGreaterThan(0)
         expect(screen.getByRole('button', { name: /Collapse Hiking/i })).toBeTruthy()
     })
 
     it('shows items without category under "Other"', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Legacy item')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Legacy item' })).toBeTruthy())
         expect(screen.getByRole('button', { name: /Collapse Other/i })).toBeTruthy()
     })
 
@@ -301,7 +223,7 @@ describe('ViewPackingList category grouping', () => {
 
     it('shows a "Check all" button per category section', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
         // 3 expanded categories (Essentials for Alice, Hiking, Other) plus Essentials for Bob = 4
         const checkAllButtons = screen.getAllByRole('button', { name: /check all/i })
         expect(checkAllButtons.length).toBeGreaterThanOrEqual(1)
@@ -318,117 +240,18 @@ describe('ViewPackingList category grouping', () => {
         })
     })
 
-    it('renders Essentials category independently for each person', async () => {
+    it('gives a category one card, with everyone who needs something in it on it', async () => {
+        // Two people both have an Essentials item. The old person view gave the
+        // category a heading inside each of their cards; the grid writes the
+        // name once and puts the people across it.
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-        const essentialsToggles = screen.getAllByRole('button', { name: /Collapse Essentials/i })
-        expect(essentialsToggles.length).toBe(2)
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Toothbrush' })).toBeTruthy())
+
+        expect(screen.getAllByRole('button', { name: /Collapse Essentials/i }).length).toBe(1)
+        expect(screen.getByRole('checkbox', { name: 'Toothbrush for Alice' })).toBeTruthy()
+        expect(screen.getByRole('checkbox', { name: 'Nappies for Bob' })).toBeTruthy()
     })
 })
-
-describe('ViewPackingList person/category view toggle', () => {
-    beforeEach(() => {
-        mockUseSolidPod.mockReturnValue({
-            isLoggedIn: false,
-            session: null,
-            webId: undefined,
-            isLoading: false,
-            login: vi.fn(),
-            logout: vi.fn(),
-        })
-        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
-        mockUseSyncCoordinator.mockReturnValue({
-            syncingFromPod: false,
-            handleSyncSuccess: vi.fn(),
-            handleSyncError: vi.fn(),
-            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...multiCategoryPackingList, _rev: '2' }),
-        })
-        mockUseDatabase.mockReturnValue({ db: makeDbMultiCategory() as unknown as PackingAppDatabase })
-    })
-
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
-
-    it('defaults to person view, showing person section titles', async () => {
-        renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-        expect(screen.getByText("Alice's Items")).toBeTruthy()
-        expect(screen.getByText("Bob's Items")).toBeTruthy()
-    })
-
-    it('switches to category view, showing category section titles', async () => {
-        renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-
-        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
-
-        // Top-level sections are now categories, not people
-        expect(screen.queryByText("Alice's Items")).toBeNull()
-        expect(screen.queryByText("Bob's Items")).toBeNull()
-        expect(screen.getAllByText('Essentials').length).toBeGreaterThan(0)
-        expect(screen.getByText('Hiking')).toBeTruthy()
-        expect(screen.getByText('Toothbrush')).toBeTruthy()
-        expect(screen.getByText('Nappies')).toBeTruthy()
-    })
-
-    it('writes each item once, with a chip per person', async () => {
-        renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-
-        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
-
-        // One key for the page, naming everyone in the order the chips sit in
-        const key = within(screen.getByTestId('people-key'))
-        expect(key.getByText('Alice')).toBeTruthy()
-        expect(key.getByText('Bob')).toBeTruthy()
-
-        // Toothbrush is Alice's alone: she has a chip, Bob has a gap
-        const essentials = screen.getAllByTestId('list-section')[0]
-        expect(within(essentials).getByRole('checkbox', { name: 'Toothbrush for Alice' })).toBeTruthy()
-        expect(within(essentials).queryByRole('checkbox', { name: 'Toothbrush for Bob' })).toBeNull()
-        expect(within(essentials).getByTitle("Bob doesn't need this — open to change")).toBeTruthy()
-        expect(within(essentials).getByRole('checkbox', { name: 'Nappies for Bob' })).toBeTruthy()
-    })
-
-    it('packs an item from its cell', async () => {
-        renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
-
-        const cell = screen.getByRole('checkbox', { name: 'Toothbrush for Alice' }) as HTMLInputElement
-        fireEvent.click(cell)
-
-        await waitFor(() => expect(
-            (screen.getByRole('checkbox', { name: 'Toothbrush for Alice' }) as HTMLInputElement).checked,
-        ).toBe(true))
-    })
-
-    it('keeps the key to itself — nothing in it can be pressed', async () => {
-        renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
-
-        // A key that packs a person's whole category on a stray tap is a
-        // hazard, not a shortcut; person view has a labelled button for that.
-        expect(within(screen.getByTestId('people-key')).queryAllByRole('button')).toEqual([])
-        expect(within(screen.getByTestId('people-key')).queryAllByRole('checkbox')).toEqual([])
-    })
-
-    it('switches back to person view', async () => {
-        renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-
-        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
-        await waitFor(() => expect(screen.getByText('Hiking')).toBeTruthy())
-
-        fireEvent.click(screen.getByRole('button', { name: 'Person View' }))
-        expect(screen.getByText("Alice's Items")).toBeTruthy()
-        expect(screen.getByText("Bob's Items")).toBeTruthy()
-    })
-})
-
-// ─── The category grid: an item down the side, the people across the top ────
 
 describe('ViewPackingList category grid', () => {
     // Alice and Bob both need a toothbrush; only Bob has nappies. One name, two
@@ -482,7 +305,6 @@ describe('ViewPackingList category grid', () => {
             </MemoryRouter>
         )
         await waitFor(() => expect(screen.getAllByText('Toothbrush').length).toBeGreaterThan(0))
-        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
     }
 
     function checkbox(name: string): HTMLInputElement {
@@ -792,8 +614,7 @@ describe('ViewPackingList hidden items banner', () => {
             { id: 'item-2', itemText: 'Sunhat', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', packed: false },
         ],
     }
-    const checkPassport = () =>
-        fireEvent.click(screen.getByText('Passport').closest('label')!.querySelector('input')!)
+    const checkPassport = () => fireEvent.click(chipFor('Passport', 'Alice'))
 
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({
@@ -966,24 +787,39 @@ describe('progress indicators', () => {
         expect(screen.getByText(/2 \/ 4 packed \(50%\)/)).toBeTruthy()
     })
 
-    it('shows per-person packed count in each column header', async () => {
+    it("shows a person's own progress on their chip once they are the one being packed for", async () => {
         renderProgressComponent()
-        await waitFor(() => expect(screen.getByText('Sunscreen')).toBeTruthy())
+        await waitFor(() => expect(row('Sunscreen')).toBeTruthy())
 
-        // The groups inside each card carry counts of their own, so the
-        // assertion is scoped to the section headers themselves.
-        expect(screen.getByRole('button', { name: /collapse alice's list/i }).textContent).toContain('1 / 2')
-        expect(screen.getByRole('button', { name: /collapse bob's list/i }).textContent).toContain('1 / 2')
+        // Unselected chips carry no numbers: every chip carrying them makes the
+        // strip twice as long, and a chip that grows when pressed moves the one
+        // beside it out from under the finger going there next.
+        expect(screen.getByRole('button', { name: /^Alice/ }).textContent).not.toContain('1/2')
+
+        fireEvent.click(screen.getByRole('button', { name: /^Alice/ }))
+
+        expect(screen.getByRole('button', { name: /^Alice/ }).textContent).toContain('1/2')
     })
 
-    it('counts every item in a group, not just the ones on screen', async () => {
+    it('counts every item in a section, not just the ones on screen', async () => {
         renderProgressComponent()
-        await waitFor(() => expect(screen.getByText('Sunscreen')).toBeTruthy())
+        await waitFor(() => expect(row('Sunscreen')).toBeTruthy())
 
-        // Alice's packed Passport is hidden, but her "Other" group is still
-        // half done — showing "1" there would read as a group barely started.
-        const aliceGroup = screen.getAllByRole('button', { name: /collapse other/i })[0]
-        expect(aliceGroup.textContent).toContain('1 / 2')
+        // The packed items are hidden, but the section is still half done —
+        // showing "0 / 2" there would read as a section barely started.
+        expect(screen.getByRole('button', { name: /collapse other list/i }).textContent).toContain('2 / 4')
+    })
+
+    it('counts only the filtered person once the list is narrowed to them', async () => {
+        renderProgressComponent()
+        await waitFor(() => expect(row('Sunscreen')).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /^Alice/ }))
+
+        // And says whose: an unqualified "1 / 2" beside a page total of "2 / 4"
+        // is a number with no referent.
+        expect(screen.getByRole('button', { name: /collapse other list/i }).textContent)
+            .toContain('1 / 2 for Alice')
     })
 })
 
@@ -1062,7 +898,7 @@ describe('packing progress bar and milestones', () => {
 
     it('leaves the bar empty when nothing is packed', async () => {
         setup(eightItemList)
-        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Item 0' })).toBeTruthy())
 
         expect(screen.getByTestId('packing-progress-fill').style.width).toBe('0%')
     })
@@ -1079,7 +915,7 @@ describe('packing progress bar and milestones', () => {
 
     it('grows the bar as items are packed', async () => {
         setup(eightItemList)
-        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Item 0' })).toBeTruthy())
         keepPackedItemsVisible()
 
         toggleItems(0, 4)
@@ -1089,7 +925,7 @@ describe('packing progress bar and milestones', () => {
 
     it('says nothing encouraging before the first milestone', async () => {
         setup(eightItemList)
-        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Item 0' })).toBeTruthy())
         keepPackedItemsVisible()
 
         toggleItems(0, 1)
@@ -1100,7 +936,7 @@ describe('packing progress bar and milestones', () => {
 
     it('cheers the user on at each milestone', async () => {
         setup(eightItemList)
-        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Item 0' })).toBeTruthy())
         keepPackedItemsVisible()
 
         toggleItems(0, 2)
@@ -1115,7 +951,7 @@ describe('packing progress bar and milestones', () => {
 
     it('does not flicker the milestone when a single item is toggled around the boundary', async () => {
         setup(eightItemList)
-        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Item 0' })).toBeTruthy())
         keepPackedItemsVisible()
 
         toggleItems(0, 2)
@@ -1135,7 +971,7 @@ describe('packing progress bar and milestones', () => {
 
     it('drops the milestone once progress falls well below it', async () => {
         setup(eightItemList)
-        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Item 0' })).toBeTruthy())
         keepPackedItemsVisible()
 
         toggleItems(0, 2)
@@ -1149,7 +985,7 @@ describe('packing progress bar and milestones', () => {
 
     it('hands over to the all-packed treatment at 100%', async () => {
         setup(eightItemList)
-        await waitFor(() => expect(screen.getByText('Item 0')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Item 0' })).toBeTruthy())
         keepPackedItemsVisible()
 
         toggleItems(0, 8)
@@ -1196,8 +1032,8 @@ describe('ViewPackingList checked item styling', () => {
         fireEvent.click(screen.getByRole('checkbox'))
 
         await waitFor(() => {
-            const span = screen.getByText('Passport')
-            expect(span.className).toContain('line-through')
+            // The name's own span, inside the button that opens the row panel
+            expect(row('Passport').querySelector('span')!.className).toContain('line-through')
         })
     })
 
@@ -1245,9 +1081,10 @@ describe('ViewPackingList new item feedback', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Add' }))
 
         await waitFor(() => {
-            const span = screen.getByText('Sunscreen')
-            const row = span.closest('div.rounded-lg')
-            expect(row?.className).toContain('ring-green-400')
+            const added = screen.getAllByTestId(/^grid-cell-/).find(
+                cell => cell.getAttribute('title') === 'Sunscreen for Alice',
+            )
+            expect(added!.className).toContain('ring-green-400')
         })
     })
 
@@ -1273,101 +1110,6 @@ describe('ViewPackingList new item feedback', () => {
 
         await waitFor(() => expect(screen.getByText('Sunscreen')).toBeTruthy())
         await waitFor(() => expect(scrollIntoView).toHaveBeenCalled())
-    })
-})
-
-describe('ViewPackingList inline item editing', () => {
-    let db: ReturnType<typeof makeDb>
-
-    beforeEach(() => {
-        db = makeDb()
-        mockUseSolidPod.mockReturnValue({
-            isLoggedIn: false,
-            session: null,
-            webId: undefined,
-            isLoading: false,
-            login: vi.fn(),
-            logout: vi.fn(),
-        })
-        mockUsePodSync.mockReturnValue({
-            saveToPod: vi.fn(),
-        })
-        mockUseSyncCoordinator.mockReturnValue({
-            syncingFromPod: false,
-            handleSyncSuccess: vi.fn(),
-            handleSyncError: vi.fn(),
-            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
-        })
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
-    })
-
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
-
-    it('double-clicking item text enters edit mode with current value', async () => {
-        renderComponent()
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-
-        fireEvent.dblClick(screen.getByText('Passport'))
-
-        const input = screen.getByRole('textbox', { name: /edit item name/i })
-        expect(input).toBeTruthy()
-        expect((input as HTMLInputElement).value).toBe('Passport')
-    })
-
-    it('clicking pencil icon enters edit mode', async () => {
-        renderComponent()
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-
-        fireEvent.click(screen.getByTitle('Edit item'))
-
-        expect(screen.getByRole('textbox', { name: /edit item name/i })).toBeTruthy()
-    })
-
-    it('pressing Enter saves renamed item and exits edit mode', async () => {
-        renderComponent()
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-
-        fireEvent.click(screen.getByTitle('Edit item'))
-        const input = screen.getByRole('textbox', { name: /edit item name/i })
-        fireEvent.change(input, { target: { value: 'Sunscreen SPF50' } })
-        fireEvent.keyDown(input, { key: 'Enter' })
-
-        await waitFor(() => expect(screen.getByText('Sunscreen SPF50')).toBeTruthy())
-        expect(db.savePackingList).toHaveBeenCalledWith(
-            expect.objectContaining({
-                items: expect.arrayContaining([
-                    expect.objectContaining({ id: 'item-1', itemText: 'Sunscreen SPF50' }),
-                ]),
-            })
-        )
-    })
-
-    it('pressing Escape cancels edit and restores original name', async () => {
-        renderComponent()
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-
-        fireEvent.click(screen.getByTitle('Edit item'))
-        const input = screen.getByRole('textbox', { name: /edit item name/i })
-        fireEvent.change(input, { target: { value: 'Bogus' } })
-        fireEvent.keyDown(input, { key: 'Escape' })
-
-        expect(screen.getByText('Passport')).toBeTruthy()
-        expect(db.savePackingList).not.toHaveBeenCalled()
-    })
-
-    it('clearing all text and pressing Enter does not save and restores original name', async () => {
-        renderComponent()
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-
-        fireEvent.click(screen.getByTitle('Edit item'))
-        const input = screen.getByRole('textbox', { name: /edit item name/i })
-        fireEvent.change(input, { target: { value: '' } })
-        fireEvent.keyDown(input, { key: 'Enter' })
-
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-        expect(db.savePackingList).not.toHaveBeenCalled()
     })
 })
 
@@ -1439,14 +1181,16 @@ describe('ViewPackingList item quantities', () => {
 
     it('edit mode pre-fills the quantity and saves an updated value', async () => {
         renderComponent()
-        await waitFor(() => expect(screen.getByText('Socks')).toBeTruthy())
+        await waitFor(() => expect(row('Socks')).toBeTruthy())
 
-        fireEvent.dblClick(screen.getByText('Socks'))
-        const quantityInput = screen.getByRole('spinbutton', { name: /edit item quantity/i })
+        // Quantities live in the row's panel, reached through its name
+        fireEvent.click(row('Socks'))
+        const quantityInput = screen.getByRole('spinbutton', { name: /quantity for alice/i })
         expect((quantityInput as HTMLInputElement).value).toBe('3')
 
         fireEvent.change(quantityInput, { target: { value: '5' } })
         fireEvent.keyDown(quantityInput, { key: 'Enter' })
+        fireEvent.blur(quantityInput)
 
         await waitFor(() => expect(db.savePackingList).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -1459,24 +1203,25 @@ describe('ViewPackingList item quantities', () => {
 
     it('clearing the quantity removes it from the item', async () => {
         renderComponent()
-        await waitFor(() => expect(screen.getByText('Socks')).toBeTruthy())
+        await waitFor(() => expect(row('Socks')).toBeTruthy())
 
-        fireEvent.dblClick(screen.getByText('Socks'))
-        const quantityInput = screen.getByRole('spinbutton', { name: /edit item quantity/i })
+        // Quantities live in the row's panel, reached through its name
+        fireEvent.click(row('Socks'))
+        const quantityInput = screen.getByRole('spinbutton', { name: /quantity for alice/i })
         fireEvent.change(quantityInput, { target: { value: '' } })
         fireEvent.keyDown(quantityInput, { key: 'Enter' })
+        fireEvent.blur(quantityInput)
 
-        await waitFor(() => expect(db.savePackingList).toHaveBeenCalledWith(
-            expect.objectContaining({
-                items: expect.arrayContaining([
-                    expect.objectContaining({ id: 'item-socks', quantity: undefined }),
-                ]),
-            })
-        ))
+        // The panel drops the key rather than storing an undefined against it
+        await waitFor(() => {
+            const saved = db.savePackingList.mock.calls.at(-1)![0] as { items: PackingListItem[] }
+            const socks = saved.items.find(item => item.id === 'item-socks')!
+            expect(socks).not.toHaveProperty('quantity')
+        })
     })
 })
 
-describe('ViewPackingList expandable person sections', () => {
+describe('ViewPackingList expandable sections', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({
             isLoggedIn: false,
@@ -1500,43 +1245,48 @@ describe('ViewPackingList expandable person sections', () => {
         vi.restoreAllMocks()
     })
 
-    it('person sections are expanded by default', async () => {
+    it('sections are expanded by default', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-        expect(screen.getByText('Toothbrush')).toBeTruthy()
-        expect(screen.getByText('Nappies')).toBeTruthy()
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Toothbrush' })).toBeTruthy())
+        expect(screen.getByRole('button', { name: 'Edit Nappies' })).toBeTruthy()
     })
 
-    it('clicking person header collapses that person section', async () => {
+    it('clicking a section header collapses that section', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: /collapse alice's list/i }))
-        expect(screen.queryByText('Toothbrush')).toBeNull()
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Toothbrush' })).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /collapse essentials list/i }))
+
+        expect(screen.queryByRole('button', { name: 'Edit Toothbrush' })).toBeNull()
     })
 
-    it('collapsing one person section does not affect another', async () => {
+    it('collapsing one section does not affect another', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: /collapse alice's list/i }))
-        expect(screen.getByText('Nappies')).toBeTruthy()
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Tent' })).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /collapse essentials list/i }))
+
+        expect(screen.getByRole('button', { name: 'Edit Tent' })).toBeTruthy()
     })
 
-    it('clicking a collapsed person header expands their section', async () => {
+    it('clicking a collapsed section header expands it again', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: /collapse alice's list/i }))
-        fireEvent.click(screen.getByRole('button', { name: /expand alice's list/i }))
-        expect(screen.getByText('Toothbrush')).toBeTruthy()
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Toothbrush' })).toBeTruthy())
+
+        fireEvent.click(screen.getByRole('button', { name: /collapse essentials list/i }))
+        fireEvent.click(screen.getByRole('button', { name: /expand essentials list/i }))
+
+        expect(screen.getByRole('button', { name: 'Edit Toothbrush' })).toBeTruthy()
     })
 
-    it('add-item input is hidden when person section is collapsed', async () => {
+    it('hides the add-item input when the section is collapsed', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-        const addInputs = screen.getAllByPlaceholderText('Add new item...')
-        expect(addInputs.length).toBeGreaterThan(0)
-        fireEvent.click(screen.getByRole('button', { name: /collapse alice's list/i }))
-        const remainingInputs = screen.getAllByPlaceholderText('Add new item...')
-        expect(remainingInputs.length).toBeLessThan(addInputs.length)
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Toothbrush' })).toBeTruthy())
+        const before = screen.getAllByPlaceholderText('Add new item...').length
+
+        fireEvent.click(screen.getByRole('button', { name: /collapse essentials list/i }))
+
+        expect(screen.getAllByPlaceholderText('Add new item...').length).toBeLessThan(before)
     })
 })
 
@@ -1988,139 +1738,7 @@ const communalPackingList = {
     ],
 }
 
-describe('ViewPackingList shared (communal) section', () => {
-    beforeEach(() => {
-        mockUseSolidPod.mockReturnValue({
-            isLoggedIn: false,
-            session: null,
-            webId: undefined,
-            isLoading: false,
-            login: vi.fn(),
-            logout: vi.fn(),
-        })
-        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
-        mockUseSyncCoordinator.mockReturnValue({
-            syncingFromPod: false,
-            handleSyncSuccess: vi.fn(),
-            handleSyncError: vi.fn(),
-            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...communalPackingList, _rev: '2' }),
-        })
-    })
-
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
-
-    function renderCommunal(list = communalPackingList) {
-        const db = {
-            getPackingList: vi.fn().mockResolvedValue(list),
-            savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
-        }
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
-        render(
-            <MemoryRouter initialEntries={[`/view-list/${list.id}`]}>
-                <Routes>
-                    <Route path="/view-list/:id" element={<ViewPackingList />} />
-                </Routes>
-            </MemoryRouter>
-        )
-        return db
-    }
-
-    it('renders communal items in a Shared Items section', async () => {
-        renderCommunal()
-        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
-        expect(screen.getByText('Shared Items')).toBeTruthy()
-        expect(screen.getByText('First aid kit')).toBeTruthy()
-        // Per-person items still appear under the person
-        expect(screen.getByText("Alice's Items")).toBeTruthy()
-        expect(screen.getByText('Sleeping bag')).toBeTruthy()
-    })
-
-    it('celebrates the Shared Items section when all communal items are packed', async () => {
-        renderCommunal({
-            ...communalPackingList,
-            items: communalPackingList.items.map(i => i.communal ? { ...i, packed: true } : i),
-        })
-        await waitFor(() => expect(screen.getByText('Sleeping bag')).toBeTruthy())
-        // Packed items are hidden by default, but the fully-packed shared section
-        // stays put with its celebration, just like a fully-packed person's section
-        expect(screen.getByText('Shared Items')).toBeTruthy()
-        expect(screen.getByLabelText(/all packed for shared items/i)).toBeTruthy()
-
-        // Showing packed items reveals the items themselves again
-        fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
-        expect(screen.getByText('Tent')).toBeTruthy()
-    })
-
-    it('does not render a Shared Items section when there are no communal items', async () => {
-        renderCommunal({ ...communalPackingList, items: communalPackingList.items.filter(i => !i.communal) })
-        await waitFor(() => expect(screen.getByText('Sleeping bag')).toBeTruthy())
-        expect(screen.queryByText('Shared Items')).toBeNull()
-    })
-
-    it('shows shared packed stats in the section header', async () => {
-        renderCommunal()
-        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
-        const header = screen.getByRole('button', { name: /collapse the shared items list/i })
-        expect(header.textContent).toContain('0 / 2')
-    })
-
-    it('collapsing the shared section hides its items but not person items', async () => {
-        renderCommunal()
-        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: /collapse the shared items list/i }))
-        expect(screen.queryByText('Tent')).toBeNull()
-        expect(screen.getByText('Sleeping bag')).toBeTruthy()
-    })
-
-    it('"+ Add Shared Items" reveals an empty shared section and is hidden once the section exists', async () => {
-        const db = renderCommunal({ ...communalPackingList, items: communalPackingList.items.filter(i => !i.communal) })
-        await waitFor(() => expect(screen.getByText('Sleeping bag')).toBeTruthy())
-        expect(screen.queryByText('Shared Items')).toBeNull()
-
-        fireEvent.click(screen.getByRole('button', { name: /add shared items/i }))
-
-        expect(screen.getByText('Shared Items')).toBeTruthy()
-        expect(screen.queryByRole('button', { name: /add shared items/i })).toBeNull()
-
-        // Adding an item through the revealed section creates a communal item
-        const inputs = screen.getAllByPlaceholderText('Add new item...')
-        fireEvent.change(inputs[0], { target: { value: 'Tent' } })
-        fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
-
-        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
-        const savedList = db.savePackingList.mock.calls[0][0]
-        const added = savedList.items.find((i: { itemText: string }) => i.itemText === 'Tent')
-        expect(added.communal).toBe(true)
-    })
-
-    it('does not show "+ Add Shared Items" when the list already has communal items', async () => {
-        renderCommunal()
-        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
-        expect(screen.queryByRole('button', { name: /add shared items/i })).toBeNull()
-    })
-
-    it('adding an item in the shared section creates a communal item', async () => {
-        const db = renderCommunal()
-        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
-
-        // Shared section is rendered first
-        const inputs = screen.getAllByPlaceholderText('Add new item...')
-        fireEvent.change(inputs[0], { target: { value: 'Camping stove' } })
-        fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
-
-        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
-        const savedList = db.savePackingList.mock.calls[0][0]
-        const added = savedList.items.find((i: { itemText: string }) => i.itemText === 'Camping stove')
-        expect(added).toBeTruthy()
-        expect(added.communal).toBe(true)
-        expect(added.personId).toBe('')
-        expect(added.personName).toBe('')
-    })
-})
-
-describe('ViewPackingList shared (communal) items in category view', () => {
+describe('ViewPackingList shared (communal) items', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({
             isLoggedIn: false,
@@ -2156,8 +1774,9 @@ describe('ViewPackingList shared (communal) items in category view', () => {
                 </Routes>
             </MemoryRouter>
         )
-        await waitFor(() => expect(screen.getByText('Sleeping bag')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
+        // By the row's button rather than by its text: a row's name is split so
+        // its last word can hold on to the chevron — see `splitLastWord`.
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Sleeping bag' })).toBeTruthy())
         return db
     }
 
@@ -2244,21 +1863,13 @@ describe('ViewPackingList shared (communal) items in category view', () => {
         expect(added.communal).toBeUndefined()
     })
 
-    it('hides the "+ Add Shared Items" reveal, which belongs to person view', async () => {
+    it('offers no separate shared card to reveal — a shared item belongs to its section', async () => {
         const listWithoutCommunal = { ...communalPackingList, items: communalPackingList.items.filter(i => !i.communal) }
         await renderInQuestionView(listWithoutCommunal)
 
         expect(screen.queryByRole('button', { name: /add shared items/i })).toBeNull()
     })
 
-    it('keeps the Shared Items card in person view', async () => {
-        await renderInQuestionView()
-
-        fireEvent.click(screen.getByRole('button', { name: 'Person View' }))
-
-        expect(screen.getByText('Shared Items')).toBeTruthy()
-        expect(screen.getByText('Tent')).toBeTruthy()
-    })
 })
 
 describe('grouping honours generated item order', () => {
@@ -2560,48 +2171,48 @@ describe('ViewPackingList section completion celebration', () => {
         )
     }
 
-    it("keeps a fully packed person's section visible while packed items are hidden", async () => {
+    it('keeps a fully packed section visible while packed items are hidden', async () => {
         renderList()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
-        expect(screen.getByText("Alice's Items")).toBeTruthy()
+        expect(screen.getByRole('button', { name: /(expand|collapse) documents list/i })).toBeTruthy()
     })
 
-    it("celebrates a person whose items are all packed", async () => {
+    it('celebrates a section whose items are all packed', async () => {
         renderList()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
-        expect(screen.getByLabelText(/all packed for alice/i)).toBeTruthy()
+        expect(screen.getByLabelText(/all packed for documents/i)).toBeTruthy()
     })
 
-    it('does not celebrate a person with items still to pack', async () => {
+    it('does not celebrate a section with items still to pack', async () => {
         renderList()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
-        expect(screen.queryByLabelText(/all packed for bob/i)).toBeNull()
+        expect(screen.queryByLabelText(/all packed for toiletries/i)).toBeNull()
     })
 
-    it('celebrates a person as soon as their last item is checked', async () => {
+    it('celebrates a section as soon as its last item is checked', async () => {
         renderList()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-        expect(screen.queryByLabelText(/all packed for bob/i)).toBeNull()
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
+        expect(screen.queryByLabelText(/all packed for toiletries/i)).toBeNull()
 
         // Toothbrush is the only unpacked item, so the only visible checkbox
         fireEvent.click(screen.getAllByRole('checkbox')[0])
 
-        await waitFor(() => expect(screen.getByLabelText(/all packed for bob/i)).toBeTruthy())
+        await waitFor(() => expect(screen.getByLabelText(/all packed for toiletries/i)).toBeTruthy())
     })
 
-    it('celebrates a fully packed category in category view', async () => {
+    it('does not celebrate a card that is only finished for the person filtered to', async () => {
+        // Alice has packed her half of Clothes; Bob's Wellies are in it too.
+        // The emerald pill is how this app says a section of the trip is done,
+        // and one person's share of it being done is not that.
         renderList()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
-        fireEvent.click(screen.getByRole('button', { name: /category view/i }))
+        fireEvent.click(screen.getByRole('button', { name: /^Alice/ }))
 
-        // Documents (Passport) is fully packed; Toiletries (Toothbrush) is not
-        expect(screen.getByText('Documents')).toBeTruthy()
-        expect(screen.getByLabelText(/all packed for documents/i)).toBeTruthy()
-        expect(screen.queryByLabelText(/all packed for toiletries/i)).toBeNull()
+        expect(screen.queryByLabelText(/all packed for clothes/i)).toBeNull()
     })
 })
 
@@ -2661,14 +2272,14 @@ describe('ViewPackingList completion', () => {
 
     it('does not fire confetti while items remain', async () => {
         setup(oneItemLeftList)
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
         expect(screen.queryByTestId('completion-confetti')).toBeNull()
     })
 
     it('fires confetti when the last item is checked', async () => {
         setup(oneItemLeftList)
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
         fireEvent.click(screen.getAllByRole('checkbox')[0])
 
@@ -2682,30 +2293,29 @@ describe('ViewPackingList completion', () => {
         expect(screen.queryByTestId('completion-confetti')).toBeNull()
     })
 
-    it('folds the person cards away once everything is packed', async () => {
+    it('folds the cards away once everything is packed', async () => {
         setup(oneItemLeftList)
-        await waitFor(() => expect(screen.getByText("Bob's Items")).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
         fireEvent.click(screen.getAllByRole('checkbox')[0])
 
-        await waitFor(() => expect(screen.queryByText("Bob's Items")).toBeNull())
-        expect(screen.queryByText("Alice's Items")).toBeNull()
+        await waitFor(() => expect(screen.queryByTestId('list-section')).toBeNull())
     })
 
     it('leaves the celebration banner standing when the cards fold away', async () => {
         setup(oneItemLeftList)
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
         fireEvent.click(screen.getAllByRole('checkbox')[0])
 
-        await waitFor(() => expect(screen.queryByText("Bob's Items")).toBeNull())
+        await waitFor(() => expect(screen.queryByTestId('list-section')).toBeNull())
         expect(screen.getByText("You're all packed!")).toBeTruthy()
     })
 
     it('opens an already-packed list with the cards already folded away', async () => {
         setup(fullyPackedList)
-        await waitFor(() => expect(screen.queryByText("Alice's Items")).toBeNull())
-        expect(screen.getByText("You're all packed!")).toBeTruthy()
+        await waitFor(() => expect(screen.getByText("You're all packed!")).toBeTruthy())
+        expect(screen.queryByTestId('list-section')).toBeNull()
     })
 
     it('brings the cards back when packed items are shown', async () => {
@@ -2714,8 +2324,8 @@ describe('ViewPackingList completion', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
 
-        expect(screen.getByText("Alice's Items")).toBeTruthy()
-        expect(screen.getByText('Passport')).toBeTruthy()
+        expect(screen.getByTestId('list-section')).toBeTruthy()
+        expect(row('Passport')).toBeTruthy()
     })
 
     it('hides the "packed items hidden" nag once everything is packed', async () => {
@@ -2727,7 +2337,7 @@ describe('ViewPackingList completion', () => {
 
     it('holds the banner back while the cards are still folding away', async () => {
         setup(oneItemLeftList)
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
         fireEvent.click(screen.getAllByRole('checkbox')[0])
 
@@ -2739,7 +2349,7 @@ describe('ViewPackingList completion', () => {
 
     it('rises the banner in once the cards have gone', async () => {
         setup(oneItemLeftList)
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
         fireEvent.click(screen.getAllByRole('checkbox')[0])
 
@@ -2758,11 +2368,11 @@ describe('ViewPackingList completion', () => {
 
     it('shows the banner straight away when packed items are being shown', async () => {
         setup(oneItemLeftList)
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
         // Nothing folds away in this mode, so there is no stage to clear
         fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
-        fireEvent.click(screen.getByText('Toothbrush').closest('label')!.querySelector('input')!)
+        fireEvent.click(chipFor('Toothbrush', 'Bob'))
 
         await waitFor(() => expect(screen.getByTestId('completion-banner')).toBeTruthy())
         expect(screen.getByTestId('completion-banner').className).not.toContain('celebration-banner-rising')
@@ -2773,11 +2383,10 @@ describe('ViewPackingList completion', () => {
         await waitFor(() => expect(screen.getByText("You're all packed!")).toBeTruthy())
 
         fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
-        const passport = screen.getByText('Passport').closest('label')!.querySelector('input')!
-        fireEvent.click(passport)
+        fireEvent.click(chipFor('Passport', 'Alice'))
         fireEvent.click(screen.getByRole('button', { name: 'Hide Packed' }))
 
-        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: /(expand|collapse) other list/i })).toBeTruthy())
     })
 })
 
@@ -2910,8 +2519,12 @@ describe('ViewPackingList check-off feedback', () => {
         )
     }
 
-    function checkboxFor(itemText: string) {
-        return screen.getByText(itemText).closest('label')!.querySelector('input')!
+    /**
+     * The grid's checkbox is the person's chip, labelled with both the item and
+     * whose it is — the same name can be on the row twice.
+     */
+    function checkboxFor(itemText: string, person = 'Alice') {
+        return screen.getByRole('checkbox', { name: `${itemText} for ${person}` }) as HTMLInputElement
     }
 
     function preferReducedMotion() {
@@ -2941,7 +2554,7 @@ describe('ViewPackingList check-off feedback', () => {
         await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
 
         fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
-        fireEvent.click(checkboxFor('Wellies'))
+        fireEvent.click(checkboxFor('Wellies', 'Bob'))
 
         expect(mockTapFeedback).not.toHaveBeenCalled()
     })
@@ -2953,7 +2566,7 @@ describe('ViewPackingList check-off feedback', () => {
         fireEvent.click(checkboxFor('Passport'))
 
         expect(screen.getByTestId('item-tick-a1')).toBeTruthy()
-        expect(screen.getByTestId('item-row-a1').className).toContain('item-row-packed')
+        expect(screen.getByTestId('grid-cell-a1').className).toContain('grid-cell-packed')
     })
 
     it('flourishes only the row that was checked', async () => {
@@ -2963,7 +2576,7 @@ describe('ViewPackingList check-off feedback', () => {
         fireEvent.click(checkboxFor('Passport'))
 
         expect(screen.queryByTestId('item-tick-a2')).toBeNull()
-        expect(screen.getByTestId('item-row-a2').className).not.toContain('item-row-packed')
+        expect(screen.getByTestId('grid-cell-a2').className).not.toContain('grid-cell-packed')
     })
 
     it('holds the row on screen for the flourish before whisking it away', async () => {
@@ -2982,10 +2595,10 @@ describe('ViewPackingList check-off feedback', () => {
         await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
 
         fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
-        fireEvent.click(checkboxFor('Wellies'))
+        fireEvent.click(checkboxFor('Wellies', 'Bob'))
 
         expect(screen.queryByTestId('item-tick-b1')).toBeNull()
-        expect(screen.getByTestId('item-row-b1').className).not.toContain('item-row-packed')
+        expect(screen.getByTestId('grid-cell-b1').className).not.toContain('grid-cell-packed')
     })
 
     it('holds still for anyone who asked for reduced motion', async () => {
@@ -3073,13 +2686,13 @@ describe('ViewPackingList adding items', () => {
         fireEvent.keyDown(input, { key: 'Enter' })
     }
 
-    it('files a new item under the section chosen on the person card', async () => {
+    it('files a new item into the card it was typed into', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Toothbrush' })).toBeTruthy())
 
-        const { input, fields } = composerFor("Alice's items")
+        const { input, fields } = composerFor('Hiking')
         fireEvent.change(input, { target: { value: 'Trail map' } })
-        fireEvent.change(fields.getByLabelText('Section'), { target: { value: 'Hiking' } })
+        fireEvent.change(fields.getByLabelText('Who for'), { target: { value: 'Alice' } })
         fireEvent.keyDown(input, { key: 'Enter' })
 
         const added = await savedItem('Trail map')
@@ -3087,55 +2700,46 @@ describe('ViewPackingList adding items', () => {
         expect(added.personName).toBe('Alice')
     })
 
-    it('still files into the catch-all section when no section is chosen', async () => {
+    it('files into the catch-all section from the catch-all card', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Toothbrush' })).toBeTruthy())
 
-        typeAndAdd(composerFor("Alice's items").input, 'Odds and ends')
+        const { input, fields } = composerFor('Other')
+        fireEvent.change(input, { target: { value: 'Odds and ends' } })
+        fireEvent.change(fields.getByLabelText('Who for'), { target: { value: 'Alice' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
 
         expect((await savedItem('Odds and ends')).category).toBeUndefined()
     })
 
     it('saves a quantity typed alongside the item', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Toothbrush' })).toBeTruthy())
 
-        const { input, fields } = composerFor("Alice's items")
+        const { input, fields } = composerFor('Hiking')
         fireEvent.change(input, { target: { value: 'Socks' } })
+        fireEvent.change(fields.getByLabelText('Who for'), { target: { value: 'Alice' } })
         fireEvent.change(fields.getByLabelText('Quantity'), { target: { value: '5' } })
         fireEvent.keyDown(input, { key: 'Enter' })
 
         expect((await savedItem('Socks')).quantity).toBe(5)
     })
 
-    it('adds straight into a section from that section’s own + Add button', async () => {
+    it('files an item for whoever the list is filtered to, without being asked again', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Toothbrush' })).toBeTruthy())
 
-        fireEvent.click(screen.getByRole('button', { name: 'Add item to Hiking for Alice' }))
-        typeAndAdd(composerFor('Hiking for Alice').input, 'Compass')
+        fireEvent.click(screen.getByRole('button', { name: /^Bob/ }))
+        typeAndAdd(composerFor('Essentials').input, 'Compass')
 
         const added = await savedItem('Compass')
-        expect(added.category).toBe('Hiking')
-        expect(added.personName).toBe('Alice')
-    })
-
-    it('opens only one in-place composer at a time', async () => {
-        renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
-
-        fireEvent.click(screen.getByRole('button', { name: 'Add item to Hiking for Alice' }))
-        expect(screen.getByLabelText('Add an item to Hiking for Alice')).toBeTruthy()
-
-        fireEvent.click(screen.getByRole('button', { name: 'Add item to Other for Alice' }))
-        expect(screen.queryByLabelText('Add an item to Hiking for Alice')).toBeNull()
-        expect(screen.getByLabelText('Add an item to Other for Alice')).toBeTruthy()
+        expect(added.category).toBe('Essentials')
+        expect(added.personName).toBe('Bob')
     })
 
     it('adds for someone with nothing in a section yet, from category view', async () => {
         renderComponentMultiCategory()
         await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
 
         const { input, fields } = composerFor('Hiking')
         fireEvent.change(input, { target: { value: 'Walking poles' } })
@@ -3150,9 +2754,12 @@ describe('ViewPackingList adding items', () => {
 
     it('suggests an item someone else has, and files it in the same section', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Tent' })).toBeTruthy())
 
-        const { input } = composerFor("Bob's items")
+        fireEvent.click(screen.getByRole('button', { name: /^Bob/ }))
+        // Bob has nothing in Hiking, so the card is off the page until asked for
+        fireEvent.click(screen.getByRole('button', { name: /^show them$/ }))
+        const { input } = composerFor('Hiking')
         fireEvent.change(input, { target: { value: 'ten' } })
         fireEvent.click(screen.getByRole('option', { name: /Tent/ }))
         fireEvent.keyDown(input, { key: 'Enter' })
@@ -3164,9 +2771,11 @@ describe('ViewPackingList adding items', () => {
 
     it('does not suggest what this person already has', async () => {
         renderComponentMultiCategory()
-        await waitFor(() => expect(screen.getByText('Tent')).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Tent' })).toBeTruthy())
 
-        fireEvent.change(composerFor("Alice's items").input, { target: { value: 'ten' } })
+        fireEvent.click(screen.getByRole('button', { name: /^Alice/ }))
+        fireEvent.change(composerFor('Hiking').input, { target: { value: 'ten' } })
+
         expect(screen.queryByRole('option', { name: /Tent/ })).toBeNull()
     })
 })
@@ -3226,9 +2835,7 @@ describe('ViewPackingList folding sections away', () => {
         )
     }
 
-    function checkboxFor(itemText: string) {
-        return screen.getByText(itemText).closest('label')!.querySelector('input')!
-    }
+    const checkboxFor = chipFor
 
     beforeEach(() => {
         mockList(familyList)
@@ -3239,73 +2846,75 @@ describe('ViewPackingList folding sections away', () => {
     })
 
     describe('when everything in a section is packed', () => {
+        // Sections are categories. Documents holds one item and it is packed,
+        // so it is the section that arrives finished.
         it('folds a section that was already finished when the list opened', async () => {
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
-            expect(screen.getByRole('button', { name: /expand alice's list/i })).toBeTruthy()
+            expect(screen.getByRole('button', { name: /expand documents list/i })).toBeTruthy()
         })
 
         it('leaves a section with items still to pack open', async () => {
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
-            expect(screen.getByText('Toothbrush')).toBeTruthy()
-            expect(screen.getByText('Armbands')).toBeTruthy()
+            expect(row('Toothbrush')).toBeTruthy()
+            expect(row('Armbands')).toBeTruthy()
         })
 
         it('keeps the folded section on the page with its count and its celebration', async () => {
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
-            const header = screen.getByRole('button', { name: /expand alice's list/i })
-            expect(header.textContent).toContain("Alice's Items")
-            expect(header.textContent).toContain('2 / 2')
-            expect(screen.getByLabelText(/all packed for alice/i)).toBeTruthy()
+            const header = screen.getByRole('button', { name: /expand documents list/i })
+            expect(header.textContent).toContain('Documents')
+            expect(header.textContent).toContain('1 / 1')
+            expect(screen.getByLabelText(/all packed for documents/i)).toBeTruthy()
         })
 
         it('folds a section that is finished in front of the user', async () => {
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
-            fireEvent.click(checkboxFor('Toothbrush'))
+            fireEvent.click(checkboxFor('Toothbrush', 'Bob'))
 
             await waitFor(
-                () => expect(screen.getByRole('button', { name: /expand bob's list/i })).toBeTruthy(),
+                () => expect(screen.getByRole('button', { name: /expand toiletries list/i })).toBeTruthy(),
                 { timeout: 3000 },
             )
         })
 
         it('leaves a section the user reopened open when something else is packed', async () => {
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-            fireEvent.click(screen.getByRole('button', { name: /expand alice's list/i }))
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /expand documents list/i }))
 
-            fireEvent.click(checkboxFor('Toothbrush'))
+            fireEvent.click(checkboxFor('Toothbrush', 'Bob'))
             await waitFor(
-                () => expect(screen.getByRole('button', { name: /expand bob's list/i })).toBeTruthy(),
+                () => expect(screen.getByRole('button', { name: /expand toiletries list/i })).toBeTruthy(),
                 { timeout: 3000 },
             )
 
-            expect(screen.getByRole('button', { name: /collapse alice's list/i })).toBeTruthy()
+            expect(screen.getByRole('button', { name: /collapse documents list/i })).toBeTruthy()
         })
 
         it('folds a section again once it is packed back up', async () => {
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
             fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
 
-            // Unpacking reopens Alice; packing it back folds her away again
-            fireEvent.click(checkboxFor('Sunhat'))
+            // Unpacking reopens Documents; packing it back folds it away again
+            fireEvent.click(checkboxFor('Passport', 'Alice'))
             fireEvent.click(screen.getByRole('button', { name: 'Hide Packed' }))
-            expect(screen.getByRole('button', { name: /collapse alice's list/i })).toBeTruthy()
+            expect(screen.getByRole('button', { name: /collapse documents list/i })).toBeTruthy()
 
             fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
-            fireEvent.click(checkboxFor('Sunhat'))
+            fireEvent.click(checkboxFor('Passport', 'Alice'))
             fireEvent.click(screen.getByRole('button', { name: 'Hide Packed' }))
 
             await waitFor(
-                () => expect(screen.getByRole('button', { name: /expand alice's list/i })).toBeTruthy(),
+                () => expect(screen.getByRole('button', { name: /expand documents list/i })).toBeTruthy(),
                 { timeout: 3000 },
             )
         })
@@ -3314,58 +2923,58 @@ describe('ViewPackingList folding sections away', () => {
     describe('showing packed items', () => {
         it('hands back the sections the page folded', async () => {
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-            expect(screen.getByRole('button', { name: /expand alice's list/i })).toBeTruthy()
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
+            expect(screen.getByRole('button', { name: /expand documents list/i })).toBeTruthy()
 
             fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
 
-            expect(screen.getByText('Passport')).toBeTruthy()
-            expect(screen.getByRole('button', { name: /collapse alice's list/i })).toBeTruthy()
+            expect(row('Passport')).toBeTruthy()
+            expect(screen.getByRole('button', { name: /collapse documents list/i })).toBeTruthy()
         })
 
         it('leaves a section the user folded by hand alone', async () => {
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-            fireEvent.click(screen.getByRole('button', { name: /collapse cara's list/i }))
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /collapse toiletries list/i }))
 
             fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
 
-            expect(screen.getByRole('button', { name: /expand cara's list/i })).toBeTruthy()
+            expect(screen.getByRole('button', { name: /expand toiletries list/i })).toBeTruthy()
         })
     })
 
     describe('collapse all / expand all', () => {
         it('folds every section', async () => {
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
             fireEvent.click(screen.getByRole('button', { name: /collapse all/i }))
 
-            expect(screen.queryByText('Toothbrush')).toBeNull()
-            expect(screen.queryByText('Armbands')).toBeNull()
+            expect(screen.queryByRole('button', { name: 'Edit Toothbrush' })).toBeNull()
+            expect(screen.queryByRole('button', { name: 'Edit Armbands' })).toBeNull()
         })
 
         it('opens every section, including the ones folded automatically', async () => {
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
             fireEvent.click(screen.getByRole('button', { name: /collapse all/i }))
 
             fireEvent.click(screen.getByRole('button', { name: /expand all/i }))
 
-            expect(screen.getByText('Toothbrush')).toBeTruthy()
-            expect(screen.getByRole('button', { name: /collapse alice's list/i })).toBeTruthy()
+            expect(row('Toothbrush')).toBeTruthy()
+            expect(screen.getByRole('button', { name: /collapse documents list/i })).toBeTruthy()
         })
 
         it('does not re-fold a finished section after the user opens everything', async () => {
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
             fireEvent.click(screen.getByRole('button', { name: /collapse all/i }))
             fireEvent.click(screen.getByRole('button', { name: /expand all/i }))
 
-            fireEvent.click(checkboxFor('Armbands'))
+            fireEvent.click(checkboxFor('Armbands', 'Cara'))
             await new Promise(resolve => setTimeout(resolve, 1200))
 
-            expect(screen.getByRole('button', { name: /collapse alice's list/i })).toBeTruthy()
+            expect(screen.getByRole('button', { name: /collapse documents list/i })).toBeTruthy()
         })
 
         it('is not offered when the list has only one section', async () => {
@@ -3375,7 +2984,7 @@ describe('ViewPackingList folding sections away', () => {
                 items: [familyList.items[4]],
             })
             renderList('test-list-solo')
-            await waitFor(() => expect(screen.getByText('Armbands')).toBeTruthy())
+            await waitFor(() => expect(row('Armbands')).toBeTruthy())
 
             expect(screen.queryByRole('button', { name: /collapse all/i })).toBeNull()
         })
@@ -3384,86 +2993,91 @@ describe('ViewPackingList folding sections away', () => {
     describe('remembering how the list was left', () => {
         it('reopens with the sections the user folded still folded', async () => {
             const { unmount } = renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-            fireEvent.click(screen.getByRole('button', { name: /collapse cara's list/i }))
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /collapse toiletries list/i }))
             unmount()
 
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Armbands')).toBeTruthy())
 
-            expect(screen.getByRole('button', { name: /expand cara's list/i })).toBeTruthy()
+            expect(screen.getByRole('button', { name: /expand toiletries list/i })).toBeTruthy()
         })
 
-        it('reopens in the view mode the user chose', async () => {
+        it('opens showing everyone, whoever the user was last packing for', async () => {
+            // Fold state is how this list is kept; a filter is something the
+            // user was doing. Restoring one a week later shows them a third of
+            // their list and no reason why.
             const { unmount } = renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-            fireEvent.click(screen.getByRole('button', { name: /category view/i }))
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /^Cara/ }))
+            expect(screen.queryByRole('button', { name: 'Edit Toothbrush' })).toBeNull()
             unmount()
 
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
-            expect(screen.getByRole('button', { name: /category view/i }).getAttribute('aria-pressed')).toBe('true')
+            expect(screen.getByRole('button', { name: /^Cara/ }).getAttribute('aria-pressed')).toBe('false')
         })
 
         it('reopens still showing packed items', async () => {
             const { unmount } = renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
             fireEvent.click(screen.getByRole('button', { name: 'Show Packed' }))
             unmount()
 
             renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
             expect(screen.getByText('Passport')).toBeTruthy()
         })
 
         it('reopens a folded group inside a section still folded', async () => {
             const { unmount } = renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
             fireEvent.click(screen.getByRole('button', { name: /collapse toiletries/i }))
             expect(screen.queryByText('Toothbrush')).toBeNull()
             unmount()
 
             renderList()
-            await waitFor(() => expect(screen.getByText('Armbands')).toBeTruthy())
+            await waitFor(() => expect(row('Armbands')).toBeTruthy())
 
             expect(screen.queryByText('Toothbrush')).toBeNull()
         })
 
         it('does not carry one list\'s folded sections onto another', async () => {
             const { unmount } = renderList()
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-            fireEvent.click(screen.getByRole('button', { name: /collapse cara's list/i }))
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
+            fireEvent.click(screen.getByRole('button', { name: /collapse toiletries list/i }))
             unmount()
 
             mockList({ ...familyList, id: 'test-list-other' })
             renderList('test-list-other')
-            await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
+            await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
-            expect(screen.getByRole('button', { name: /collapse cara's list/i })).toBeTruthy()
+            expect(screen.getByRole('button', { name: /collapse toiletries list/i })).toBeTruthy()
         })
     })
 })
 
 describe('ViewPackingList opening a long list for the first time', () => {
-    // Six people so the list has plenty to fold, and 36 items so it clears the
-    // "long enough to arrive as a wall" threshold.
-    const people = ['Alice', 'Bob', 'Cara', 'Dev', 'Eve', 'Finn']
-    function bigList(id: string, itemsPerPerson: number) {
+    // Six categories so the list has plenty to fold, and 36 items so it clears
+    // the "long enough to arrive as a wall" threshold. Sections are categories,
+    // so it is the spread of categories that decides how much there is to fold.
+    const categories = ['Clothes', 'Toiletries', 'Documents', 'Electronics', 'Camping', 'Food']
+    function bigList(id: string, itemsPerCategory: number) {
         return {
             id,
             name: 'Big Trip',
             createdAt: '2026-01-01T00:00:00Z',
-            items: people.flatMap((person, p) =>
-                Array.from({ length: itemsPerPerson }, (_, i) => ({
-                    id: `${person}-${i}`,
-                    itemText: `${person} item ${i}`,
-                    personName: person,
-                    personId: `p${p}`,
+            items: categories.flatMap((category) =>
+                Array.from({ length: itemsPerCategory }, (_, i) => ({
+                    id: `${category}-${i}`,
+                    itemText: `${category} item ${i}`,
+                    personName: 'Alice',
+                    personId: 'p0',
                     questionId: 'q1',
                     optionId: 'o1',
-                    category: 'Clothes',
+                    category,
                     packed: false,
                 })),
             ),
@@ -3512,19 +3126,19 @@ describe('ViewPackingList opening a long list for the first time', () => {
     it('opens a long list folded', async () => {
         mockList(bigList('big-1', 6))
         renderList('big-1')
-        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: /(expand|collapse) clothes list/i })).toBeTruthy())
 
-        expect(screen.queryByText('Alice item 0')).toBeNull()
-        expect(screen.getByRole('button', { name: /expand alice's list/i })).toBeTruthy()
+        expect(screen.queryByRole('button', { name: 'Edit Clothes item 0' })).toBeNull()
+        expect(screen.getByRole('button', { name: /expand clothes list/i })).toBeTruthy()
     })
 
     it('keeps every section and its count on the page', async () => {
         mockList(bigList('big-2', 6))
         renderList('big-2')
-        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: /(expand|collapse) clothes list/i })).toBeTruthy())
 
-        for (const person of people) {
-            expect(screen.getByRole('button', { name: new RegExp(`expand ${person}'s list`, 'i') }).textContent)
+        for (const category of categories) {
+            expect(screen.getByRole('button', { name: new RegExp(`expand ${category} list`, 'i') }).textContent)
                 .toContain('0 / 6')
         }
     })
@@ -3532,71 +3146,71 @@ describe('ViewPackingList opening a long list for the first time', () => {
     it('says why the list arrived folded, and offers the way out', async () => {
         mockList(bigList('big-3', 6))
         renderList('big-3')
-        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: /(expand|collapse) clothes list/i })).toBeTruthy())
 
         const note = screen.getByTestId('folded-on-open-note')
         expect(note.textContent).toContain('all 6 sections start folded')
 
         fireEvent.click(within(note).getByRole('button', { name: /expand all/i }))
 
-        expect(screen.getByText('Alice item 0')).toBeTruthy()
+        expect(screen.getByRole('button', { name: 'Edit Clothes item 0' })).toBeTruthy()
         expect(screen.queryByTestId('folded-on-open-note')).toBeNull()
     })
 
     it('drops the note as soon as the user opens a section themselves', async () => {
         mockList(bigList('big-4', 6))
         renderList('big-4')
-        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: /(expand|collapse) clothes list/i })).toBeTruthy())
 
-        fireEvent.click(screen.getByRole('button', { name: /expand alice's list/i }))
+        fireEvent.click(screen.getByRole('button', { name: /expand clothes list/i }))
 
         expect(screen.queryByTestId('folded-on-open-note')).toBeNull()
     })
 
     it('leaves a short list open', async () => {
-        // Six people, one item each — plenty of sections, but no wall
+        // Six categories, one item each — plenty of sections, but no wall
         mockList(bigList('small-1', 1))
         renderList('small-1')
-        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: /(expand|collapse) clothes list/i })).toBeTruthy())
 
-        expect(screen.getByText('Alice item 0')).toBeTruthy()
+        expect(screen.getByRole('button', { name: 'Edit Clothes item 0' })).toBeTruthy()
         expect(screen.queryByTestId('folded-on-open-note')).toBeNull()
     })
 
     it('leaves a long list with a single section open, having nothing to fold into', async () => {
         const list = bigList('solo-1', 6)
-        mockList({ ...list, items: list.items.map(item => ({ ...item, personName: 'Alice', personId: 'p0' })) })
+        mockList({ ...list, items: list.items.map(item => ({ ...item, category: 'Clothes' })) })
         renderList('solo-1')
-        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: /(expand|collapse) clothes list/i })).toBeTruthy())
 
-        expect(screen.getByText('Alice item 0')).toBeTruthy()
+        expect(screen.getByRole('button', { name: 'Edit Clothes item 0' })).toBeTruthy()
     })
 
     it('does not fold a list the user has opened before', async () => {
         mockList(bigList('big-5', 6))
         const { unmount } = renderList('big-5')
-        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: /(expand|collapse) clothes list/i })).toBeTruthy())
         fireEvent.click(within(screen.getByTestId('folded-on-open-note')).getByRole('button', { name: /expand all/i }))
         unmount()
 
         renderList('big-5')
-        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: /(expand|collapse) clothes list/i })).toBeTruthy())
 
         // Their arrangement wins, even though it matches the plain defaults
-        expect(screen.getByText('Alice item 0')).toBeTruthy()
+        expect(screen.getByRole('button', { name: 'Edit Clothes item 0' })).toBeTruthy()
         expect(screen.queryByTestId('folded-on-open-note')).toBeNull()
     })
 
     it('reopens folded if that is how the user left it', async () => {
         mockList(bigList('big-6', 6))
         const { unmount } = renderList('big-6')
-        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: /(expand|collapse) clothes list/i })).toBeTruthy())
         unmount()
 
         renderList('big-6')
-        await waitFor(() => expect(screen.getByText("Alice's Items")).toBeTruthy())
+        await waitFor(() => expect(screen.getByRole('button', { name: /(expand|collapse) clothes list/i })).toBeTruthy())
 
-        expect(screen.queryByText('Alice item 0')).toBeNull()
+        expect(screen.queryByRole('button', { name: 'Edit Clothes item 0' })).toBeNull()
         // Second time around it is their arrangement, not something to explain
         expect(screen.queryByTestId('folded-on-open-note')).toBeNull()
     })
@@ -3801,9 +3415,10 @@ describe('ViewPackingList last minute items', () => {
             lastMinuteBaseItems[1],
         ])
 
-        await waitFor(() => expect(screen.getByText('Toothbrush')).toBeTruthy())
-        expect(within(sectionCard('Last Minute')).getByText('Passport')).toBeTruthy()
-        expect(within(sectionCard("Alice's Items")).queryByText('Passport')).toBeNull()
+        await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
+        expect(within(sectionCard('Last Minute')).getByRole('button', { name: 'Edit Passport' })).toBeTruthy()
+        // Its own category card has gone with it — the card was only holding it
+        expect(screen.queryByRole('button', { name: /(expand|collapse) documents list/i })).toBeNull()
     })
 
     it('says what the section is for', async () => {
@@ -3816,11 +3431,13 @@ describe('ViewPackingList last minute items', () => {
     it('moves an item into the last minute section when it is marked', async () => {
         const db = renderLastMinuteList()
 
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: /mark passport as .*last minute/i }))
+        await waitFor(() => expect(row('Passport')).toBeTruthy())
+        // Marking lives in the row's panel, reached through its name
+        fireEvent.click(row('Passport'))
+        fireEvent.click(screen.getByRole('button', { name: /mark alice's passport as a last minute item/i }))
 
-        await waitFor(() => expect(within(sectionCard('Last Minute')).getByText('Passport')).toBeTruthy())
-        expect(within(sectionCard("Alice's Items")).queryByText('Passport')).toBeNull()
+        await waitFor(() => expect(within(sectionCard('Last Minute')).getByRole('button', { name: 'Edit Passport' })).toBeTruthy())
+        expect(screen.queryByRole('button', { name: /(expand|collapse) documents list/i })).toBeNull()
         expect(savedItems(db).find(item => item.id === 'lm-1')?.lastMinute).toBe(true)
     })
 
@@ -3830,10 +3447,11 @@ describe('ViewPackingList last minute items', () => {
             lastMinuteBaseItems[1],
         ])
 
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: /remove passport from .*last minute/i }))
+        await waitFor(() => expect(row('Passport')).toBeTruthy())
+        fireEvent.click(row('Passport'))
+        fireEvent.click(screen.getByRole('button', { name: /pack alice's passport with everything else/i }))
 
-        await waitFor(() => expect(within(sectionCard("Alice's Items")).getByText('Passport')).toBeTruthy())
+        await waitFor(() => expect(within(sectionCard('Documents')).getByRole('button', { name: 'Edit Passport' })).toBeTruthy())
         expect(screen.queryByText('Last Minute')).toBeNull()
         expect(savedItems(db).find(item => item.id === 'lm-1')?.lastMinute).toBeUndefined()
     })
@@ -3845,7 +3463,7 @@ describe('ViewPackingList last minute items', () => {
         ])
 
         await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-        expect(within(sectionCard('Last Minute')).getByText('Phone charger')).toBeTruthy()
+        expect(within(sectionCard('Last Minute')).getByRole('button', { name: 'Edit Phone charger' })).toBeTruthy()
         expect(screen.queryByText('Shared Items')).toBeNull()
     })
 
@@ -3856,23 +3474,25 @@ describe('ViewPackingList last minute items', () => {
         ])
 
         await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: 'Category View' }))
 
-        expect(within(sectionCard('Last Minute')).getByText('Passport')).toBeTruthy()
+        expect(within(sectionCard('Last Minute')).getByRole('button', { name: 'Edit Passport' })).toBeTruthy()
         expect(screen.queryByText('Documents')).toBeNull()
-        expect(within(sectionCard('Toiletries')).getByText('Toothbrush')).toBeTruthy()
+        expect(within(sectionCard('Toiletries')).getByRole('button', { name: 'Edit Toothbrush' })).toBeTruthy()
     })
 
-    it('groups the last minute section by person', async () => {
+    it('reads the last minute card the way every other card reads', async () => {
+        // It holds everybody's, so it is a grid like the rest: the item down
+        // the side, whose it is across it, and shared items on their own row.
         renderLastMinuteList([
             { ...lastMinuteBaseItems[0], lastMinute: true },
             { ...lastMinuteBaseItems[2], lastMinute: true },
         ])
 
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-        const card = sectionCard('Last Minute')
-        expect(within(card).getByRole('button', { name: /Collapse Alice$/i })).toBeTruthy()
-        expect(within(card).getByRole('button', { name: /Collapse Shared$/i })).toBeTruthy()
+        await waitFor(() => expect(row('Passport')).toBeTruthy())
+
+        const card = within(sectionCard('Last Minute'))
+        expect(card.getByRole('checkbox', { name: 'Passport for Alice' })).toBeTruthy()
+        expect(card.getByRole('checkbox', { name: 'Phone charger for the whole group' })).toBeTruthy()
     })
 
     it('stays where the user is reading when an item is marked', async () => {
@@ -3880,15 +3500,15 @@ describe('ViewPackingList last minute items', () => {
         Element.prototype.scrollIntoView = scrollIntoView
         renderLastMinuteList()
 
-        await waitFor(() => expect(screen.getByText('Passport')).toBeTruthy())
-        fireEvent.click(screen.getByRole('button', { name: /mark passport as .*last minute/i }))
+        await waitFor(() => expect(row('Passport')).toBeTruthy())
+        fireEvent.click(row('Passport'))
+        fireEvent.click(screen.getByRole('button', { name: /mark alice's passport as a last minute item/i }))
 
         // The card is at the far end of a list being read down; the highlight
         // says where the item went without taking the page with it.
-        await waitFor(() => expect(within(sectionCard('Last Minute')).getByText('Passport')).toBeTruthy())
+        await waitFor(() => expect(within(sectionCard('Last Minute')).getByRole('button', { name: 'Edit Passport' })).toBeTruthy())
         expect(scrollIntoView).not.toHaveBeenCalled()
-        const row = within(sectionCard('Last Minute')).getByText('Passport').closest('div.rounded-lg')
-        expect(row?.className).toContain('ring-green-400')
+        expect(screen.getByTestId('grid-cell-lm-1').className).toContain('ring-green-400')
     })
 
     it('marks items added inside the last minute section as last minute', async () => {
@@ -3899,7 +3519,202 @@ describe('ViewPackingList last minute items', () => {
         fireEvent.change(within(card).getAllByPlaceholderText(/add/i)[0], { target: { value: 'Contact lenses' } })
         fireEvent.click(within(card).getAllByRole('button', { name: /^add$/i })[0])
 
-        await waitFor(() => expect(within(sectionCard('Last Minute')).getByText('Contact lenses')).toBeTruthy())
+        await waitFor(() => expect(within(sectionCard('Last Minute')).getByRole('button', { name: 'Edit Contact lenses' })).toBeTruthy())
         expect(savedItems(db).find(item => item.itemText === 'Contact lenses')?.lastMinute).toBe(true)
+    })
+})
+
+// ─── Packing for one person ─────────────────────────────────────────────────
+
+describe('ViewPackingList people filter', () => {
+    // Alice is in all three sections; Bob only in Clothes; the tent is nobody's.
+    const familyList = {
+        id: 'test-list-filter',
+        name: 'Filter Trip',
+        createdAt: '2026-01-01T00:00:00Z',
+        items: [
+            { id: 'f1', itemText: 'Sunhat', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: false },
+            { id: 'f2', itemText: 'Wellies', personName: 'Bob', personId: 'p2', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: false },
+            { id: 'f3', itemText: 'Toothbrush', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', category: 'Toiletries', packed: false },
+            { id: 'f4', itemText: 'Passport', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', category: 'Documents', packed: true },
+            { id: 'f5', itemText: 'Tent', personName: '', personId: '', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: false, communal: true },
+        ],
+    }
+
+    let db: ReturnType<typeof makeDb>
+
+    beforeEach(() => {
+        db = makeDb()
+        db.getPackingList.mockResolvedValue(familyList)
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...familyList, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    async function renderList() {
+        render(
+            <MemoryRouter initialEntries={['/view-list/test-list-filter']}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+        await waitFor(() => expect(row('Sunhat')).toBeTruthy())
+    }
+
+    const chip = (name: string) => screen.getByRole('button', { name: new RegExp(`^${name}`) })
+
+    describe('choosing who', () => {
+        it('starts on everybody, with nothing pressed', async () => {
+            await renderList()
+
+            expect(chip('Alice').getAttribute('aria-pressed')).toBe('false')
+            expect(chip('Bob').getAttribute('aria-pressed')).toBe('false')
+            expect(row('Wellies')).toBeTruthy()
+        })
+
+        it('narrows to one person on the first tap', async () => {
+            await renderList()
+
+            fireEvent.click(chip('Alice'))
+
+            expect(row('Sunhat')).toBeTruthy()
+            expect(screen.queryByRole('button', { name: 'Edit Wellies' })).toBeNull()
+        })
+
+        it('adds a second person rather than replacing the first', async () => {
+            await renderList()
+
+            fireEvent.click(chip('Alice'))
+            fireEvent.click(chip('Bob'))
+
+            expect(row('Sunhat')).toBeTruthy()
+            expect(row('Wellies')).toBeTruthy()
+        })
+
+        it('takes a person back out of the selection', async () => {
+            await renderList()
+
+            fireEvent.click(chip('Alice'))
+            fireEvent.click(chip('Bob'))
+            fireEvent.click(chip('Alice'))
+
+            expect(screen.queryByRole('button', { name: 'Edit Sunhat' })).toBeNull()
+            expect(row('Wellies')).toBeTruthy()
+        })
+
+        it('goes back to everybody when the last person is tapped off', async () => {
+            await renderList()
+
+            fireEvent.click(chip('Bob'))
+            fireEvent.click(chip('Bob'))
+
+            expect(row('Sunhat')).toBeTruthy()
+            expect(row('Wellies')).toBeTruthy()
+        })
+
+        it('offers Clear only while a filter is on', async () => {
+            await renderList()
+            expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull()
+
+            fireEvent.click(chip('Alice'))
+            fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+
+            expect(row('Wellies')).toBeTruthy()
+            expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull()
+        })
+    })
+
+    describe('what the cards show', () => {
+        it('drops a section with nothing for the selection, and says how many went', async () => {
+            await renderList()
+
+            fireEvent.click(chip('Bob'))
+
+            expect(screen.queryByRole('button', { name: /(expand|collapse) toiletries list/i })).toBeNull()
+            expect(screen.getByText(/2 categories have nothing for Bob/)).toBeTruthy()
+        })
+
+        it('puts the dropped sections back when asked', async () => {
+            await renderList()
+            fireEvent.click(chip('Bob'))
+
+            fireEvent.click(screen.getByRole('button', { name: /^show them$/ }))
+
+            expect(screen.getByRole('button', { name: /(expand|collapse) toiletries list/i })).toBeTruthy()
+        })
+
+        it('keeps a shared item, folded away rather than answering a question nobody asked', async () => {
+            await renderList()
+
+            fireEvent.click(chip('Bob'))
+
+            const shared = screen.getByRole('button', { name: /Shared \(1\)/ })
+            expect(shared.getAttribute('aria-expanded')).toBe('false')
+
+            fireEvent.click(shared)
+            expect(row('Tent')).toBeTruthy()
+        })
+
+        it('leaves shared items among the rest when nobody is filtered to', async () => {
+            await renderList()
+
+            expect(screen.queryByRole('button', { name: /Shared \(1\)/ })).toBeNull()
+            expect(row('Tent')).toBeTruthy()
+        })
+
+        it('never lets a shared item into one person’s count', async () => {
+            await renderList()
+
+            fireEvent.click(chip('Alice'))
+
+            // Clothes holds Alice's Sunhat, Bob's Wellies and the group's Tent.
+            // Only the Sunhat is hers.
+            expect(screen.getByRole('button', { name: /collapse clothes list/i }).textContent)
+                .toContain('0 / 1 for Alice')
+        })
+    })
+
+    describe('one person at a time', () => {
+        it('packs everything of one person’s, and offers it back', async () => {
+            await renderList()
+            fireEvent.click(chip('Alice'))
+
+            // Passport is already packed, so it is two items, not three
+            fireEvent.click(screen.getByRole('button', { name: "Pack all 2 of Alice's" }))
+
+            expect(mockShowToast).toHaveBeenCalledWith(
+                "Packed 2 of Alice's items",
+                'success',
+                undefined,
+                expect.objectContaining({ label: 'Undo' }),
+            )
+        })
+
+        it('says nothing about packing for two people at once', async () => {
+            await renderList()
+
+            fireEvent.click(chip('Alice'))
+            fireEvent.click(chip('Bob'))
+
+            expect(screen.queryByRole('button', { name: /^Pack all/ })).toBeNull()
+        })
     })
 })

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -3532,7 +3532,7 @@ describe('ViewPackingList people filter', () => {
         id: 'test-list-filter',
         name: 'Filter Trip',
         createdAt: '2026-01-01T00:00:00Z',
-        guests: [{ id: 'g1', name: 'Zoe' }],
+        guests: [{ id: 'g1', name: 'Zoe' }, { id: 'g2', name: 'Dan' }],
         items: [
             { id: 'f6', itemText: 'Armbands', personName: 'Zoe', personId: 'g1', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: false },
             { id: 'f1', itemText: 'Sunhat', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: false },
@@ -3772,6 +3772,41 @@ describe('ViewPackingList people filter', () => {
             fireEvent.click(chip('Bob'))
 
             expect(screen.queryByRole('button', { name: /^Pack all/ })).toBeNull()
+        })
+
+        it('counts by headcount past one person, rather than listing names', async () => {
+            // A comma-joined list beside a fraction reads as a truncated list,
+            // and on a phone it runs straight under the button beside it. The
+            // strip above is what says which people.
+            await renderList()
+
+            fireEvent.click(chip('Alice'))
+            fireEvent.click(chip('Bob'))
+
+            expect(screen.getByRole('button', { name: /collapse clothes list/i }).textContent)
+                .toContain('for 2 people')
+        })
+
+        it('keeps Clear reachable, out of the strip that scrolls', async () => {
+            // Inside the strip it was pushed off the end of a phone by the
+            // fifth person, so the one control that undoes the filter never
+            // reached the screen.
+            await renderList()
+            fireEvent.click(chip('Alice'))
+
+            const clear = screen.getByRole('button', { name: 'Clear' })
+            expect(clear.closest('[aria-label="Filter by person"]')).toBeNull()
+        })
+
+        it('offers a way in when the filter leaves nothing on the page', async () => {
+            // Every composer lives inside a card, and a fresh guest's cards
+            // have all been dropped — so without this there is no way to give
+            // them their first item, and the page just looks broken.
+            await renderList()
+
+            fireEvent.click(chip('Dan'))
+
+            expect(screen.getByText(/Nothing on this list is for Dan yet/)).toBeTruthy()
         })
     })
 })

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -2129,6 +2129,7 @@ describe('ViewPackingList section completion celebration', () => {
             { id: 'a2', itemText: 'Sunhat', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: true },
             { id: 'b1', itemText: 'Wellies', personName: 'Bob', personId: 'p2', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: true },
             { id: 'b2', itemText: 'Toothbrush', personName: 'Bob', personId: 'p2', questionId: 'q1', optionId: 'o1', category: 'Toiletries', packed: false },
+            { id: 'a3', itemText: 'Comb', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', category: 'Toiletries', packed: true },
         ],
     }
 
@@ -2203,16 +2204,18 @@ describe('ViewPackingList section completion celebration', () => {
         await waitFor(() => expect(screen.getByLabelText(/all packed for toiletries/i)).toBeTruthy())
     })
 
-    it('does not celebrate a card that is only finished for the person filtered to', async () => {
-        // Alice has packed her half of Clothes; Bob's Wellies are in it too.
-        // The emerald pill is how this app says a section of the trip is done,
-        // and one person's share of it being done is not that.
+    it('celebrates a card finished for whoever is being packed for', async () => {
+        // Alice's comb is packed and Bob's toothbrush isn't, so Toiletries is
+        // unfinished for the trip. Packing Alice's bag it is done — what Bob
+        // still owes is not part of the question being asked.
         renderList()
         await waitFor(() => expect(row('Toothbrush')).toBeTruthy())
 
+        expect(screen.queryByLabelText(/all packed for toiletries/i)).toBeNull()
+
         fireEvent.click(screen.getByRole('button', { name: /^Alice/ }))
 
-        expect(screen.queryByLabelText(/all packed for clothes/i)).toBeNull()
+        expect(screen.getByLabelText(/all packed for toiletries for alice/i)).toBeTruthy()
     })
 })
 
@@ -2757,11 +2760,10 @@ describe('ViewPackingList adding items', () => {
         renderComponentMultiCategory()
         await waitFor(() => expect(screen.getByRole('button', { name: 'Edit Tent' })).toBeTruthy())
 
-        fireEvent.click(screen.getByRole('button', { name: /^Bob/ }))
-        // Bob has nothing in Hiking, so the card is off the page until asked for
-        fireEvent.click(screen.getByRole('button', { name: /empty — show$/ }))
-        const { input } = composerFor('Hiking')
+        const { input, fields } = composerFor('Hiking')
+        // The who-for picker only appears once there is something typed
         fireEvent.change(input, { target: { value: 'ten' } })
+        fireEvent.change(fields.getByLabelText('Who for'), { target: { value: 'Bob' } })
         fireEvent.click(screen.getByRole('option', { name: /Tent/ }))
         fireEvent.keyDown(input, { key: 'Enter' })
 
@@ -3652,29 +3654,14 @@ describe('ViewPackingList people filter', () => {
             fireEvent.click(chip('Bob'))
 
             expect(screen.queryByRole('button', { name: /(expand|collapse) toiletries list/i })).toBeNull()
-            // Said beside the filter that caused it, not at the foot of a page
-            // three thousand pixels down
-            expect(screen.getByRole('button', { name: '2 empty — show' })).toBeTruthy()
+            expect(screen.getByRole('button', { name: /(expand|collapse) clothes list/i })).toBeTruthy()
         })
 
-        it('puts the empty sections away again, having offered to show them', async () => {
+        it('brings them back when the filter is cleared', async () => {
             await renderList()
             fireEvent.click(chip('Bob'))
 
-            fireEvent.click(screen.getByRole('button', { name: '2 empty — show' }))
-            expect(screen.getByRole('button', { name: 'Hide 2 empty' })).toBeTruthy()
-
-            fireEvent.click(screen.getByRole('button', { name: 'Hide 2 empty' }))
-
-            expect(screen.queryByRole('button', { name: /(expand|collapse) toiletries list/i })).toBeNull()
-            expect(screen.getByRole('button', { name: '2 empty — show' })).toBeTruthy()
-        })
-
-        it('puts the dropped sections back when asked', async () => {
-            await renderList()
-            fireEvent.click(chip('Bob'))
-
-            fireEvent.click(screen.getByRole('button', { name: /empty — show$/ }))
+            fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
 
             expect(screen.getByRole('button', { name: /(expand|collapse) toiletries list/i })).toBeTruthy()
         })

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -2758,7 +2758,7 @@ describe('ViewPackingList adding items', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /^Bob/ }))
         // Bob has nothing in Hiking, so the card is off the page until asked for
-        fireEvent.click(screen.getByRole('button', { name: /^show them$/ }))
+        fireEvent.click(screen.getByRole('button', { name: /empty — show$/ }))
         const { input } = composerFor('Hiking')
         fireEvent.change(input, { target: { value: 'ten' } })
         fireEvent.click(screen.getByRole('option', { name: /Tent/ }))
@@ -3532,7 +3532,9 @@ describe('ViewPackingList people filter', () => {
         id: 'test-list-filter',
         name: 'Filter Trip',
         createdAt: '2026-01-01T00:00:00Z',
+        guests: [{ id: 'g1', name: 'Zoe' }],
         items: [
+            { id: 'f6', itemText: 'Armbands', personName: 'Zoe', personId: 'g1', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: false },
             { id: 'f1', itemText: 'Sunhat', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: false },
             { id: 'f2', itemText: 'Wellies', personName: 'Bob', personId: 'p2', questionId: 'q1', optionId: 'o1', category: 'Clothes', packed: false },
             { id: 'f3', itemText: 'Toothbrush', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', category: 'Toiletries', packed: false },
@@ -3649,14 +3651,29 @@ describe('ViewPackingList people filter', () => {
             fireEvent.click(chip('Bob'))
 
             expect(screen.queryByRole('button', { name: /(expand|collapse) toiletries list/i })).toBeNull()
-            expect(screen.getByText(/2 categories have nothing for Bob/)).toBeTruthy()
+            // Said beside the filter that caused it, not at the foot of a page
+            // three thousand pixels down
+            expect(screen.getByRole('button', { name: '2 empty — show' })).toBeTruthy()
+        })
+
+        it('puts the empty sections away again, having offered to show them', async () => {
+            await renderList()
+            fireEvent.click(chip('Bob'))
+
+            fireEvent.click(screen.getByRole('button', { name: '2 empty — show' }))
+            expect(screen.getByRole('button', { name: 'Hide 2 empty' })).toBeTruthy()
+
+            fireEvent.click(screen.getByRole('button', { name: 'Hide 2 empty' }))
+
+            expect(screen.queryByRole('button', { name: /(expand|collapse) toiletries list/i })).toBeNull()
+            expect(screen.getByRole('button', { name: '2 empty — show' })).toBeTruthy()
         })
 
         it('puts the dropped sections back when asked', async () => {
             await renderList()
             fireEvent.click(chip('Bob'))
 
-            fireEvent.click(screen.getByRole('button', { name: /^show them$/ }))
+            fireEvent.click(screen.getByRole('button', { name: /empty — show$/ }))
 
             expect(screen.getByRole('button', { name: /(expand|collapse) toiletries list/i })).toBeTruthy()
         })
@@ -3706,6 +3723,46 @@ describe('ViewPackingList people filter', () => {
                 undefined,
                 expect.objectContaining({ label: 'Undo' }),
             )
+        })
+
+        it('keeps the filter on a guest who has just been renamed', async () => {
+            // The filter holds names. Leave the old one in it and the page is
+            // filtered to somebody no chip names — every card empty, no chip
+            // pressed, and nothing on screen to undo it.
+            await renderList()
+            fireEvent.click(chip('Zoe'))
+
+            fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+            const field = screen.getByRole('textbox', { name: 'Rename Zoe' })
+            fireEvent.change(field, { target: { value: 'Zoey' } })
+            fireEvent.blur(field)
+
+            await waitFor(() => expect(chip('Zoey').getAttribute('aria-pressed')).toBe('true'))
+            expect(row('Armbands')).toBeTruthy()
+        })
+
+        it('goes back to everybody when the filtered guest is removed', async () => {
+            await renderList()
+            fireEvent.click(chip('Zoe'))
+
+            fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+            // The bar's button opens the confirmation; the dialog's does it
+            const dialog = within(await screen.findByRole('dialog'))
+            fireEvent.click(dialog.getByRole('button', { name: 'Remove' }))
+
+            // Not left filtered to a person who no longer exists
+            await waitFor(() => expect(row('Wellies')).toBeTruthy())
+        })
+
+        it('marks a bag that is finished rather than leaving a name on its own', async () => {
+            await renderList()
+            fireEvent.click(chip('Zoe'))
+
+            fireEvent.click(screen.getByRole('button', { name: "Pack all 1 of Zoe's" }))
+
+            await waitFor(() => expect(screen.getByText(/Zoe's bag is packed/)).toBeTruthy())
+            // The trip's own celebration is still the trip's
+            expect(screen.queryByTestId('completion-banner')).toBeNull()
         })
 
         it('says nothing about packing for two people at once', async () => {

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -2315,7 +2315,8 @@ describe('ViewPackingList completion', () => {
     it('opens an already-packed list with the cards already folded away', async () => {
         setup(fullyPackedList)
         await waitFor(() => expect(screen.getByText("You're all packed!")).toBeTruthy())
-        expect(screen.queryByTestId('list-section')).toBeNull()
+        // The banner arrives first and the cards fold out from under it
+        await waitFor(() => expect(screen.queryByTestId('list-section')).toBeNull())
     })
 
     it('brings the cards back when packed items are shown', async () => {
@@ -3713,6 +3714,26 @@ describe('ViewPackingList people filter', () => {
         // Scoped to the strip: the card's own "Shared (n)" disclosure shares
         // the word, and the chip's emoji is decorative so it carries no name.
         const shared = () => within(screen.getByTestId('people-key')).getByRole('button', { name: /^Shared/ })
+
+        it('keeps a filled chip meaning pressed, and nothing else', async () => {
+            // A chip filled green for "finished" read as selected beside the
+            // white ones that read as not — two states after one signal.
+            await renderList()
+
+            fireEvent.click(chip('Zoe'))
+            fireEvent.click(screen.getByRole('button', { name: "Pack all 1 of Zoe's" }))
+            await waitFor(() => expect(screen.getByText(/Zoe's bag is packed/)).toBeTruthy())
+
+            // Pressed: filled
+            expect(chip('Zoe').className).toContain('bg-blue-600')
+
+            // Finished but not pressed: the same white as everyone else, with
+            // the news carried on her face instead
+            fireEvent.click(chip('Zoe'))
+            expect(chip('Zoe').className).not.toContain('bg-emerald')
+            expect(chip('Zoe').className).toContain('bg-white')
+            expect(chip('Zoe').className).toBe(chip('Bob').className)
+        })
 
         it('offers the group alongside the people', async () => {
             await renderList()

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1808,7 +1808,7 @@ describe('ViewPackingList shared (communal) items', () => {
         // No column belongs to it, and it comes first — the shared card's place
         // in person view, kept
         expect(camping.getAllByTestId('grid-row')[0].textContent).toContain('Tent')
-        expect(camping.getByText('👥 Everyone')).toBeTruthy()
+        expect(camping.getByText('👥 Shared')).toBeTruthy()
     })
 
     it('counts shared items in the section total', async () => {
@@ -3706,6 +3706,63 @@ describe('ViewPackingList people filter', () => {
             // Only the Sunhat is hers.
             expect(screen.getByRole('button', { name: /collapse clothes list/i }).textContent)
                 .toContain('0 / 1 for Alice')
+        })
+    })
+
+    describe('the group\'s own chip', () => {
+        // Scoped to the strip: the card's own "Shared (n)" disclosure shares
+        // the word, and the chip's emoji is decorative so it carries no name.
+        const shared = () => within(screen.getByTestId('people-key')).getByRole('button', { name: /^Shared/ })
+
+        it('offers the group alongside the people', async () => {
+            await renderList()
+
+            expect(shared().getAttribute('aria-pressed')).toBe('false')
+        })
+
+        it('shows the group\'s items and nobody else\'s', async () => {
+            await renderList()
+
+            fireEvent.click(shared())
+
+            expect(row('Tent')).toBeTruthy()
+            expect(screen.queryByRole('button', { name: 'Edit Sunhat' })).toBeNull()
+            expect(screen.queryByRole('button', { name: 'Edit Wellies' })).toBeNull()
+        })
+
+        it('brings the shared items back among the rest when asked for by name', async () => {
+            await renderList()
+
+            fireEvent.click(chip('Alice'))
+            // Filtered to a person they fold away; asked for, they come out
+            expect(screen.getByRole('button', { name: /Shared \(1\)/ })).toBeTruthy()
+
+            fireEvent.click(shared())
+
+            expect(screen.queryByRole('button', { name: /Shared \(1\)/ })).toBeNull()
+            expect(row('Tent')).toBeTruthy()
+            expect(row('Sunhat')).toBeTruthy()
+        })
+
+        it('counts the group\'s items against the group, and nobody else', async () => {
+            await renderList()
+
+            fireEvent.click(shared())
+
+            expect(shared().textContent).toContain('0/1')
+            // Clothes holds Alice's Sunhat, Bob's Wellies, Zoe's Armbands and
+            // the group's Tent — only the Tent is the group's.
+            expect(screen.getByRole('button', { name: /collapse clothes list/i }).textContent)
+                .toContain('0 / 1 for shared items')
+        })
+
+        it('is not somebody, so it is offered no bag to pack and no name to change', async () => {
+            await renderList()
+
+            fireEvent.click(shared())
+
+            expect(screen.queryByRole('button', { name: /^Pack all/ })).toBeNull()
+            expect(screen.queryByRole('button', { name: 'Rename' })).toBeNull()
         })
     })
 

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -261,8 +261,6 @@ export function ViewPackingList() {
      * list that looks like it has lost two thirds of itself.
      */
     const [selectedPeople, setSelectedPeople] = useState<ReadonlySet<string>>(() => new Set<string>())
-    /** Categories with nothing for the filter are dropped; this puts them back. */
-    const [showEmptyCategories, setShowEmptyCategories] = useState(false)
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
     const [itemToDelete, setItemToDelete] = useState<string | null>(null)
     // Which row of the category grid has its "who needs this?" panel open, held
@@ -487,11 +485,9 @@ export function ViewPackingList() {
     const visibleColumnKeys = filtering ? selectedPeople : undefined
 
     const handleTogglePerson = useCallback((name: string) => {
-        setShowEmptyCategories(false)
         setSelectedPeople(prev => togglePerson(prev, name))
     }, [])
     const handleClearFilter = useCallback(() => {
-        setShowEmptyCategories(false)
         setSelectedPeople(new Set<string>())
     }, [])
 
@@ -1466,11 +1462,7 @@ export function ViewPackingList() {
     // same question answered with three real cards adrift in nine empty ones
     // would be a worse list, not a simpler app. What is missing is said in one
     // line under the cards instead, and that line puts them back.
-    const emptyForFilter = filtering ? allCategorySections.filter(section => !hasSomethingForFilter(section)) : []
-    const emptyCategoriesShown = filtering && showEmptyCategories && emptyForFilter.length > 0
-    const categorySections = filtering && !showEmptyCategories
-        ? allCategorySections.filter(hasSomethingForFilter)
-        : allCategorySections
+    const categorySections = filtering ? allCategorySections.filter(hasSomethingForFilter) : allCategorySections
     const listSections: ListSection[] = [...categorySections, ...lastMinuteSections]
 
     const soleGuest = solePerson === undefined
@@ -1850,21 +1842,6 @@ export function ViewPackingList() {
                                         {filterNames(selectedPeople)}
                                     </span>
                                 )}
-                                {/* Cards vanishing is an alarming thing for a
-                                    packing list to do, and the explanation used
-                                    to sit three thousand pixels below the cause.
-                                    It belongs where the filter is. */}
-                                {emptyForFilter.length > 0 && (
-                                    <button
-                                        type="button"
-                                        onClick={() => setShowEmptyCategories(shown => !shown)}
-                                        className="ml-auto shrink-0 whitespace-nowrap rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
-                                    >
-                                        {emptyCategoriesShown
-                                            ? `Hide ${emptyForFilter.length} empty`
-                                            : `${emptyForFilter.length} empty — show`}
-                                    </button>
-                                )}
                             </div>
                         )}
                         {/* Announced rather than shown: the strip above says the
@@ -1988,13 +1965,14 @@ export function ViewPackingList() {
                             // total of "24 / 58" is a number with no referent.
                             const stats = filtering ? filteredStatsFor(section) : unfilteredStats
                             const isLastMinute = section.lastMinute === true
-                            // Emerald borders, the "all packed" pill and the
-                            // fold-away are how this app says the trip is done.
-                            // One person finishing their share of a category is
-                            // not that, so under a filter a card keeps its
-                            // ordinary clothes and the person's own chip goes
-                            // green instead.
-                            const isComplete = !filtering && isSectionComplete(unfilteredStats)
+                            // A card is finished when the part of it on screen
+                            // is finished — packing for Alice, Toiletries is
+                            // done when hers are, whatever Bob still owes. The
+                            // fold-away is the one part of the celebration a
+                            // filter doesn't get: folding writes to storage, and
+                            // a filter used once would leave the list folded up
+                            // for good (see `completeSectionKeys`).
+                            const isComplete = isSectionComplete(stats)
                             const completeLabel = title
                             const collapseLabelTarget = isLastMinute ? 'the last minute items' : title
                             // Every card is a grid now: the name down the side,
@@ -2033,7 +2011,7 @@ export function ViewPackingList() {
                                         </button>
                                         {isComplete && (
                                             <span
-                                                aria-label={`All packed for ${completeLabel}`}
+                                                aria-label={`All packed for ${completeLabel}${filterQualifier}`}
                                                 className="animate-pop-in text-xs font-semibold text-emerald-700 bg-emerald-100 border border-emerald-200 rounded-full px-2 py-0.5 shrink-0"
                                             >
                                                 🎉 All packed!
@@ -2116,7 +2094,7 @@ export function ViewPackingList() {
                                 Nothing on this list is{filterQualifier} yet.
                             </p>
                             <p className="mt-1 text-sm text-gray-500">
-                                Show the empty sections above to add the first thing, or pick somebody else.
+                                Clear the filter to add the first thing{filterQualifier}, or pick somebody else.
                             </p>
                         </div>
                     )}

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -38,7 +38,7 @@ import { CategoryItemGrid } from '../components/CategoryItemGrid'
 import { ItemRowPanel } from '../components/ItemRowPanel'
 import { buildCategoryRows, buildGridColumns, UNASSIGNED_COLUMN_KEY, type GridRow } from '../utils/categoryItemGrid'
 import { PeopleFilterBar } from '../components/PeopleFilterBar'
-import { togglePerson, isFiltered, personTotals, filterSummary } from '../utils/peopleFilter'
+import { togglePerson, isFiltered, personTotals, filterSummary, sharedTotal, sharedSelected, filterLabel } from '../utils/peopleFilter'
 import { buildSuggestionIndex } from '../utils/itemSuggestions'
 import { useIsDesktop } from '../hooks/useIsDesktop'
 import { loadListViewPreferences, saveListViewPreferences, hasStoredListViewPreferences, hasStalePersonViewSections } from '../utils/listViewPreferences'
@@ -502,7 +502,7 @@ export function ViewPackingList() {
      * filter by — it is every item nobody has claimed yet — but it is not
      * somebody to rename, remove, or pack a bag for.
      */
-    const solePerson = selectedPeople.size === 1
+    const solePerson = selectedPeople.size === 1 && !sharedSelected(selectedPeople)
         ? gridColumns.find(column => column.key === [...selectedPeople][0] && !column.unassigned)
         : undefined
 
@@ -537,6 +537,10 @@ export function ViewPackingList() {
     // thing from anywhere.
     const peopleTotals = useMemo(
         () => personTotals(packingList?.items ?? [], watchedItems),
+        [packingList?.items, watchedItems],
+    )
+    const sharedStat = useMemo(
+        () => sharedTotal(packingList?.items ?? [], watchedItems),
         [packingList?.items, watchedItems],
     )
 
@@ -1451,9 +1455,11 @@ export function ViewPackingList() {
      * a question the group's tent answers, and a card kept alive by one is a
      * card the user opens to find nothing of what they were looking for.
      */
-    const hasSomethingForFilter = (section: ListSection) => !filtering || (section.rows ?? []).some(
-        row => !row.communal && row.items.some(item => selectedPeople.has(item.personName || UNASSIGNED_COLUMN_KEY)),
-    )
+    const hasSomethingForFilter = (section: ListSection) => !filtering || (section.rows ?? []).some(row => (
+        row.communal
+            ? sharedSelected(selectedPeople)
+            : row.items.some(item => selectedPeople.has(item.personName || UNASSIGNED_COLUMN_KEY))
+    ))
 
     // Under a filter the empty ones go rather than staying as muted headers.
     // Person view used to answer "what is left for Alice?" with one card; the
@@ -1484,11 +1490,7 @@ export function ViewPackingList() {
      * list beside a fraction reads as a truncated list, and on a phone it runs
      * straight under the button beside it. The strip above says which people.
      */
-    const filterQualifier = !filtering
-        ? ''
-        : selectedPeople.size === 1
-            ? ` for ${[...selectedPeople][0]}`
-            : ` for ${selectedPeople.size} people`
+    const filterQualifier = filtering ? ` for ${filterLabel(selectedPeople)}` : ''
 
     /**
      * What "Check all" on a card ticks: what the card is showing. Under a
@@ -1497,7 +1499,7 @@ export function ViewPackingList() {
      */
     const checkableItemsOf = (section: ListSection) => (section.rows ?? []).flatMap(row => (
         row.communal
-            ? (filtering ? [] : row.items)
+            ? (!filtering || sharedSelected(selectedPeople) ? row.items : [])
             : row.items.filter(item => !filtering || selectedPeople.has(item.personName || UNASSIGNED_COLUMN_KEY))
     ))
 
@@ -1506,9 +1508,17 @@ export function ViewPackingList() {
         let packed = 0
         let total = 0
         for (const row of section.rows ?? []) {
-            // Shared items belong to no one person, so counting them here would
-            // put the tent in Alice's total and in Bob's.
-            if (row.communal) continue
+            // Shared items belong to no one person, so counting them against a
+            // person would put the tent in Alice's total and in Bob's. Counted
+            // only when the group's own chip is what is asking.
+            if (row.communal) {
+                if (!sharedSelected(selectedPeople)) continue
+                for (const item of row.items) {
+                    total += 1
+                    if (watchedItems[item.id]) packed += 1
+                }
+                continue
+            }
             for (const item of row.items) {
                 if (!selectedPeople.has(item.personName || UNASSIGNED_COLUMN_KEY)) continue
                 total += 1
@@ -1526,9 +1536,11 @@ export function ViewPackingList() {
             (rowCount, row) => {
                 // Counted the way the grid hides them: over the cells actually
                 // on screen, so a filter's numbers describe the filter.
-                const shown = filtering && !row.communal
-                    ? row.items.filter(item => selectedPeople.has(item.personName || UNASSIGNED_COLUMN_KEY))
-                    : row.items
+                const shown = !filtering
+                    ? row.items
+                    : row.communal
+                        ? (sharedSelected(selectedPeople) ? row.items : [])
+                        : row.items.filter(item => selectedPeople.has(item.personName || UNASSIGNED_COLUMN_KEY))
                 return rowCount + (shown.length > 0 && shown.every(item => watchedItems[item.id]) ? shown.length : 0)
             },
             0,
@@ -1737,6 +1749,7 @@ export function ViewPackingList() {
                                 columns={gridColumns}
                                 selected={selectedPeople}
                                 totals={peopleTotals}
+                                sharedStat={sharedStat.total > 0 ? sharedStat : undefined}
                                 personColor={personColor}
                                 onToggle={handleTogglePerson}
                                 controlsId={LIST_SECTIONS_ID}

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -38,7 +38,7 @@ import { CategoryItemGrid } from '../components/CategoryItemGrid'
 import { ItemRowPanel } from '../components/ItemRowPanel'
 import { buildCategoryRows, buildGridColumns, UNASSIGNED_COLUMN_KEY, type GridRow } from '../utils/categoryItemGrid'
 import { PeopleFilterBar } from '../components/PeopleFilterBar'
-import { togglePerson, isFiltered, personTotals, filterSummary, sharedTotal, sharedSelected, filterLabel } from '../utils/peopleFilter'
+import { togglePerson, isFiltered, personTotals, filterSummary, sharedTotal, sharedSelected, filterLabel, filterNames } from '../utils/peopleFilter'
 import { buildSuggestionIndex } from '../utils/itemSuggestions'
 import { useIsDesktop } from '../hooks/useIsDesktop'
 import { loadListViewPreferences, saveListViewPreferences, hasStoredListViewPreferences, hasStalePersonViewSections } from '../utils/listViewPreferences'
@@ -1788,7 +1788,16 @@ export function ViewPackingList() {
                                                 className="w-40 shrink-0 rounded-md border border-blue-400 px-2 py-1 text-xs font-semibold text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
                                             />
                                         ) : (
-                                            <span className="shrink-0 text-xs font-semibold text-gray-700">{solePerson.name}</span>
+                                            <>
+                                                <span className="shrink-0 text-xs font-semibold text-gray-700">{solePerson.name}</span>
+                                                {/* On a phone the chips are faces
+                                                    with no names on them, so the
+                                                    numbers come off the chip and
+                                                    land here beside the name. */}
+                                                <span className="shrink-0 text-xs tabular-nums text-gray-500 sm:hidden">
+                                                    {solePersonTotal - solePersonUnpacked}/{solePersonTotal}
+                                                </span>
+                                            </>
                                         )}
                                         {soleGuest && renamingGuestId !== soleGuest.id && (
                                             <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">Guest</span>
@@ -1832,6 +1841,14 @@ export function ViewPackingList() {
                                             </>
                                         )}
                                     </>
+                                )}
+                                {/* Which faces are pressed, in words. The strip
+                                    above says it in colour, which is no answer
+                                    on a phone where the chips carry no names. */}
+                                {solePerson === undefined && (
+                                    <span className="shrink-0 text-xs font-semibold text-gray-700">
+                                        {filterNames(selectedPeople)}
+                                    </span>
                                 )}
                                 {/* Cards vanishing is an alarming thing for a
                                     packing list to do, and the explanation used

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -33,14 +33,15 @@ import { CATEGORY_ORDER } from '../edit-questions/item-sections'
 import { useSectionOrder } from '../hooks/useSectionOrder'
 import { clearPendingSignInAction, getPendingSignInAction, setPendingSignInAction } from '../utils/pendingSignInAction'
 import { usePersonColors } from '../hooks/usePersonColors'
-import { PersonAvatar } from '../components/PersonAvatar'
 import { AddItemComposer, UNCATEGORISED_LABEL, type AddItemTarget, type PersonOption } from '../components/AddItemComposer'
 import { CategoryItemGrid } from '../components/CategoryItemGrid'
 import { ItemRowPanel } from '../components/ItemRowPanel'
-import { buildCategoryRows, buildGridColumns, type GridRow } from '../utils/categoryItemGrid'
+import { buildCategoryRows, buildGridColumns, UNASSIGNED_COLUMN_KEY, type GridRow } from '../utils/categoryItemGrid'
+import { PeopleFilterBar } from '../components/PeopleFilterBar'
+import { togglePerson, isFiltered, personTotals, filterSummary } from '../utils/peopleFilter'
 import { buildSuggestionIndex } from '../utils/itemSuggestions'
 import { useIsDesktop } from '../hooks/useIsDesktop'
-import { loadListViewPreferences, saveListViewPreferences, hasStoredListViewPreferences, type ListViewMode } from '../utils/listViewPreferences'
+import { loadListViewPreferences, saveListViewPreferences, hasStoredListViewPreferences, hasStalePersonViewSections } from '../utils/listViewPreferences'
 import { profile, profileEvent } from '../utils/profiling'
 
 type FormData = {
@@ -208,14 +209,8 @@ export function groupByPerson(items: PackingListItem[]): ItemGroup[] {
 }
 
 
-/**
- * Which top-level card an item belongs to in person view. Last minute wins over
- * everything: the point of marking an item is that it leaves the card it was in.
- */
-function personViewSectionKey(item: PackingListItem): string {
-    if (item.lastMinute) return LAST_MINUTE_SECTION_KEY
-    return item.communal ? SHARED_SECTION_KEY : item.personName
-}
+/** Ties the people filter to the cards it narrows, for assistive tech. */
+const LIST_SECTIONS_ID = 'packing-list-sections'
 
 export function ViewPackingList() {
     const { id } = useParams<{ id: string }>()
@@ -259,12 +254,16 @@ export function ViewPackingList() {
     // one moment worth explaining, and only until the user touches anything.
     const [foldedOnOpen, setFoldedOnOpen] = useState(false)
     const [showPacked, setShowPacked] = useState(storedPreferences.showPacked)
-    const [viewMode, setViewMode] = useState<ListViewMode>(storedPreferences.viewMode)
+    /**
+     * Who the user is packing for. Empty means everyone, which is where a list
+     * always opens: unlike a folded section, a filter is a thing you are doing
+     * rather than a way you keep this list, and one restored a week later is a
+     * list that looks like it has lost two thirds of itself.
+     */
+    const [selectedPeople, setSelectedPeople] = useState<ReadonlySet<string>>(() => new Set<string>())
+    /** Categories with nothing for the filter are dropped; this puts them back. */
+    const [showEmptyCategories, setShowEmptyCategories] = useState(false)
     const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
-    // Which section has an add-item composer open inside it. Only one is mounted
-    // at a time: a composer per group would put an input in front of every
-    // heading on the page, which is what the list already pays for in item rows.
-    const [openComposerKey, setOpenComposerKey] = useState<string | null>(null)
     const [itemToDelete, setItemToDelete] = useState<string | null>(null)
     // Which row of the category grid has its "who needs this?" panel open, held
     // as keys rather than as the row itself: the row is rebuilt whenever the
@@ -274,12 +273,9 @@ export function ViewPackingList() {
     // A row can hold one item or one each for four people; removing the second
     // kind is worth naming who it affects.
     const [rowToDelete, setRowToDelete] = useState<{ label: string; items: PackingListItem[]; who: string } | null>(null)
-    const [editingItemId, setEditingItemId] = useState<string | null>(null)
-    const [editingItemText, setEditingItemText] = useState<string>('')
-    const [editingItemQuantity, setEditingItemQuantity] = useState<string>('')
     // Groups within a section, keyed `sectionKey::groupLabel`
     const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set(storedPreferences.collapsedGroups))
-    // Top-level sections: a person, a category, or the shared section
+    // Top-level sections: a category, or the last minute card
     const [collapsedSections, setCollapsedSections] = useState<Set<string>>(() => new Set(storedPreferences.collapsedSections))
     // Sections this page folded away on the user's behalf once everything in
     // them was packed. Tracked apart from the folded set so a section is only
@@ -293,7 +289,6 @@ export function ViewPackingList() {
     const [showAddGuest, setShowAddGuest] = useState(false)
     // Reveals an empty Shared Items section on lists that have no communal
     // items yet; once an item is added the section persists from the data.
-    const [showSharedSection, setShowSharedSection] = useState(false)
     const [newGuestName, setNewGuestName] = useState('')
     const [renamingGuestId, setRenamingGuestId] = useState<string | null>(null)
     const [renamingGuestName, setRenamingGuestName] = useState('')
@@ -342,20 +337,12 @@ export function ViewPackingList() {
     // by killing the tab is remembered just as well as one navigated away from.
     useEffect(() => {
         saveListViewPreferences(id, {
-            viewMode,
             showPacked,
             collapsedSections: [...collapsedSections],
             collapsedGroups: [...collapsedGroups],
         })
-    }, [id, viewMode, showPacked, collapsedSections, collapsedGroups])
+    }, [id, showPacked, collapsedSections, collapsedGroups])
 
-
-    const toggleGroup = (key: string) =>
-        setCollapsedGroups(prev => {
-            const next = new Set(prev)
-            if (next.has(key)) { next.delete(key) } else { next.add(key) }
-            return next
-        })
 
     const toggleSection = (sectionKey: string) => {
         // Once the user has arranged the list themselves, the note explaining
@@ -464,15 +451,6 @@ export function ViewPackingList() {
         [packingList?.items, packingList?.deletedItems],
     )
 
-    // The sections a new item can be filed into: the ones this list already
-    // shows, in the order it shows them, plus the catch-all. Offering sections
-    // the list doesn't use would invent cards no one asked for — new sections
-    // belong to the question set, where they can be arranged.
-    const categoryOptions = useMemo(() => {
-        const labels = groupByCategory(packingList?.items ?? [], sectionOrder).map(group => group.label)
-        return labels.includes(UNCATEGORISED_LABEL) ? labels : [...labels, UNCATEGORISED_LABEL]
-    }, [packingList?.items, sectionOrder])
-
     const peopleOptions = useMemo<PersonOption[]>(() => {
         const byName = new Map<string, string>()
         for (const guest of packingList?.guests ?? []) byName.set(guest.name, guest.id)
@@ -499,8 +477,37 @@ export function ViewPackingList() {
         [peopleOptions, packingList?.items],
     )
 
+    const filtering = isFiltered(selectedPeople)
+    /**
+     * Whose chips the cards draw. Handed to the grid and to nothing else: the
+     * rows themselves, and the row panel that says who needs what, are built
+     * from the full column set, because which cells exist is a fact about the
+     * list rather than about what is on screen.
+     */
+    const visibleColumnKeys = filtering ? selectedPeople : undefined
 
-    const { register, setValue, getValues, control, reset } = useForm<FormData>({
+    const handleTogglePerson = useCallback((name: string) => {
+        setShowEmptyCategories(false)
+        setSelectedPeople(prev => togglePerson(prev, name))
+    }, [])
+    const handleClearFilter = useCallback(() => {
+        setShowEmptyCategories(false)
+        setSelectedPeople(new Set<string>())
+    }, [])
+
+    /**
+     * The column the filter is down to, when it is down to exactly one person.
+     *
+     * The unassigned column is never one: "Unassigned" is a useful thing to
+     * filter by — it is every item nobody has claimed yet — but it is not
+     * somebody to rename, remove, or pack a bag for.
+     */
+    const solePerson = selectedPeople.size === 1
+        ? gridColumns.find(column => column.key === [...selectedPeople][0] && !column.unassigned)
+        : undefined
+
+
+    const { setValue, getValues, control, reset } = useForm<FormData>({
         defaultValues: {
             items: {}
         }
@@ -524,6 +531,40 @@ export function ViewPackingList() {
         setValue(`items.${item.id}`, checked)
         handleItemToggle(item.id, checked)
     }, [setValue, handleItemToggle])
+
+    // What each person still has to pack, over the whole list — the figure sits
+    // on their chip, which is readable from anywhere, so it has to mean the same
+    // thing from anywhere.
+    const peopleTotals = useMemo(
+        () => personTotals(packingList?.items ?? [], watchedItems),
+        [packingList?.items, watchedItems],
+    )
+
+    /**
+     * Everything of one person's, packed in a stroke.
+     *
+     * The old key was deliberately inert because the one thing it could do was
+     * this, and doing it by accident is nine items changed with no way back. A
+     * labelled button behind a filter answers the accident; the undo answers the
+     * rest, which a confirmation dialog never did — a dialog you meet often is a
+     * dialog you learn to dismiss.
+     */
+    const handlePackAllFor = useCallback((personName: string) => {
+        const before = { ...getValues('items') }
+        const toPack = (packingList?.items ?? []).filter(
+            item => !item.communal && item.personName === personName && !before[item.id],
+        )
+        if (toPack.length === 0) return
+        // The effect watching the form's values does the saving; setting them
+        // here is the whole of the change.
+        for (const item of toPack) setValue(`items.${item.id}`, true)
+        showToast(`Packed ${toPack.length} of ${personName}'s items`, 'success', undefined, {
+            label: 'Undo',
+            onAction: () => {
+                for (const item of toPack) setValue(`items.${item.id}`, before[item.id] === true)
+            },
+        })
+    }, [getValues, packingList?.items, setValue, showToast])
 
     const registerCellRef = useCallback((itemId: string, element: HTMLElement | null) => {
         if (element) itemRowRefs.current.set(itemId, element)
@@ -957,52 +998,6 @@ export function ViewPackingList() {
         }
     }
 
-    const handleStartEdit = (item: PackingListItem) => {
-        setEditingItemId(item.id)
-        setEditingItemText(item.itemText)
-        setEditingItemQuantity(item.quantity !== undefined ? String(item.quantity) : '')
-    }
-
-    const handleCancelEdit = () => {
-        setEditingItemId(null)
-        setEditingItemText('')
-        setEditingItemQuantity('')
-    }
-
-    const handleSaveEdit = async (itemId: string) => {
-        const trimmed = editingItemText.trim()
-        if (!trimmed) {
-            handleCancelEdit()
-            return
-        }
-        if (!packingList) return
-
-        const parsedQuantity = parseInt(editingItemQuantity, 10)
-        const quantity = Number.isFinite(parsedQuantity) && parsedQuantity > 0 ? parsedQuantity : undefined
-
-        try {
-            setAutoSaveStatus('saving')
-
-            const now = new Date().toISOString()
-            const updatedItems = packingList.items.map(item =>
-                item.id === itemId
-                    ? { ...item, itemText: trimmed, quantity, lastModified: now }
-                    : item
-            )
-            await persistPackingList({ ...packingList, items: updatedItems })
-
-            setAutoSaveStatus('saved')
-            setTimeout(() => setAutoSaveStatus('idle'), 2000)
-        } catch (err) {
-            reportError(err, 'Error saving item name')
-            setAutoSaveStatus('error')
-        } finally {
-            setEditingItemId(null)
-            setEditingItemText('')
-            setEditingItemQuantity('')
-        }
-    }
-
     /**
      * Everything a row of the category grid can be asked to do, in one place.
      *
@@ -1167,8 +1162,6 @@ export function ViewPackingList() {
         (target: AddItemTarget, itemText: string, quantity?: number) => {
             addItemRef.current(target, itemText, quantity)
         }, [])
-    const closeComposer = useCallback(() => setOpenComposerKey(null), [])
-
     const handleAddGuest = async () => {
         if (!packingList || !newGuestName.trim()) return
         const guest = { id: crypto.randomUUID(), name: newGuestName.trim() }
@@ -1218,20 +1211,6 @@ export function ViewPackingList() {
     // nothing on a list that is in fact half done.
     const formHydrated = totalCount === 0 || Object.keys(watchedItems).length > 0
 
-    // Per-section and per-group stats are wanted by the auto-fold effect as well
-    // as by the rendering below, so they're derived here rather than inline in
-    // the JSX — effects can't live after the early returns.
-    const sectionStats = useMemo(() => {
-        const stats: Record<string, SectionStats> = {}
-        for (const item of listItems ?? []) {
-            const key = personViewSectionKey(item)
-            stats[key] ??= { packed: 0, total: 0 }
-            stats[key].total++
-            if (watchedItems[item.id]) stats[key].packed++
-        }
-        return stats
-    }, [listItems, watchedItems])
-
     // Stats per category, used by question-centric top-level sections. Communal
     // items count here too: question view files them under their category
     // alongside everyone else's, so a section's total has to include them.
@@ -1248,47 +1227,19 @@ export function ViewPackingList() {
         return stats
     }, [listItems, watchedItems])
 
-    // Stats for the groups *inside* a section. Both views are keyed here because
-    // both are one toggle away: person view groups a person's items by category,
-    // question view groups a category's items by person (communal items under
-    // the shared key), and the person-view shared card groups by category.
-    const groupStats = useMemo(() => {
-        const stats: Record<string, SectionStats> = {}
-        const count = (key: string, packed: boolean) => {
-            stats[key] ??= { packed: 0, total: 0 }
-            stats[key].total++
-            if (packed) stats[key].packed++
-        }
-        for (const item of listItems ?? []) {
-            const category = item.category ?? UNCATEGORISED_LABEL
-            const packed = !!watchedItems[item.id]
-            // The last minute card groups by person, and holds its items whole:
-            // they are not also counted under the section they were lifted from.
-            if (item.lastMinute) {
-                const personKey = item.communal ? SHARED_SECTION_KEY : (item.personName || UNASSIGNED_LABEL)
-                count(`${LAST_MINUTE_SECTION_KEY}::${personKey}`, packed)
-                continue
-            }
-            if (item.communal) {
-                count(`${SHARED_SECTION_KEY}::${category}`, packed)
-                count(`${category}::${SHARED_SECTION_KEY}`, packed)
-                continue
-            }
-            count(`${item.personName}::${category}`, packed)
-            count(`${category}::${item.personName || UNASSIGNED_LABEL}`, packed)
-        }
-        return stats
-    }, [listItems, watchedItems])
-
     // Which top-level sections have nothing left to pack, keyed the way the
     // active view keys them. Sorted so the value is stable enough to compare.
     const completeSectionKeys = useMemo(() => {
-        const stats = viewMode === 'person' ? sectionStats : categoryStats
-        return Object.entries(stats)
+        // A filter narrows a card to one person's part of it, and one person
+        // finishing their share of Toiletries is not Toiletries being done.
+        // Folding on it would also write the fold to storage, so a filter used
+        // once would leave the list folded up for good.
+        if (filtering) return []
+        return Object.entries(categoryStats)
             .filter(([, sectionStat]) => isSectionComplete(sectionStat))
             .map(([key]) => key)
             .sort()
-    }, [viewMode, sectionStats, categoryStats])
+    }, [filtering, categoryStats])
     // Depending on the joined form rather than the array keeps the fold timer
     // below from being cancelled and restarted by every unrelated re-render.
     const completeSectionSignature = completeSectionKeys.join(KEY_SEPARATOR)
@@ -1300,19 +1251,24 @@ export function ViewPackingList() {
     // alone: a freshly generated list is a thing worth showing someone, and
     // folding it would trade the payoff for tidiness it doesn't need.
     useLayoutEffect(() => {
-        if (listSeenBefore || hasSeededFoldRef.current || !listItems) return
+        if (hasSeededFoldRef.current || !listItems) return
         if (listItems.length <= FOLD_ON_OPEN_MIN_ITEMS) return
 
         // Keyed the way the view the list is about to open in keys them —
         // folding people away while the page is showing categories folds
         // nothing at all.
-        const sectionKeys = new Set(listItems.map(item => viewMode === 'category'
-            ? (item.lastMinute ? LAST_MINUTE_SECTION_KEY : (item.category ?? UNCATEGORISED_LABEL))
-            : personViewSectionKey(item)))
-        // Guests with nothing in them yet still have a card to fold
-        if (viewMode === 'person') {
-            for (const guest of packingList?.guests ?? []) sectionKeys.add(guest.name)
-        }
+        const sectionKeys = new Set(listItems.map(item => (
+            item.lastMinute ? LAST_MINUTE_SECTION_KEY : (item.category ?? UNCATEGORISED_LABEL)
+        )))
+
+        // A list last left in the old person view has people's names folded
+        // away, and not one of them names a card any more — so it would open as
+        // a wall of everything, which is exactly what the fold exists to spare
+        // the user. Seeding once more puts it back the way they left it in the
+        // only sense that survives: folded.
+        const foldingAfterPersonView = listSeenBefore
+            && hasStalePersonViewSections(storedPreferences, [...sectionKeys])
+        if (listSeenBefore && !foldingAfterPersonView) return
         // Nothing to fold *into* — one long section stays open, since folding it
         // would leave the user looking at a single closed box.
         if (sectionKeys.size < 2) return
@@ -1320,8 +1276,7 @@ export function ViewPackingList() {
         hasSeededFoldRef.current = true
         setCollapsedSections(prev => new Set([...prev, ...sectionKeys]))
         setFoldedOnOpen(true)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- viewMode is read once, when the list first opens
-    }, [listSeenBefore, listItems, packingList?.guests])
+    }, [listSeenBefore, listItems, storedPreferences])
 
     // Showing packed items is a request to see everything, so it hands back the
     // sections this page folded away — but not the ones the user folded, which
@@ -1429,48 +1384,12 @@ export function ViewPackingList() {
     const foldPending = allPacked && wasAllPackedRef.current === false && !showPacked
     const bannerHidden = sectionsExiting || foldPending
 
-    const guestNames = new Set((packingList.guests ?? []).map(g => g.name))
-    const personIdByName = new Map(peopleOptions.map(person => [person.name, person.id]))
-    // Only worth offering a section picker once the list has sections to pick.
-    const sectionChoices = categoryOptions.length > 1 ? categoryOptions : undefined
     // A section's card asks who an item is for, and "the whole group" is one of
     // the answers — it is how a shared item gets added in question view, where
     // there is no shared card to type into. Last, so the picker still opens on a
     // person: most items are somebody's.
     const sectionPeopleChoices: PersonOption[] = [...peopleOptions, { name: SHARED_GROUP_LABEL, id: '', communal: true }]
 
-    // Build grouped item map, seeding guest names so their sections exist even when empty
-    const groupedItems: Record<string, PackingListItem[]> = {}
-    for (const guest of (packingList.guests ?? [])) groupedItems[guest.name] = []
-    // Seed fully packed people too, so finishing someone off leaves a celebration
-    // behind rather than silently removing their card along with their last item.
-    for (const [name, stats] of Object.entries(sectionStats)) {
-        if (name === SHARED_SECTION_KEY || name === LAST_MINUTE_SECTION_KEY) continue
-        if (isSectionComplete(stats)) groupedItems[name] ??= []
-    }
-    for (const item of filteredItems) {
-        if (item.communal || item.lastMinute) continue
-        if (!groupedItems[item.personName]) groupedItems[item.personName] = []
-        groupedItems[item.personName].push(item)
-    }
-
-    // Person view gives communal items a card of their own, first, because they
-    // are the one part of the list that is nobody's. Question view has no use
-    // for it: there the sections are the question set's, and a shared item
-    // belongs to its section as much as anyone's does — see below.
-    const hasCommunalItems = packingList.items.some(i => i.communal && !i.lastMinute)
-    const visibleCommunalItems = filteredItems.filter(i => i.communal && !i.lastMinute)
-    // Like person sections, the shared section disappears when all its items are
-    // packed and packed items are hidden.
-    const sharedSections: ListSection[] = (visibleCommunalItems.length > 0 || showSharedSection || isSectionComplete(sectionStats[SHARED_SECTION_KEY]))
-        ? [{
-            key: SHARED_SECTION_KEY,
-            title: 'Shared Items',
-            name: '',
-            communal: true,
-            items: visibleCommunalItems,
-        }]
-        : []
 
     // The one card that outranks both groupings: whatever it is grouped by, an
     // item you can't pack yet doesn't belong among the ones you can. It comes
@@ -1482,73 +1401,116 @@ export function ViewPackingList() {
             title: LAST_MINUTE_TITLE,
             name: '',
             lastMinute: true,
-            // Person view reads the filtered items directly; the grid takes all
-            // of them and decides row by row what to show — see below.
             items: filteredItems.filter(i => i.lastMinute),
-            ...(viewMode === 'category'
-                ? { rows: buildCategoryRows(lastMinuteItems, gridColumns) }
-                : {}),
+            rows: buildCategoryRows(lastMinuteItems, gridColumns),
         }]
         : []
 
-    let listSections: ListSection[]
-    if (viewMode === 'person') {
-        // Regular people (from question set) alphabetically, then guests in add-order
-        const regularSections: ListSection[] = Object.entries(groupedItems)
-            .filter(([name]) => !guestNames.has(name))
-            .sort(([a], [b]) => a.localeCompare(b))
-            .map(([name, items]) => ({ key: name, title: `${name}'s Items`, name, items }))
-        const guestSections: ListSection[] = (packingList.guests ?? [])
-            .map(g => ({
-                key: g.name,
-                title: `${g.name}'s Items`,
-                name: g.name,
-                guestId: g.id,
-                items: groupedItems[g.name] ?? [],
-            }))
-        listSections = [...sharedSections, ...regularSections, ...guestSections, ...lastMinuteSections]
-    } else {
-        // Communal items are filed by category here, same as everyone else's —
-        // they sit among the rows of the section they belong to rather than in a
-        // card of their own.
-        //
-        // Every item goes into the grid, packed ones included: a cell that
-        // disappeared when it was ticked would leave a gap indistinguishable
-        // from a person who never needed the item, and telling those two apart
-        // is the whole of what the grid is for. Hiding what's packed is decided
-        // a row at a time, inside the grid.
-        const categorySections: ListSection[] = groupByCategory(packingList.items.filter(i => !i.lastMinute), sectionOrder)
-            .map(({ label, items }) => ({
-                key: label,
-                title: label,
-                name: '',
-                items,
-                isCategory: true,
-                rows: buildCategoryRows(items, gridColumns),
-            }))
-        listSections = [...categorySections, ...lastMinuteSections]
+    // Communal items are filed by category, same as everyone else's — they sit
+    // among the rows of the section they belong to rather than in a card of
+    // their own.
+    //
+    // Every item goes into the grid, packed ones included: a cell that
+    // disappeared when it was ticked would leave a gap indistinguishable from a
+    // person who never needed the item, and telling those two apart is the whole
+    // of what the grid is for. Hiding what's packed is decided a row at a time,
+    // inside the grid.
+    const allCategorySections: ListSection[] = groupByCategory(packingList.items.filter(i => !i.lastMinute), sectionOrder)
+        .map(({ label, items }) => ({
+            key: label,
+            title: label,
+            name: '',
+            items,
+            isCategory: true,
+            rows: buildCategoryRows(items, gridColumns),
+        }))
+
+    /**
+     * A category holds something for the people being packed for.
+     *
+     * Shared items don't count. "What is left for the baby in Camping?" is not
+     * a question the group's tent answers, and a card kept alive by one is a
+     * card the user opens to find nothing of what they were looking for.
+     */
+    const hasSomethingForFilter = (section: ListSection) => !filtering || (section.rows ?? []).some(
+        row => !row.communal && row.items.some(item => selectedPeople.has(item.personName || UNASSIGNED_COLUMN_KEY)),
+    )
+
+    // Under a filter the empty ones go rather than staying as muted headers.
+    // Person view used to answer "what is left for Alice?" with one card; the
+    // same question answered with three real cards adrift in nine empty ones
+    // would be a worse list, not a simpler app. What is missing is said in one
+    // line under the cards instead, and that line puts them back.
+    const emptyForFilter = filtering ? allCategorySections.filter(section => !hasSomethingForFilter(section)) : []
+    const categorySections = filtering && !showEmptyCategories
+        ? allCategorySections.filter(hasSomethingForFilter)
+        : allCategorySections
+    const listSections: ListSection[] = [...categorySections, ...lastMinuteSections]
+
+    const soleGuest = solePerson === undefined
+        ? undefined
+        : (packingList.guests ?? []).find(guest => guest.name === solePerson.name)
+    const solePersonUnpacked = solePerson === undefined
+        ? 0
+        : packingList.items.filter(
+            item => !item.communal && item.personName === solePerson.name && !watchedItems[item.id],
+        ).length
+    const filterAnnouncement = filterSummary(selectedPeople, categorySections.length, allCategorySections.length)
+
+    /** " for Alice" — what makes a filtered count a number about somebody. */
+    const filterQualifier = filtering
+        ? ` for ${[...selectedPeople].sort((a, b) => a.localeCompare(b)).join(', ')}`
+        : ''
+
+    /**
+     * What "Check all" on a card ticks: what the card is showing. Under a
+     * filter that is the selected people's items and not the group's tent —
+     * packing Alice's bag should never quietly pack for everyone.
+     */
+    const checkableItemsOf = (section: ListSection) => (section.rows ?? []).flatMap(row => (
+        row.communal
+            ? (filtering ? [] : row.items)
+            : row.items.filter(item => !filtering || selectedPeople.has(item.personName || UNASSIGNED_COLUMN_KEY))
+    ))
+
+    /** What a card holds for the people being packed for, not for everybody. */
+    const filteredStatsFor = (section: ListSection) => {
+        let packed = 0
+        let total = 0
+        for (const row of section.rows ?? []) {
+            // Shared items belong to no one person, so counting them here would
+            // put the tent in Alice's total and in Bob's.
+            if (row.communal) continue
+            for (const item of row.items) {
+                if (!selectedPeople.has(item.personName || UNASSIGNED_COLUMN_KEY)) continue
+                total += 1
+                if (watchedItems[item.id]) packed += 1
+            }
+        }
+        return { packed, total }
     }
 
     // How much of the list the grid is holding back: the items on rows where
     // every cell is already packed, which are the only ones it hides.
-    const hiddenGridItemCount = showPacked || viewMode === 'person'
+    const hiddenGridItemCount = showPacked
         ? 0
         : listSections.reduce((count, section) => count + (section.rows ?? []).reduce(
-            (rowCount, row) =>
-                rowCount + (row.items.length > 0 && row.items.every(item => watchedItems[item.id]) ? row.items.length : 0),
+            (rowCount, row) => {
+                // Counted the way the grid hides them: over the cells actually
+                // on screen, so a filter's numbers describe the filter.
+                const shown = filtering && !row.communal
+                    ? row.items.filter(item => selectedPeople.has(item.personName || UNASSIGNED_COLUMN_KEY))
+                    : row.items
+                return rowCount + (shown.length > 0 && shown.every(item => watchedItems[item.id]) ? shown.length : 0)
+            },
             0,
         ), 0)
 
     // What the banner offers to bring back has to be what is actually missing.
-    // Person view hides every packed item; category view hides a row only once
-    // every cell on it is packed, so most of a half-packed list is still on
-    // screen and counting all of it would send the user looking for items that
-    // are right in front of them.
-    const hiddenPackedCount = showPacked
-        ? 0
-        : viewMode === 'person'
-            ? packingList.items.filter(item => watchedItems[item.id]).length
-            : hiddenGridItemCount
+    // A row is hidden only once every cell on it is packed, so most of a
+    // half-packed list is still on screen and counting all of it would send the
+    // user looking for items that are right in front of them.
+    const hiddenPackedCount = showPacked ? 0 : hiddenGridItemCount
 
     // The panel shows a row that is rebuilt from the list on every render, so it
     // has to be found again each time rather than held. By key first; by one of
@@ -1612,18 +1574,6 @@ export function ViewPackingList() {
                         </div>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
-                        {/* The reveal opens an empty shared *card*, which only
-                            person view has — category view offers "Shared" in
-                            each section's who-for picker instead. */}
-                        {!foreignPodUrl && viewMode === 'person' && !hasCommunalItems && !showSharedSection && (
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                onClick={() => setShowSharedSection(true)}
-                            >
-                                + Add Shared Items
-                            </Button>
-                        )}
                         {!foreignPodUrl && (
                             <Button
                                 type="button"
@@ -1742,29 +1692,6 @@ export function ViewPackingList() {
                                         {everySectionFolded ? (isDesktop ? 'Expand all' : 'Expand') : (isDesktop ? 'Collapse all' : 'Collapse')}
                                     </button>
                                 )}
-                                {/* "View" is what the group is labelled; repeating it in both
-                                    buttons is what pushes this row off a 390px screen. The
-                                    accessible name keeps the full wording either way. */}
-                                <div className="flex shrink-0 items-center rounded-md border border-gray-300 overflow-hidden" role="group" aria-label="View mode">
-                                    <button
-                                        type="button"
-                                        aria-pressed={viewMode === 'person'}
-                                        aria-label="Person View"
-                                        onClick={() => setViewMode('person')}
-                                        className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors ${viewMode === 'person' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
-                                    >
-                                        {isDesktop ? 'Person View' : 'Person'}
-                                    </button>
-                                    <button
-                                        type="button"
-                                        aria-pressed={viewMode === 'category'}
-                                        aria-label="Category View"
-                                        onClick={() => setViewMode('category')}
-                                        className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors border-l border-gray-300 ${viewMode === 'category' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
-                                    >
-                                        {isDesktop ? 'Category View' : 'Category'}
-                                    </button>
-                                </div>
                                 <Button
                                     type="button"
                                     variant={hiddenPackedCount > 0 ? 'primary' : 'secondary'}
@@ -1774,31 +1701,90 @@ export function ViewPackingList() {
                                 </Button>
                             </div>
                         </div>
-                        {/* Which coloured initial is whose, written once and kept
-                            in view rather than repeated on every card — a key is
-                            only any use while you are looking at the thing it
-                            explains. Nothing here is pressable: the one thing it
-                            could do is pack somebody's whole category on a stray
-                            tap, and person view has a button that says so. */}
-                        {viewMode === 'category' && gridColumns.length > 0 && (
-                            <div
-                                data-testid="people-key"
-                                className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-gray-100 pt-1.5"
-                            >
-                                {gridColumns.map(column => (
-                                    <span key={column.key} className="flex items-center gap-1 text-[11px] font-medium text-gray-600">
-                                        {!column.unassigned && (
-                                            <PersonAvatar
-                                                name={column.name}
-                                                color={personColor({ id: column.personId, name: column.name })}
-                                                size="sm"
+                        {/* Which coloured initial is whose — and, since it already
+                            names everyone the cards can show, which of them the
+                            user is packing for. */}
+                        <div data-testid="people-key">
+                            <PeopleFilterBar
+                                columns={gridColumns}
+                                selected={selectedPeople}
+                                totals={peopleTotals}
+                                personColor={personColor}
+                                onToggle={handleTogglePerson}
+                                onClear={handleClearFilter}
+                                controlsId={LIST_SECTIONS_ID}
+                            />
+                        </div>
+                        {/* Held open whether or not it has anything in it: it
+                            appears as the selection crosses one person, under a
+                            sticky header, with the user's finger on the chips —
+                            and a page that jumps a row on every tap is worse
+                            than one that keeps an empty line. */}
+                        {gridColumns.length > 1 && (
+                            <div className="mt-1.5 flex min-h-[2.25rem] flex-wrap items-center gap-2 border-t border-gray-100 pt-1.5">
+                                {solePerson !== undefined ? (
+                                    <>
+                                        {soleGuest && renamingGuestId === soleGuest.id ? (
+                                            <input
+                                                type="text"
+                                                aria-label={`Rename ${soleGuest.name}`}
+                                                value={renamingGuestName}
+                                                onChange={(e) => setRenamingGuestName(e.target.value)}
+                                                onKeyDown={(e) => {
+                                                    if (e.key === 'Enter') { e.preventDefault(); handleRenameGuest(soleGuest.id, renamingGuestName) }
+                                                    if (e.key === 'Escape') { setRenamingGuestId(null); setRenamingGuestName('') }
+                                                }}
+                                                onBlur={() => handleRenameGuest(soleGuest.id, renamingGuestName)}
+                                                autoFocus
+                                                className="w-40 rounded-md border border-blue-400 px-2 py-1 text-xs font-semibold text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
                                             />
+                                        ) : (
+                                            <span className="text-xs font-semibold text-gray-700">{solePerson.name}</span>
                                         )}
-                                        {column.name}
+                                        {soleGuest && (
+                                            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">Guest</span>
+                                        )}
+                                        {solePersonUnpacked > 0 && (
+                                            <button
+                                                type="button"
+                                                onClick={() => handlePackAllFor(solePerson.name)}
+                                                className="rounded-full border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-100"
+                                            >
+                                                {/* The number is in the button, where it
+                                                    is read before the tap rather than in a
+                                                    dialog after it. */}
+                                                Pack all {solePersonUnpacked} of {solePerson.name}'s
+                                            </button>
+                                        )}
+                                        {soleGuest && !foreignPodUrl && renamingGuestId !== soleGuest.id && (
+                                            <>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => { setRenamingGuestId(soleGuest.id); setRenamingGuestName(soleGuest.name) }}
+                                                    className="rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                                                >
+                                                    Rename
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setGuestToRemove(soleGuest.id)}
+                                                    className="rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-red-50 hover:text-red-700"
+                                                >
+                                                    Remove
+                                                </button>
+                                            </>
+                                        )}
+                                    </>
+                                ) : (
+                                    <span className="text-xs text-gray-400">
+                                        {filtering ? 'Packing for more than one person' : 'Everyone\u2019s items'}
                                     </span>
-                                ))}
+                                )}
                             </div>
                         )}
+                        {/* Announced rather than shown: the strip above says the
+                            same thing in colour and position. */}
+                        <p role="status" aria-live="polite" className="sr-only">{filterAnnouncement}</p>
                     </div>
                 </div>
             </div>
@@ -1901,91 +1887,65 @@ export function ViewPackingList() {
                         celebrations, so they fold away and leave the banner as the
                         last thing standing — the fold itself is the celebration.
                         Showing packed items brings them straight back. */}
-                    {/* Person view's cards are narrow and ragged, so they flow
-                        into masonry columns. A grid card is a table that has to
-                        be read across, so category view stacks them instead —
+                    {/* A grid card is a table that has to be read across, so the
+                        cards stack rather than flowing into masonry columns —
                         two abreast once there is room for two tables. */}
                     {!sectionsPackedAway && <div
-                        className={`${sectionsExiting ? 'sections-packing-away' : ''} ${viewMode === 'category' ? 'grid grid-cols-1 items-start gap-4 xl:grid-cols-2' : ''}`}
-                        style={viewMode === 'category' ? undefined : { columnWidth: '300px', columnGap: '1rem' }}
+                        id={LIST_SECTIONS_ID}
+                        className={`${sectionsExiting ? 'sections-packing-away' : ''} grid grid-cols-1 items-start gap-4 xl:grid-cols-2`}
                     >
                         {listSections.map((section) => {
-                            const { key: sectionKey, title, items, guestId } = section
-                            const isCategorySection = section.isCategory === true
-                            const stats = isCategorySection
-                                ? (categoryStats[sectionKey] ?? { packed: 0, total: 0 })
-                                : (sectionStats[sectionKey] ?? { packed: 0, total: 0 })
-                            const isGuest = guestId !== undefined
-                            const isShared = section.communal === true
+                            const { key: sectionKey, title, items } = section
+                            const unfilteredStats = categoryStats[sectionKey] ?? { packed: 0, total: 0 }
+                            // A card says what is on it. Under a filter that is
+                            // one person's part of the category, so the count
+                            // says whose — an unqualified "2 / 5" beside a page
+                            // total of "24 / 58" is a number with no referent.
+                            const stats = filtering ? filteredStatsFor(section) : unfilteredStats
                             const isLastMinute = section.lastMinute === true
-                            const isComplete = isSectionComplete(stats)
-                            const completeLabel = isShared ? 'shared items' : (isCategorySection || isLastMinute) ? title : section.name
-                            const collapseLabelTarget = isShared ? 'the shared items' : isLastMinute ? 'the last minute items' : isCategorySection ? title : `${section.name}'s`
-                            // The last minute card holds everybody's, so it groups
-                            // by person the way a category card does.
-                            // Category view arranges a section as a grid; person
-                            // view still folds each card into groups, and so does
-                            // the last minute card while it is being read by
-                            // person.
-                            const isGridSection = viewMode === 'category' && (isCategorySection || isLastMinute)
-                            const innerGroups: ItemGroup[] = isGridSection
-                                ? []
-                                : (isCategorySection || isLastMinute)
-                                    ? groupByPerson(items)
-                                    : groupByCategory(items, sectionOrder).map(({ label, items: groupItems }) => ({ key: label, label, items: groupItems }))
+                            // Emerald borders, the "all packed" pill and the
+                            // fold-away are how this app says the trip is done.
+                            // One person finishing their share of a category is
+                            // not that, so under a filter a card keeps its
+                            // ordinary clothes and the person's own chip goes
+                            // green instead.
+                            const isComplete = !filtering && isSectionComplete(unfilteredStats)
+                            const completeLabel = title
+                            const collapseLabelTarget = isLastMinute ? 'the last minute items' : title
+                            // Every card is a grid now: the name down the side,
+                            // the people across it. There are no groups folded
+                            // inside one any more — the people filter above the
+                            // cards is what narrows a card to somebody.
+                            const isGridSection = true
                             const isSectionCollapsed = collapsedSections.has(sectionKey)
-                            // Only a card that belongs to one person can wear
-                            // their colour: a category card holds everybody's.
-                            const sectionPersonColor = (isShared || isCategorySection || isLastMinute)
-                                ? undefined
-                                : personColor({ id: guestId ?? personIdByName.get(section.name) ?? '', name: section.name })
                             const sectionBorder = isComplete
                                 ? 'border-emerald-300 bg-emerald-50'
                                 // Amber, because the card is a reminder rather than
                                 // a pile: nothing in it can be dealt with yet.
                                 : isLastMinute
                                     ? 'border-amber-300 bg-amber-50'
-                                    : `bg-white ${sectionPersonColor?.border ?? (isShared ? 'border-blue-200' : 'border-gray-200')}`
+                                    : 'bg-white border-gray-200'
                             return (
-                            <div key={sectionKey} data-testid="list-section" className={`border rounded-lg p-3 shadow-sm transition-colors duration-300 sm:p-4 ${viewMode === 'category' ? '' : 'mb-4'} ${sectionBorder}`} style={{ breakInside: 'avoid' }}>
+                            <div key={sectionKey} data-testid="list-section" className={`border rounded-lg p-3 shadow-sm transition-colors duration-300 sm:p-4 ${sectionBorder}`} style={{ breakInside: 'avoid' }}>
                                 {/* The rule under the heading separates it from the items
                                     below; a folded card has none, so it would just be a
                                     line ruling off empty space. */}
                                 <div className={isSectionCollapsed ? undefined : 'mb-4 pb-2 border-b border-gray-200'}>
                                     <div className="flex flex-wrap items-center gap-1 min-h-[2rem]">
-                                        {isGuest && renamingGuestId === guestId ? (
-                                            <>
-                                                <span className="text-sm text-gray-400 px-1" aria-hidden>▼</span>
-                                                <input
-                                                    type="text"
-                                                    value={renamingGuestName}
-                                                    onChange={(e) => setRenamingGuestName(e.target.value)}
-                                                    onKeyDown={(e) => {
-                                                        if (e.key === 'Enter') { e.preventDefault(); handleRenameGuest(guestId, renamingGuestName) }
-                                                        if (e.key === 'Escape') { setRenamingGuestId(null); setRenamingGuestName('') }
-                                                    }}
-                                                    onBlur={() => handleRenameGuest(guestId, renamingGuestName)}
-                                                    autoFocus
-                                                    className="flex-1 px-2 py-1 border border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-lg font-semibold text-gray-800"
-                                                />
-                                            </>
-                                        ) : (
-                                            <button
-                                                type="button"
-                                                aria-label={`${isSectionCollapsed ? 'Expand' : 'Collapse'} ${collapseLabelTarget} list`}
-                                                onClick={() => toggleSection(sectionKey)}
-                                                className="flex items-center gap-2 flex-1 min-w-0 text-left"
-                                            >
-                                                <span className="shrink-0 text-sm text-gray-400">{isSectionCollapsed ? '▶' : '▼'}</span>
-                                                {sectionPersonColor && (
-                                                    <PersonAvatar name={section.name} color={sectionPersonColor} />
-                                                )}
-                                                <span className="text-xl font-semibold text-gray-800">{title}</span>
-                                                {/* Never let a count break across lines — "9 /" above "9" is
-                                                    a fraction the eye has to reassemble. */}
-                                                <span className="ml-1 shrink-0 whitespace-nowrap text-sm font-normal text-gray-500">{stats.packed} / {stats.total}</span>
-                                            </button>
-                                        )}
+                                        <button
+                                            type="button"
+                                            aria-label={`${isSectionCollapsed ? 'Expand' : 'Collapse'} ${collapseLabelTarget} list`}
+                                            onClick={() => toggleSection(sectionKey)}
+                                            className="flex items-center gap-2 flex-1 min-w-0 text-left"
+                                        >
+                                            <span className="shrink-0 text-sm text-gray-400">{isSectionCollapsed ? '▶' : '▼'}</span>
+                                            <span className="text-xl font-semibold text-gray-800">{title}</span>
+                                            {/* Never let a count break across lines — "9 /" above "9" is
+                                                a fraction the eye has to reassemble. */}
+                                            <span className="ml-1 shrink-0 whitespace-nowrap text-sm font-normal text-gray-500">
+                                                {stats.packed} / {stats.total}{filterQualifier}
+                                            </span>
+                                        </button>
                                         {isComplete && (
                                             <span
                                                 aria-label={`All packed for ${completeLabel}`}
@@ -1994,35 +1954,19 @@ export function ViewPackingList() {
                                                 🎉 All packed!
                                             </span>
                                         )}
-                                        {isShared && (
-                                            <span className="text-xs font-medium text-blue-700 bg-blue-100 rounded-full px-2 py-0.5 shrink-0" title="Packed once for the whole group">
-                                                👥 For everyone
-                                            </span>
-                                        )}
-                                        {isGuest && renamingGuestId !== guestId && (
-                                            <>
-                                                <span className="text-xs font-medium text-amber-700 bg-amber-100 rounded-full px-2 py-0.5 shrink-0">Guest</span>
-                                                <button
-                                                    type="button"
-                                                    aria-label={`Rename ${section.name}`}
-                                                    onClick={() => { setRenamingGuestId(guestId); setRenamingGuestName(section.name) }}
-                                                    className="p-2 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-md transition-colors"
-                                                >
-                                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                                                        <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-                                                    </svg>
-                                                </button>
-                                                <button
-                                                    type="button"
-                                                    aria-label={`Remove ${section.name}`}
-                                                    onClick={() => setGuestToRemove(guestId)}
-                                                    className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
-                                                >
-                                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                                                        <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
-                                                    </svg>
-                                                </button>
-                                            </>
+                                        {/* Used to sit on each folded group inside a card. The
+                                            groups have gone, so it works on the card — and with
+                                            the filter above, "check all of Alice's toiletries"
+                                            is this button with Alice selected. */}
+                                        {!isSectionCollapsed && stats.packed < stats.total && (
+                                            <button
+                                                type="button"
+                                                aria-label={`Check all${filterQualifier} in ${title}`}
+                                                onClick={() => handleCheckAll(checkableItemsOf(section))}
+                                                className="shrink-0 rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-50"
+                                            >
+                                                Check all
+                                            </button>
                                         )}
                                     </div>
                                 </div>
@@ -2037,16 +1981,20 @@ export function ViewPackingList() {
                                         knows who, and asks which section; a section's card knows
                                         which section, and asks who. */}
                                     <div className="mb-4 pb-4 border-b border-gray-200">
+                                        {/* The card knows which section it is;
+                                            who it is for follows the filter when
+                                            the filter names one person, so an
+                                            item typed while packing Alice's bag
+                                            doesn't land somewhere she can't see
+                                            it. */}
                                         <AddItemComposer
-                                            personName={(isCategorySection || isLastMinute) ? '' : section.name}
-                                            personId={(isCategorySection || isLastMinute) ? '' : (guestId ?? personIdByName.get(section.name) ?? '')}
-                                            communal={section.communal}
-                                            category={isCategorySection ? categoryFromLabel(title) : undefined}
+                                            personName={solePerson?.name ?? ''}
+                                            personId={solePerson?.personId ?? ''}
+                                            category={isLastMinute ? undefined : categoryFromLabel(title)}
                                             lastMinute={isLastMinute}
-                                            categoryOptions={(isCategorySection || isLastMinute) ? undefined : sectionChoices}
-                                            peopleOptions={(isCategorySection || isLastMinute) ? sectionPeopleChoices : undefined}
+                                            peopleOptions={sectionPeopleChoices}
                                             suggestions={suggestionIndex}
-                                            targetLabel={isShared ? 'shared items' : isLastMinute ? 'last minute items' : isCategorySection ? title : `${section.name}'s items`}
+                                            targetLabel={isLastMinute ? 'last minute items' : title}
                                             onAdd={handleComposerAdd}
                                         />
                                     </div>
@@ -2058,6 +2006,7 @@ export function ViewPackingList() {
                                     {isGridSection && (
                                         <CategoryItemGrid
                                             columns={gridColumns}
+                                            visibleColumnKeys={visibleColumnKeys}
                                             rows={section.rows ?? []}
                                             personColor={personColor}
                                             packedById={watchedItems}
@@ -2072,247 +2021,28 @@ export function ViewPackingList() {
                                             onOpenRow={(row) => setOpenRowKeys({ sectionKey, rowKey: row.key, anchorItemId: row.items[0]?.id })}
                                         />
                                     )}
-                                    {!isGridSection && innerGroups.map(({ key: groupKey, label, items: catItems, communal: isSharedGroup }) => {
-                                        const categoryKey = `${sectionKey}::${groupKey}`
-                                        const isCollapsed = collapsedGroups.has(categoryKey)
-                                        // Counted over every item in the group, not the ones on
-                                        // screen: with packed items hidden, "2" next to a group
-                                        // seven-ninths done reads as a group barely started.
-                                        const groupStat = groupStats[categoryKey] ?? { packed: catItems.length, total: catItems.length }
-                                        // Both views end up describing the same place; only which
-                                        // half the card supplies changes.
-                                        const groupLabel = (isCategorySection || isLastMinute)
-                                            ? `${title} for ${isSharedGroup ? 'shared items' : label}`
-                                            : `${label} for ${isShared ? 'shared items' : section.name}`
-                                        const groupTarget: AddItemTarget = (isCategorySection || isLastMinute)
-                                            ? {
-                                                personName: isSharedGroup ? '' : label,
-                                                personId: isSharedGroup ? '' : (personIdByName.get(label) ?? ''),
-                                                communal: isSharedGroup,
-                                                // A last minute item's section is
-                                                // the last minute card itself.
-                                                ...(isLastMinute
-                                                    ? { lastMinute: true }
-                                                    : { category: categoryFromLabel(title) }),
-                                            }
-                                            : {
-                                                personName: section.name,
-                                                personId: guestId ?? personIdByName.get(section.name) ?? '',
-                                                communal: section.communal,
-                                                category: categoryFromLabel(label),
-                                            }
-                                        const composerOpen = openComposerKey === categoryKey
-                                        return (
-                                            <div key={categoryKey} className="mb-3">
-                                                <div className="flex items-center justify-between gap-2 py-1 mb-1">
-                                                    <button
-                                                        type="button"
-                                                        aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${label}`}
-                                                        onClick={() => toggleGroup(categoryKey)}
-                                                        className="flex items-center gap-1 text-left text-sm font-semibold text-gray-600 hover:text-gray-900"
-                                                    >
-                                                        <span>{isCollapsed ? '▶' : '▼'}</span>
-                                                        {/* A category card's groups are people, so each one
-                                                            gets the same mark its owner's card would have.
-                                                            The catch-all and shared groups are nobody's —
-                                                            the shared one says so instead. */}
-                                                        {isSharedGroup && (
-                                                            <span aria-hidden title="Packed once for the whole group">👥</span>
-                                                        )}
-                                                        {(isCategorySection || isLastMinute) && !isSharedGroup && label !== UNASSIGNED_LABEL && (
-                                                            <PersonAvatar
-                                                                name={label}
-                                                                color={personColor({ id: personIdByName.get(label) ?? '', name: label })}
-                                                                size="sm"
-                                                            />
-                                                        )}
-                                                        <span>{label}</span>
-                                                        <span className="ml-1 shrink-0 whitespace-nowrap text-xs font-normal text-gray-400">{groupStat.packed} / {groupStat.total}</span>
-                                                    </button>
-                                                    {!isCollapsed && (
-                                                        <div className="flex shrink-0 items-center gap-2">
-                                                            {/* Adding straight into a group is the whole point: the
-                                                                item lands where it was typed instead of falling
-                                                                into the catch-all section. */}
-                                                            <button
-                                                                type="button"
-                                                                aria-label={`Add item to ${groupLabel}`}
-                                                                aria-expanded={composerOpen}
-                                                                onClick={() => setOpenComposerKey(composerOpen ? null : categoryKey)}
-                                                                className={`rounded-full border px-2.5 py-1 text-xs font-semibold transition-colors ${composerOpen ? 'border-blue-300 bg-blue-100 text-blue-800' : 'border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100'}`}
-                                                            >
-                                                                {/* A section name is what the heading is for; on a
-                                                                    phone the word "Add" is what pushes it off. */}
-                                                                {isDesktop ? '+ Add' : '+'}
-                                                            </button>
-                                                            <button
-                                                                type="button"
-                                                                aria-label="Check all"
-                                                                onClick={() => handleCheckAll(catItems)}
-                                                                className="text-xs text-blue-600 hover:text-blue-800"
-                                                            >
-                                                                Check all
-                                                            </button>
-                                                        </div>
-                                                    )}
-                                                </div>
-                                                {!isCollapsed && composerOpen && (
-                                                    <div className="mb-2">
-                                                        <AddItemComposer
-                                                            personName={groupTarget.personName}
-                                                            personId={groupTarget.personId}
-                                                            communal={groupTarget.communal}
-                                                            category={groupTarget.category}
-                                                            lastMinute={groupTarget.lastMinute}
-                                                            suggestions={suggestionIndex}
-                                                            targetLabel={groupLabel}
-                                                            placeholder={`Add to ${label}...`}
-                                                            onAdd={handleComposerAdd}
-                                                            onClose={closeComposer}
-                                                            autoFocus
-                                                        />
-                                                    </div>
-                                                )}
-                                                {!isCollapsed && (
-                                                    <div className="space-y-2">
-                                                        {catItems.map((item) => (
-                                                            <div
-                                                                key={`${item.id}-${sectionKey}`}
-                                                                data-testid={`item-row-${item.id}`}
-                                                                ref={(el) => {
-                                                                    if (el) itemRowRefs.current.set(item.id, el)
-                                                                    else itemRowRefs.current.delete(item.id)
-                                                                }}
-                                                                className={`relative rounded-lg p-3 transition-colors duration-1000 ${item.id === highlightedItem?.id ? 'bg-green-100 ring-2 ring-green-400' : 'bg-gray-50'} ${item.id === flourish?.itemId ? 'item-row-packed' : ''}`}
-                                                            >
-                                                                {item.id === flourish?.itemId && (
-                                                                    <span
-                                                                        key={flourish.nonce}
-                                                                        data-testid={`item-tick-${item.id}`}
-                                                                        aria-hidden="true"
-                                                                        // Themed green rather than text-green-600 — that class is the
-                                                                        // "Saved" indicator's, and the e2e suite waits on it by selector
-                                                                        // Anchored over the checkbox; the animation owns the transform,
-                                                                        // so no translate utilities here. Themed green rather than
-                                                                        // text-green-600 — that class belongs to the "Saved" indicator,
-                                                                        // which the e2e suite waits on by selector.
-                                                                        className="item-packed-tick pointer-events-none absolute left-[22px] top-1/2 z-10 text-xl font-bold text-success-600"
-                                                                    >
-                                                                        ✓
-                                                                    </span>
-                                                                )}
-                                                                <div className="flex items-center justify-between">
-                                                                    <label className="flex items-center space-x-3 cursor-pointer flex-1 min-w-0">
-                                                                        <input
-                                                                            type="checkbox"
-                                                                            {...register(`items.${item.id}`, {
-                                                                                onChange: (e) => handleItemToggle(item.id, e.target.checked),
-                                                                            })}
-                                                                            className="h-5 w-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
-                                                                        />
-                                                                        {editingItemId === item.id ? (
-                                                                            <span
-                                                                                className="flex items-center gap-1 flex-1 min-w-0"
-                                                                                onBlur={(e) => {
-                                                                                    // Only save when focus leaves both the name and quantity inputs
-                                                                                    if (!e.currentTarget.contains(e.relatedTarget)) handleSaveEdit(item.id)
-                                                                                }}
-                                                                            >
-                                                                                <input
-                                                                                    type="text"
-                                                                                    value={editingItemText}
-                                                                                    onChange={(e) => setEditingItemText(e.target.value)}
-                                                                                    onKeyDown={(e) => {
-                                                                                        if (e.key === 'Enter') { e.preventDefault(); handleSaveEdit(item.id) }
-                                                                                        if (e.key === 'Escape') { e.preventDefault(); handleCancelEdit() }
-                                                                                    }}
-                                                                                    autoFocus
-                                                                                    aria-label="Edit item name"
-                                                                                    className="flex-1 min-w-0 px-2 py-1 border border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm text-gray-700"
-                                                                                />
-                                                                                <input
-                                                                                    type="number"
-                                                                                    min={1}
-                                                                                    value={editingItemQuantity}
-                                                                                    onChange={(e) => setEditingItemQuantity(e.target.value)}
-                                                                                    onKeyDown={(e) => {
-                                                                                        if (e.key === 'Enter') { e.preventDefault(); handleSaveEdit(item.id) }
-                                                                                        if (e.key === 'Escape') { e.preventDefault(); handleCancelEdit() }
-                                                                                    }}
-                                                                                    placeholder="Qty"
-                                                                                    aria-label="Edit item quantity"
-                                                                                    title="How many to pack (leave blank for no quantity)"
-                                                                                    className="w-12 sm:w-16 shrink-0 px-1.5 sm:px-2 py-1 border border-blue-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm text-gray-700"
-                                                                                />
-                                                                            </span>
-                                                                        ) : (
-                                                                            <span
-                                                                                className={watchedItems[item.id] ? 'text-gray-400 line-through' : 'text-gray-700'}
-                                                                                onDoubleClick={() => handleStartEdit(item)}
-                                                                            >
-                                                                                {item.itemText}
-                                                                                {item.quantity !== undefined && item.quantity > 1 && (
-                                                                                    <span className="ml-1.5 text-xs font-semibold text-blue-700 bg-blue-100 rounded-full px-1.5 py-0.5 align-middle">
-                                                                                        ×{item.quantity}
-                                                                                    </span>
-                                                                                )}
-                                                                            </span>
-                                                                        )}
-                                                                    </label>
-                                                                    {editingItemId !== item.id && (
-                                                                        <button
-                                                                            type="button"
-                                                                            onClick={() => handleToggleLastMinute(item)}
-                                                                            aria-pressed={item.lastMinute === true}
-                                                                            aria-label={item.lastMinute
-                                                                                ? `Remove ${item.itemText} from the last minute items`
-                                                                                : `Mark ${item.itemText} as a last minute item`}
-                                                                            title={item.lastMinute
-                                                                                ? 'Packed with everything else after all'
-                                                                                : "Can't be packed until just before you go"}
-                                                                            className={`ml-1 rounded-md p-1 transition-colors hover:bg-amber-50 hover:text-amber-600 ${item.lastMinute ? 'text-amber-600' : 'text-gray-400'}`}
-                                                                        >
-                                                                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                                                                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.5 2.5a1 1 0 101.414-1.414L11 9.586V6z" clipRule="evenodd" />
-                                                                            </svg>
-                                                                        </button>
-                                                                    )}
-                                                                    {editingItemId !== item.id && (
-                                                                        <button
-                                                                            type="button"
-                                                                            onClick={() => handleStartEdit(item)}
-                                                                            className="ml-1 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-md p-1 transition-colors"
-                                                                            title="Edit item"
-                                                                        >
-                                                                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                                                                <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-                                                                            </svg>
-                                                                        </button>
-                                                                    )}
-                                                                    {editingItemId !== item.id && (
-                                                                    <button
-                                                                        type="button"
-                                                                        onClick={() => setItemToDelete(item.id)}
-                                                                        className="ml-2 text-red-600 hover:text-red-800 hover:bg-red-50 rounded-md p-1 transition-colors"
-                                                                        title="Delete item"
-                                                                    >
-                                                                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                                                            <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
-                                                                        </svg>
-                                                                    </button>
-                                                                    )}
-                                                                </div>
-                                                            </div>
-                                                        ))}
-                                                    </div>
-                                                )}
-                                            </div>
-                                        )
-                                    })}
                                 </div>}
                             </div>
                         )})}
                     </div>}
+                    {/* What the filter took off the page, said once. The grid's
+                        fixed columns exist so that a gap is an answer — nobody
+                        has packed a thing for the baby in here — and dropping
+                        nine cards silently would throw that answer away. */}
+                    {!sectionsPackedAway && emptyForFilter.length > 0 && (
+                        <p className="mt-3 text-sm text-gray-500">
+                            {emptyForFilter.length} {emptyForFilter.length === 1 ? 'category has' : 'categories have'} nothing
+                            {filterQualifier}
+                            {' — '}
+                            <button
+                                type="button"
+                                onClick={() => setShowEmptyCategories(true)}
+                                className="font-semibold text-blue-700 underline underline-offset-2 hover:text-blue-900"
+                            >
+                                show {emptyForFilter.length === 1 ? 'it' : 'them'}
+                            </button>
+                        </p>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1181,6 +1181,16 @@ export function ViewPackingList() {
         if (!trimmed) return
         const oldGuest = (packingList.guests ?? []).find(g => g.id === guestId)
         if (!oldGuest || trimmed === oldGuest.name) return
+        // The filter holds names. Leave the old one in it and the page stays
+        // filtered to somebody no chip names any more — every card empty, no
+        // chip pressed, and nothing on screen to undo it.
+        setSelectedPeople(prev => {
+            if (!prev.has(oldGuest.name)) return prev
+            const next = new Set(prev)
+            next.delete(oldGuest.name)
+            next.add(trimmed)
+            return next
+        })
         await persistPackingList({
             ...packingList,
             guests: (packingList.guests ?? []).map(g => g.id === guestId ? { ...g, name: trimmed } : g),
@@ -1191,6 +1201,15 @@ export function ViewPackingList() {
 
     const handleRemoveGuest = async (guestId: string) => {
         if (!packingList) return
+        const guest = (packingList.guests ?? []).find(g => g.id === guestId)
+        if (guest) {
+            setSelectedPeople(prev => {
+                if (!prev.has(guest.name)) return prev
+                const next = new Set(prev)
+                next.delete(guest.name)
+                return next
+            })
+        }
         await persistPackingList({
             ...packingList,
             guests: (packingList.guests ?? []).filter(g => g.id !== guestId),
@@ -1442,6 +1461,7 @@ export function ViewPackingList() {
     // would be a worse list, not a simpler app. What is missing is said in one
     // line under the cards instead, and that line puts them back.
     const emptyForFilter = filtering ? allCategorySections.filter(section => !hasSomethingForFilter(section)) : []
+    const emptyCategoriesShown = filtering && showEmptyCategories && emptyForFilter.length > 0
     const categorySections = filtering && !showEmptyCategories
         ? allCategorySections.filter(hasSomethingForFilter)
         : allCategorySections
@@ -1450,11 +1470,11 @@ export function ViewPackingList() {
     const soleGuest = solePerson === undefined
         ? undefined
         : (packingList.guests ?? []).find(guest => guest.name === solePerson.name)
-    const solePersonUnpacked = solePerson === undefined
-        ? 0
-        : packingList.items.filter(
-            item => !item.communal && item.personName === solePerson.name && !watchedItems[item.id],
-        ).length
+    const solePersonItems = solePerson === undefined
+        ? []
+        : packingList.items.filter(item => !item.communal && item.personName === solePerson.name)
+    const solePersonTotal = solePersonItems.length
+    const solePersonUnpacked = solePersonItems.filter(item => !watchedItems[item.id]).length
     const filterAnnouncement = filterSummary(selectedPeople, categorySections.length, allCategorySections.length)
 
     /** " for Alice" — what makes a filtered count a number about somebody. */
@@ -1715,14 +1735,16 @@ export function ViewPackingList() {
                                 controlsId={LIST_SECTIONS_ID}
                             />
                         </div>
-                        {/* Held open whether or not it has anything in it: it
-                            appears as the selection crosses one person, under a
-                            sticky header, with the user's finger on the chips —
-                            and a page that jumps a row on every tap is worse
-                            than one that keeps an empty line. */}
-                        {gridColumns.length > 1 && (
-                            <div className="mt-1.5 flex min-h-[2.25rem] flex-wrap items-center gap-2 border-t border-gray-100 pt-1.5">
-                                {solePerson !== undefined ? (
+                        {/* Only while a filter is on: unfiltered it held a line
+                            of grey text restating the strip above it, which is a
+                            36th of a phone screen spent on nothing. Within a
+                            filter its height doesn't change, so moving between
+                            people never shifts the cards. It scrolls rather than
+                            wraps for the same reason the strip does — a guest's
+                            row of controls is wider than a phone. */}
+                        {filtering && (
+                            <div className="mt-1.5 flex min-h-[2.75rem] items-center gap-2 overflow-x-auto border-t border-gray-100 pt-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                                {solePerson !== undefined && (
                                     <>
                                         {soleGuest && renamingGuestId === soleGuest.id ? (
                                             <input
@@ -1736,19 +1758,27 @@ export function ViewPackingList() {
                                                 }}
                                                 onBlur={() => handleRenameGuest(soleGuest.id, renamingGuestName)}
                                                 autoFocus
-                                                className="w-40 rounded-md border border-blue-400 px-2 py-1 text-xs font-semibold text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                                className="w-40 shrink-0 rounded-md border border-blue-400 px-2 py-1 text-xs font-semibold text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
                                             />
                                         ) : (
-                                            <span className="text-xs font-semibold text-gray-700">{solePerson.name}</span>
+                                            <span className="shrink-0 text-xs font-semibold text-gray-700">{solePerson.name}</span>
                                         )}
-                                        {soleGuest && (
-                                            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">Guest</span>
+                                        {soleGuest && renamingGuestId !== soleGuest.id && (
+                                            <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">Guest</span>
                                         )}
-                                        {solePersonUnpacked > 0 && (
+                                        {/* One person finishing their bag is a
+                                            real thing to have done. The trip's
+                                            own celebration stays for the trip,
+                                            but this shouldn't pass in silence. */}
+                                        {solePersonUnpacked === 0 && solePersonTotal > 0 ? (
+                                            <span className="shrink-0 whitespace-nowrap rounded-full border border-emerald-200 bg-emerald-100 px-2.5 py-1 text-xs font-semibold text-emerald-700">
+                                                🎉 {solePerson.name}'s bag is packed!
+                                            </span>
+                                        ) : solePersonUnpacked > 0 && (
                                             <button
                                                 type="button"
                                                 onClick={() => handlePackAllFor(solePerson.name)}
-                                                className="rounded-full border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-100"
+                                                className="shrink-0 whitespace-nowrap rounded-full border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-100"
                                             >
                                                 {/* The number is in the button, where it
                                                     is read before the tap rather than in a
@@ -1761,24 +1791,35 @@ export function ViewPackingList() {
                                                 <button
                                                     type="button"
                                                     onClick={() => { setRenamingGuestId(soleGuest.id); setRenamingGuestName(soleGuest.name) }}
-                                                    className="rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                                                    className="shrink-0 rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
                                                 >
                                                     Rename
                                                 </button>
                                                 <button
                                                     type="button"
                                                     onClick={() => setGuestToRemove(soleGuest.id)}
-                                                    className="rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-red-50 hover:text-red-700"
+                                                    className="shrink-0 rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-red-50 hover:text-red-700"
                                                 >
                                                     Remove
                                                 </button>
                                             </>
                                         )}
                                     </>
-                                ) : (
-                                    <span className="text-xs text-gray-400">
-                                        {filtering ? 'Packing for more than one person' : 'Everyone\u2019s items'}
-                                    </span>
+                                )}
+                                {/* Cards vanishing is an alarming thing for a
+                                    packing list to do, and the explanation used
+                                    to sit three thousand pixels below the cause.
+                                    It belongs where the filter is. */}
+                                {emptyForFilter.length > 0 && (
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowEmptyCategories(shown => !shown)}
+                                        className="ml-auto shrink-0 whitespace-nowrap rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                                    >
+                                        {emptyCategoriesShown
+                                            ? `Hide ${emptyForFilter.length} empty`
+                                            : `${emptyForFilter.length} empty — show`}
+                                    </button>
                                 )}
                             </div>
                         )}
@@ -2025,24 +2066,6 @@ export function ViewPackingList() {
                             </div>
                         )})}
                     </div>}
-                    {/* What the filter took off the page, said once. The grid's
-                        fixed columns exist so that a gap is an answer — nobody
-                        has packed a thing for the baby in here — and dropping
-                        nine cards silently would throw that answer away. */}
-                    {!sectionsPackedAway && emptyForFilter.length > 0 && (
-                        <p className="mt-3 text-sm text-gray-500">
-                            {emptyForFilter.length} {emptyForFilter.length === 1 ? 'category has' : 'categories have'} nothing
-                            {filterQualifier}
-                            {' — '}
-                            <button
-                                type="button"
-                                onClick={() => setShowEmptyCategories(true)}
-                                className="font-semibold text-blue-700 underline underline-offset-2 hover:text-blue-900"
-                            >
-                                show {emptyForFilter.length === 1 ? 'it' : 'them'}
-                            </button>
-                        </p>
-                    )}
                 </div>
             </div>
         </div>

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1477,10 +1477,18 @@ export function ViewPackingList() {
     const solePersonUnpacked = solePersonItems.filter(item => !watchedItems[item.id]).length
     const filterAnnouncement = filterSummary(selectedPeople, categorySections.length, allCategorySections.length)
 
-    /** " for Alice" — what makes a filtered count a number about somebody. */
-    const filterQualifier = filtering
-        ? ` for ${[...selectedPeople].sort((a, b) => a.localeCompare(b)).join(', ')}`
-        : ''
+    /**
+     * " for Alice" — what makes a filtered count a number about somebody.
+     *
+     * Only ever one name: past that it says how many, because a comma-joined
+     * list beside a fraction reads as a truncated list, and on a phone it runs
+     * straight under the button beside it. The strip above says which people.
+     */
+    const filterQualifier = !filtering
+        ? ''
+        : selectedPeople.size === 1
+            ? ` for ${[...selectedPeople][0]}`
+            : ` for ${selectedPeople.size} people`
 
     /**
      * What "Check all" on a card ticks: what the card is showing. Under a
@@ -1731,7 +1739,6 @@ export function ViewPackingList() {
                                 totals={peopleTotals}
                                 personColor={personColor}
                                 onToggle={handleTogglePerson}
-                                onClear={handleClearFilter}
                                 controlsId={LIST_SECTIONS_ID}
                             />
                         </div>
@@ -1744,6 +1751,13 @@ export function ViewPackingList() {
                             row of controls is wider than a phone. */}
                         {filtering && (
                             <div className="mt-1.5 flex min-h-[2.75rem] items-center gap-2 overflow-x-auto border-t border-gray-100 pt-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                                <button
+                                    type="button"
+                                    onClick={handleClearFilter}
+                                    className="shrink-0 rounded-full border border-blue-200 px-2.5 py-1 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-50"
+                                >
+                                    Clear
+                                </button>
                                 {solePerson !== undefined && (
                                     <>
                                         {soleGuest && renamingGuestId === soleGuest.id ? (
@@ -2066,6 +2080,16 @@ export function ViewPackingList() {
                             </div>
                         )})}
                     </div>}
+                    {!sectionsPackedAway && listSections.length === 0 && filtering && (
+                        <div className="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-center">
+                            <p className="text-sm font-medium text-gray-700">
+                                Nothing on this list is{filterQualifier} yet.
+                            </p>
+                            <p className="mt-1 text-sm text-gray-500">
+                                Show the empty sections above to add the first thing, or pick somebody else.
+                            </p>
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/utils/categoryItemGrid.test.ts
+++ b/src/utils/categoryItemGrid.test.ts
@@ -206,3 +206,38 @@ describe('buildCategoryRows', () => {
         })
     })
 })
+
+describe('column initials', () => {
+    const initialsOf = (people: { name: string; id: string }[], items: PackingListItem[] = []) =>
+        buildGridColumns(people, items).map(column => column.initial)
+
+    it('uses a single letter when that is enough to tell everyone apart', () => {
+        expect(initialsOf([alice, bob])).toEqual(['A', 'B'])
+    })
+
+    it('grows the initial when two people share a first letter', () => {
+        expect(initialsOf([alice, { name: 'Amy', id: 'p3' }])).toEqual(['Al', 'Am'])
+    })
+
+    it('keeps every initial the same length, so the chips stay one size', () => {
+        const initials = initialsOf([alice, { name: 'Amy', id: 'p3' }, bob])
+
+        expect(initials).toEqual(['Al', 'Am', 'Bo'])
+    })
+
+    it('prefers first and last initials for someone with two names', () => {
+        expect(initialsOf([{ name: 'Alice Smith', id: 'p1' }, { name: 'Alice Jones', id: 'p2' }]))
+            .toEqual(['AS', 'AJ'])
+    })
+
+    it('goes to three letters when two will not do', () => {
+        expect(initialsOf([{ name: 'Alan', id: 'p1' }, { name: 'Alba', id: 'p2' }]))
+            .toEqual(['Ala', 'Alb'])
+    })
+
+    it('leaves the unassigned column its question mark', () => {
+        const columns = buildGridColumns([alice], [item({ id: '1', itemText: 'Torch' })])
+
+        expect(columns[1].initial).toBe('?')
+    })
+})

--- a/src/utils/categoryItemGrid.ts
+++ b/src/utils/categoryItemGrid.ts
@@ -41,6 +41,11 @@ export interface GridColumn {
     personId: string
     /** Nobody's in particular — items added without a person. */
     unassigned?: boolean
+    /**
+     * What the chip says when there is no room for the name — the shortest
+     * label that tells this person apart from everyone else in the list.
+     */
+    initial: string
 }
 
 export interface GridRow {
@@ -99,16 +104,66 @@ export function buildGridColumns(
     }
 
     const columns: GridColumn[] = [
-        ...people.map(person => ({ key: person.name, name: person.name, personId: person.id })),
+        ...people.map(person => ({ key: person.name, name: person.name, personId: person.id, initial: '' })),
         ...[...strangers.entries()]
             .sort(([a], [b]) => a.localeCompare(b))
-            .map(([name, personId]) => ({ key: name, name, personId })),
+            .map(([name, personId]) => ({ key: name, name, personId, initial: '' })),
     ]
     // Last, because it is where the eye should end up rather than start.
     if (anyUnassigned) {
-        columns.push({ key: UNASSIGNED_COLUMN_KEY, name: UNASSIGNED_COLUMN_LABEL, personId: '', unassigned: true })
+        columns.push({ key: UNASSIGNED_COLUMN_KEY, name: UNASSIGNED_COLUMN_LABEL, personId: '', unassigned: true, initial: '?' })
     }
-    return columns
+    return withInitials(columns)
+}
+
+/**
+ * The labels the chips wear.
+ *
+ * A chip carries a colour and a letter, and the letter is what a user who
+ * can't separate two colours has to read. One letter puts Alice and Amy in the
+ * same chip, and there is no longer a person view to fall back to — so the
+ * label grows until it tells everyone apart.
+ *
+ * Everyone grows together. Chips are one fixed size on purpose (see the note in
+ * `CategoryItemGrid`), and a list where one person wears two letters and the
+ * rest wear one is a list of chips that are not the same size.
+ *
+ * Three letters is the ceiling: past that the label stops fitting the disc, and
+ * the pair it would separate — Alice and Alison on one trip — still have their
+ * colours and their full names in every accessible label.
+ */
+const MAX_INITIAL_LENGTH = 3
+
+function candidateInitial(name: string, level: number): string {
+    const compact = name.replace(/\s+/g, ' ').trim()
+    if (compact === '') return '?'
+    const words = compact.split(' ')
+    if (level <= 0) return compact.slice(0, 1).toUpperCase()
+    // Someone with two names is better told apart by both of them than by the
+    // first two letters of the first: Alice Smith and Alice Jones share "Al".
+    if (level === 1 && words.length > 1) {
+        return (words[0]!.slice(0, 1) + words[words.length - 1]!.slice(0, 1)).toUpperCase()
+    }
+    const length = Math.min(level + 1, compact.length)
+    return compact.slice(0, 1).toUpperCase() + compact.slice(1, length).toLowerCase()
+}
+
+function withInitials(columns: GridColumn[]): GridColumn[] {
+    // The unassigned column is a '?' at every level, so it never forces the
+    // people's labels to grow and never collides with one of them.
+    const people = columns.filter(column => !column.unassigned)
+
+    for (let level = 0; level < MAX_INITIAL_LENGTH; level++) {
+        const labels = people.map(column => candidateInitial(column.name, level))
+        if (new Set(labels).size === labels.length) return applyLevel(columns, level)
+    }
+    return applyLevel(columns, MAX_INITIAL_LENGTH - 1)
+}
+
+function applyLevel(columns: GridColumn[], level: number): GridColumn[] {
+    return columns.map(column => (
+        column.unassigned ? column : { ...column, initial: candidateInitial(column.name, level) }
+    ))
 }
 
 /**

--- a/src/utils/listViewPreferences.test.ts
+++ b/src/utils/listViewPreferences.test.ts
@@ -5,6 +5,7 @@ import {
     saveListViewPreferences,
     listViewPreferencesKey,
     hasStoredListViewPreferences,
+    hasStalePersonViewSections,
 } from './listViewPreferences'
 
 describe('listViewPreferences', () => {
@@ -27,17 +28,15 @@ describe('listViewPreferences', () => {
 
         it('reads back what was saved', () => {
             saveListViewPreferences('list-1', {
-                viewMode: 'category',
                 showPacked: true,
-                collapsedSections: ['Alice', '__shared__'],
-                collapsedGroups: ['Alice::Clothes'],
+                collapsedSections: ['Toiletries', '__last_minute__'],
+                collapsedGroups: ['Toiletries::Alice'],
             })
 
             expect(loadListViewPreferences('list-1')).toEqual({
-                viewMode: 'category',
                 showPacked: true,
-                collapsedSections: ['Alice', '__shared__'],
-                collapsedGroups: ['Alice::Clothes'],
+                collapsedSections: ['Toiletries', '__last_minute__'],
+                collapsedGroups: ['Toiletries::Alice'],
             })
         })
 
@@ -61,16 +60,18 @@ describe('listViewPreferences', () => {
             expect(loadListViewPreferences('list-1')).toEqual(DEFAULT_LIST_VIEW_PREFERENCES)
         })
 
-        it('reads a list left in the old "question" view as the category view', () => {
-            localStorage.setItem(listViewPreferencesKey('list-1'), JSON.stringify({ viewMode: 'question' }))
+        it('drops the view mode entries written before the toggle was removed', () => {
+            localStorage.setItem(
+                listViewPreferencesKey('list-1'),
+                JSON.stringify({ viewMode: 'person', showPacked: true, collapsedSections: ['Toiletries'] }),
+            )
 
-            expect(loadListViewPreferences('list-1').viewMode).toBe('category')
-        })
+            const prefs = loadListViewPreferences('list-1')
 
-        it('ignores a view mode it does not recognise', () => {
-            localStorage.setItem(listViewPreferencesKey('list-1'), JSON.stringify({ viewMode: 'sideways' }))
-
-            expect(loadListViewPreferences('list-1').viewMode).toBe('person')
+            expect(prefs).not.toHaveProperty('viewMode')
+            // Everything alongside it still survives the read.
+            expect(prefs.showPacked).toBe(true)
+            expect(prefs.collapsedSections).toEqual(['Toiletries'])
         })
 
         it('ignores collapsed keys that are not strings', () => {
@@ -158,5 +159,25 @@ describe('listViewPreferences', () => {
 
             expect(hasStoredListViewPreferences('list-1')).toBe(false)
         })
+    })
+})
+
+describe('hasStalePersonViewSections', () => {
+    const sections = ['Toiletries', 'Clothes', '__last_minute__']
+
+    it('spots fold state left behind by the old person view', () => {
+        const prefs = { ...DEFAULT_LIST_VIEW_PREFERENCES, collapsedSections: ['Alice', 'Bob'] }
+
+        expect(hasStalePersonViewSections(prefs, sections)).toBe(true)
+    })
+
+    it('leaves alone fold state that still names a card', () => {
+        const prefs = { ...DEFAULT_LIST_VIEW_PREFERENCES, collapsedSections: ['Alice', 'Clothes'] }
+
+        expect(hasStalePersonViewSections(prefs, sections)).toBe(false)
+    })
+
+    it('is not stale when nothing was folded — that is a choice, not a leftover', () => {
+        expect(hasStalePersonViewSections(DEFAULT_LIST_VIEW_PREFERENCES, sections)).toBe(false)
     })
 })

--- a/src/utils/listViewPreferences.ts
+++ b/src/utils/listViewPreferences.ts
@@ -1,6 +1,6 @@
 /**
- * How the user last left a particular packing list: which view they were in,
- * whether packed items were showing, and which sections they had folded away.
+ * How the user last left a particular packing list: whether packed items were
+ * showing, and which sections they had folded away.
  *
  * A big family list is only manageable once you can put away the parts you
  * aren't packing right now — and that's worthless if the app forgets the moment
@@ -14,19 +14,15 @@
  * different bag.
  */
 
-export type ListViewMode = 'person' | 'category'
-
 export interface ListViewPreferences {
-    viewMode: ListViewMode
     showPacked: boolean
-    /** Keys of folded top-level sections — a person, a category, or the shared section. */
+    /** Keys of folded top-level sections — a category, or the last minute section. */
     collapsedSections: string[]
     /** Keys of folded groups within a section, in `sectionKey::groupLabel` form. */
     collapsedGroups: string[]
 }
 
 export const DEFAULT_LIST_VIEW_PREFERENCES: ListViewPreferences = {
-    viewMode: 'person',
     showPacked: false,
     collapsedSections: [],
     collapsedGroups: [],
@@ -88,13 +84,32 @@ export function loadListViewPreferences(listId: string | undefined): ListViewPre
 
     const stored = parsed as Partial<Record<keyof ListViewPreferences, unknown>>
     return {
-        // 'question' is what the category view was called before it was named
-        // after what it groups by. Lists left in it stay in it.
-        viewMode: stored.viewMode === 'category' || stored.viewMode === 'question' ? 'category' : 'person',
+        // Entries written before the person/category toggle was removed carry a
+        // `viewMode`. It is read by nothing now and simply dropped — there is
+        // one view, so there is nothing for it to choose between.
         showPacked: stored.showPacked === true,
         collapsedSections: stringsOnly(stored.collapsedSections),
         collapsedGroups: stringsOnly(stored.collapsedGroups),
     }
+}
+
+/**
+ * Whether this list's stored fold state was written by the old person view.
+ *
+ * The person/category toggle defaulted to person, so the grid was opt-in and
+ * most lists were never seen in it. Their stored `collapsedSections` are
+ * people's names, which match no card now: a user who had folded four of five
+ * people away opens a fully expanded wall of category cards instead, and the
+ * fold-on-open seeding won't rescue them because it only runs on a list's first
+ * open. Recognising those entries lets the page seed the fold once more.
+ */
+export function hasStalePersonViewSections(
+    prefs: ListViewPreferences,
+    currentSectionKeys: readonly string[],
+): boolean {
+    if (prefs.collapsedSections.length === 0) return false
+    const current = new Set(currentSectionKeys)
+    return !prefs.collapsedSections.some(key => current.has(key))
 }
 
 export function saveListViewPreferences(listId: string | undefined, prefs: ListViewPreferences): void {

--- a/src/utils/peopleFilter.test.ts
+++ b/src/utils/peopleFilter.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { togglePerson, isFiltered, filterSummary, personTotals } from './peopleFilter'
+import type { PackingListItem } from '../create-packing-list/types'
+
+function item(overrides: Partial<PackingListItem> & { id: string; itemText: string }): PackingListItem {
+    return {
+        personId: '',
+        personName: '',
+        questionId: 'q1',
+        optionId: 'o1',
+        packed: false,
+        ...overrides,
+    }
+}
+
+describe('togglePerson', () => {
+    it('selects only that person when nothing is filtered yet', () => {
+        expect([...togglePerson(new Set(), 'Alice')]).toEqual(['Alice'])
+    })
+
+    it('adds a second person to an existing selection', () => {
+        expect([...togglePerson(new Set(['Alice']), 'Bob')].sort()).toEqual(['Alice', 'Bob'])
+    })
+
+    it('takes a person back out of a selection', () => {
+        expect([...togglePerson(new Set(['Alice', 'Bob']), 'Alice')]).toEqual(['Bob'])
+    })
+
+    it('returns to no filter when the last person is tapped off', () => {
+        expect(togglePerson(new Set(['Bob']), 'Bob').size).toBe(0)
+    })
+
+    it('never mutates the set it was given', () => {
+        const before = new Set(['Alice'])
+        togglePerson(before, 'Bob')
+        expect([...before]).toEqual(['Alice'])
+    })
+})
+
+describe('isFiltered', () => {
+    it('is false for an empty selection, which means everyone', () => {
+        expect(isFiltered(new Set())).toBe(false)
+        expect(isFiltered(new Set(['Alice']))).toBe(true)
+    })
+})
+
+describe('personTotals', () => {
+    const items = [
+        item({ id: '1', itemText: 'Socks', personName: 'Alice', packed: true }),
+        item({ id: '2', itemText: 'Hat', personName: 'Alice' }),
+        item({ id: '3', itemText: 'Boots', personName: 'Bob' }),
+        item({ id: '4', itemText: 'Tent', communal: true, packed: true }),
+    ]
+
+    it("counts what is packed of each person's own items", () => {
+        const totals = personTotals(items, { '1': true, '4': true })
+
+        expect(totals.get('Alice')).toEqual({ packed: 1, total: 2 })
+        expect(totals.get('Bob')).toEqual({ packed: 0, total: 1 })
+    })
+
+    it('leaves shared items out, so no denominator is inflated by the tent', () => {
+        const totals = personTotals(items, { '1': true, '4': true })
+
+        expect([...totals.values()].reduce((sum, stat) => sum + stat.total, 0)).toBe(3)
+    })
+
+    it('reads packed state from the form rather than the stored item', () => {
+        const totals = personTotals(items, {})
+
+        expect(totals.get('Alice')).toEqual({ packed: 0, total: 2 })
+    })
+})
+
+describe('filterSummary', () => {
+    it('says nothing when there is no filter', () => {
+        expect(filterSummary(new Set(), 12, 12)).toBe('')
+    })
+
+    it('names the person and how much of the list is left, without guessing a pronoun', () => {
+        expect(filterSummary(new Set(['Alice']), 3, 12)).toBe("Showing Alice's items. 3 of 12 categories.")
+    })
+
+    it('lists two people rather than picking one', () => {
+        expect(filterSummary(new Set(['Alice', 'Bob']), 5, 12))
+            .toBe("Showing Alice and Bob's items. 5 of 12 categories.")
+    })
+
+    it('uses commas past two', () => {
+        expect(filterSummary(new Set(['Alice', 'Bob', 'Cara']), 9, 12))
+            .toBe("Showing Alice, Bob and Cara's items. 9 of 12 categories.")
+    })
+})

--- a/src/utils/peopleFilter.test.ts
+++ b/src/utils/peopleFilter.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { togglePerson, isFiltered, filterSummary, personTotals } from './peopleFilter'
+import {
+    togglePerson,
+    isFiltered,
+    filterSummary,
+    personTotals,
+    filterNames,
+    filterLabel,
+    sharedTotal,
+    SHARED_FILTER_KEY,
+} from './peopleFilter'
 import type { PackingListItem } from '../create-packing-list/types'
 
 function item(overrides: Partial<PackingListItem> & { id: string; itemText: string }): PackingListItem {
@@ -89,5 +98,51 @@ describe('filterSummary', () => {
     it('uses commas past two', () => {
         expect(filterSummary(new Set(['Alice', 'Bob', 'Cara']), 9, 12))
             .toBe("Showing Alice, Bob and Cara's items. 9 of 12 categories.")
+    })
+})
+
+describe('filterNames', () => {
+    it('is empty when nothing is selected', () => {
+        expect(filterNames(new Set())).toBe('')
+    })
+
+    it('names one person', () => {
+        expect(filterNames(new Set(['Alice']))).toBe('Alice')
+    })
+
+    it('joins two with "and", so the bar reads as a sentence', () => {
+        expect(filterNames(new Set(['Bob', 'Alice']))).toBe('Alice and Bob')
+    })
+
+    it('calls the shared chip the group, and puts it last', () => {
+        expect(filterNames(new Set([SHARED_FILTER_KEY, 'Alice']))).toBe('Alice and the group')
+        expect(filterNames(new Set([SHARED_FILTER_KEY]))).toBe('the group')
+    })
+})
+
+describe('filterLabel', () => {
+    // Beside a count, where a comma-joined list would read as a truncated one
+    it('names one person', () => {
+        expect(filterLabel(new Set(['Alice']))).toBe('Alice')
+    })
+
+    it('stops at a headcount past one', () => {
+        expect(filterLabel(new Set(['Alice', 'Bob']))).toBe('2 people')
+    })
+
+    it('calls the shared chip on its own "shared items"', () => {
+        expect(filterLabel(new Set([SHARED_FILTER_KEY]))).toBe('shared items')
+    })
+})
+
+describe('sharedTotal', () => {
+    it('counts the group’s items and nobody else’s', () => {
+        const items = [
+            item({ id: '1', itemText: 'Tent', communal: true, packed: true }),
+            item({ id: '2', itemText: 'Stove', communal: true }),
+            item({ id: '3', itemText: 'Socks', personName: 'Alice' }),
+        ]
+
+        expect(sharedTotal(items, { '1': true })).toEqual({ packed: 1, total: 2 })
     })
 })

--- a/src/utils/peopleFilter.ts
+++ b/src/utils/peopleFilter.ts
@@ -109,6 +109,21 @@ export function personTotals(
 }
 
 /**
+ * The selection written out — "Alice", "Alice and Bob", "Bob and the group".
+ *
+ * The long form, for the places with a line to spare: the bar under the strip,
+ * and what a screen reader is told. Beside a count it is `filterLabel` instead,
+ * which stops at a headcount.
+ */
+export function filterNames(selected: PeopleFilter): string {
+    const names = [...selected].filter(key => key !== SHARED_FILTER_KEY).sort((a, b) => a.localeCompare(b))
+    if (sharedSelected(selected)) names.push('the group')
+    if (names.length === 0) return ''
+    if (names.length === 1) return names[0]!
+    return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]!}`
+}
+
+/**
  * What a screen reader is told when the filter changes.
  *
  * Names are joined rather than reduced to one, and no pronoun is inferred from
@@ -118,10 +133,5 @@ export function personTotals(
  */
 export function filterSummary(selected: PeopleFilter, shownCategories: number, totalCategories: number): string {
     if (!isFiltered(selected)) return ''
-    const names = [...selected].filter(key => key !== SHARED_FILTER_KEY).sort((a, b) => a.localeCompare(b))
-    if (sharedSelected(selected)) names.push('the group')
-    const joined = names.length === 1
-        ? names[0]!
-        : `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]!}`
-    return `Showing ${joined}'s items. ${shownCategories} of ${totalCategories} categories.`
+    return `Showing ${filterNames(selected)}'s items. ${shownCategories} of ${totalCategories} categories.`
 }

--- a/src/utils/peopleFilter.ts
+++ b/src/utils/peopleFilter.ts
@@ -1,0 +1,83 @@
+/**
+ * Which of the list's people the user is packing for right now.
+ *
+ * The list view used to offer two whole views of the same data — one card per
+ * person, or one card per category — and made you choose between them in a
+ * toggle. The category grid already carries every person on every row, so the
+ * question person view existed to answer ("what is left for Alice?") is a
+ * matter of narrowing the grid rather than rebuilding it. This is that
+ * narrowing.
+ *
+ * An empty selection means everyone, not nobody. That is the resting state, so
+ * a list opens showing all of itself, and the way back to it is taking the last
+ * person out of the selection.
+ *
+ * Kept out of the page, and out of `categoryItemGrid`, deliberately: the grid's
+ * rows are a fact about the list rather than about what is on screen, so the
+ * filter lives beside them rather than inside them.
+ */
+import type { PackingListItem } from '../create-packing-list/types'
+
+/** Names of the selected people; empty means everyone. */
+export type PeopleFilter = ReadonlySet<string>
+
+export interface PersonStat { packed: number; total: number }
+
+/**
+ * The chip semantics: the first tap narrows to one person, later taps add and
+ * remove, and taking the last one out puts the whole list back.
+ *
+ * The first-tap case is not a special rule — an empty selection has nothing to
+ * remove — but it is the one that matters, because "I am packing Alice's bag
+ * now" is what almost every use of this starts as.
+ */
+export function togglePerson(selected: PeopleFilter, name: string): Set<string> {
+    const next = new Set(selected)
+    if (!next.delete(name)) next.add(name)
+    return next
+}
+
+export function isFiltered(selected: PeopleFilter): boolean {
+    return selected.size > 0
+}
+
+/**
+ * How much each person still has to pack, over the whole list rather than the
+ * part of it on screen — the number lives on their chip, which is visible from
+ * everywhere, so it has to mean the same thing from everywhere.
+ *
+ * Shared items are nobody's in particular and are counted nowhere here. Putting
+ * the tent in Alice's total and Bob's total would have the list's parts add up
+ * to more than the list.
+ */
+export function personTotals(
+    items: readonly PackingListItem[],
+    packedById: Record<string, boolean>,
+): Map<string, PersonStat> {
+    const totals = new Map<string, PersonStat>()
+    for (const item of items) {
+        if (item.communal || !item.personName) continue
+        const stat = totals.get(item.personName) ?? { packed: 0, total: 0 }
+        stat.total += 1
+        if (packedById[item.id]) stat.packed += 1
+        totals.set(item.personName, stat)
+    }
+    return totals
+}
+
+/**
+ * What a screen reader is told when the filter changes.
+ *
+ * Names are joined rather than reduced to one, and no pronoun is inferred from
+ * a name: "her items" is wrong for a Sam and wrong for every child called by a
+ * nickname, and the possessive on the list of names says the same thing without
+ * guessing.
+ */
+export function filterSummary(selected: PeopleFilter, shownCategories: number, totalCategories: number): string {
+    if (!isFiltered(selected)) return ''
+    const names = [...selected].sort((a, b) => a.localeCompare(b))
+    const joined = names.length === 1
+        ? names[0]!
+        : `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]!}`
+    return `Showing ${joined}'s items. ${shownCategories} of ${totalCategories} categories.`
+}

--- a/src/utils/peopleFilter.ts
+++ b/src/utils/peopleFilter.ts
@@ -18,7 +18,18 @@
  */
 import type { PackingListItem } from '../create-packing-list/types'
 
-/** Names of the selected people; empty means everyone. */
+/**
+ * The group's own place in the filter.
+ *
+ * Shared items belong to nobody, so no person's chip reaches them — and with
+ * every filter folding them away, the tent was only findable by clearing the
+ * filter or opening a disclosure on every card. It gets a chip of its own.
+ *
+ * Not a name: a person actually called "Shared" keeps their own chip.
+ */
+export const SHARED_FILTER_KEY = '__shared__'
+
+/** Keys of the selected chips — people's names, and `SHARED_FILTER_KEY`. */
 export type PeopleFilter = ReadonlySet<string>
 
 export interface PersonStat { packed: number; total: number }
@@ -39,6 +50,38 @@ export function togglePerson(selected: PeopleFilter, name: string): Set<string> 
 
 export function isFiltered(selected: PeopleFilter): boolean {
     return selected.size > 0
+}
+
+/** Whether the group's own items are among what the filter is asking for. */
+export function sharedSelected(selected: PeopleFilter): boolean {
+    return selected.has(SHARED_FILTER_KEY)
+}
+
+/** How many of the group's own items are packed — the Shared chip's numbers. */
+export function sharedTotal(
+    items: readonly PackingListItem[],
+    packedById: Record<string, boolean>,
+): PersonStat {
+    const communal = items.filter(item => item.communal)
+    return {
+        packed: communal.filter(item => packedById[item.id]).length,
+        total: communal.length,
+    }
+}
+
+/**
+ * What a filtered count is *of*, as it reads beside the number.
+ *
+ * One name where there is one, "the group" for the shared chip, and a headcount
+ * past that: a comma-joined list beside a fraction reads as a truncated list,
+ * and on a phone it runs under the button beside it.
+ */
+export function filterLabel(selected: PeopleFilter): string {
+    if (!isFiltered(selected)) return ''
+    const people = [...selected].filter(key => key !== SHARED_FILTER_KEY)
+    if (people.length === 0) return 'shared items'
+    if (selected.size === 1) return people[0]!
+    return `${people.length}${sharedSelected(selected) ? '' : ''} people`
 }
 
 /**
@@ -75,7 +118,8 @@ export function personTotals(
  */
 export function filterSummary(selected: PeopleFilter, shownCategories: number, totalCategories: number): string {
     if (!isFiltered(selected)) return ''
-    const names = [...selected].sort((a, b) => a.localeCompare(b))
+    const names = [...selected].filter(key => key !== SHARED_FILTER_KEY).sort((a, b) => a.localeCompare(b))
+    if (sharedSelected(selected)) names.push('the group')
     const joined = names.length === 1
         ? names[0]!
         : `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]!}`


### PR DESCRIPTION
The list view offered two whole views of the same data and made the user
choose between them. The category grid already carries every person on
every row, so the question person view existed to answer — "what is left
for Alice?" — is a matter of narrowing the grid rather than rebuilding
it. The key above the cards already named everyone the grid can show, so
it becomes the control that does the narrowing.

Multi-select is the point: {Alice, Bob} — the suitcase they share — is
something neither view could do.

- The strip is one line, scrolled rather than wrapped: it is sticky above
  a progress line and a controls row that already goes to two lines on a
  phone, and packing a bag one-handed in a hallway is what this is for.
  Counts ride on the selected chip only, so no chip moves when pressed.
- Filtering narrows the chips the grid draws, never `gridColumns`: rows
  line up with the full column set, and the row panel — the only route to
  "Bob needs one too" — walks the same set.
- A section with nothing for the selection is dropped, not muted. Person
  view answered with one card; the same answer in three real cards adrift
  in nine empty ones is a worse list. A line under the cards says how many
  went and puts them back.
- Cards describe the filter, the page describes the list. A filtered count
  says whose ("1 / 2 for Alice"), and filtering never fires the emerald
  pill, the fold-away or the confetti: one person finishing their share of
  a category is not the trip being packed.
- Shared items fold into one line under a filter and are counted in
  nobody's total, so no denominator is inflated by the tent.
- Filter-driven collapse is never written to storage; the fold-on-complete
  effect is exempt while a filter is on. Otherwise one use of the filter
  would leave the list folded up for good.
- Chip initials grow until they tell everyone apart (Alice/Amy -> Al/Am).
  Colour alone was the only distinction, and there is no longer a person
  view to fall back on.
- Guest rename/remove and "pack all of X's" move to a context bar whose
  height is always reserved. Pack-all names its count in the button and
  is taken back with an Undo toast rather than guarded by a dialog.
- Per-group "Check all" moves to the card header, over the filtered rows.
- The composer follows the filter when it names one person, so an item
  added while packing Alice's bag doesn't land where she can't see it.
- The filter is not persisted, and a list last left in person view gets
  its fold seeded once more — its stored keys are people's names, which
  name no card now.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012227sKETHXX7e4woFW1FBM