### PR TITLE
Lead the auth control with sync & share, not Solid Pod

### DIFF
--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -19,7 +19,7 @@ export async function loginToCss(
   options?: { waitForLoggedIn?: boolean },
 ): Promise<void> {
   // Open provider selector
-  await page.getByRole('button', { name: 'Login with Solid Pod' }).click()
+  await page.getByRole('button', { name: 'Sync & Share' }).click()
   await page.getByRole('dialog').waitFor()
 
   // Show other providers

--- a/e2e/tests/e-auth.spec.ts
+++ b/e2e/tests/e-auth.spec.ts
@@ -8,7 +8,7 @@ const TEST_PASSWORD = 'test1234'
 test.describe('E – Solid Pod Authentication', () => {
   test('E1: full login flow completes and shows logged-in state', async ({ freshPage: page }) => {
     await page.goto('/')
-    await expect(page.getByRole('button', { name: 'Login with Solid Pod' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Sync & Share' })).toBeVisible()
     await loginToCss(page, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD)
     await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
     // webId should be displayed (use .first() to avoid strict mode violations when multiple elements match)
@@ -20,7 +20,7 @@ test.describe('E – Solid Pod Authentication', () => {
   test('E2: logout returns to unauthenticated state', async ({ authedPage: page }) => {
     await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
     await page.getByRole('button', { name: 'Logout' }).click()
-    await expect(page.getByRole('button', { name: 'Login with Solid Pod' })).toBeVisible({ timeout: 8_000 })
+    await expect(page.getByRole('button', { name: 'Sync & Share' })).toBeVisible({ timeout: 8_000 })
     await expect(page.getByRole('button', { name: 'Logout' })).not.toBeVisible()
   })
 

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -123,3 +123,48 @@ describe('Navigation', () => {
         expect(screen.getAllByText('Backups').length).toBeGreaterThan(0)
     })
 })
+
+describe('Navigation – signed-out auth control', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            sessionExpired: false,
+            clearSessionExpired: vi.fn(),
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+    })
+
+    it('labels the auth control with the benefit in both desktop nav and mobile menu', () => {
+        render(
+            <MemoryRouter>
+                <Navigation />
+            </MemoryRouter>
+        )
+
+        expect(screen.getAllByRole('button', { name: 'Sync & Share' })).toHaveLength(2)
+    })
+
+    it('does not lead with "Solid Pod" on the auth control', () => {
+        render(
+            <MemoryRouter>
+                <Navigation />
+            </MemoryRouter>
+        )
+
+        expect(screen.queryByRole('button', { name: /solid pod/i })).toBeNull()
+    })
+
+    it('notes the payoff alongside the auth control', () => {
+        render(
+            <MemoryRouter>
+                <Navigation />
+            </MemoryRouter>
+        )
+
+        expect(screen.getAllByText(/sync across devices/i).length).toBeGreaterThanOrEqual(2)
+    })
+})

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -134,11 +134,11 @@ export const Navigation = () => {
                                     <button
                                         onClick={handleSolidLogin}
                                         className="px-4 py-2 rounded-xl text-sm font-semibold bg-white/90 text-primary-700 hover:bg-white hover:scale-105 transition-all duration-200 shadow-soft"
-                                        title="Store your packing lists in your own personal Pod - you own your data"
+                                        title="Sign in to sync your lists across devices and share them - your data stays in your own Solid Pod"
                                     >
-                                        Login with Solid Pod
+                                        Sync &amp; Share
                                     </button>
-                                    <span className="text-xs text-white mt-1 font-medium">Own your data</span>
+                                    <span className="text-xs text-white mt-1 font-medium">Sync across devices</span>
                                 </div>
                             )}
                         </div>
@@ -242,11 +242,11 @@ export const Navigation = () => {
                                             setIsOpen(false)
                                         }}
                                         className="w-full text-left px-3 py-3 rounded-xl text-base font-semibold bg-white/90 text-primary-700 hover:bg-white transition-all duration-200"
-                                        title="Store your packing lists in your own personal Pod - you own your data"
+                                        title="Sign in to sync your lists across devices and share them - your data stays in your own Solid Pod"
                                     >
-                                        Login with Solid Pod
+                                        Sync &amp; Share
                                     </button>
-                                    <p className="px-3 py-1 text-xs text-white font-medium">Own your data</p>
+                                    <p className="px-3 py-1 text-xs text-white font-medium">Sync across devices and share lists</p>
                                 </div>
                             )}
                         </div>

--- a/src/components/SolidPodPrompt.tsx
+++ b/src/components/SolidPodPrompt.tsx
@@ -43,9 +43,9 @@ export function SolidPodPrompt({
   onClose,
   title,
   message,
-  benefitsTitle = 'Benefits of using a Solid Pod:',
+  benefitsTitle = 'What signing in unlocks:',
   benefits = DEFAULT_BENEFITS,
-  confirmLabel = '🔒 Set Up Solid Pod',
+  confirmLabel = '🔒 Sync & Share',
   dismissLabel = 'Maybe Later',
   onBeforeLogin,
 }: SolidPodPromptProps) {

--- a/src/components/SolidProviderSelector.test.tsx
+++ b/src/components/SolidProviderSelector.test.tsx
@@ -103,3 +103,25 @@ describe('SolidProviderSelector', () => {
     })
   })
 })
+
+describe('SolidProviderSelector – sign-in framing', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('titles the sign-in screen with the benefit rather than the mechanism', () => {
+    render(<SolidProviderSelector {...defaultProps} />)
+    expect(screen.getByText('Sync & Share your lists')).toBeTruthy()
+  })
+
+  it('spells out the payoff of signing in', () => {
+    render(<SolidProviderSelector {...defaultProps} />)
+    expect(screen.getByText(/sync across (?:your )?devices/i)).toBeTruthy()
+  })
+
+  it('still explains that this uses a Solid Pod', () => {
+    render(<SolidProviderSelector {...defaultProps} />)
+    expect(screen.getByText('What is a Solid Pod?')).toBeTruthy()
+  })
+})

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -76,13 +76,16 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
   const isLastUsed = localStorage.getItem(LAST_PROVIDER_KEY) === primaryProvider.issuer;
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} title="Login with Your Solid Pod">
+    <Modal isOpen={isOpen} onClose={handleClose} title="Sync &amp; Share your lists">
       <div className="space-y-4">
-        {/* Explanation section */}
+        {/* Payoff first, mechanism second — signing in is what unlocks these */}
         <div className="bg-blue-50 border border-blue-200 rounded-md p-4 space-y-2">
+          <p className="text-sm text-gray-700">
+            Signing in lets you <strong>sync across your devices</strong> and <strong>share lists</strong> — a single list with a friend, or your whole question set with the person you travel with.
+          </p>
           <h3 className="font-semibold text-gray-900 text-sm">What is a Solid Pod?</h3>
           <p className="text-sm text-gray-700">
-            A Solid Pod is your personal data storage that <strong>you control</strong>. Instead of storing your packing lists on our servers, they're stored in your own secure space.
+            Signing in uses a Solid Pod: personal data storage that <strong>you control</strong>. Instead of storing your packing lists on our servers, they're stored in your own secure space.
           </p>
           <ul className="text-sm text-gray-700 space-y-1 ml-4 list-disc">
             <li><strong>You own your data</strong> - it stays in your Pod</li>

--- a/src/components/SyncAcrossDevicesPrompt.test.tsx
+++ b/src/components/SyncAcrossDevicesPrompt.test.tsx
@@ -55,7 +55,7 @@ describe('SyncAcrossDevicesPrompt', () => {
         render(<SyncAcrossDevicesPrompt />)
         fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
 
-        expect(screen.getByText(/login with your solid pod/i)).toBeTruthy()
+        expect(screen.getByText(/sync & share your lists/i)).toBeTruthy()
     })
 
     it('logs in with the chosen provider', () => {

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -601,13 +601,13 @@ describe('CreatePackingList - login button', () => {
         mockUseToast.mockReturnValue({ showToast: vi.fn() as (message: string, type: ToastType) => void })
     })
 
-    it('shows a "Login with Solid Pod" button in the page when not logged in and no questions found', () => {
+    it('shows a "Sync & Share" button in the page when not logged in and no questions found', () => {
         render(
             <MemoryRouter>
                 <CreatePackingList />
             </MemoryRouter>
         )
-        expect(screen.getByRole('button', { name: /login with solid pod/i })).toBeTruthy()
+        expect(screen.getByRole('button', { name: /sync & share/i })).toBeTruthy()
     })
 
     it('opens the provider selector modal when the login button is clicked', () => {
@@ -616,7 +616,7 @@ describe('CreatePackingList - login button', () => {
                 <CreatePackingList />
             </MemoryRouter>
         )
-        const loginButton = screen.getByRole('button', { name: /login with solid pod/i })
+        const loginButton = screen.getByRole('button', { name: /sync & share/i })
         fireEvent.click(loginButton)
         expect(screen.getByRole('dialog')).toBeTruthy()
     })

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -714,15 +714,15 @@ export function CreatePackingList() {
 
                             {!isLoggedIn && (
                                 <div className="bg-gradient-to-br from-accent-50 to-accent-100 p-6 rounded-xl border-2 border-accent-200">
-                                    <h3 className="text-lg font-bold text-accent-900 mb-2">🔒 Login to Sync Questions</h3>
+                                    <h3 className="text-lg font-bold text-accent-900 mb-2">🔄 Sync Questions From Another Device</h3>
                                     <p className="text-gray-700 mb-4">
-                                        If you've already created questions and saved them to your Solid Pod, login to sync them.
+                                        If you've already created questions on another device, sign in to sync them here. Signing in uses your Solid Pod.
                                     </p>
                                     <button
                                         className="text-sm font-semibold text-accent-700 underline hover:text-accent-900"
                                         onClick={() => setIsProviderSelectorOpen(true)}
                                     >
-                                        Login with Solid Pod
+                                        Sync &amp; Share
                                     </button>
                                 </div>
                             )}


### PR DESCRIPTION
"Login with Solid Pod" named the mechanism, not what the user gets. The
primary auth control now reads "Sync & Share" everywhere it appears —
desktop nav, mobile hamburger menu, and the sync-questions CTA on the
create-list page — with a short line underneath naming the payoff.

The mechanism stays transparent where it matters: the sign-in modal now
leads with what signing in unlocks and then keeps the "What is a Solid
Pod?" explanation, and the landing page's "Get a free Solid Pod" helper
is unchanged.

Closes #200

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013cdefvN24VP5rcxN9qnDUY