### PR TITLE
Surface sharing your full setup as a thing you can find

### DIFF
--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -382,6 +382,35 @@ test.describe('C – Contextual sign-in prompts (logged out)', () => {
     await expect(prompt).toHaveCount(0)
   })
 
+  test('C17: the sharing page pitches the full setup to a logged-out user, on desktop and on a phone', async ({ freshPage: page }) => {
+    // The nav link is the entry point — hiding it logged out is what made
+    // whole-setup sharing invisible in the first place
+    await page.goto('/#/home')
+    await page.getByRole('link', { name: 'Sharing' }).first().click()
+    await page.waitForURL(/#\/sharing/, { timeout: 8_000 })
+
+    await expect(page.getByRole('heading', { name: 'Share your full setup' })).toBeVisible({ timeout: 8_000 })
+    await expect(page.getByText(/let someone else use your questions and lists/i)).toBeVisible()
+    await expect(page.getByText(/sharing just one list\?/i)).toBeVisible()
+    await expect(page.getByText(/please log in/i)).toHaveCount(0)
+
+    // Sign-in is offered framed around the payoff, and backing out remembers nothing
+    await page.getByRole('button', { name: 'Sign in to share your setup' }).click()
+    await expect(page.getByRole('heading', { name: /sign in to share your full setup/i })).toBeVisible({ timeout: 5_000 })
+    await page.getByRole('button', { name: 'Not now' }).click()
+    await expect(page.getByRole('heading', { name: /sign in to share your full setup/i })).toHaveCount(0)
+    expect(await page.evaluate(() => sessionStorage.getItem('pending-sign-in-action'))).toBeNull()
+
+    // Reachable through the hamburger on a phone, and the page fits
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/#/home')
+    await page.getByRole('button', { name: 'Open main menu' }).click()
+    await page.getByRole('link', { name: 'Sharing' }).click()
+    await expect(page.getByRole('heading', { name: 'Share your full setup' })).toBeVisible({ timeout: 8_000 })
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)
+    expect(overflow).toBeLessThanOrEqual(0)
+  })
+
   test('C14: a last minute item moves to its own section and survives a reload', async ({ freshPage: page }) => {
     await runWizard(page)
     // A name with no "last minute" in it, so the assertions below can't be

--- a/e2e/tests/m-collaboration.spec.ts
+++ b/e2e/tests/m-collaboration.spec.ts
@@ -80,13 +80,13 @@ test.describe('M – Full pod collaboration', () => {
 
     test('M1: Owner navigates to sharing settings', async () => {
         await pageA.goto('/#/sharing')
-        await expect(pageA.getByRole('heading', { name: /sharing settings/i })).toBeVisible({ timeout: 10_000 })
+        await expect(pageA.getByRole('heading', { name: /share your full setup/i })).toBeVisible({ timeout: 10_000 })
     })
 
     test('M2: Owner grants full access to collaborator and gets invite link', async () => {
         await pageA.goto('/#/sharing')
-        await pageA.getByLabel(/collaborator webid/i).fill(collabWebId)
-        await pageA.getByRole('button', { name: /grant access/i }).click()
+        await pageA.getByLabel(/their webid/i).fill(collabWebId)
+        await pageA.getByRole('button', { name: /share my setup/i }).click()
 
         await expect(pageA.getByLabel(/invite link/i)).toBeVisible({ timeout: 15_000 })
         inviteLink = await pageA.getByLabel(/invite link/i).inputValue()
@@ -95,8 +95,14 @@ test.describe('M – Full pod collaboration', () => {
         expect(inviteLink).toContain(encodeURIComponent(ownerPodUrl))
         expect(inviteLink).toContain('/view-lists')
 
-        // Collaborator should now appear in the list
-        await expect(pageA.getByText(collabWebId)).toBeVisible({ timeout: 10_000 })
+        // The share is confirmed in the page's own words, and the collaborator
+        // appears in the list of people who have the full setup
+        // "with <webid>" pins this to the confirmation panel — the success toast
+        // says the same thing without it
+        await expect(pageA.getByText(/your full setup is shared with/i)).toBeVisible({ timeout: 10_000 })
+        await expect(
+            pageA.getByRole('button', { name: `Revoke access for ${collabWebId}` })
+        ).toBeVisible({ timeout: 10_000 })
     })
 
     test('M3: Collab visits invite link and sees foreign context banner', async () => {
@@ -173,9 +179,10 @@ test.describe('M – Full pod collaboration', () => {
     test('M9: Owner revokes access; collab sees access denied', async ({ browser }) => {
         // Owner revokes
         await pageA.goto('/#/sharing')
-        await expect(pageA.getByText(collabWebId)).toBeVisible({ timeout: 10_000 })
-        await pageA.getByRole('button', { name: /revoke/i }).first().click()
-        await expect(pageA.getByText(collabWebId)).not.toBeVisible({ timeout: 10_000 })
+        const revokeCollab = pageA.getByRole('button', { name: `Revoke access for ${collabWebId}` })
+        await expect(revokeCollab).toBeVisible({ timeout: 10_000 })
+        await revokeCollab.click()
+        await expect(revokeCollab).not.toBeVisible({ timeout: 10_000 })
 
         // Fresh context required: pageB has stale PouchDB cache from M3-M6, so the app serves
         // cached data rather than detecting the 403. A fresh login has no local cache.

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -48,6 +48,17 @@ describe('Navigation', () => {
         expect(screen.queryByText('Backups')).toBeNull()
     })
 
+    it('keeps the Sharing link reachable when logged out so sharing is discoverable', () => {
+        render(
+            <MemoryRouter>
+                <Navigation />
+            </MemoryRouter>
+        )
+
+        // Desktop and mobile menus each render one
+        expect(screen.getAllByText('Sharing').length).toBeGreaterThan(0)
+    })
+
     it('shows "My Questions & Items" nav link instead of "Edit Questions"', () => {
         render(
             <MemoryRouter>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -81,14 +81,17 @@ export const Navigation = () => {
                                             Backups
                                         </Link>
                                     )}
-                                    {isLoggedIn && (
-                                        <Link
-                                            to="/sharing"
-                                            className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
-                                        >
-                                            Sharing
-                                        </Link>
-                                    )}
+                                    {/*
+                                      * Sharing stays visible logged out: the page's own
+                                      * benefit-framed sign-in handles that case, and hiding
+                                      * the link is what made whole-setup sharing invisible.
+                                      */}
+                                    <Link
+                                        to="/sharing"
+                                        className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
+                                    >
+                                        Sharing
+                                    </Link>
                                 </div>
                             </div>
                         </div>
@@ -208,15 +211,13 @@ export const Navigation = () => {
                                 Backups
                             </Link>
                         )}
-                        {isLoggedIn && (
-                            <Link
-                                to="/sharing"
-                                className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
-                                onClick={() => setIsOpen(false)}
-                            >
-                                Sharing
-                            </Link>
-                        )}
+                        <Link
+                            to="/sharing"
+                            className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
+                            onClick={() => setIsOpen(false)}
+                        >
+                            Sharing
+                        </Link>
                         {/* Mobile Solid Login/Logout */}
                         <div className="border-t border-white/20 pt-2 mt-2">
                             {isLoggedIn ? (

--- a/src/pages/sharing-settings.test.tsx
+++ b/src/pages/sharing-settings.test.tsx
@@ -32,7 +32,8 @@ vi.mock('../services/solidPod', () => ({
 
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
-import { saveRdfToPod } from '../services/solidPod'
+import { saveRdfToPod, getFullCollaborators, getCollaborators } from '../services/solidPod'
+import { useToast } from '../components/ToastContext'
 import { getPendingSignInAction, setPendingSignInAction } from '../utils/pendingSignInAction'
 
 const mockUseDatabase = vi.mocked(useDatabase)
@@ -198,5 +199,52 @@ describe('SharingSettingsPage — share your full setup', () => {
         await waitFor(() => expect(document.activeElement).toBe(screen.getByLabelText(/webid/i)))
         // Consumed, so a later visit does not steal focus again
         expect(getPendingSignInAction()).toBeNull()
+    })
+})
+
+describe('SharingSettingsPage — full setup vs individual lists', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        sessionStorage.clear()
+    })
+
+    it('confirms the share in the language of the feature, not the plumbing', async () => {
+        const showToast = vi.fn()
+        vi.mocked(useToast).mockReturnValue({ showToast } as unknown as ReturnType<typeof useToast>)
+        renderPage()
+
+        fireEvent.change(await screen.findByLabelText(/webid/i), {
+            target: { value: 'https://alice.example.com/profile/card#me' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: /share my setup/i }))
+
+        await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.stringMatching(/full setup is shared/i), 'success'))
+    })
+
+    it('does not count a full-setup collaborator as an individual list share', async () => {
+        vi.mocked(getFullCollaborators).mockResolvedValue(['https://alice.example.com/profile/card#me'])
+        // The whole-setup grant sits on the container, so the ACL check on each
+        // child list reports the same person
+        vi.mocked(getCollaborators).mockResolvedValue(['https://alice.example.com/profile/card#me'])
+        renderPage({
+            getAllPackingLists: vi.fn(() => Promise.resolve([
+                { id: 'list-1', name: 'Alps hut trip' },
+            ] as unknown as PackingList[])),
+        })
+
+        expect(await screen.findByText(/haven't shared any individual lists yet/i)).toBeTruthy()
+        expect(screen.queryByText(/Alps hut trip/)).toBeNull()
+    })
+
+    it('still lists a genuinely individually shared list', async () => {
+        vi.mocked(getFullCollaborators).mockResolvedValue([])
+        vi.mocked(getCollaborators).mockResolvedValue(['https://bob.example.com/profile/card#me'])
+        renderPage({
+            getAllPackingLists: vi.fn(() => Promise.resolve([
+                { id: 'list-1', name: 'Alps hut trip' },
+            ] as unknown as PackingList[])),
+        })
+
+        expect(await screen.findByText(/Alps hut trip/)).toBeTruthy()
     })
 })

--- a/src/pages/sharing-settings.test.tsx
+++ b/src/pages/sharing-settings.test.tsx
@@ -33,6 +33,7 @@ vi.mock('../services/solidPod', () => ({
 import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { saveRdfToPod } from '../services/solidPod'
+import { getPendingSignInAction, setPendingSignInAction } from '../utils/pendingSignInAction'
 
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockUseSolidPod = vi.mocked(useSolidPod)
@@ -103,5 +104,99 @@ describe('SharingSettingsPage — remove shared context', () => {
         await waitFor(() => {
             expect(screen.queryByRole('button', { name: /remove/i })).toBeNull()
         })
+    })
+})
+
+// ── Share your full setup ─────────────────────────────────────────────────────
+
+function renderLoggedOut(login = vi.fn()) {
+    const db: Partial<PackingAppDatabase> = {
+        getSharedWithMe: vi.fn(() => Promise.resolve({ contexts: [], lastModified: '' })),
+        saveSharedWithMe: vi.fn(() => Promise.resolve({ rev: '1' })),
+        getSharedListsWithMe: vi.fn(() => Promise.resolve({ lists: [], lastModified: '' })),
+        saveSharedListsWithMe: vi.fn(() => Promise.resolve({ rev: '1' })),
+        getAllPackingLists: vi.fn(() => Promise.resolve([])),
+    }
+    mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+    mockUseSolidPod.mockReturnValue({ session: null, isLoggedIn: false, login } as unknown as ReturnType<typeof useSolidPod>)
+    return render(<MemoryRouter><SharingSettingsPage /></MemoryRouter>)
+}
+
+describe('SharingSettingsPage — share your full setup', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        sessionStorage.clear()
+    })
+
+    it('leads with a clearly labelled full-setup entry point', async () => {
+        renderPage()
+
+        expect(await screen.findByRole('heading', { name: /share your full setup/i })).toBeTruthy()
+        expect(screen.getByText(/let someone else use your questions and lists/i)).toBeTruthy()
+    })
+
+    it('spells out that the question set and every list go together', async () => {
+        renderPage()
+
+        expect(await screen.findByText(/your question set and every packing list/i)).toBeTruthy()
+    })
+
+    it('keeps the copy relationship-agnostic', async () => {
+        const { container } = renderPage()
+
+        await screen.findByRole('heading', { name: /share your full setup/i })
+        expect(container.textContent).not.toMatch(/partner/i)
+        // Breadth is shown by example rather than assumed
+        expect(container.textContent).toMatch(/families/i)
+    })
+
+    it('points single-list sharing somewhere else so the two are not confused', async () => {
+        renderPage()
+
+        expect(await screen.findByText(/just one list/i)).toBeTruthy()
+    })
+
+    it('confirms the share and offers the invite link to copy', async () => {
+        const writeText = vi.fn(() => Promise.resolve())
+        Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+        renderPage()
+
+        fireEvent.change(await screen.findByLabelText(/webid/i), {
+            target: { value: 'https://alice.example.com/profile/card#me' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: /share my setup/i }))
+
+        expect(await screen.findByText(/your full setup is shared/i)).toBeTruthy()
+        fireEvent.click(screen.getByRole('button', { name: /copy link/i }))
+        await waitFor(() => expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/view-lists')))
+    })
+
+    it('offers a benefit-framed sign-in instead of a bare log-in notice when logged out', async () => {
+        renderLoggedOut()
+
+        expect(await screen.findByRole('heading', { name: /share your full setup/i })).toBeTruthy()
+        expect(screen.getByRole('button', { name: /sign in to share your setup/i })).toBeTruthy()
+        expect(screen.queryByText(/please log in to manage sharing settings/i)).toBeNull()
+    })
+
+    it('remembers the full-setup share while the user signs in', async () => {
+        const login = vi.fn()
+        renderLoggedOut(login)
+
+        fireEvent.click(await screen.findByRole('button', { name: /sign in to share your setup/i }))
+        fireEvent.click(screen.getByRole('button', { name: /sign in and share/i }))
+        fireEvent.click(screen.getByLabelText('Inrupt PodSpaces'))
+
+        expect(login).toHaveBeenCalledWith('https://login.inrupt.com')
+        expect(getPendingSignInAction()).toEqual({ type: 'share-full-setup' })
+    })
+
+    it('picks the share back up once the user returns signed in', async () => {
+        setPendingSignInAction({ type: 'share-full-setup' })
+        renderPage()
+
+        await waitFor(() => expect(document.activeElement).toBe(screen.getByLabelText(/webid/i)))
+        // Consumed, so a later visit does not steal focus again
+        expect(getPendingSignInAction()).toBeNull()
     })
 })

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -193,11 +193,11 @@ export function SharingSettingsPage() {
             setSharedWith(collaboratorWebId.trim())
             setCollaboratorWebId('')
             await loadCollaborators()
-            showToast('Access granted successfully', 'success')
+            showToast('Your full setup is shared', 'success')
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err)
             const details = reportError(err, 'SharingSettingsPage: failed to grant access')
-            showToast(`Failed to grant access: ${msg}`, 'error', details)
+            showToast(`Failed to share your setup: ${msg}`, 'error', details)
         } finally {
             setIsGranting(false)
         }
@@ -308,11 +308,21 @@ export function SharingSettingsPage() {
         )
     }
 
-    const sharedOwnLists = ownLists.filter(list => {
-        const status = sharingStatusByListId[list.id]
+    // The whole-setup grant lives on the pack-me-up container, so an ACL check on
+    // any single list reports those people too. Section 4 is about lists shared
+    // one at a time, so the full-setup collaborators come off first — otherwise
+    // sharing your setup silently makes every list look individually shared.
+    const individualCollaborators = (status: ListSharingStatus) =>
+        typeof status === 'object' && status !== null
+            ? status.collaborators.filter(webId => !collaborators.includes(webId))
+            : []
+
+    const isIndividuallyShared = (status: ListSharingStatus | undefined) => {
         if (typeof status !== 'object' || status === null) return false
-        return status.isPublic || status.collaborators.length > 0
-    })
+        return status.isPublic || individualCollaborators(status).length > 0
+    }
+
+    const sharedOwnLists = ownLists.filter(list => isIndividuallyShared(sharingStatusByListId[list.id]))
 
     return (
         <div className="max-w-2xl mx-auto py-8 px-4 space-y-10">
@@ -471,7 +481,8 @@ export function SharingSettingsPage() {
             <section className="space-y-4">
                 <h2 className="text-xl font-semibold text-gray-900">Individual lists I've shared</h2>
                 <p className="text-sm text-gray-600">
-                    Lists you've shared with specific people or publicly. Use "Manage sharing" to update access.
+                    Lists you've shared on their own — with specific people or publicly. People who have
+                    your full setup are not listed here; they already have every list.
                 </p>
                 {ownLists.length === 0 ? (
                     <p className="text-sm text-gray-500">No packing lists yet.</p>
@@ -483,8 +494,7 @@ export function SharingSettingsPage() {
                             .filter(list => {
                                 const status = sharingStatusByListId[list.id]
                                 if (status === 'loading') return true
-                                if (typeof status !== 'object' || status === null) return false
-                                return status.isPublic || status.collaborators.length > 0
+                                return isIndividuallyShared(status)
                             })
                             .map(list => {
                                 const status = sharingStatusByListId[list.id]
@@ -497,7 +507,7 @@ export function SharingSettingsPage() {
                                                     status === 'error' ? 'Could not load sharing info' :
                                                     [
                                                         status.isPublic ? '🌐 Public' : null,
-                                                        status.collaborators.length > 0 ? `👤 ${status.collaborators.length} person${status.collaborators.length > 1 ? 's' : ''}` : null,
+                                                        individualCollaborators(status).length > 0 ? `👤 ${individualCollaborators(status).length} person${individualCollaborators(status).length > 1 ? 's' : ''}` : null,
                                                     ].filter(Boolean).join(' · ')}
                                             </span>
                                         </div>

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useDatabase } from '../components/DatabaseContext'
@@ -22,8 +22,42 @@ import { SharePackingListModal } from '../components/SharePackingListModal'
 import type { PackingList } from '../create-packing-list/types'
 import { useSharedListsSync } from '../hooks/useSharedListsSync'
 import { useSharedWithMeSync } from '../hooks/useSharedWithMeSync'
+import { SolidPodPrompt } from '../components/SolidPodPrompt'
+import { Button } from '../components/Button'
+import {
+    clearPendingSignInAction,
+    getPendingSignInAction,
+    setPendingSignInAction,
+} from '../utils/pendingSignInAction'
 
 type ListSharingStatus = { collaborators: string[]; isPublic: boolean } | 'loading' | 'error'
+
+/**
+ * The whole-set share has always worked; it was just buried under a label
+ * ("People who can access my data") that described plumbing rather than the
+ * thing anyone wants. The copy below is deliberately relationship-agnostic —
+ * the examples carry the breadth so nobody has to be someone's "partner" to
+ * see themselves in it.
+ */
+const FULL_SETUP_TAGLINE = 'Let someone else use your questions and lists.'
+
+function FullSetupIntro() {
+    return (
+        <div className="space-y-2">
+            <p className="text-sm text-gray-700">{FULL_SETUP_TAGLINE}</p>
+            <p className="text-sm text-gray-600">
+                They get your question set and every packing list you have — including the ones you
+                make later — and can view and edit them. Handy for anyone who packs with the same
+                people over and over: couples, families, sports clubs, scout troops, climbing
+                buddies.
+            </p>
+            <p className="text-sm text-gray-500">
+                Sharing just one list? Open that list and choose <strong>Share</strong> — that sends
+                a single list, not your whole setup.
+            </p>
+        </div>
+    )
+}
 
 export function SharingSettingsPage() {
     const { session, isLoggedIn } = useSolidPod()
@@ -37,6 +71,9 @@ export function SharingSettingsPage() {
     const [collaboratorWebId, setCollaboratorWebId] = useState('')
     const [isGranting, setIsGranting] = useState(false)
     const [inviteLink, setInviteLink] = useState<string | null>(null)
+    const [sharedWith, setSharedWith] = useState<string | null>(null)
+    const [signInPromptOpen, setSignInPromptOpen] = useState(false)
+    const webIdInputRef = useRef<HTMLInputElement>(null)
     const [collaborators, setCollaborators] = useState<string[]>([])
     const [isLoadingCollaborators, setIsLoadingCollaborators] = useState(false)
     const [revokingWebId, setRevokingWebId] = useState<string | null>(null)
@@ -61,6 +98,18 @@ export function SharingSettingsPage() {
         if (!isLoggedIn || !session) return
         getPrimaryPodUrl(session).then(url => setOwnPodUrl(url ?? null))
     }, [isLoggedIn, session])
+
+    // Someone who signed in from the "share your full setup" prompt lands back
+    // here — put the cursor where they were going rather than making them find
+    // the field again.
+    useEffect(() => {
+        if (!isLoggedIn) return
+        const pending = getPendingSignInAction()
+        if (pending?.type !== 'share-full-setup') return
+        clearPendingSignInAction()
+        webIdInputRef.current?.focus()
+        webIdInputRef.current?.scrollIntoView?.({ block: 'center', behavior: 'smooth' })
+    }, [isLoggedIn])
 
     const loadCollaborators = useCallback(async () => {
         if (!session || !ownPodUrl) return
@@ -134,12 +183,14 @@ export function SharingSettingsPage() {
         if (!session || !ownPodUrl || !collaboratorWebId.trim()) return
         setIsGranting(true)
         setInviteLink(null)
+        setSharedWith(null)
         try {
             await grantFullCollaboratorAccess(session, ownPodUrl, collaboratorWebId.trim())
             const ownerWebId = session?.info.webId
             const ownerParam = ownerWebId ? `?owner=${encodeURIComponent(ownerWebId)}` : ''
             const link = `${window.location.origin}/#/pod/${encodeURIComponent(ownPodUrl)}/view-lists${ownerParam}`
             setInviteLink(link)
+            setSharedWith(collaboratorWebId.trim())
             setCollaboratorWebId('')
             await loadCollaborators()
             showToast('Access granted successfully', 'success')
@@ -149,6 +200,20 @@ export function SharingSettingsPage() {
             showToast(`Failed to grant access: ${msg}`, 'error', details)
         } finally {
             setIsGranting(false)
+        }
+    }
+
+    const handleCopyInviteLink = async () => {
+        if (!inviteLink) return
+        try {
+            await navigator.clipboard.writeText(inviteLink)
+            showToast('Invite link copied', 'success')
+        } catch (err) {
+            // Clipboard access can be refused (permissions, insecure origin) —
+            // the link is on screen and selectable, so say so rather than fail
+            // silently.
+            const details = reportError(err, 'SharingSettingsPage: failed to copy invite link')
+            showToast('Could not copy — select the link and copy it manually.', 'error', details)
         }
     }
 
@@ -204,10 +269,41 @@ export function SharingSettingsPage() {
         }
     }
 
+    const fullSetupSignInPrompt = (
+        <SolidPodPrompt
+            isOpen={signInPromptOpen}
+            onClose={() => setSignInPromptOpen(false)}
+            title="Sign in to share your full setup"
+            message="Handing someone your questions and lists needs somewhere online for them to live. Sign in with a Solid Pod and we'll bring you straight back here to finish."
+            benefitsTitle="What signing in unlocks:"
+            benefits={[
+                { label: 'Share your full setup', text: 'Your question set and every list, in one go' },
+                { label: 'Pack together', text: 'You both work from the same questions and lists' },
+                { label: 'Free', text: 'All major Pod providers are free to sign up' },
+                { label: 'You own your data', text: 'Everything stays in your personal storage' },
+            ]}
+            confirmLabel="🔗 Sign in and share"
+            dismissLabel="Not now"
+            onBeforeLogin={() => setPendingSignInAction({ type: 'share-full-setup' })}
+        />
+    )
+
     if (!isLoggedIn) {
         return (
-            <div className="max-w-2xl mx-auto py-8 px-4">
-                <p className="text-gray-700">Please log in to manage sharing settings.</p>
+            <div className="max-w-2xl mx-auto py-8 px-4 space-y-6">
+                <h1 className="text-3xl font-bold text-primary-900">Sharing</h1>
+                <section className="space-y-4">
+                    <h2 className="text-xl font-semibold text-gray-900">Share your full setup</h2>
+                    <FullSetupIntro />
+                    <Button type="button" variant="primary" onClick={() => setSignInPromptOpen(true)}>
+                        Sign in to share your setup
+                    </Button>
+                    <p className="text-sm text-gray-500">
+                        Everything you have made so far stays on this device until you sign in — nothing
+                        is shared before you say who with.
+                    </p>
+                </section>
+                {fullSetupSignInPrompt}
             </div>
         )
     }
@@ -221,51 +317,62 @@ export function SharingSettingsPage() {
     return (
         <div className="max-w-2xl mx-auto py-8 px-4 space-y-10">
             <div>
-                <h1 className="text-3xl font-bold text-primary-900">Sharing Settings</h1>
+                <h1 className="text-3xl font-bold text-primary-900">Sharing</h1>
             </div>
 
-            {/* Section 1: Grant access to others */}
+            {/* Section 1: Share the whole setup — questions + every list */}
             <section className="space-y-4">
-                <h2 className="text-xl font-semibold text-gray-900">People who can access my data</h2>
-                <p className="text-sm text-gray-600">
-                    Grant someone access to all your packing lists and questions. They'll be able to view
-                    and edit your data.
-                </p>
-                <div className="flex gap-2">
+                <h2 className="text-xl font-semibold text-gray-900">Share your full setup</h2>
+                <FullSetupIntro />
+                <div className="flex flex-col sm:flex-row gap-2">
                     <input
+                        ref={webIdInputRef}
                         type="text"
                         value={collaboratorWebId}
                         onChange={e => setCollaboratorWebId(e.target.value)}
-                        placeholder="Collaborator WebID (e.g. https://alice.solidcommunity.net/profile/card#me)"
-                        aria-label="Collaborator WebID"
-                        className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                        placeholder="e.g. https://alice.solidcommunity.net/profile/card#me"
+                        aria-label="Their WebID"
+                        className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
                     />
                     <button
                         onClick={handleGrantAccess}
                         disabled={isGranting || !collaboratorWebId.trim()}
-                        className="px-4 py-2 rounded-lg text-sm font-semibold bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 transition-colors"
+                        className="px-4 py-2 rounded-lg text-sm font-semibold bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 transition-colors whitespace-nowrap"
                     >
-                        {isGranting ? 'Granting…' : 'Grant access'}
+                        {isGranting ? 'Sharing…' : 'Share my setup'}
                     </button>
                 </div>
+                <p className="text-xs text-gray-500">
+                    A WebID is the address of someone's Solid Pod — ask them to copy theirs from their
+                    own sharing page.
+                </p>
 
                 {inviteLink && (
-                    <div className="mt-2">
-                        <label className="block text-sm font-medium text-gray-700 mb-1">Invite link</label>
+                    <div className="mt-2 rounded-xl border-2 border-primary-200 bg-primary-50 p-4 space-y-2">
+                        <p className="text-sm font-semibold text-primary-900">
+                            ✅ Your full setup is shared{sharedWith ? ' with ' + sharedWith : ''}
+                        </p>
+                        <p className="text-sm text-gray-700">
+                            They now have your question set and all your packing lists. Send them this
+                            link so they can open it:
+                        </p>
                         <input
                             type="text"
                             readOnly
                             value={inviteLink}
                             aria-label="Invite link"
-                            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-gray-50 focus:outline-none"
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none"
                             onClick={e => (e.target as HTMLInputElement).select()}
                         />
-                        <p className="text-xs text-gray-500 mt-1">Share this link with your collaborator.</p>
+                        <Button type="button" variant="secondary" onClick={handleCopyInviteLink}>
+                            Copy link
+                        </Button>
                     </div>
                 )}
 
+                <h3 className="text-sm font-semibold text-gray-700 pt-2">People with your full setup</h3>
                 {isLoadingCollaborators ? (
-                    <p className="text-sm text-gray-500">Loading collaborators…</p>
+                    <p className="text-sm text-gray-500">Loading…</p>
                 ) : collaborators.length > 0 ? (
                     <ul className="space-y-2 mt-2">
                         {collaborators.map(webId => (
@@ -283,7 +390,7 @@ export function SharingSettingsPage() {
                         ))}
                     </ul>
                 ) : (
-                    <p className="text-sm text-gray-500">No collaborators yet.</p>
+                    <p className="text-sm text-gray-500">You haven't shared your full setup with anyone yet.</p>
                 )}
             </section>
 

--- a/src/utils/pendingSignInAction.test.ts
+++ b/src/utils/pendingSignInAction.test.ts
@@ -21,6 +21,12 @@ describe('pendingSignInAction', () => {
         expect(getPendingSignInAction()).toEqual({ type: 'share', listId: 'list-1' })
     })
 
+    it('round-trips a full-setup share action', () => {
+        setPendingSignInAction({ type: 'share-full-setup' })
+
+        expect(getPendingSignInAction()).toEqual({ type: 'share-full-setup' })
+    })
+
     it('clears the pending action', () => {
         setPendingSignInAction({ type: 'share', listId: 'list-1' })
 

--- a/src/utils/pendingSignInAction.ts
+++ b/src/utils/pendingSignInAction.ts
@@ -7,11 +7,16 @@
  */
 export const PENDING_SIGN_IN_ACTION_KEY = 'pending-sign-in-action'
 
-export type PendingSignInAction = { type: 'share'; listId: string }
+export type PendingSignInAction =
+    /** Share one packing list — resumed on that list's page. */
+    | { type: 'share'; listId: string }
+    /** Share the whole setup (question set + every list) — resumed on the sharing page. */
+    | { type: 'share-full-setup' }
 
 function isPendingSignInAction(value: unknown): value is PendingSignInAction {
     if (typeof value !== 'object' || value === null) return false
     const candidate = value as Record<string, unknown>
+    if (candidate.type === 'share-full-setup') return true
     return candidate.type === 'share' && typeof candidate.listId === 'string'
 }
 


### PR DESCRIPTION
The whole-set share has worked for a while, but it was filed under
"People who can access my data" on a page only signed-in users could
reach — plumbing language behind a hidden door. Anyone who packs with
the same people repeatedly never learned it existed.

The section now leads with what it does for you: share your full setup,
your question set and every list, with examples (couples, families,
clubs, troops) doing the work of showing the breadth rather than
assuming a relationship. Sharing lands on a confirmation naming who it
went to, with the invite link and a Copy link button, and a line
pointing single-list sharing back to the list's own Share button so the
two are not confused.

Logged out, /sharing no longer says "please log in". It shows the same
pitch and a benefit-framed sign-in prompt, remembering the intent so
the WebID field takes focus when the user comes back. The nav link
stays visible signed out for the same reason — hiding it is what made
the feature invisible.