### PR TITLE
One search box that finds a provider or takes your Pod URL

### DIFF
--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -22,15 +22,10 @@ export async function loginToCss(
   await page.getByRole('button', { name: 'Sync & Share' }).click()
   await page.getByRole('dialog').waitFor()
 
-  // Show other providers
-  await page.getByText('Other providers').click()
-
-  // Show custom provider input
-  await page.getByRole('button', { name: 'Use Custom Provider' }).click()
-
-  // Fill in CSS URL
-  await page.getByLabel('Custom Provider URL').fill(cssIssuer)
-  await page.getByRole('button', { name: 'Connect' }).click()
+  // Search box doubles as Pod URL entry: type the CSS issuer, then pick the
+  // "use this URL" option it offers.
+  await page.getByLabel('Search providers or paste your Pod URL').fill(cssIssuer)
+  await page.getByRole('button', { name: `Connect to ${cssIssuer.replace(/\/$/, '')}` }).click()
 
   // Wait for navigation to CSS password login page specifically.
   // (CSS redirects: /.oidc/auth → /.account/ → /.account/login/password/)

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -15,7 +15,7 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
             <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
                 <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={onClose} />
 
-                <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+                <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 w-full sm:max-w-lg sm:p-6">
                     <div className="absolute right-0 top-0 pr-4 pt-4">
                         <button
                             type="button"

--- a/src/components/SolidProviderSelector.test.tsx
+++ b/src/components/SolidProviderSelector.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import React from 'react'
-import { SolidProviderSelector, LAST_PROVIDER_KEY } from './SolidProviderSelector'
+import { SolidProviderSelector, LAST_PROVIDER_KEY, normalizeIssuerUrl } from './SolidProviderSelector'
 
 const defaultProps = {
   isOpen: true,
@@ -11,24 +11,54 @@ const defaultProps = {
 
 // Queries that avoid role+name accessible-name computation (broken in happy-dom on Node 20
 // for buttons whose accessible name comes from nested div children).
-function getPrimaryProviderName() {
-  // The primary button has a distinct blue-border class; its first child div holds the name.
-  const btn = document.querySelector('button.border-blue-400') as HTMLElement | null
-  return btn?.querySelector('div.font-medium')?.textContent ?? null
+function optionNames(): string[] {
+  return Array.from(document.querySelectorAll('button[data-provider-option]'))
+    .map(b => b.querySelector('div.font-medium')?.textContent ?? '')
 }
 
-function clickProvider(name: string) {
-  // Find the button that contains an exact-text name div, then click it.
-  const all = Array.from(document.querySelectorAll('button'))
+function clickOption(name: string) {
+  const all = Array.from(document.querySelectorAll('button[data-provider-option]'))
   const btn = all.find(b => b.querySelector('div.font-medium')?.textContent === name)
-  if (!btn) throw new Error(`Provider button "${name}" not found`)
+  if (!btn) throw new Error(`Option "${name}" not found. Visible: ${optionNames().join(', ')}`)
   fireEvent.click(btn)
 }
 
-function isProviderVisible(name: string): boolean {
-  const all = Array.from(document.querySelectorAll('button'))
-  return all.some(b => b.querySelector('div.font-medium')?.textContent === name)
+function searchBox(): HTMLInputElement {
+  return screen.getByLabelText(/search providers or paste your pod url/i) as HTMLInputElement
 }
+
+function type(query: string) {
+  fireEvent.change(searchBox(), { target: { value: query } })
+}
+
+function pressEnter() {
+  fireEvent.keyDown(searchBox(), { key: 'Enter' })
+}
+
+describe('normalizeIssuerUrl', () => {
+  it('defaults a scheme-less URL to https://', () => {
+    expect(normalizeIssuerUrl('my-pod.example.org')).toBe('https://my-pod.example.org')
+  })
+
+  it('preserves an explicit http:// scheme', () => {
+    expect(normalizeIssuerUrl('http://localhost:3000')).toBe('http://localhost:3000')
+  })
+
+  it('preserves an explicit https:// scheme', () => {
+    expect(normalizeIssuerUrl('https://my-pod.example.org')).toBe('https://my-pod.example.org')
+  })
+
+  it('keeps a path but drops a bare trailing slash', () => {
+    expect(normalizeIssuerUrl('https://example.org/')).toBe('https://example.org')
+    expect(normalizeIssuerUrl('https://example.org/solid')).toBe('https://example.org/solid')
+  })
+
+  it('rejects text that is not a URL', () => {
+    expect(normalizeIssuerUrl('community')).toBeNull()
+    expect(normalizeIssuerUrl('inrupt pod')).toBeNull()
+    expect(normalizeIssuerUrl('   ')).toBeNull()
+  })
+})
 
 describe('SolidProviderSelector', () => {
   beforeEach(() => {
@@ -40,66 +70,146 @@ describe('SolidProviderSelector', () => {
     localStorage.clear()
   })
 
-  describe('default provider (no last-used stored)', () => {
-    it('shows Inrupt PodSpaces as the primary option', () => {
+  describe('searching known providers', () => {
+    it('lists every known provider when the search is empty', () => {
       render(<SolidProviderSelector {...defaultProps} />)
-      expect(getPrimaryProviderName()).toBe('Inrupt PodSpaces')
+      expect(optionNames()).toEqual(
+        expect.arrayContaining(['Inrupt PodSpaces', 'solidcommunity.net', 'Private Data Pod'])
+      )
     })
 
-    it('hides other providers by default', () => {
+    it('filters the list live as you type', () => {
       render(<SolidProviderSelector {...defaultProps} />)
-      expect(isProviderVisible('solidcommunity.net')).toBe(false)
-      expect(isProviderVisible('Private Data Pod')).toBe(false)
+      type('community')
+      expect(optionNames()).toEqual(['solidcommunity.net'])
     })
 
-    it('shows other providers when "Other providers" is clicked', () => {
+    it('matches the issuer as well as the name, case-insensitively', () => {
       render(<SolidProviderSelector {...defaultProps} />)
-      fireEvent.click(screen.getByRole('button', { name: /other providers/i }))
-      expect(isProviderVisible('solidcommunity.net')).toBe(true)
-      expect(isProviderVisible('Private Data Pod')).toBe(true)
-    })
-  })
-
-  describe('with last-used provider stored', () => {
-    it('shows the last-used provider as the primary option', () => {
-      localStorage.setItem(LAST_PROVIDER_KEY, 'https://solidcommunity.net')
-      render(<SolidProviderSelector {...defaultProps} />)
-      expect(getPrimaryProviderName()).toBe('solidcommunity.net')
+      type('LOGIN.INRUPT.COM')
+      expect(optionNames()).toContain('Inrupt PodSpaces')
     })
 
-    it('does not show other providers by default', () => {
-      localStorage.setItem(LAST_PROVIDER_KEY, 'https://solidcommunity.net')
+    it('says so when nothing matches', () => {
       render(<SolidProviderSelector {...defaultProps} />)
-      expect(isProviderVisible('Inrupt PodSpaces')).toBe(false)
-      expect(isProviderVisible('Private Data Pod')).toBe(false)
-    })
-
-    it('falls back to Inrupt PodSpaces for an unrecognised issuer', () => {
-      localStorage.setItem(LAST_PROVIDER_KEY, 'https://unknown-provider.example.com')
-      render(<SolidProviderSelector {...defaultProps} />)
-      expect(getPrimaryProviderName()).toBe('Inrupt PodSpaces')
+      type('nothing here')
+      expect(optionNames()).toEqual([])
+      expect(screen.getByText(/no matching providers/i)).toBeTruthy()
     })
   })
 
-  describe('saving last-used provider', () => {
-    it('saves the selected provider issuer to localStorage', () => {
+  describe('pasting a Pod URL', () => {
+    it('offers the typed URL as an explicit option in the list', () => {
       render(<SolidProviderSelector {...defaultProps} />)
-      clickProvider('Inrupt PodSpaces')
-      expect(localStorage.getItem(LAST_PROVIDER_KEY)).toBe('https://login.inrupt.com')
+      type('my-pod.example.org')
+      expect(optionNames()).toContain('https://my-pod.example.org')
+      expect(screen.getByText(/use this pod url/i)).toBeTruthy()
     })
 
-    it('saves a different provider when selected from the expanded list', () => {
-      render(<SolidProviderSelector {...defaultProps} />)
-      fireEvent.click(screen.getByRole('button', { name: /other providers/i }))
-      clickProvider('solidcommunity.net')
-      expect(localStorage.getItem(LAST_PROVIDER_KEY)).toBe('https://solidcommunity.net')
-    })
-
-    it('calls onSelect with the issuer', () => {
+    it('connects to the normalised URL when the option is clicked', () => {
       const onSelect = vi.fn()
       render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
-      clickProvider('Inrupt PodSpaces')
-      expect(onSelect).toHaveBeenCalledWith('https://login.inrupt.com')
+      type('my-pod.example.org')
+      clickOption('https://my-pod.example.org')
+      expect(onSelect).toHaveBeenCalledWith('https://my-pod.example.org')
+    })
+
+    it('preserves an explicit http:// URL', () => {
+      const onSelect = vi.fn()
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+      type('http://localhost:3000')
+      clickOption('http://localhost:3000')
+      expect(onSelect).toHaveBeenCalledWith('http://localhost:3000')
+    })
+
+    it('does not offer a URL option for a plain search term', () => {
+      render(<SolidProviderSelector {...defaultProps} />)
+      type('community')
+      expect(screen.queryByText(/use this pod url/i)).toBeNull()
+    })
+  })
+
+  describe('pressing Enter', () => {
+    it('connects to the typed URL even when it substring-matches a known provider', () => {
+      const onSelect = vi.fn()
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+      // "inrupt.com" is a substring of Inrupt PodSpaces' issuer, so the provider still
+      // shows in the results — but Enter must connect to the pod the user typed.
+      type('inrupt.com')
+      expect(optionNames()).toContain('Inrupt PodSpaces')
+      pressEnter()
+      expect(onSelect).toHaveBeenCalledWith('https://inrupt.com')
+      expect(onSelect).not.toHaveBeenCalledWith('https://login.inrupt.com')
+    })
+
+    it('connects to the first match when the query is not a URL', () => {
+      const onSelect = vi.fn()
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+      type('community')
+      pressEnter()
+      expect(onSelect).toHaveBeenCalledWith('https://solidcommunity.net')
+    })
+
+    it('does nothing when the query matches nothing and is not a URL', () => {
+      const onSelect = vi.fn()
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+      type('nothing here')
+      pressEnter()
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('last-used provider', () => {
+    it('is only written after a successful connection', async () => {
+      const onSelect = vi.fn().mockRejectedValue(new Error('unreachable'))
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+      type('typo.example.org')
+      clickOption('https://typo.example.org')
+      await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy())
+      expect(localStorage.getItem(LAST_PROVIDER_KEY)).toBeNull()
+    })
+
+    it('is written once the connection succeeds', async () => {
+      const onSelect = vi.fn().mockResolvedValue(undefined)
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+      clickOption('Inrupt PodSpaces')
+      await waitFor(() =>
+        expect(localStorage.getItem(LAST_PROVIDER_KEY)).toBe('https://login.inrupt.com')
+      )
+    })
+
+    it('is offered first, badged, when the search is empty', () => {
+      localStorage.setItem(LAST_PROVIDER_KEY, 'https://solidcommunity.net')
+      render(<SolidProviderSelector {...defaultProps} />)
+      expect(optionNames()[0]).toBe('solidcommunity.net')
+      expect(screen.getByText(/last used/i)).toBeTruthy()
+    })
+
+    it('remembers a self-hosted Pod URL that is not a known provider', () => {
+      localStorage.setItem(LAST_PROVIDER_KEY, 'https://my-pod.example.org')
+      render(<SolidProviderSelector {...defaultProps} />)
+      expect(optionNames()[0]).toBe('https://my-pod.example.org')
+    })
+  })
+
+  describe('connecting', () => {
+    it('holds the modal open with a spinner while the redirect is in flight', async () => {
+      const onClose = vi.fn()
+      const onSelect = vi.fn().mockReturnValue(new Promise<void>(() => {}))
+      render(<SolidProviderSelector {...defaultProps} onClose={onClose} onSelect={onSelect} />)
+      clickOption('Inrupt PodSpaces')
+      await waitFor(() => expect(screen.getByText(/connecting to inrupt podspaces/i)).toBeTruthy())
+      expect(screen.getByRole('dialog')).toBeTruthy()
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('reports a failed connection and lets you try again', async () => {
+      const onSelect = vi.fn().mockRejectedValue(new Error('unreachable'))
+      render(<SolidProviderSelector {...defaultProps} onSelect={onSelect} />)
+      type('typo.example.org')
+      clickOption('https://typo.example.org')
+      await waitFor(() => expect(screen.getByRole('alert').textContent).toMatch(/couldn't connect/i))
+      expect(searchBox()).toBeTruthy()
     })
   })
 })
@@ -120,8 +230,12 @@ describe('SolidProviderSelector – sign-in framing', () => {
     expect(screen.getByText(/sync across (?:your )?devices/i)).toBeTruthy()
   })
 
-  it('still explains that this uses a Solid Pod', () => {
+  it('keeps the "What is a Solid Pod?" explainer, collapsed behind a disclosure', () => {
     render(<SolidProviderSelector {...defaultProps} />)
-    expect(screen.getByText('What is a Solid Pod?')).toBeTruthy()
+    const details = document.querySelector('details')
+    expect(details).toBeTruthy()
+    expect(details!.open).toBe(false)
+    expect(details!.querySelector('summary')!.textContent).toMatch(/what is a solid pod\?/i)
+    expect(screen.getByText(/personal data storage that/i)).toBeTruthy()
   })
 })

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useMemo, useState, type KeyboardEvent } from 'react';
 import { Modal } from './Modal';
-import { Button } from './Button';
+import { Input } from './Input';
 
 export interface SolidProvider {
   name: string;
@@ -29,51 +29,115 @@ export const COMMON_PROVIDERS: SolidProvider[] = [
 
 export const LAST_PROVIDER_KEY = 'solid-last-provider-issuer';
 
-const DEFAULT_PROVIDER = COMMON_PROVIDERS.find(p => p.issuer === 'https://login.inrupt.com')!;
+/**
+ * Turn what the user typed into an OIDC issuer URL, or null if it isn't one.
+ *
+ * The search box does double duty — a query like "community" must stay a search,
+ * while "my-pod.example.org" is a pod the user wants to connect to. A scheme-less
+ * host defaults to `https://`; an explicit `http://` (a local dev server, usually)
+ * is preserved.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function normalizeIssuerUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed || /\s/.test(trimmed)) return null;
 
-function getLastUsedProvider(): SolidProvider | null {
-  const issuer = localStorage.getItem(LAST_PROVIDER_KEY);
-  if (!issuer) return null;
-  return COMMON_PROVIDERS.find(p => p.issuer === issuer) ?? null;
+  const hasScheme = /^https?:\/\//i.test(trimmed);
+  let url: URL;
+  try {
+    url = new URL(hasScheme ? trimmed : `https://${trimmed}`);
+  } catch {
+    return null;
+  }
+
+  // Without a scheme to go on, only host-shaped text counts as a URL — otherwise
+  // every search term would parse as https://<term>.
+  const hostLooksReal = url.hostname === 'localhost' || /\.[a-z]{2,}$/i.test(url.hostname);
+  if (!hasScheme && !hostLooksReal) return null;
+
+  const normalized = url.toString();
+  return url.pathname === '/' && !url.search && !url.hash
+    ? normalized.replace(/\/$/, '')
+    : normalized;
+}
+
+function knownProvider(issuer: string): SolidProvider | undefined {
+  return COMMON_PROVIDERS.find(p => p.issuer === issuer);
+}
+
+/** Known providers keep their name and blurb; a self-hosted pod is known by its URL. */
+function providerForIssuer(issuer: string): SolidProvider {
+  return knownProvider(issuer) ?? { name: issuer, issuer };
+}
+
+function getLastUsedIssuer(): string | null {
+  return localStorage.getItem(LAST_PROVIDER_KEY);
 }
 
 interface SolidProviderSelectorProps {
   isOpen: boolean;
   onClose: () => void;
-  onSelect: (issuer: string) => void;
+  onSelect: (issuer: string) => void | Promise<void>;
 }
 
 export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProviderSelectorProps) {
-  const primaryProvider = getLastUsedProvider() ?? DEFAULT_PROVIDER;
-  const otherProviders = COMMON_PROVIDERS.filter(p => p.issuer !== primaryProvider.issuer);
+  const [query, setQuery] = useState('');
+  const [connectingTo, setConnectingTo] = useState<SolidProvider | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const [showOthers, setShowOthers] = useState(false);
-  const [showCustomInput, setShowCustomInput] = useState(false);
-  const [customIssuer, setCustomIssuer] = useState('');
+  const lastUsedIssuer = getLastUsedIssuer();
+  const typedUrl = normalizeIssuerUrl(query);
 
-  const handleProviderSelect = (issuer: string) => {
-    localStorage.setItem(LAST_PROVIDER_KEY, issuer);
-    onSelect(issuer);
-    onClose();
-    setShowOthers(false);
-    setShowCustomInput(false);
-    setCustomIssuer('');
+  const providers = useMemo(() => {
+    const term = query.trim().toLowerCase();
+
+    if (!term) {
+      // Nothing typed: the pod you used last time is the one you most likely want.
+      const ordered = [...COMMON_PROVIDERS];
+      if (lastUsedIssuer) {
+        const last = providerForIssuer(lastUsedIssuer);
+        return [last, ...ordered.filter(p => p.issuer !== last.issuer)];
+      }
+      return ordered;
+    }
+
+    return COMMON_PROVIDERS.filter(
+      p => p.name.toLowerCase().includes(term) || p.issuer.toLowerCase().includes(term)
+    );
+  }, [query, lastUsedIssuer]);
+
+  const connect = async (provider: SolidProvider) => {
+    setConnectingTo(provider);
+    setError(null);
+    try {
+      await onSelect(provider.issuer);
+      // Only a connection that got as far as the provider's redirect is worth
+      // remembering — a typo'd pod URL must not become next time's default.
+      localStorage.setItem(LAST_PROVIDER_KEY, provider.issuer);
+    } catch {
+      setConnectingTo(null);
+      setError(`Couldn't connect to ${provider.issuer}. Check the address and try again.`);
+    }
   };
 
-  const handleCustomSubmit = () => {
-    if (customIssuer.trim()) {
-      handleProviderSelect(customIssuer.trim());
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    // What the user typed wins: a pasted pod URL that happens to contain
+    // "inrupt" is their pod, not Inrupt PodSpaces.
+    if (typedUrl) {
+      void connect(providerForIssuer(typedUrl));
+    } else if (providers.length > 0) {
+      void connect(providers[0]);
     }
   };
 
   const handleClose = () => {
     onClose();
-    setShowOthers(false);
-    setShowCustomInput(false);
-    setCustomIssuer('');
+    setQuery('');
+    setConnectingTo(null);
+    setError(null);
   };
-
-  const isLastUsed = localStorage.getItem(LAST_PROVIDER_KEY) === primaryProvider.issuer;
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose} title="Sync &amp; Share your lists">
@@ -83,111 +147,106 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
           <p className="text-sm text-gray-700">
             Signing in lets you <strong>sync across your devices</strong> and <strong>share lists</strong> — a single list with a friend, or your whole question set with the person you travel with.
           </p>
-          <h3 className="font-semibold text-gray-900 text-sm">What is a Solid Pod?</h3>
-          <p className="text-sm text-gray-700">
-            Signing in uses a Solid Pod: personal data storage that <strong>you control</strong>. Instead of storing your packing lists on our servers, they're stored in your own secure space.
-          </p>
-          <ul className="text-sm text-gray-700 space-y-1 ml-4 list-disc">
-            <li><strong>You own your data</strong> - it stays in your Pod</li>
-            <li><strong>Privacy-focused</strong> - you choose who can access it</li>
-            <li><strong>Portable</strong> - use your Pod with any Solid app</li>
-          </ul>
+          <details className="group">
+            <summary className="text-sm font-semibold text-gray-900 cursor-pointer list-none marker:content-none">
+              <span className="group-open:hidden">▸ </span>
+              <span className="hidden group-open:inline">▾ </span>
+              What is a Solid Pod?
+            </summary>
+            <div className="mt-2 space-y-2">
+              <p className="text-sm text-gray-700">
+                Signing in uses a Solid Pod: personal data storage that <strong>you control</strong>. Instead of storing your packing lists on our servers, they're stored in your own secure space.
+              </p>
+              <ul className="text-sm text-gray-700 space-y-1 ml-4 list-disc">
+                <li><strong>You own your data</strong> - it stays in your Pod</li>
+                <li><strong>Privacy-focused</strong> - you choose who can access it</li>
+                <li><strong>Portable</strong> - use your Pod with any Solid app</li>
+              </ul>
+            </div>
+          </details>
         </div>
 
-        <div className="border-t border-gray-200 pt-4">
-          <p className="text-sm text-gray-600 mb-3">
-            {isLastUsed ? 'Continue with your last-used provider:' : 'Get started with a free provider:'}
-          </p>
+        {connectingTo ? (
+          <div className="border-t border-gray-200 pt-6 pb-4 flex flex-col items-center gap-3" aria-live="polite">
+            <svg className="h-8 w-8 animate-spin text-blue-500" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+            </svg>
+            <p className="text-sm text-gray-700">Connecting to {connectingTo.name}…</p>
+            <p className="text-xs text-gray-500 text-center">
+              You'll be taken to your provider to sign in.
+            </p>
+          </div>
+        ) : (
+          <div className="border-t border-gray-200 pt-4 space-y-3">
+            <Input
+              label="Search providers or paste your Pod URL"
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="e.g. Inrupt, or my-pod.example.org"
+              autoFocus
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
 
-          {/* Primary provider */}
-          <button
-            aria-label={primaryProvider.name}
-            onClick={() => handleProviderSelect(primaryProvider.issuer)}
-            className="w-full text-left px-4 py-3 border-2 border-blue-400 bg-blue-50 hover:bg-blue-100 hover:border-blue-500 rounded-md transition-colors"
-          >
-            <div className="font-medium text-gray-900">{primaryProvider.name}</div>
-            {primaryProvider.description && (
-              <div className="text-xs text-green-700 font-medium">{primaryProvider.description}</div>
+            {error && (
+              <p role="alert" className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2">
+                {error}
+              </p>
             )}
-            <div className="text-xs text-gray-400">{primaryProvider.issuer}</div>
-          </button>
-        </div>
 
-        {/* Other providers toggle */}
-        <div className="space-y-2">
-          <button
-            type="button"
-            onClick={() => setShowOthers(v => !v)}
-            className="w-full text-sm text-gray-500 hover:text-gray-700 transition-colors text-center"
-          >
-            {showOthers ? 'Hide other providers ▲' : 'Other providers ▼'}
-          </button>
-
-          {showOthers && (
             <div className="space-y-2">
-              {otherProviders.map((provider) => (
+              {typedUrl && (
                 <button
-                  key={provider.issuer}
-                  aria-label={provider.name}
-                  onClick={() => handleProviderSelect(provider.issuer)}
-                  className="w-full text-left px-4 py-3 border border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
-                >
-                  <div className="font-medium text-gray-900">{provider.name}</div>
-                  {provider.description && (
-                    <div className="text-xs text-green-700 font-medium">{provider.description}</div>
-                  )}
-                  <div className="text-xs text-gray-400">{provider.issuer}</div>
-                </button>
-              ))}
-
-              {!showCustomInput ? (
-                <Button
                   type="button"
-                  onClick={() => setShowCustomInput(true)}
-                  variant="secondary"
-                  className="w-full"
+                  data-provider-option
+                  aria-label={`Connect to ${typedUrl}`}
+                  onClick={() => void connect(providerForIssuer(typedUrl))}
+                  className="w-full text-left px-4 py-3 border-2 border-blue-400 bg-blue-50 hover:bg-blue-100 hover:border-blue-500 rounded-md transition-colors"
                 >
-                  Use Custom Provider
-                </Button>
-              ) : (
-                <div className="space-y-3 pt-2 border-t border-gray-200">
-                  <label className="block">
-                    <span className="text-sm font-medium text-gray-700">Custom Provider URL</span>
-                    <input
-                      type="url"
-                      value={customIssuer}
-                      onChange={(e) => setCustomIssuer(e.target.value)}
-                      placeholder="https://your-provider.com"
-                      className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-                      autoFocus
-                    />
-                  </label>
-                  <div className="flex gap-2">
-                    <Button
-                      type="button"
-                      onClick={handleCustomSubmit}
-                      disabled={!customIssuer.trim()}
-                      className="flex-1"
-                    >
-                      Connect
-                    </Button>
-                    <Button
-                      type="button"
-                      onClick={() => {
-                        setShowCustomInput(false);
-                        setCustomIssuer('');
-                      }}
-                      variant="secondary"
-                      className="flex-1"
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
+                  <div className="font-medium text-gray-900 break-all">{typedUrl}</div>
+                  <div className="text-xs text-blue-700 font-medium">Use this Pod URL</div>
+                </button>
+              )}
+
+              {providers.map((provider) => {
+                const isLastUsed = provider.issuer === lastUsedIssuer;
+                return (
+                  <button
+                    key={provider.issuer}
+                    type="button"
+                    data-provider-option
+                    aria-label={provider.name}
+                    onClick={() => void connect(provider)}
+                    className="w-full text-left px-4 py-3 border border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
+                  >
+                    <div className="font-medium text-gray-900 break-all">{provider.name}</div>
+                    {provider.description && (
+                      <div className="text-xs text-green-700 font-medium">{provider.description}</div>
+                    )}
+                    <div className="flex items-baseline justify-between gap-2">
+                      {provider.name === provider.issuer
+                        ? <span />
+                        : <span className="text-xs text-gray-400 break-all">{provider.issuer}</span>}
+                      {isLastUsed && (
+                        <span className="text-xs font-medium text-blue-700 whitespace-nowrap">Last used</span>
+                      )}
+                    </div>
+                  </button>
+                );
+              })}
+
+              {providers.length === 0 && !typedUrl && (
+                <p className="text-sm text-gray-500 text-center py-2">
+                  No matching providers. Paste your Pod's URL to connect to it directly.
+                </p>
               )}
             </div>
-          )}
-        </div>
+          </div>
+        )}
 
         <p className="text-xs text-gray-500 text-center">
           No Pod? No problem — your data saves locally in your browser automatically.


### PR DESCRIPTION
Closes #303

The sign-in modal offered three hardcoded providers, an "Other providers" disclosure and, hidden inside it, a separate custom-URL form. It is now a single field that filters the known providers as you type and, when what you typed parses as a URL, offers that URL as a visible option in the same list.

## What changed

**`SolidProviderSelector`** — rebuilt around one search field:

- Live substring filtering of `COMMON_PROVIDERS` on name and issuer.
- A typed URL appears as an explicit **"Use this Pod URL"** entry at the top of the results, not as a hidden form you have to find. `normalizeIssuerUrl` defaults a scheme-less host to `https://`, preserves an explicit `http://` (local dev servers), drops a bare trailing slash, and returns `null` for anything that isn't host-shaped so plain search terms stay searches.
- **Enter connects to what you typed** whenever it looks like a URL. Previously the first search result always won, so pasting `inrupt.com` — which substring-matches Inrupt PodSpaces' issuer — connected you to Inrupt instead of your pod, and the custom-URL path was only reachable when the query matched nothing at all.
- **"Last used" is written only after the connection is handed off to the provider.** It used to be stored before the attempt, so a typo'd pod URL that never connected became the remembered default. A self-hosted URL is now remembered too, shown by its URL and badged "Last used" at the top of the empty-query list.
- The modal **holds itself open with a spinner and "Connecting to …"** through the redirect instead of vanishing, and reports a failure in place (`role="alert"`) so the address can be corrected without reopening it.
- The search field uses the shared `Input`, so it has a real `<label>` for screen readers.

**`Modal`** — `sm:w-full` → `w-full`, so the dialog no longer shrink-wraps its content on small viewports and stops resizing as results change.

**Explainer (the product decision in the issue)** — "What is a Solid Pod?" is **kept, collapsed behind a disclosure**. The in-context explanation is the main adoption hurdle for a Solid-first app, so deleting it outright (as in #281) loses more than the clutter is worth; the payoff sentence stays always-visible above it. This sits comfortably with the demotion of Solid messaging in #199 / #200 / #201 — the modal now leads with sync and sharing, and the pod explanation is one click away.

**`e2e/helpers/login.ts`** — updated to drive the new UI: fill the search box with the CSS issuer, click the offered "Connect to …" option.

## Testing

- 25 unit tests in `SolidProviderSelector.test.tsx`, including the two the issue asks for by name: a pasted URL that substring-matches a known provider (`inrupt.com` → connects to `https://inrupt.com`, not `https://login.inrupt.com`), and "last used" staying unwritten when the connection fails. Full suite green: 1782 tests, plus typecheck and lint.
- E2E `e-auth` suite (real Community Solid Server login through the rebuilt modal): 4 passed.
- Manually driven in the running app at 1280px and 390px. Dialog width measured across empty / filtered / URL-typed / no-match / explainer-open / connecting states: **512px at every state on desktop, 358px at every state on mobile**. The connecting spinner was captured mid-flight by holding OIDC discovery open, and `solid-last-provider-issuer` was verified `null` both mid-flight and after a failed connection.

## Not included

Dark-mode contrast in this modal (`text-green-700` descriptions, the blue last-used row) is left to the dark mode issue, as the issue notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcpWpmNptkroSZbKu7aDtK)_