### PR TITLE
Lead the landing page with the travel benefit, not Solid Pod

### DIFF
--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -69,16 +69,54 @@ describe('LandingPage', () => {
         expect(screen.queryByRole('link', { name: /create a new packing list/i })).toBeNull()
     })
 
-    it('displays the correct h1 heading', () => {
+    it('leads with the travel and sharing benefit in the h1', () => {
         mockUseHasQuestions.mockReturnValue(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
-        expect(screen.getByRole('heading', { level: 1, name: /smart packing lists, made simple/i })).toBeTruthy()
+        const heading = screen.getByRole('heading', { level: 1 })
+        expect(heading.textContent).toMatch(/packing lists for couples and families/i)
     })
 
-    it('does not show a separate tagline below the h1', () => {
+    it('does not mention Solid Pod or data ownership above the fold', () => {
         mockUseHasQuestions.mockReturnValue(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
-        expect(screen.queryByText(/smart packing lists for every trip/i)).toBeNull()
+        const heading = screen.getByRole('heading', { level: 1 })
+        const hero = heading.parentElement as HTMLElement
+        expect(hero.textContent).not.toMatch(/solid pod/i)
+        expect(hero.textContent).not.toMatch(/own your data/i)
+    })
+
+    it('supports the h1 with a sharing-focused subheadline', () => {
+        mockUseHasQuestions.mockReturnValue(false)
+        render(<MemoryRouter><LandingPage /></MemoryRouter>)
+        expect(screen.getByText(/share one list, pack as a team/i)).toBeTruthy()
+    })
+
+    it('renders the primary CTA before the "How it works" section so it is above the fold', () => {
+        mockUseHasQuestions.mockReturnValue(false)
+        render(<MemoryRouter><LandingPage /></MemoryRouter>)
+        const cta = screen.getByRole('link', { name: /get started with the wizard/i })
+        const howItWorks = screen.getByRole('heading', { name: /how it works/i })
+        expect(
+            cta.compareDocumentPosition(howItWorks) & Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy()
+    })
+
+    it('renders the "View Packing Lists" CTA before the "How it works" section too', () => {
+        mockUseHasQuestions.mockReturnValue(true)
+        render(<MemoryRouter><LandingPage /></MemoryRouter>)
+        const cta = screen.getByRole('link', { name: /view packing lists/i })
+        const howItWorks = screen.getByRole('heading', { name: /how it works/i })
+        expect(
+            cta.compareDocumentPosition(howItWorks) & Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy()
+    })
+
+    it('frames the data-ownership section as a benefit rather than a mechanism', () => {
+        mockUseHasQuestions.mockReturnValue(false)
+        render(<MemoryRouter><LandingPage /></MemoryRouter>)
+        const trustSection = screen.getByRole('heading', { name: /own your data/i })
+            .closest('div') as HTMLElement
+        expect(trustSection.textContent).toMatch(/your lists live in storage you control/i)
     })
 
     it('renders the Solid Pod section after the CTA in the DOM', () => {

--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -73,7 +73,7 @@ describe('LandingPage', () => {
         mockUseHasQuestions.mockReturnValue(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         const heading = screen.getByRole('heading', { level: 1 })
-        expect(heading.textContent).toMatch(/packing lists for couples and families/i)
+        expect(heading.textContent).toMatch(/packing lists that learn how you travel/i)
     })
 
     it('does not mention Solid Pod or data ownership above the fold', () => {
@@ -88,7 +88,7 @@ describe('LandingPage', () => {
     it('supports the h1 with a sharing-focused subheadline', () => {
         mockUseHasQuestions.mockReturnValue(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
-        expect(screen.getByText(/share one list, pack as a team/i)).toBeTruthy()
+        expect(screen.getByText(/share one list with your partner or the whole family/i)).toBeTruthy()
     })
 
     it('renders the primary CTA before the "How it works" section so it is above the fold', () => {

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -8,6 +8,21 @@ export const LandingPage = () => {
     const { isLoggedIn, webId, login } = useSolidPod()
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
     const hasQuestions = useHasQuestions()
+    const primaryCta = hasQuestions ? (
+        <Link
+            to="/view-lists"
+            className="inline-block bg-gradient-primary text-white px-8 py-4 rounded-2xl text-lg font-bold hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
+        >
+            📋 View Packing Lists
+        </Link>
+    ) : (
+        <Link
+            to="/wizard"
+            className="inline-block bg-gradient-primary text-white px-8 py-4 rounded-2xl text-lg font-bold hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
+        >
+            ✨ Get Started with the Wizard
+        </Link>
+    )
     return (
         <>
             {isLoggedIn && (
@@ -18,10 +33,19 @@ export const LandingPage = () => {
                 </div>
             )}
             <div className="max-w-4xl mx-auto">
-                <div className="text-center mb-12 animate-slide-up">
-                    <h1 className="text-5xl font-bold mb-4 text-primary-900">
-                        Smart Packing Lists, Made Simple
+                {/* Hero leads with the travel benefit and keeps the primary CTA above the
+                    fold — the data-ownership story lives in the trust section further down. */}
+                <div className="text-center mb-10 animate-slide-up">
+                    <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-primary-900 text-balance">
+                        Personalised packing lists for couples and families
                     </h1>
+                    <p className="text-lg sm:text-xl text-gray-700 max-w-2xl mx-auto">
+                        Share one list, pack as a team — and never argue about who packed the passports again.
+                    </p>
+                </div>
+
+                <div className="text-center space-y-4 mb-14">
+                    {primaryCta}
                 </div>
 
                 <div className="mb-12">
@@ -53,31 +77,9 @@ export const LandingPage = () => {
                     </div>
                 </div>
 
-                <div className="text-center space-y-4">
-                    {hasQuestions ? (
-                        <>
-                            <Link
-                                to="/view-lists"
-                                className="inline-block bg-gradient-primary text-white px-8 py-4 rounded-2xl text-lg font-bold hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
-                            >
-                                📋 View Packing Lists
-                            </Link>
-                        </>
-                    ) : (
-                        <>
-                            <Link
-                                to="/wizard"
-                                className="inline-block bg-gradient-primary text-white px-8 py-4 rounded-2xl text-lg font-bold hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
-                            >
-                                ✨ Get Started with the Wizard
-                            </Link>
-                        </>
-                    )}
-                </div>
-
                 <div className="mt-10 p-4 rounded-xl border border-gray-200 bg-gray-50 text-center text-sm text-gray-500">
                     <h2 className="font-semibold text-gray-600 inline">Own Your Data</h2>
-                    {' '}— Login with your Solid Pod to store your lists in your own free personal storage you control. Your data saves locally in your browser automatically, even without an account.
+                    {' '}— Your lists live in storage you control, never on our servers. They save to this device automatically, even without an account.
                     {!isLoggedIn && (
                         <span className="block mt-1">
                             <button
@@ -86,7 +88,7 @@ export const LandingPage = () => {
                             >
                                 Get a free Solid Pod
                             </button>
-                            {' '}to sync across devices.
+                            {' '}to sync across your devices and share lists with the people you travel with.
                         </span>
                     )}
                 </div>

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -37,10 +37,10 @@ export const LandingPage = () => {
                     fold — the data-ownership story lives in the trust section further down. */}
                 <div className="text-center mb-10 animate-slide-up">
                     <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-primary-900 text-balance">
-                        Personalised packing lists for couples and families
+                        Packing lists that learn how you travel
                     </h1>
                     <p className="text-lg sm:text-xl text-gray-700 max-w-2xl mx-auto">
-                        Share one list, pack as a team — and never argue about who packed the passports again.
+                        Set up your questions once, then get a personalised list for every trip. Share one list with your partner or the whole family and pack as a team.
                     </p>
                 </div>
 
@@ -53,9 +53,9 @@ export const LandingPage = () => {
                     <div className="grid md:grid-cols-3 gap-6">
                         <div className="bg-gradient-to-br from-primary-50 to-primary-100 p-6 rounded-2xl shadow-soft hover:shadow-glow-primary transition-all duration-300 hover:scale-105 border-2 border-primary-200">
                             <div className="text-3xl mb-2">✨</div>
-                            <h3 className="text-xl font-bold mb-3 text-primary-900">1. Set up once</h3>
+                            <h3 className="text-xl font-bold mb-3 text-primary-900">1. Set up in a minute</h3>
                             <p className="text-gray-700">
-                                Run the quick wizard — tell us who you travel with and we'll generate a starter set of packing questions for you.
+                                One screen — tell us who you travel with, and we'll generate a starter set of packing questions for your group.
                             </p>
                         </div>
 


### PR DESCRIPTION
The hero now sells personalised, shareable packing lists for couples and
families, and the primary CTA sits directly beneath it so it is visible
without scrolling on both desktop (1280px) and mobile (390px).

Data ownership stays on the page as a secondary trust note below the
"How it works" section, reworded as a benefit ("your lists live in
storage you control") rather than the Solid Pod mechanism.

Closes #199

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0112c3f6fFEfbXtdTQZ6X41A