### PR TITLE
Add an item search to the questions page

### DIFF
--- a/e2e/tests/b-questions.spec.ts
+++ b/e2e/tests/b-questions.spec.ts
@@ -449,6 +449,32 @@ test.describe('B – Editing Questions', () => {
     await expect(page.getByRole('button', { name: 'Organise items' })).toHaveCount(0)
   })
 
+  test('B17: find an item by name, wherever in the set it lives', async ({ freshPage: page }) => {
+    // Without this the only way to answer "have I got sunscreen in here?" is to
+    // open questions one at a time until one of them turns out to have it.
+    await setupWizardAndGoToQuestions(page)
+    await page.getByLabel('Search items').fill('sunscr')
+
+    const results = page.getByTestId('item-search-results')
+    await expect(results).toBeVisible({ timeout: 5_000 })
+    const row = results.getByTestId('item-row').filter({ hasText: 'Sunscreen' }).first()
+    await expect(row).toBeVisible({ timeout: 5_000 })
+    // The trail is the point: it says which question and answer hold the item,
+    // and which section it will land in on the packing list.
+    await expect(results.getByTestId('search-group-crumbs').first()).toContainText('What weather do you expect?')
+    await expect(results.getByTestId('search-section-label').first()).toContainText('Day Bag')
+    // The list itself is out of the way while a search is on screen.
+    await expect(page.getByRole('button', { name: '+ Add Question' })).not.toBeVisible()
+
+    // A result is a real row: it opens the same editor as the list does.
+    await row.click()
+    await expect(page.getByTestId('item-inline-editor')).toBeVisible({ timeout: 3_000 })
+
+    await page.getByRole('button', { name: 'Clear search' }).click()
+    await expect(results).toHaveCount(0)
+    await expect(page.getByRole('button', { name: '+ Add Question' })).toBeVisible()
+  })
+
   test('B12: an answer with no items can take its first one', async ({ freshPage: page }) => {
     // Before, an empty answer had no expander and no input at all: its only way
     // in was the option modal.

--- a/src/components/ItemRow.tsx
+++ b/src/components/ItemRow.tsx
@@ -1,0 +1,120 @@
+/**
+ * One item as a row: the shape every list on the questions page is made of.
+ *
+ * Read-only by design — mounting an editor per item is what made large sets slow
+ * on phones — but the whole row is the target that opens `ItemInlineEditor` for
+ * it, so "change one word" is one tap on the word itself.
+ *
+ * Lives here rather than in the page because the search results are the same
+ * rows: an item found by searching should look, and edit, exactly like the item
+ * found by unfolding the list it lives in.
+ */
+import { memo } from 'react'
+import { quantityTitle, rateLabel } from './ItemEditorControls'
+import { PERSON_COLOR_OFF, personColorFor } from '../edit-questions/person-colors'
+import type { Item, Person } from '../edit-questions/types'
+
+export function PersonDot({ person, index, selected }: { person: Person; index: number; selected: boolean }) {
+    return (
+        <span
+            title={person.name}
+            className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold select-none shrink-0 ${selected ? personColorFor(person, index).avatar : PERSON_COLOR_OFF}`}
+        >
+            {person.name.charAt(0).toUpperCase()}
+        </span>
+    )
+}
+
+/** Part of the name to mark up — where a search matched it. */
+export interface TextHighlight {
+    start: number
+    length: number
+}
+
+function ItemText({ text, highlight }: { text: string; highlight?: TextHighlight }) {
+    // The parent span already styles an unnamed item; this only supplies words.
+    if (!text) return <>no text</>
+    if (!highlight || highlight.start < 0) return <>{text}</>
+    const end = highlight.start + highlight.length
+    return (
+        <>
+            {text.slice(0, highlight.start)}
+            <mark className="bg-amber-200 text-gray-900 rounded-sm px-0.5">{text.slice(highlight.start, end)}</mark>
+            {text.slice(end)}
+        </>
+    )
+}
+
+export const ItemRow = memo(function ItemRow({ item, people, index, isOpen, highlight, onOpen }: {
+    item: Item
+    people: Person[]
+    index: number
+    isOpen?: boolean
+    /** Where a search matched the name, so the row can show why it is here. */
+    highlight?: TextHighlight
+    onOpen?: (index: number) => void
+}) {
+    const showDots = people.length > 1
+    const content = (
+        <>
+            <span className={`flex-1 min-w-0 text-left ${item.text ? 'text-gray-700' : 'text-gray-400 italic'}`}>
+                <ItemText text={item.text} highlight={highlight} />
+            </span>
+            {item.communal && (
+                <span
+                    title="Shared — packed once for the whole group"
+                    className="inline-flex items-center justify-center h-5 rounded-full px-1.5 text-[10px] font-medium bg-blue-100 text-blue-700 select-none shrink-0"
+                >
+                    👥
+                </span>
+            )}
+            {item.perNight !== undefined && (
+                <span
+                    title={quantityTitle(item)}
+                    className="inline-flex items-center justify-center h-5 rounded-full px-1.5 text-[10px] font-medium bg-emerald-100 text-emerald-700 select-none shrink-0"
+                >
+                    ×{rateLabel(item).replace(' per ', '/')}
+                </span>
+            )}
+            {showDots && (
+                <div className="flex gap-0.5 shrink-0">
+                    {people.map((person, i) => (
+                        <PersonDot
+                            key={person.id}
+                            person={person}
+                            index={i}
+                            selected={item.personSelections?.[i]?.selected ?? false}
+                        />
+                    ))}
+                </div>
+            )}
+        </>
+    )
+    if (!onOpen) {
+        return <div className="flex items-center gap-2 py-0.5 px-2 text-sm">{content}</div>
+    }
+    return (
+        <button
+            type="button"
+            data-testid="item-row"
+            onClick={() => onOpen(index)}
+            aria-expanded={isOpen ?? false}
+            title={`Edit ${item.text || 'item'}`}
+            className={`group w-full flex items-center gap-2 py-1 px-2 text-sm rounded transition-colors ${isOpen ? 'bg-primary-50' : 'hover:bg-gray-100'}`}
+        >
+            {content}
+            {/* Decorative, not a button of its own: the whole row is the target,
+                and a second hit area inside it would only make the real one
+                harder to hit. Sits last so it lines up down the right edge —
+                a column of pencils is what says the rows are editable. */}
+            <svg
+                data-testid="item-edit-icon"
+                aria-hidden="true"
+                className={`w-3.5 h-3.5 shrink-0 transition-colors ${isOpen ? 'text-primary-500' : 'text-gray-400 group-hover:text-gray-700'}`}
+                fill="none" viewBox="0 0 24 24" stroke="currentColor"
+            >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+        </button>
+    )
+})

--- a/src/components/ItemSearch.test.tsx
+++ b/src/components/ItemSearch.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import React from 'react'
+import { ItemSearchBar, ItemSearchResults } from './ItemSearch'
+import type { Item, PackingListQuestionSet, Person, Question } from '../edit-questions/types'
+
+const people: Person[] = [{ id: 'p1', name: 'Alice' }]
+
+function item(text: string, overrides: Partial<Item> = {}): Item {
+    return { id: text.toLowerCase(), text, personSelections: [{ personId: 'p1', selected: true }], ...overrides }
+}
+
+function question(overrides: Partial<Question> & { id: string; text: string }): Question {
+    return { type: 'saved', order: 0, questionType: 'single-choice', options: [], ...overrides } as Question
+}
+
+function makeSet(overrides: Partial<PackingListQuestionSet> = {}): PackingListQuestionSet {
+    return {
+        people,
+        alwaysNeededItems: [item('Passport'), item('Sun hat', { category: 'Clothes' })],
+        questions: [question({
+            id: 'q1', text: 'Beach holiday?', options: [{
+                id: 'o1', order: 0, text: 'Yes', items: [
+                    item('Bucket and spade'),
+                    item('Sun cream', { category: 'Toiletries' }),
+                ],
+            }],
+        })],
+        ...overrides,
+    }
+}
+
+function renderResults(query: string, set = makeSet()) {
+    const handlers = {
+        onOptionItemChange: vi.fn(),
+        onOptionItemDelete: vi.fn(),
+        onAlwaysItemChange: vi.fn(),
+        onAlwaysItemDelete: vi.fn(),
+    }
+    const view = render(
+        <ItemSearchResults
+            questionSet={set}
+            query={query}
+            people={people}
+            allItemNames={['Sun cream', 'Sun hat']}
+            sectionNames={['Toiletries', 'Clothes']}
+            {...handlers}
+        />
+    )
+    return { ...handlers, rerenderWith: (next: PackingListQuestionSet) => view.rerender(
+        <ItemSearchResults
+            questionSet={next}
+            query={query}
+            people={people}
+            allItemNames={['Sun cream', 'Sun hat']}
+            sectionNames={['Toiletries', 'Clothes']}
+            {...handlers}
+        />
+    ) }
+}
+
+describe('ItemSearchResults', () => {
+    it('shows each match under the trail that leads to it', () => {
+        renderResults('sun')
+        const trails = screen.getAllByTestId('search-group-crumbs').map(c => c.textContent)
+        expect(trails).toEqual(['Always Needed Items', 'Beach holiday? › Yes'])
+        // The section is named inside the card, where a phone can still read it.
+        expect(screen.getAllByTestId('search-section-label').map(s => s.textContent))
+            .toEqual(['Clothes', 'Toiletries'])
+        expect(screen.getAllByTestId('item-row').map(r => r.textContent?.trim())).toEqual(['Sun hat', 'Sun cream'])
+    })
+
+    it('marks the part of the name that matched', () => {
+        const { container } = render(
+            <ItemSearchResults
+                questionSet={makeSet()}
+                query="cream"
+                people={people}
+                allItemNames={[]}
+                sectionNames={[]}
+                onOptionItemChange={vi.fn()}
+                onOptionItemDelete={vi.fn()}
+                onAlwaysItemChange={vi.fn()}
+                onAlwaysItemDelete={vi.fn()}
+            />
+        )
+        expect(container.querySelector('mark')?.textContent).toBe('cream')
+    })
+
+    it('counts what it found', () => {
+        renderResults('sun')
+        expect(screen.getByTestId('item-search-summary').textContent).toContain('2 items')
+    })
+
+    it('says so when nothing matches', () => {
+        renderResults('kayak')
+        expect(screen.getByTestId('item-search-summary').textContent).toMatch(/No items match/i)
+        expect(screen.queryByTestId('search-group')).toBeNull()
+    })
+
+    it('edits an option item in place, addressing its own list', () => {
+        const { onOptionItemChange } = renderResults('cream')
+        fireEvent.click(screen.getByTestId('item-row'))
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Clothes' } })
+        expect(onOptionItemChange).toHaveBeenCalledWith('q1', 'o1', 1,
+            expect.objectContaining({ text: 'Sun cream', category: 'Clothes' }))
+    })
+
+    it('edits an always-needed item by its position among the undeleted ones', () => {
+        const set = makeSet({
+            alwaysNeededItems: [
+                item('Old passport', { deletedAt: '2024-01-01T00:00:00.000Z' }),
+                item('Passport'),
+                item('Sun hat', { category: 'Clothes' }),
+            ],
+        })
+        const { onAlwaysItemChange } = renderResults('sun hat', set)
+        fireEvent.click(screen.getByTestId('item-row'))
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Toiletries' } })
+        expect(onAlwaysItemChange).toHaveBeenCalledWith(1, expect.objectContaining({ category: 'Toiletries' }))
+    })
+
+    it('closes the editor after a delete, since every index below it has moved', () => {
+        const { onOptionItemDelete } = renderResults('cream')
+        fireEvent.click(screen.getByTestId('item-row'))
+        fireEvent.click(within(screen.getByTestId('item-inline-editor')).getByRole('button', { name: /Delete/ }))
+        expect(onOptionItemDelete).toHaveBeenCalledWith('q1', 'o1', 1)
+        expect(screen.queryByTestId('item-inline-editor')).toBeNull()
+    })
+
+    it('keeps the open editor when the rename it just made stops the item matching', () => {
+        const { rerenderWith } = renderResults('cream')
+        fireEvent.click(screen.getByTestId('item-row'))
+        rerenderWith(makeSet({
+            questions: [question({
+                id: 'q1', text: 'Beach holiday?', options: [{
+                    id: 'o1', order: 0, text: 'Yes', items: [
+                        item('Bucket and spade'),
+                        { ...item('Sunblock'), id: 'sun cream', category: 'Toiletries' },
+                    ],
+                }],
+            })],
+        }))
+        expect(screen.getByTestId('item-inline-editor')).toBeTruthy()
+        expect(screen.getByTestId('item-search-summary').textContent).toMatch(/No items match/i)
+    })
+})
+
+describe('ItemSearchBar', () => {
+    it('asks for more before it will search', () => {
+        render(<ItemSearchBar value="s" onChange={vi.fn()} />)
+        expect(screen.getByText(/Keep typing/i)).toBeTruthy()
+    })
+
+    it('clears the query', () => {
+        const onChange = vi.fn()
+        render(<ItemSearchBar value="sun" onChange={onChange} />)
+        fireEvent.click(screen.getByRole('button', { name: /clear/i }))
+        expect(onChange).toHaveBeenCalledWith('')
+    })
+
+    it('clears on Escape, so the page comes back without reaching for the mouse', () => {
+        const onChange = vi.fn()
+        render(<ItemSearchBar value="sun" onChange={onChange} />)
+        fireEvent.keyDown(screen.getByLabelText('Search items'), { key: 'Escape' })
+        expect(onChange).toHaveBeenCalledWith('')
+    })
+})

--- a/src/components/ItemSearch.tsx
+++ b/src/components/ItemSearch.tsx
@@ -1,0 +1,235 @@
+/**
+ * Searching the questions page for an item.
+ *
+ * The page is a page of folded lists, and everything on it is addressed by
+ * where it lives: which question, which answer, which section. That is exactly
+ * what you don't know when the question in your head is "have I got sun cream in
+ * here anywhere?" — so this finds the item and then *tells you where it lives*,
+ * because the location is half the answer. The other half is being able to fix
+ * it there and then, so a result is the same row as on the page, opening the
+ * same inline editor, writing through the same handlers.
+ *
+ * Results are grouped by the trail that leads to them rather than listed flat.
+ * A flat list repeats "Beach holiday? › Yes › Toiletries" against every row and
+ * still leaves you to notice that three of the rows are the same place; the
+ * group says it once, which is also what makes a near-duplicate ("Suncream"
+ * under one answer, "Sun cream" under another) obvious at a glance.
+ */
+import { Fragment, useMemo, useState } from 'react'
+import { ItemInlineEditor } from './ItemInlineEditor'
+import { ItemRow } from './ItemRow'
+import { MIN_QUERY_LENGTH, searchQuestionSetItems, sectionNamesItsList, type ItemSearchGroup, type ItemSearchMatch } from '../edit-questions/item-search'
+import { sectionAccent } from '../edit-questions/section-accent'
+import type { Item, PackingListQuestionSet, Person } from '../edit-questions/types'
+
+export function ItemSearchBar({ value, onChange }: {
+    value: string
+    onChange: (value: string) => void
+}) {
+    const typed = value.trim().length
+    return (
+        <div>
+            <div className="relative">
+                <svg
+                    aria-hidden="true"
+                    className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none"
+                    fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z" />
+                </svg>
+                <input
+                    // Not type="search": that draws a clear button of its own,
+                    // beside the one below, and only in some browsers. The
+                    // inputMode still asks a phone for the search keyboard.
+                    type="text"
+                    inputMode="search"
+                    enterKeyHint="search"
+                    aria-label="Search items"
+                    value={value}
+                    onChange={e => onChange(e.target.value)}
+                    // Escape is the shortest way back to the page you were on,
+                    // and the one people already expect from a search field.
+                    onKeyDown={e => { if (e.key === 'Escape') onChange('') }}
+                    placeholder="Search items — e.g. sun cream"
+                    className="w-full border border-gray-300 rounded-lg pl-9 pr-9 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                />
+                {typed > 0 && (
+                    <button
+                        type="button"
+                        onClick={() => onChange('')}
+                        aria-label="Clear search"
+                        title="Clear search"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-700 rounded"
+                    >
+                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                )}
+            </div>
+            {/* One letter matches most of a question set, so the page keeps
+                showing the set and says what it is waiting for. */}
+            {typed > 0 && typed < MIN_QUERY_LENGTH && (
+                <p className="mt-1 text-xs text-gray-400">
+                    Keep typing — search starts at {MIN_QUERY_LENGTH} letters
+                </p>
+            )}
+        </div>
+    )
+}
+
+/** Which row has its editor open, keyed by the item rather than its position. */
+function openKeyFor(group: ItemSearchGroup, match: ItemSearchMatch): string {
+    return `${group.key}#${match.item.id ?? match.index}`
+}
+
+export function ItemSearchResults({ questionSet, query, people, allItemNames, sectionNames, onOptionItemChange, onOptionItemDelete, onAlwaysItemChange, onAlwaysItemDelete }: {
+    questionSet: PackingListQuestionSet
+    query: string
+    people: Person[]
+    allItemNames: string[]
+    sectionNames: string[]
+    onOptionItemChange: (questionId: string, optionId: string, index: number, edited: Item) => void
+    onOptionItemDelete: (questionId: string, optionId: string, index: number) => void
+    onAlwaysItemChange: (index: number, edited: Item) => void
+    onAlwaysItemDelete: (index: number) => void
+}) {
+    const [open, setOpen] = useState<{ key: string; itemId?: string } | null>(null)
+    // A new search is a new question; whatever was open belonged to the old one.
+    const [searched, setSearched] = useState(query)
+    if (query !== searched) {
+        setSearched(query)
+        setOpen(null)
+    }
+
+    const needle = query.trim()
+    const results = useMemo(
+        () => searchQuestionSetItems(questionSet, needle, { pinnedItemId: open?.itemId }),
+        [questionSet, needle, open?.itemId])
+
+    const applyChange = (group: ItemSearchGroup, match: ItemSearchMatch, edited: Item) => {
+        if (group.location.kind === 'always') onAlwaysItemChange(match.index, edited)
+        else onOptionItemChange(group.location.questionId, group.location.optionId, match.index, edited)
+    }
+
+    // Closing first, for the same reason the page's own lists do: the row has
+    // gone and every index below it has shifted up under the open panel.
+    const applyDelete = (group: ItemSearchGroup, match: ItemSearchMatch) => {
+        setOpen(null)
+        if (group.location.kind === 'always') onAlwaysItemDelete(match.index)
+        else onOptionItemDelete(group.location.questionId, group.location.optionId, match.index)
+    }
+
+    const found = results.total > 0
+
+    return (
+        <div data-testid="item-search-results" className="space-y-2">
+            {found ? (
+                <p data-testid="item-search-summary" role="status" className="text-sm text-gray-500">
+                    {results.total} item{results.total === 1 ? '' : 's'} match{results.total === 1 ? 'es' : ''} “{needle}”
+                    {results.shown < results.total && (
+                        <span className="text-gray-400"> — showing the first {results.shown}. Try a longer search.</span>
+                    )}
+                </p>
+            ) : (
+                // The one line the count would have been, said inside the card
+                // rather than above it — twice is once too often for "nothing".
+                <div
+                    data-testid="item-search-summary"
+                    role="status"
+                    className="rounded-lg border border-dashed border-gray-200 bg-white px-4 py-6 text-center"
+                >
+                    <p className="text-sm text-gray-500">No items match “{needle}”</p>
+                    <p className="mt-1 text-xs text-gray-400">
+                        Search looks at item names — try part of a word, or check the spelling.
+                    </p>
+                </div>
+            )}
+
+            {results.groups.map(group => (
+                <div
+                    key={group.key}
+                    data-testid="search-group"
+                    className="rounded-lg border border-gray-200 bg-white"
+                >
+                    <div className="flex items-center gap-2 rounded-t-lg bg-gray-50 px-2.5 py-1.5">
+                        <span
+                            data-testid="search-group-crumbs"
+                            className="flex items-baseline text-sm min-w-0 text-gray-700"
+                        >
+                            {group.crumbs.map((crumb, i) => (
+                                <Fragment key={`${group.key}-crumb-${i}`}>
+                                    {i > 0 && (
+                                        <span aria-hidden="true" className="shrink-0 whitespace-pre text-gray-400">{' \u203a '}</span>
+                                    )}
+                                    {/* The answer is what holds the items and what
+                                        tells two cards of the same question apart,
+                                        so it is the crumb that keeps its room on a
+                                        phone: the question above it gives way. */}
+                                    <span className={i === group.crumbs.length - 1
+                                        ? 'font-semibold shrink-0 max-w-[55%] truncate'
+                                        : 'truncate'}>{crumb}</span>
+                                </Fragment>
+                            ))}
+                        </span>
+                        <span className="ml-auto shrink-0 text-[11px] font-medium text-gray-400">
+                            {group.count} match{group.count === 1 ? '' : 'es'}
+                        </span>
+                    </div>
+                    <div className="p-1 space-y-1">
+                        {group.sections.map(section => {
+                            const accent = sectionAccent(section.label, section.isDefault)
+                            return (
+                                <div key={`${group.key}-${section.label}`}>
+                                    {/* Named only where the name says something the
+                                        trail above hasn't already — see
+                                        `sectionNamesItsList`. */}
+                                    {!sectionNamesItsList(group, section) && (
+                                        <div data-testid="search-section-label" className="flex items-center gap-1.5 px-1.5 pb-0.5 pt-1">
+                                            <span aria-hidden="true" className={`w-1.5 h-1.5 rounded-full ${accent.rail}`} />
+                                            <span className={`text-[11px] font-semibold uppercase tracking-wide ${accent.text}`}>
+                                                {section.label}
+                                            </span>
+                                        </div>
+                                    )}
+                                    <div className="space-y-0.5">
+                                        {section.matches.map(match => {
+                                            const key = openKeyFor(group, match)
+                                            const isOpen = open?.key === key
+                                            return (
+                                                <Fragment key={key}>
+                                                    <ItemRow
+                                                        item={match.item}
+                                                        people={people}
+                                                        index={match.index}
+                                                        isOpen={isOpen}
+                                                        highlight={match.matchStart >= 0
+                                                            ? { start: match.matchStart, length: needle.length }
+                                                            : undefined}
+                                                        onOpen={() => setOpen(isOpen ? null : { key, itemId: match.item.id })}
+                                                    />
+                                                    {isOpen && (
+                                                        <ItemInlineEditor
+                                                            item={match.item}
+                                                            people={people}
+                                                            allItemNames={allItemNames}
+                                                            sectionNames={sectionNames}
+                                                            sectionDefaultLabel={group.defaultLabel}
+                                                            onChange={edited => applyChange(group, match, edited)}
+                                                            onDelete={() => applyDelete(group, match)}
+                                                            onClose={() => setOpen(null)}
+                                                        />
+                                                    )}
+                                                </Fragment>
+                                            )
+                                        })}
+                                    </div>
+                                </div>
+                            )
+                        })}
+                    </div>
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/src/edit-questions/item-search.test.ts
+++ b/src/edit-questions/item-search.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import { MIN_QUERY_LENGTH, searchQuestionSetItems, sectionNamesItsList } from './item-search'
+import type { Item, PackingListQuestionSet, Question } from './types'
+
+function item(overrides: Partial<Item> & { text: string }): Item {
+    return { id: overrides.text.toLowerCase(), personSelections: [], ...overrides }
+}
+
+function question(overrides: Partial<Question> & { id: string; text: string }): Question {
+    return {
+        type: 'saved',
+        order: 0,
+        questionType: 'single-choice',
+        options: [],
+        ...overrides,
+    } as Question
+}
+
+/** A set with one item in an option, one in the always-needed list. */
+function makeSet(overrides: Partial<PackingListQuestionSet> = {}): PackingListQuestionSet {
+    return {
+        people: [],
+        alwaysNeededItems: [item({ text: 'Sun hat', category: 'Clothes' })],
+        questions: [
+            question({
+                id: 'q1',
+                text: 'Beach holiday?',
+                options: [
+                    {
+                        id: 'o1', order: 0, text: 'Yes', items: [
+                            item({ text: 'Sun cream', category: 'Toiletries' }),
+                            item({ text: 'Towel' }),
+                        ],
+                    },
+                ],
+            }),
+        ],
+        ...overrides,
+    }
+}
+
+describe('searchQuestionSetItems', () => {
+    it('finds items by case-insensitive substring, in the list order the page shows', () => {
+        const results = searchQuestionSetItems(makeSet(), 'SUN')
+        expect(results.total).toBe(2)
+        expect(results.groups.flatMap(g => g.sections.flatMap(s => s.matches.map(m => m.item.text))))
+            .toEqual(['Sun hat', 'Sun cream'])
+    })
+
+    it('reports where the match starts, so the row can highlight it', () => {
+        const results = searchQuestionSetItems(makeSet(), 'cream')
+        expect(results.groups[0].sections[0].matches[0].matchStart).toBe(4)
+    })
+
+    it('gives an option item its question, answer and section as context', () => {
+        const results = searchQuestionSetItems(makeSet(), 'cream')
+        expect(results.groups).toHaveLength(1)
+        expect(results.groups[0].crumbs).toEqual(['Beach holiday?', 'Yes'])
+        expect(results.groups[0].sections[0].label).toBe('Toiletries')
+        expect(results.groups[0].location).toEqual({ kind: 'option', questionId: 'q1', optionId: 'o1' })
+    })
+
+    it('names the always-needed list and the section within it', () => {
+        const results = searchQuestionSetItems(makeSet(), 'hat')
+        expect(results.groups[0].crumbs).toEqual(['Always Needed Items'])
+        expect(results.groups[0].sections[0].label).toBe('Clothes')
+        expect(results.groups[0].location).toEqual({ kind: 'always' })
+        expect(results.groups[0].defaultLabel).toBe('Essentials')
+    })
+
+    it('falls back to the question text for an item with no section of its own, without repeating it', () => {
+        const results = searchQuestionSetItems(makeSet(), 'towel')
+        const [group] = results.groups
+        expect(group.crumbs).toEqual(['Beach holiday?', 'Yes'])
+        expect(group.sections[0].label).toBe('Beach holiday?')
+        expect(group.sections[0].isDefault).toBe(true)
+        // ...and saying so under the trail would only repeat it.
+        expect(sectionNamesItsList(group, group.sections[0])).toBe(true)
+    })
+
+    it('falls back to the option text on a multiple-choice question', () => {
+        const set = makeSet({
+            questions: [question({
+                id: 'q1',
+                text: 'What are you doing?',
+                questionType: 'multiple-choice',
+                options: [{ id: 'o1', order: 0, text: 'Swimming', items: [item({ text: 'Goggles' })] }],
+            })],
+        })
+        const results = searchQuestionSetItems(set, 'goggles')
+        expect(results.groups[0].crumbs).toEqual(['What are you doing?', 'Swimming'])
+        expect(results.groups[0].defaultLabel).toBe('Swimming')
+    })
+
+    it('gathers an answer\'s matches under it, split by section', () => {
+        const set = makeSet({
+            alwaysNeededItems: [],
+            questions: [question({
+                id: 'q1', text: 'Beach holiday?', options: [{
+                    id: 'o1', order: 0, text: 'Yes', items: [
+                        item({ text: 'Sun cream', category: 'Toiletries' }),
+                        item({ text: 'Sun hat' }),
+                        item({ text: 'Sunglasses', category: 'Toiletries' }),
+                    ],
+                }],
+            })],
+        })
+        const results = searchQuestionSetItems(set, 'sun')
+        // One card for the answer, its sections inside it — the answer is named
+        // once however many of its sections matched.
+        expect(results.groups).toHaveLength(1)
+        expect(results.groups[0].count).toBe(3)
+        expect(results.groups[0].sections.map(s => s.label)).toEqual(['Toiletries', 'Beach holiday?'])
+        // Two hits in one section stay together rather than splitting it in two.
+        expect(results.groups[0].sections[0].matches.map(m => m.item.text))
+            .toEqual(['Sun cream', 'Sunglasses'])
+    })
+
+    it('indexes option items by their position in the stored list', () => {
+        const results = searchQuestionSetItems(makeSet(), 'towel')
+        expect(results.groups[0].sections[0].matches[0].index).toBe(1)
+    })
+
+    it('indexes always-needed items by their position among the undeleted ones', () => {
+        const set = makeSet({
+            alwaysNeededItems: [
+                item({ text: 'Old passport', deletedAt: '2024-01-01T00:00:00.000Z' }),
+                item({ text: 'Passport' }),
+            ],
+        })
+        const results = searchQuestionSetItems(set, 'passport')
+        expect(results.total).toBe(1)
+        expect(results.groups[0].sections[0].matches[0].index).toBe(0)
+    })
+
+    it('skips deleted questions and deleted items', () => {
+        const set = makeSet({
+            questions: [
+                question({ id: 'q1', text: 'Gone?', deletedAt: '2024-01-01T00:00:00.000Z', options: [
+                    { id: 'o1', order: 0, text: 'Yes', items: [item({ text: 'Sun cream' })] },
+                ] }),
+                question({ id: 'q2', text: 'Here?', options: [
+                    { id: 'o2', order: 0, text: 'Yes', items: [
+                        item({ text: 'Sun lotion', deletedAt: '2024-01-01T00:00:00.000Z' }),
+                    ] },
+                ] }),
+            ],
+            alwaysNeededItems: [],
+        })
+        expect(searchQuestionSetItems(set, 'sun').total).toBe(0)
+    })
+
+    it('finds nothing for a query shorter than the minimum', () => {
+        const short = 's'.repeat(MIN_QUERY_LENGTH - 1)
+        expect(searchQuestionSetItems(makeSet(), short).groups).toEqual([])
+        expect(searchQuestionSetItems(makeSet(), '   ').groups).toEqual([])
+    })
+
+    it('caps how many matches it returns but counts them all', () => {
+        const set = makeSet({
+            alwaysNeededItems: [item({ text: 'Sun hat' }), item({ text: 'Sun cream' }), item({ text: 'Sunglasses' })],
+            questions: [],
+        })
+        const results = searchQuestionSetItems(set, 'sun', { limit: 2 })
+        expect(results.total).toBe(3)
+        expect(results.shown).toBe(2)
+    })
+
+    it('keeps a pinned item in the results even once it stops matching', () => {
+        const set = makeSet({
+            alwaysNeededItems: [item({ id: 'renamed', text: 'Beach towel' })],
+            questions: [],
+        })
+        const results = searchQuestionSetItems(set, 'sun', { pinnedItemId: 'renamed' })
+        // Present so an editor open on it doesn't vanish mid-rename, but not
+        // counted: nothing here matches what was typed.
+        expect(results.total).toBe(0)
+        expect(results.groups[0].sections[0].matches[0].item.text).toBe('Beach towel')
+        expect(results.groups[0].sections[0].matches[0].matchStart).toBe(-1)
+    })
+})

--- a/src/edit-questions/item-search.ts
+++ b/src/edit-questions/item-search.ts
@@ -1,0 +1,216 @@
+/**
+ * Finding one item in a whole question set.
+ *
+ * The questions page is a page of folded lists: an item lives inside a section,
+ * inside an answer, inside a question, and the only way to find "sun cream" was
+ * to remember which question you filed it under and unfold your way down to it.
+ * That is fine with six questions and hopeless with thirty — and it is the same
+ * problem behind the two things people actually do here: *is this already in the
+ * set somewhere?* and *where does this end up on my list?*
+ *
+ * So a match is never returned on its own. It comes with the trail that leads to
+ * it — question, answer, section — because the trail is what answers both
+ * questions, and matches are gathered under that trail so a run of hits in one
+ * answer reads as one place rather than six unrelated rows.
+ *
+ * Deliberately a pure function over the stored set: the page's own item handlers
+ * address a list by index, so a result carries the index its list's handlers
+ * take, and editing from the results is then the same write as editing in place.
+ */
+import { ALWAYS_NEEDED_CATEGORY, defaultCategoryFor } from './item-sections'
+import type { Item, PackingListQuestionSet } from './types'
+
+/** What the always-needed list is called where a question would be named. */
+export const ALWAYS_LIST_LABEL = 'Always Needed Items'
+
+/**
+ * Below this a search says more about the size of the set than about what was
+ * typed — one letter matches most of it — so the page keeps showing the set.
+ */
+export const MIN_QUERY_LENGTH = 2
+
+/** Whether what has been typed is enough to search on. */
+export function isSearchQuery(query: string): boolean {
+    return query.trim().length >= MIN_QUERY_LENGTH
+}
+
+/**
+ * How many matches are worth drawing. A cap rather than a scroll of everything:
+ * past this the answer is "narrow it down", and the page says so with the total.
+ */
+export const DEFAULT_SEARCH_LIMIT = 50
+
+/** The list an item lives in, in the terms the page's save handlers take. */
+export type ItemLocation =
+    | { kind: 'always' }
+    | { kind: 'option'; questionId: string; optionId: string }
+
+export interface ItemSearchMatch {
+    item: Item
+    /**
+     * Where the item sits in the list its handlers address: the whole stored
+     * array for an option, the undeleted ones for the always-needed list, which
+     * is what the page renders and indexes there.
+     */
+    index: number
+    /** Where the query starts in `item.text`; -1 for a pinned item that no longer matches. */
+    matchStart: number
+}
+
+/** The matches within one section of a list. */
+export interface ItemSearchSection {
+    label: string
+    /** Whether it is the list's own default rather than a section someone named. */
+    isDefault: boolean
+    matches: ItemSearchMatch[]
+}
+
+/**
+ * Every match in one item list, under the trail that leads to it.
+ *
+ * The trail stops at the answer, and the sections sit inside it, because a set
+ * asked about "sun" answers with six rows spread over three sections of the same
+ * two questions: repeating "What weather do you expect? › Hot" above each of
+ * them says the same long thing three times and pushes the section — the part
+ * that differs — off the right-hand edge of a phone.
+ */
+export interface ItemSearchGroup {
+    /** Stable identity for the group — one item list. */
+    key: string
+    location: ItemLocation
+    /** The trail to this list, outermost first: question, then answer. */
+    crumbs: string[]
+    /** What this list calls items carrying no section of their own. */
+    defaultLabel: string
+    sections: ItemSearchSection[]
+    /** How many matches the group holds, across its sections. */
+    count: number
+}
+
+export interface ItemSearchResults {
+    groups: ItemSearchGroup[]
+    /** How many matches are in `groups`. */
+    shown: number
+    /** How many there are in the set — larger than `shown` once the cap bites. */
+    total: number
+}
+
+export interface ItemSearchOptions {
+    limit?: number
+    /**
+     * An item to include whatever it says now. The editor opened from a result
+     * writes straight through, so renaming an item out of its own search would
+     * otherwise pull the row out from under the panel you are typing in.
+     */
+    pinnedItemId?: string
+}
+
+/** One match before grouping, keeping the order the page lists items in. */
+interface Candidate {
+    seq: number
+    match: ItemSearchMatch
+    /** The list it lives in, and the section of that list. */
+    group: Omit<ItemSearchGroup, 'sections' | 'count'>
+    sectionLabel: string
+    isDefaultSection: boolean
+}
+
+const EMPTY: ItemSearchResults = { groups: [], shown: 0, total: 0 }
+
+/**
+ * Whether a section's name says anything the trail hasn't already. An
+ * uncategorised item's section *is* its question's or answer's own text, so
+ * naming it under "Beach holiday? › Yes" would repeat the crumb above it.
+ */
+export function sectionNamesItsList(group: ItemSearchGroup, section: ItemSearchSection): boolean {
+    return !section.label.trim() || group.crumbs.includes(section.label)
+}
+
+export function searchQuestionSetItems(
+    qs: PackingListQuestionSet,
+    query: string,
+    { limit = DEFAULT_SEARCH_LIMIT, pinnedItemId }: ItemSearchOptions = {},
+): ItemSearchResults {
+    const needle = query.trim().toLowerCase()
+    if (needle.length < MIN_QUERY_LENGTH) return EMPTY
+
+    const candidates: Candidate[] = []
+    let seq = 0
+    let total = 0
+
+    const collect = (
+        item: Item,
+        index: number,
+        listCrumbs: string[],
+        defaultLabel: string,
+        location: ItemLocation,
+    ) => {
+        const matchStart = item.text.toLowerCase().indexOf(needle)
+        const pinned = pinnedItemId !== undefined && item.id === pinnedItemId
+        if (matchStart < 0 && !pinned) return
+        if (matchStart >= 0) total++
+        candidates.push({
+            seq: seq++,
+            match: { item, index, matchStart },
+            group: {
+                key: location.kind === 'always' ? 'always' : location.questionId + ':' + location.optionId,
+                location,
+                crumbs: listCrumbs,
+                defaultLabel,
+            },
+            sectionLabel: item.category ?? defaultLabel,
+            isDefaultSection: item.category === undefined,
+        })
+    }
+
+    // The always-needed list first, exactly as the page stacks it, and indexed
+    // the way the page indexes it: tombstones are neither shown nor counted.
+    const always = (qs.alwaysNeededItems ?? []).filter(i => !i.deletedAt)
+    always.forEach((item, index) =>
+        collect(item, index, [ALWAYS_LIST_LABEL], ALWAYS_NEEDED_CATEGORY, { kind: 'always' }))
+
+    for (const question of qs.questions ?? []) {
+        if (question.deletedAt) continue
+        const questionText = question.text.trim() || 'Untitled question'
+        for (const option of question.options) {
+            const optionText = option.text.trim() || 'Untitled option'
+            const defaultLabel = defaultCategoryFor(question, option)
+            // Indexed against the stored array, tombstones included, because
+            // that is the array an option's handlers edit.
+            option.items.forEach((item, index) => {
+                if (item.deletedAt) return
+                collect(item, index, [questionText, optionText], defaultLabel,
+                    { kind: 'option', questionId: question.id, optionId: option.id })
+            })
+        }
+    }
+
+    // The cap counts matches, not the pinned straggler: an editor left open on
+    // an item that no longer matches must survive to be closed.
+    const pinnedCandidate = candidates.find(c => c.match.matchStart < 0)
+    const kept = candidates.filter(c => c.match.matchStart >= 0).slice(0, limit)
+    if (pinnedCandidate && !kept.includes(pinnedCandidate)) kept.push(pinnedCandidate)
+    kept.sort((a, b) => a.seq - b.seq)
+
+    // Two levels, both in the order the page lists things: the list a match
+    // lives in, then the section within it.
+    const groups: ItemSearchGroup[] = []
+    const byKey = new Map<string, ItemSearchGroup>()
+    for (const candidate of kept) {
+        let group = byKey.get(candidate.group.key)
+        if (!group) {
+            group = { ...candidate.group, sections: [], count: 0 }
+            byKey.set(group.key, group)
+            groups.push(group)
+        }
+        let section = group.sections.find(s => s.label === candidate.sectionLabel)
+        if (!section) {
+            section = { label: candidate.sectionLabel, isDefault: candidate.isDefaultSection, matches: [] }
+            group.sections.push(section)
+        }
+        section.matches.push(candidate.match)
+        group.count++
+    }
+
+    return { groups, shown: kept.length, total }
+}

--- a/src/pages/questions-page.search.test.tsx
+++ b/src/pages/questions-page.search.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import type { PackingAppDatabase } from '../services/database'
+
+vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
+vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn() }))
+vi.mock('../components/ForeignPodContext', () => ({ useForeignPod: vi.fn() }))
+
+const saveWithSyncPrevention = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../hooks/useSyncCoordinator', () => ({
+    useSyncCoordinator: vi.fn(() => ({
+        saveWithSyncPrevention,
+        handleSyncSuccess: vi.fn(),
+        handleSyncError: vi.fn(),
+    })),
+}))
+
+vi.mock('../hooks/usePodSync', () => ({
+    usePodSync: vi.fn(() => ({ saveToPod: vi.fn(), syncFromPod: vi.fn() })),
+}))
+
+vi.mock('../services/migration', () => ({
+    DatabaseMigration: {
+        checkMigrationNeeded: vi.fn().mockResolvedValue({ needed: false }),
+        performMigration: vi.fn(),
+    },
+}))
+
+vi.mock('../services/solidPod', () => ({
+    POD_CONTAINERS: { ROOT: 'pack-me-up/' },
+}))
+
+vi.mock('../services/rdfSerialization', () => ({
+    questionSetToDataset: vi.fn(),
+    datasetToQuestionSet: vi.fn(),
+}))
+
+import { QuestionsPage } from './questions-page'
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+import { useForeignPod } from '../components/ForeignPodContext'
+
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockUseForeignPod = vi.mocked(useForeignPod)
+
+const questionSet = {
+    _id: '1',
+    _rev: '1',
+    people: [{ id: 'p1', name: 'Alice' }],
+    alwaysNeededItems: [
+        { id: 'i1', text: 'Passport', personSelections: [{ personId: 'p1', selected: true }] },
+    ],
+    questions: [
+        {
+            id: 'q1', type: 'saved' as const, order: 0, questionType: 'single-choice' as const,
+            text: 'Beach holiday?',
+            options: [{
+                id: 'o1', order: 0, text: 'Yes', items: [
+                    { id: 'i2', text: 'Bucket and spade', personSelections: [{ personId: 'p1', selected: true }] },
+                    { id: 'i3', text: 'Sun cream', category: 'Toiletries', personSelections: [{ personId: 'p1', selected: true }] },
+                ],
+            }],
+        },
+    ],
+}
+
+async function renderPage() {
+    mockUseDatabase.mockReturnValue({
+        db: {
+            getQuestionSet: () => Promise.resolve(structuredClone(questionSet)),
+            saveQuestionSet: vi.fn(),
+        } as unknown as PackingAppDatabase,
+    })
+    render(
+        <MemoryRouter>
+            <QuestionsPage />
+        </MemoryRouter>
+    )
+    await screen.findByText('My Questions & Items')
+}
+
+function search(text: string) {
+    fireEvent.change(screen.getByLabelText('Search items'), { target: { value: text } })
+}
+
+describe('QuestionsPage item search', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseForeignPod.mockReturnValue(null)
+    })
+
+    afterEach(cleanup)
+
+    it('leaves the page alone until enough has been typed to search on', async () => {
+        await renderPage()
+        search('s')
+        expect(screen.queryByTestId('item-search-results')).toBeNull()
+        expect(screen.getByTestId('questions-list').className).not.toContain('hidden')
+    })
+
+    it('shows matches with their question, answer and section instead of the list', async () => {
+        await renderPage()
+        search('sun')
+        const results = screen.getByTestId('item-search-results')
+        expect(within(results).getByTestId('search-group-crumbs').textContent).toBe('Beach holiday? › Yes')
+        expect(within(results).getByTestId('search-section-label').textContent).toBe('Toiletries')
+        expect(within(results).getByTestId('item-row').textContent).toContain('Sun cream')
+        expect(screen.getByTestId('questions-list').className).toContain('hidden')
+    })
+
+    // The list is hidden rather than thrown away, so a search is something you
+    // can look at and back out of without losing your place on the page.
+    it('puts the page back, still unfolded as it was, when the search is cleared', async () => {
+        await renderPage()
+        fireEvent.click(screen.getByRole('button', { name: /Yes/ }))
+        expect(screen.getByText('Bucket and spade')).toBeTruthy()
+
+        search('sun')
+        fireEvent.click(screen.getByRole('button', { name: /Clear search/i }))
+
+        expect(screen.queryByTestId('item-search-results')).toBeNull()
+        expect(screen.getByTestId('questions-list').className).not.toContain('hidden')
+        expect(screen.getByText('Bucket and spade')).toBeTruthy()
+    })
+
+    it('saves an edit made from a result, against the item it found', async () => {
+        await renderPage()
+        search('sun')
+        fireEvent.click(within(screen.getByTestId('item-search-results')).getByTestId('item-row'))
+        fireEvent.change(screen.getByLabelText('Section'), { target: { value: 'Beach holiday?' } })
+
+        expect(saveWithSyncPrevention).toHaveBeenCalled()
+        const saved = saveWithSyncPrevention.mock.calls[0][0]
+        const items = saved.questions[0].options[0].items
+        expect(items.map((i: { text: string }) => i.text)).toContain('Sun cream')
+        expect(items.find((i: { text: string }) => i.text === 'Sun cream').category).toBeUndefined()
+    })
+})

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -28,27 +28,15 @@ import { ItemInlineEditor } from '../components/ItemInlineEditor'
 import { AddQuestionItem } from '../components/AddQuestionItem'
 import { ALWAYS_LIST_KEY, buildQuestionSetSuggestions, listKeyFor } from '../edit-questions/item-suggestions'
 import { buildIndexOf, type SuggestionIndex } from '../utils/itemSuggestions'
-import {
-    rateLabel,
-    quantityTitle,
-} from '../components/ItemEditorControls'
-import { PERSON_COLOR_OFF, personColorFor, type PersonColorId } from '../edit-questions/person-colors'
+import { ItemRow } from '../components/ItemRow'
+import { ItemSearchBar, ItemSearchResults } from '../components/ItemSearch'
+import { isSearchQuery } from '../edit-questions/item-search'
+import { personColorFor, type PersonColorId } from '../edit-questions/person-colors'
 import { PersonColorSwatches } from '../components/PersonColorPicker'
 
 // Stable empty default for the optional inline-editing props, so a section that
 // isn't editable doesn't hand its memoized children a new array every render.
 const NO_NAMES: string[] = []
-
-function PersonDot({ person, index, selected }: { person: Person; index: number; selected: boolean }) {
-    return (
-        <span
-            title={person.name}
-            className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold select-none shrink-0 ${selected ? personColorFor(person, index).avatar : PERSON_COLOR_OFF}`}
-        >
-            {person.name.charAt(0).toUpperCase()}
-        </span>
-    )
-}
 
 const PersonLegend = memo(function PersonLegend({ people, onEdit }: { people: Person[]; onEdit?: () => void }) {
     if (people.length < 2 && !onEdit) return null
@@ -78,84 +66,6 @@ const PersonLegend = memo(function PersonLegend({ people, onEdit }: { people: Pe
                 </button>
             )}
         </div>
-    )
-})
-
-/**
- * One item, read-only. When `onOpen` is supplied the whole row becomes the
- * target that opens the inline editor — the affordance that used to be missing,
- * and the reason changing one word meant scrolling back to the option's pencil
- * and reopening the whole list in a modal.
- */
-const ItemRow = memo(function ItemRow({ item, people, index, isOpen, onOpen }: {
-    item: Item
-    people: Person[]
-    index: number
-    isOpen?: boolean
-    onOpen?: (index: number) => void
-}) {
-    const showDots = people.length > 1
-    const content = (
-        <>
-            <span className={`flex-1 min-w-0 text-left ${item.text ? 'text-gray-700' : 'text-gray-400 italic'}`}>
-                {item.text || 'no text'}
-            </span>
-            {item.communal && (
-                <span
-                    title="Shared — packed once for the whole group"
-                    className="inline-flex items-center justify-center h-5 rounded-full px-1.5 text-[10px] font-medium bg-blue-100 text-blue-700 select-none shrink-0"
-                >
-                    👥
-                </span>
-            )}
-            {item.perNight !== undefined && (
-                <span
-                    title={quantityTitle(item)}
-                    className="inline-flex items-center justify-center h-5 rounded-full px-1.5 text-[10px] font-medium bg-emerald-100 text-emerald-700 select-none shrink-0"
-                >
-                    ×{rateLabel(item).replace(' per ', '/')}
-                </span>
-            )}
-            {showDots && (
-                <div className="flex gap-0.5 shrink-0">
-                    {people.map((person, i) => (
-                        <PersonDot
-                            key={person.id}
-                            person={person}
-                            index={i}
-                            selected={item.personSelections?.[i]?.selected ?? false}
-                        />
-                    ))}
-                </div>
-            )}
-        </>
-    )
-    if (!onOpen) {
-        return <div className="flex items-center gap-2 py-0.5 px-2 text-sm">{content}</div>
-    }
-    return (
-        <button
-            type="button"
-            data-testid="item-row"
-            onClick={() => onOpen(index)}
-            aria-expanded={isOpen ?? false}
-            title={`Edit ${item.text || 'item'}`}
-            className={`group w-full flex items-center gap-2 py-1 px-2 text-sm rounded transition-colors ${isOpen ? 'bg-primary-50' : 'hover:bg-gray-100'}`}
-        >
-            {content}
-            {/* Decorative, not a button of its own: the whole row is the target,
-                and a second hit area inside it would only make the real one
-                harder to hit. Sits last so it lines up down the right edge —
-                a column of pencils is what says the rows are editable. */}
-            <svg
-                data-testid="item-edit-icon"
-                aria-hidden="true"
-                className={`w-3.5 h-3.5 shrink-0 transition-colors ${isOpen ? 'text-primary-500' : 'text-gray-400 group-hover:text-gray-700'}`}
-                fill="none" viewBox="0 0 24 24" stroke="currentColor"
-            >
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
-        </button>
     )
 })
 
@@ -1573,6 +1483,10 @@ export function QuestionsPage() {
     const [questionModal, setQuestionModal] = useState<{ question: Question | null } | null>(null)
     const [optionModal, setOptionModal] = useState<{ questionId: string; option: Option | null } | null>(null)
     const [peopleModal, setPeopleModal] = useState(false)
+    // What is being searched for, and whether that is yet enough to search on.
+    // The page below stays put until it is — see ItemSearchBar.
+    const [query, setQuery] = useState('')
+    const searching = isSearchQuery(query)
     const [sectionOrderModal, setSectionOrderModal] = useState(false)
     // Bracket changes made by hand in the people modal; offered the same
     // item-review flow as birthday-driven transitions, then cleared.
@@ -2050,52 +1964,73 @@ export function QuestionsPage() {
                 )}
                 {!isForeign && <TemplateUpdatesCard questionSet={data} onApply={saveData} />}
                 <PersonLegend people={people} onEdit={openPeopleModal} />
-                <SectionOrderLegend labels={sectionLabels} onEdit={openSectionOrderModal} />
-                <AlwaysSection
-                    items={activeAlwaysNeededItems}
-                    people={people}
-                    emptySections={data.alwaysNeededEmptySections}
-                    allItemNames={allItemNames}
-                    sectionNames={suggestedSectionNames}
-                    suggestions={suggestions}
-                    onItemChange={handleAlwaysItemChange}
-                    onItemAdd={handleAlwaysItemAdd}
-                    onItemDelete={handleAlwaysItemDelete}
-                    onSectionAdd={handleAlwaysSectionAdd}
-                    onSectionRemove={handleAlwaysSectionRemove}
-                    onReorder={handleAlwaysReorder}
-                />
-                {activeQuestions.map((q, qi) => (
-                    <QuestionSection
-                        key={q.id}
-                        question={q}
+                {/* The legend stays above it: the person dots on a result row
+                    mean nothing without the names they stand for. */}
+                <ItemSearchBar value={query} onChange={setQuery} />
+                {searching && (
+                    <ItemSearchResults
+                        questionSet={data}
+                        query={query}
                         people={people}
-                        canMoveUp={qi > 0}
-                        canMoveDown={qi < activeQuestions.length - 1}
+                        allItemNames={allItemNames}
+                        sectionNames={suggestedSectionNames}
+                        onOptionItemChange={handleOptionItemChange}
+                        onOptionItemDelete={handleOptionItemDelete}
+                        onAlwaysItemChange={handleAlwaysItemChange}
+                        onAlwaysItemDelete={handleAlwaysItemDelete}
+                    />
+                )}
+                {/* Hidden rather than unmounted while searching: which questions
+                    and answers you had open is where you were on this page, and
+                    a search you clear should put you back there. */}
+                <div data-testid="questions-list" className={searching ? 'hidden' : 'space-y-4'}>
+                    <SectionOrderLegend labels={sectionLabels} onEdit={openSectionOrderModal} />
+                    <AlwaysSection
+                        items={activeAlwaysNeededItems}
+                        people={people}
+                        emptySections={data.alwaysNeededEmptySections}
                         allItemNames={allItemNames}
                         sectionNames={suggestedSectionNames}
                         suggestions={suggestions}
-                        onEdit={openEditQuestion}
-                        onDelete={handleDeleteQuestion}
-                        onAddOption={openAddOption}
-                        onEditOption={openEditOption}
-                        onDeleteOption={handleDeleteOption}
-                        onMove={handleMoveQuestion}
-                        onItemChange={handleOptionItemChange}
-                        onItemAdd={handleOptionItemAdd}
-                        onItemDelete={handleOptionItemDelete}
-                        onSectionAdd={handleOptionSectionAdd}
-                        onSectionRemove={handleOptionSectionRemove}
-                        onReorder={handleOptionReorder}
+                        onItemChange={handleAlwaysItemChange}
+                        onItemAdd={handleAlwaysItemAdd}
+                        onItemDelete={handleAlwaysItemDelete}
+                        onSectionAdd={handleAlwaysSectionAdd}
+                        onSectionRemove={handleAlwaysSectionRemove}
+                        onReorder={handleAlwaysReorder}
                     />
-                ))}
-                <button
-                    type="button"
-                    onClick={() => setQuestionModal({ question: null })}
-                    className="w-full py-3 border-2 border-dashed border-gray-200 rounded-lg text-sm text-gray-500 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
-                >
-                    + Add Question
-                </button>
+                    {activeQuestions.map((q, qi) => (
+                        <QuestionSection
+                            key={q.id}
+                            question={q}
+                            people={people}
+                            canMoveUp={qi > 0}
+                            canMoveDown={qi < activeQuestions.length - 1}
+                            allItemNames={allItemNames}
+                            sectionNames={suggestedSectionNames}
+                            suggestions={suggestions}
+                            onEdit={openEditQuestion}
+                            onDelete={handleDeleteQuestion}
+                            onAddOption={openAddOption}
+                            onEditOption={openEditOption}
+                            onDeleteOption={handleDeleteOption}
+                            onMove={handleMoveQuestion}
+                            onItemChange={handleOptionItemChange}
+                            onItemAdd={handleOptionItemAdd}
+                            onItemDelete={handleOptionItemDelete}
+                            onSectionAdd={handleOptionSectionAdd}
+                            onSectionRemove={handleOptionSectionRemove}
+                            onReorder={handleOptionReorder}
+                        />
+                    ))}
+                    <button
+                        type="button"
+                        onClick={() => setQuestionModal({ question: null })}
+                        className="w-full py-3 border-2 border-dashed border-gray-200 rounded-lg text-sm text-gray-500 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
+                    >
+                        + Add Question
+                    </button>
+                </div>
             </div>
             {questionModal !== null && (
                 <QuestionModal


### PR DESCRIPTION
The page is a page of folded lists, and everything on it is addressed by
where it lives: which question, which answer, which section. That is
exactly what you don't know when the question in your head is "have I got
sun cream in here anywhere?" — the only way to answer it was to unfold
questions one at a time until one of them turned out to have it.

So the page grows a search box, and a match is never shown on its own: it
comes with the trail that leads to it. Matches gather under the answer
that holds them, split by section inside it — a set asked about "sun"
answers with six rows spread over three sections of the same two
questions, and repeating the question above each of them says the same
long thing three times while pushing the section, the part that differs,
off the right-hand edge of a phone.

A result is a real row: it opens the same inline editor as the list does
and writes through the same handlers, so finding a misfiled item and
fixing it is one gesture. The list itself is hidden rather than unmounted
while a search is on screen, so clearing the search puts you back where
you were, still unfolded.

`ItemRow` moves to its own component for that: a searched item should look,
and edit, exactly like one found by unfolding the list it lives in.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VjAjEJJjD6v4WdJPxxWPqH