### PR TITLE
End the wizard on one success screen with no dead end

### DIFF
--- a/e2e/tests/a-onboarding.spec.ts
+++ b/e2e/tests/a-onboarding.spec.ts
@@ -109,4 +109,50 @@ test.describe('A – Onboarding & Wizard', () => {
     await expect(page.locator('[name="people.1.species"]')).toHaveValue('dog')
     await expect(page.getByText('2 in your group')).toBeVisible()
   })
+
+  test('A6: the wizard ends in one success screen, and dismissing it is not a dead end', async ({ freshPage: page }) => {
+    await page.goto('/#/wizard')
+    await fillPersonRequiredFields(page)
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await waitForWizardSuccess(page)
+
+    // Exactly one modal — no Solid Pod upsell queued up behind it
+    await expect(page.getByRole('dialog')).toHaveCount(1)
+    await expect(page.getByRole('button', { name: 'Maybe Later' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /Set Up Solid Pod/i })).toHaveCount(0)
+
+    // Dismissing lands on the questions just generated, not back on the wizard form
+    await page.getByRole('button', { name: /^Close$/i }).click()
+    await expect(page).toHaveURL(/#\/manage-questions/, { timeout: 5_000 })
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+  })
+
+  test('A7: the success screen fits a phone screen with both actions tappable', async ({ freshPage: page }) => {
+    await page.setViewportSize({ width: 375, height: 667 })
+    await page.goto('/#/wizard')
+    await fillPersonRequiredFields(page)
+    await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+    await waitForWizardSuccess(page)
+
+    const createList = page.getByRole('button', { name: /Create My First Packing List/i })
+    const refine = page.getByRole('button', { name: /Refine My Packing List Questions/i })
+    await expect(createList).toBeVisible({ timeout: 10_000 })
+    await expect(refine).toBeVisible()
+
+    // Both buttons stack inside the viewport, with no clipping and a tappable height
+    for (const button of [createList, refine]) {
+      const box = await button.boundingBox()
+      expect(box).not.toBeNull()
+      expect(box!.x).toBeGreaterThanOrEqual(0)
+      expect(box!.x + box!.width).toBeLessThanOrEqual(375)
+      expect(box!.height).toBeGreaterThanOrEqual(44)
+    }
+
+    // The primary CTA sits above the secondary action, and still works from here
+    const createBox = await createList.boundingBox()
+    const refineBox = await refine.boundingBox()
+    expect(createBox!.y).toBeLessThan(refineBox!.y)
+    await createList.click()
+    await expect(page).toHaveURL(/#\/create-packing-list/, { timeout: 5_000 })
+  })
 })

--- a/src/pages/wizard.test.tsx
+++ b/src/pages/wizard.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { Wizard } from './wizard'
 import type { PackingAppDatabase } from '../services/database'
 
@@ -183,32 +183,77 @@ describe('Wizard', () => {
         expect(screen.queryByText(/set up solid pod/i)).toBeNull()
     })
 
-    it('closes the success modal when the X button is clicked', async () => {
-        const db = makeDb()
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
-        mockUseWizardGeneration.mockReturnValue({
-            isLoading: false,
-            isSuccess: true,
-            generatedSet: null,
-            generateAndSave: vi.fn(),
+    describe('the single success screen', () => {
+        function renderAfterGeneration() {
+            const db = makeDb()
+            mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+            mockUseWizardGeneration.mockReturnValue({
+                isLoading: false,
+                isSuccess: true,
+                generatedSet: null,
+                generateAndSave: vi.fn(),
+            })
+
+            return render(
+                <MemoryRouter initialEntries={['/wizard']}>
+                    <Routes>
+                        <Route path="/wizard" element={<Wizard />} />
+                        <Route path="/create-packing-list" element={<div>Create list page</div>} />
+                        <Route path="/manage-questions" element={<div>Questions page</div>} />
+                    </Routes>
+                </MemoryRouter>
+            )
+        }
+
+        it('is the only thing between the wizard and the app — one modal, no second ask', async () => {
+            renderAfterGeneration()
+
+            await waitFor(() => expect(screen.getAllByRole('dialog')).toHaveLength(1))
+            expect(screen.getByText(/questions generated successfully/i)).toBeTruthy()
+            expect(screen.queryByText(/set up solid pod/i)).toBeNull()
         })
 
-        render(
-            <MemoryRouter>
-                <Wizard />
-            </MemoryRouter>
-        )
+        it('sends the primary CTA to the list builder', async () => {
+            renderAfterGeneration()
 
-        await waitFor(() =>
-            expect(screen.getByText(/questions generated successfully/i)).toBeTruthy()
-        )
+            const create = await screen.findByRole('button', { name: /create my first packing list/i })
+            create.click()
 
-        const closeButton = screen.getByRole('button', { name: /close/i })
-        closeButton.click()
+            expect(await screen.findByText('Create list page')).toBeTruthy()
+        })
 
-        await waitFor(() =>
+        it('sends the secondary action to the questions page', async () => {
+            renderAfterGeneration()
+
+            const refine = await screen.findByRole('button', { name: /refine my packing list questions/i })
+            refine.click()
+
+            expect(await screen.findByText('Questions page')).toBeTruthy()
+        })
+
+        it('gives the primary CTA more weight than the secondary action', async () => {
+            renderAfterGeneration()
+
+            const create = await screen.findByRole('button', { name: /create my first packing list/i })
+            const refine = await screen.findByRole('button', { name: /refine my packing list questions/i })
+
+            expect(create.className).toContain('bg-gradient-primary')
+            expect(refine.className).not.toContain('bg-gradient')
+        })
+
+        it('dismissing it lands on the questions just generated, not back on the wizard form', async () => {
+            renderAfterGeneration()
+
+            await waitFor(() =>
+                expect(screen.getByText(/questions generated successfully/i)).toBeTruthy()
+            )
+
+            screen.getByRole('button', { name: /close/i }).click()
+
+            // No dead-end: the wizard form is behind us, and the modal is gone
+            expect(await screen.findByText('Questions page')).toBeTruthy()
             expect(screen.queryByText(/questions generated successfully/i)).toBeNull()
-        )
+        })
     })
 
     it('acts on a success modal CTA without asking a logged-out user to sign in', async () => {

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -108,6 +108,11 @@ export const Wizard = () => {
         navigate(route)
     }
 
+    // Dismissing the one success screen must not drop the user back on the
+    // wizard form they have just finished — the questions are saved, so show
+    // them, rather than an unchanged form that would regenerate over the top.
+    const handleDismissSuccess = () => handleSuccessAction('/manage-questions')
+
     const onSubmit = async (data: WizardFormData) => {
         if (hasExistingData) {
             setShowConfirmDialog(true)
@@ -354,7 +359,7 @@ Are you sure you want to continue?"
             {/* Success Modal */}
             <Modal
                 isOpen={showSuccessModal}
-                onClose={() => setShowSuccessModal(false)}
+                onClose={handleDismissSuccess}
                 title="🎉 Questions Generated Successfully!"
             >
                 <div className="space-y-6">
@@ -395,17 +400,17 @@ Are you sure you want to continue?"
                                 Your starter questions are ready! Head to 'My Questions &amp; Items' to add, remove, or tweak them to match how you travel — then create your first list.
                             </p>
 
-                            <div className="space-y-4">
+                            <div className="space-y-3">
                                 <button
                                     onClick={() => handleSuccessAction('/create-packing-list')}
-                                    className="w-full bg-gradient-primary text-white px-6 py-4 rounded-xl font-bold text-lg hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
+                                    className="w-full bg-gradient-primary text-white px-4 sm:px-6 py-4 rounded-xl font-bold text-base sm:text-lg break-words hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
                                 >
                                     🚀 Create My First Packing List
                                 </button>
 
                                 <button
                                     onClick={() => handleSuccessAction('/manage-questions')}
-                                    className="w-full bg-gradient-secondary text-white px-6 py-4 rounded-xl font-bold text-lg hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-secondary"
+                                    className="w-full text-primary-700 border-2 border-primary-200 hover:border-primary-400 hover:bg-primary-50 px-4 sm:px-6 py-3 rounded-xl font-semibold text-sm sm:text-base break-words transition-all duration-200"
                                 >
                                     ✏️ Refine My Packing List Questions
                                 </button>


### PR DESCRIPTION
The post-wizard Solid Pod upsell went with #202, leaving the success modal
as the only thing between the wizard and the app. Finish the job for #201:

- The two CTAs were identically loud full-width gradient buttons, so there
  was no primary. "Create My First Packing List" keeps the gradient;
  "Refine My Packing List Questions" becomes a quieter outlined action.
- Dismissing the modal (X or backdrop) used to leave the user staring at
  the wizard form they had just submitted, with hasExistingData still false
  from mount — so a second submit would silently regenerate over the top.
  Dismissing now lands on the questions that were just generated.
- Both buttons size and wrap for a phone screen rather than holding text-lg
  at any width.

A6 and A7 cover the desktop and mobile criteria end to end: one dialog, no
pod ask behind it, and both actions inside a 375px viewport at a tappable
height with the primary above the secondary.

Closes #201

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ReS1pNn2b9kcJzXq1dG4Bq