### PR TITLE
Fold past trips away behind a collapsed "Past trips" section

### DIFF
--- a/src/components/PastTripsSection.tsx
+++ b/src/components/PastTripsSection.tsx
@@ -1,0 +1,39 @@
+import { useId, useState, type ReactNode } from 'react'
+
+interface PastTripsSectionProps {
+    /** How many trips are folded away — shown in the label so the count is visible while closed. */
+    count: number
+    children: ReactNode
+}
+
+/**
+ * Trips that have already happened, folded away behind a disclosure that starts
+ * closed. The history is worth keeping, but it is not what somebody opening the
+ * page came to see.
+ */
+export function PastTripsSection({ count, children }: PastTripsSectionProps) {
+    const [isExpanded, setIsExpanded] = useState(false)
+    const panelId = useId()
+
+    return (
+        <div className="mt-8">
+            <button
+                type="button"
+                onClick={() => setIsExpanded(expanded => !expanded)}
+                aria-expanded={isExpanded}
+                aria-controls={panelId}
+                className="flex items-center gap-2 w-full text-left py-2 text-gray-600 hover:text-gray-900 transition-colors"
+            >
+                <span className="shrink-0 text-sm text-gray-400">{isExpanded ? '▼' : '▶'}</span>
+                <span className="text-lg font-semibold">Past trips ({count})</span>
+            </button>
+            {/* Unmounted rather than hidden: a closed section shouldn't put its
+                cards in the tab order or read them out to a screen reader. */}
+            {isExpanded && (
+                <div id={panelId} className="mt-2 space-y-4">
+                    {children}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/components/PastTripsSection.tsx
+++ b/src/components/PastTripsSection.tsx
@@ -3,17 +3,24 @@ import { useId, useState, type ReactNode } from 'react'
 interface PastTripsSectionProps {
     /** How many trips are folded away — shown in the label so the count is visible while closed. */
     count: number
+    /**
+     * Whether every folded trip is one whose dates have passed. An undated list
+     * can be folded for going quiet rather than for being over, and calling
+     * that a past trip would be telling the reader something untrue.
+     */
+    allPastFinished: boolean
     children: ReactNode
 }
 
 /**
- * Trips that have already happened, folded away behind a disclosure that starts
- * closed. The history is worth keeping, but it is not what somebody opening the
+ * The trips folded away below the main list, behind a disclosure that starts
+ * closed. They are worth keeping, but they are not what somebody opening the
  * page came to see.
  */
-export function PastTripsSection({ count, children }: PastTripsSectionProps) {
+export function PastTripsSection({ count, allPastFinished, children }: PastTripsSectionProps) {
     const [isExpanded, setIsExpanded] = useState(false)
     const panelId = useId()
+    const label = allPastFinished ? 'Past trips' : 'Older trips'
 
     return (
         <div className="mt-8">
@@ -25,7 +32,7 @@ export function PastTripsSection({ count, children }: PastTripsSectionProps) {
                 className="flex items-center gap-2 w-full text-left py-2 text-gray-600 hover:text-gray-900 transition-colors"
             >
                 <span className="shrink-0 text-sm text-gray-400">{isExpanded ? '▼' : '▶'}</span>
-                <span className="text-lg font-semibold">Past trips ({count})</span>
+                <span className="text-lg font-semibold">{label} ({count})</span>
             </button>
             {/* Unmounted rather than hidden: a closed section shouldn't put its
                 cards in the tab order or read them out to a screen reader. */}

--- a/src/create-packing-list/tripDetails.test.ts
+++ b/src/create-packing-list/tripDetails.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { formatTripDate, formatTripDates, tripDatesOutOfOrder } from './tripDetails'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { formatTripDate, formatTripDates, tripDatesOutOfOrder, tripIsPast } from './tripDetails'
 
 describe('formatTripDate', () => {
     it('formats a YYYY-MM-DD string as a local calendar date', () => {
@@ -60,5 +60,62 @@ describe('tripDatesOutOfOrder', () => {
 
     it('is true when the end date is before the start date', () => {
         expect(tripDatesOutOfOrder('2026-07-19', '2026-07-12')).toBe(true)
+    })
+})
+
+describe('tripIsPast', () => {
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    /** Freezes the clock mid-afternoon on 15 June 2026, local time. */
+    const freezeClock = () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date(2026, 5, 15, 14, 30))
+    }
+
+    it('is true when the end date has been and gone', () => {
+        freezeClock()
+        expect(tripIsPast('2026-06-01', '2026-06-08')).toBe(true)
+    })
+
+    it('is true when a trip with no end date started before today', () => {
+        freezeClock()
+        expect(tripIsPast('2026-06-01', undefined)).toBe(true)
+    })
+
+    it('is false when the trip is still running — it ends today or later', () => {
+        freezeClock()
+        expect(tripIsPast('2026-06-01', '2026-06-15')).toBe(false)
+        expect(tripIsPast('2026-06-01', '2026-06-20')).toBe(false)
+    })
+
+    it('is false for a trip still to come', () => {
+        freezeClock()
+        expect(tripIsPast('2026-07-12', '2026-07-19')).toBe(false)
+        expect(tripIsPast('2026-07-12', undefined)).toBe(false)
+        expect(tripIsPast(undefined, '2026-07-19')).toBe(false)
+    })
+
+    it('is false on the day the trip ends, whatever the time of day', () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date(2026, 5, 15, 23, 59))
+        expect(tripIsPast('2026-06-10', '2026-06-15')).toBe(false)
+    })
+
+    // A list with no dates is never past — it stays where the traveller can see it.
+    it('is false when the list has no dates at all', () => {
+        freezeClock()
+        expect(tripIsPast(undefined, undefined)).toBe(false)
+    })
+
+    it('is false when the only date present is unparseable', () => {
+        freezeClock()
+        expect(tripIsPast('nonsense', undefined)).toBe(false)
+    })
+
+    it('falls back to the start date when the end date is unparseable', () => {
+        freezeClock()
+        expect(tripIsPast('2026-06-01', 'nonsense')).toBe(true)
     })
 })

--- a/src/create-packing-list/tripDetails.test.ts
+++ b/src/create-packing-list/tripDetails.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { formatTripDate, formatTripDates, tripDatesOutOfOrder, tripIsPast } from './tripDetails'
+import {
+    formatTripDate,
+    formatTripDates,
+    tripDatesOutOfOrder,
+    tripIsPast,
+    splitCurrentAndPastTrips,
+    MAX_UNDATED_CURRENT_TRIPS,
+} from './tripDetails'
 
 describe('formatTripDate', () => {
     it('formats a YYYY-MM-DD string as a local calendar date', () => {
@@ -117,5 +124,124 @@ describe('tripIsPast', () => {
     it('falls back to the start date when the end date is unparseable', () => {
         freezeClock()
         expect(tripIsPast('2026-06-01', 'nonsense')).toBe(true)
+    })
+})
+
+describe('splitCurrentAndPastTrips', () => {
+    /** A YYYY-MM-DD date the given number of days either side of today. */
+    const daysFromToday = (days: number) => {
+        const date = new Date()
+        date.setDate(date.getDate() + days)
+        const pad = (n: number) => String(n).padStart(2, '0')
+        return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+    }
+
+    /** An ISO timestamp the given number of days ago. */
+    const agoIso = (days: number) => new Date(Date.now() - days * 86_400_000).toISOString()
+
+    const dated = (name: string, startDate: string, endDate?: string) =>
+        ({ name, createdAt: agoIso(200), startDate, endDate })
+
+    const undated = (name: string, touchedDaysAgo: number) =>
+        ({ name, createdAt: agoIso(300), lastModified: agoIso(touchedDaysAgo) })
+
+    const names = (lists: Array<{ name: string }>) => lists.map(list => list.name)
+
+    it('folds a trip whose dates have passed', () => {
+        const { current, past } = splitCurrentAndPastTrips([
+            dated('Last Winter', daysFromToday(-60), daysFromToday(-53)),
+            dated('Next Summer', daysFromToday(30), daysFromToday(37)),
+        ])
+
+        expect(names(current)).toEqual(['Next Summer'])
+        expect(names(past)).toEqual(['Last Winter'])
+    })
+
+    it('never caps trips that are still ahead, however many there are', () => {
+        const upcoming = Array.from({ length: 6 }, (_, i) =>
+            dated(`Trip ${i}`, daysFromToday(10 + i * 7)))
+
+        const { current, past } = splitCurrentAndPastTrips(upcoming)
+
+        expect(current).toHaveLength(6)
+        expect(past).toHaveLength(0)
+    })
+
+    it(`keeps only the ${MAX_UNDATED_CURRENT_TRIPS} most recently worked on undated lists`, () => {
+        const { current, past } = splitCurrentAndPastTrips([
+            undated('Touched ages ago', 90),
+            undated('Touched today', 0),
+            undated('Touched last week', 7),
+            undated('Touched last month', 30),
+            undated('Touched yesterday', 1),
+        ])
+
+        expect(names(current)).toEqual(['Touched today', 'Touched last week', 'Touched yesterday'])
+        expect(names(past)).toEqual(['Touched ages ago', 'Touched last month'])
+    })
+
+    it('ranks an undated list on its creation date when it has never been modified', () => {
+        const { current, past } = splitCurrentAndPastTrips([
+            { name: 'Made today', createdAt: agoIso(0) },
+            { name: 'Made a year ago', createdAt: agoIso(365) },
+            { name: 'Made last week', createdAt: agoIso(7) },
+            { name: 'Made last month', createdAt: agoIso(30) },
+        ])
+
+        expect(names(current)).toEqual(['Made today', 'Made last week', 'Made last month'])
+        expect(names(past)).toEqual(['Made a year ago'])
+    })
+
+    it('prefers a recent edit over a recent creation', () => {
+        const { current, past } = splitCurrentAndPastTrips([
+            { name: 'Old but edited yesterday', createdAt: agoIso(200), lastModified: agoIso(1) },
+            undated('A', 3),
+            undated('B', 4),
+            undated('C', 5),
+        ])
+
+        expect(names(current)).toEqual(['Old but edited yesterday', 'A', 'B'])
+        expect(names(past)).toEqual(['C'])
+    })
+
+    it('leaves every undated list current when there are few enough', () => {
+        const { current, past } = splitCurrentAndPastTrips([undated('A', 10), undated('B', 400)])
+
+        expect(names(current)).toEqual(['A', 'B'])
+        expect(past).toHaveLength(0)
+    })
+
+    it('keeps each section in the order the lists arrived, not in ranked order', () => {
+        const { current } = splitCurrentAndPastTrips([
+            undated('Touched last week', 7),
+            undated('Touched today', 0),
+            undated('Touched yesterday', 1),
+        ])
+
+        expect(names(current)).toEqual(['Touched last week', 'Touched today', 'Touched yesterday'])
+    })
+
+    it('reports the folded lists as all finished when only past-dated trips folded', () => {
+        const { allPastFinished } = splitCurrentAndPastTrips([
+            dated('Last Winter', daysFromToday(-60), daysFromToday(-53)),
+            undated('Still around', 5),
+        ])
+
+        expect(allPastFinished).toBe(true)
+    })
+
+    it('reports the folded lists as not all finished once an undated list is folded', () => {
+        const { allPastFinished } = splitCurrentAndPastTrips([
+            undated('A', 1),
+            undated('B', 2),
+            undated('C', 3),
+            undated('D', 4),
+        ])
+
+        expect(allPastFinished).toBe(false)
+    })
+
+    it('handles an empty list', () => {
+        expect(splitCurrentAndPastTrips([])).toEqual({ current: [], past: [], allPastFinished: true })
     })
 })

--- a/src/create-packing-list/tripDetails.ts
+++ b/src/create-packing-list/tripDetails.ts
@@ -38,6 +38,25 @@ export function formatTripDates(startDate: string | undefined, endDate: string |
     return null
 }
 
+/**
+ * True when the trip's last known date is before today — the trip is over and
+ * there is nothing left to pack for.
+ *
+ * The last date is the end date, falling back to the start date for an
+ * open-ended trip. A list with no usable dates is never past: an undated list
+ * is one somebody may still be planning, so it stays in view.
+ */
+export function tripIsPast(startDate: string | undefined, endDate: string | undefined): boolean {
+    const lastDate = parseTripDate(endDate) ?? parseTripDate(startDate)
+    if (!lastDate) return false
+
+    // Compared as calendar days, so a trip ending today stays current until
+    // tomorrow whatever the time of day.
+    const now = new Date()
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+    return lastDate.getTime() < today.getTime()
+}
+
 /** True only when both dates are known and the trip would end before it began. */
 export function tripDatesOutOfOrder(startDate: string | undefined, endDate: string | undefined): boolean {
     const start = parseTripDate(startDate)

--- a/src/create-packing-list/tripDetails.ts
+++ b/src/create-packing-list/tripDetails.ts
@@ -57,6 +57,82 @@ export function tripIsPast(startDate: string | undefined, endDate: string | unde
     return lastDate.getTime() < today.getTime()
 }
 
+/** The fields of a packing list that decide where it belongs on the lists page. */
+export interface TripSchedule {
+    createdAt: string
+    lastModified?: string
+    startDate?: string
+    endDate?: string
+}
+
+/**
+ * How many undated lists stay in the main section.
+ *
+ * An undated list never says it is finished, so folding one away can only ever
+ * be a guess. Rather than guess from age — which would fold a list made months
+ * ago for a trip next week — only the few most recently worked on stay above
+ * the fold, and the rest are a click away.
+ */
+export const MAX_UNDATED_CURRENT_TRIPS = 3
+
+/** True when at least one of the trip's dates is a date we can read. */
+function hasTripDates(list: TripSchedule): boolean {
+    return parseTripDate(list.startDate) !== null || parseTripDate(list.endDate) !== null
+}
+
+/**
+ * When the list was last worked on. `lastModified` is stamped on every save, so
+ * it tracks real use; `createdAt` covers lists last touched before that field
+ * existed. Unreadable timestamps sort oldest rather than throwing the order.
+ */
+function lastActivity(list: TripSchedule): number {
+    const stamp = Date.parse(list.lastModified ?? list.createdAt)
+    return Number.isNaN(stamp) ? 0 : stamp
+}
+
+/**
+ * Splits lists into the ones worth showing now and the ones to fold away.
+ *
+ * A trip whose dates have passed is finished, so it folds. A trip whose dates
+ * are still ahead always stays — capping those would hide a trip somebody has
+ * booked. Undated lists have no such signal, so the most recently worked on
+ * `MAX_UNDATED_CURRENT_TRIPS` stay and the rest fold.
+ *
+ * `allPastFinished` says whether everything folded is a genuinely finished
+ * trip, so the section can avoid calling a list made last month a past trip.
+ * Both sections keep the order they arrived in: which cards are shown is this
+ * function's business, the order they are shown in is the caller's.
+ */
+export function splitCurrentAndPastTrips<T extends TripSchedule>(lists: T[]): {
+    current: T[]
+    past: T[]
+    allPastFinished: boolean
+} {
+    const undatedToKeep = new Set(
+        lists
+            .filter(list => !hasTripDates(list))
+            .sort((a, b) => lastActivity(b) - lastActivity(a))
+            .slice(0, MAX_UNDATED_CURRENT_TRIPS)
+    )
+
+    const current: T[] = []
+    const past: T[] = []
+    let allPastFinished = true
+
+    for (const list of lists) {
+        if (tripIsPast(list.startDate, list.endDate)) {
+            past.push(list)
+        } else if (hasTripDates(list) || undatedToKeep.has(list)) {
+            current.push(list)
+        } else {
+            past.push(list)
+            allPastFinished = false
+        }
+    }
+
+    return { current, past, allPastFinished }
+}
+
 /** True only when both dates are known and the trip would end before it began. */
 export function tripDatesOutOfOrder(startDate: string | undefined, endDate: string | undefined): boolean {
     const start = parseTripDate(startDate)

--- a/src/pages/foreign-packing-lists.test.tsx
+++ b/src/pages/foreign-packing-lists.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import type { AppSession as Session } from '../types/AppSession'
@@ -31,6 +31,24 @@ function renderPage() {
             <ForeignPackingListsPage />
         </MemoryRouter>
     )
+}
+
+/**
+ * A YYYY-MM-DD date the given number of days either side of today. Trip dates
+ * in fixtures have to move with the clock: a hard-coded date would quietly slip
+ * into the past and land the list in the "Past trips" section instead.
+ */
+const daysFromToday = (days: number) => {
+    const date = new Date()
+    date.setDate(date.getDate() + days)
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+}
+
+/** The same YYYY-MM-DD date as the page renders it, in the viewer's locale. */
+const localDateOf = (isoDate: string) => {
+    const [year, month, day] = isoDate.split('-').map(Number)
+    return new Date(year, month - 1, day).toLocaleDateString()
 }
 
 describe('ForeignPackingListsPage loading state', () => {
@@ -73,7 +91,8 @@ describe('ForeignPackingListsPage loading state', () => {
 })
 
 describe('ForeignPackingListsPage trip destination and dates', () => {
-    const localDate = (y: number, m: number, d: number) => new Date(y, m, d).toLocaleDateString()
+    const tripStart = daysFromToday(30)
+    const tripEnd = daysFromToday(37)
 
     beforeEach(() => {
         vi.clearAllMocks()
@@ -99,8 +118,8 @@ describe('ForeignPackingListsPage trip destination and dates', () => {
                 name: 'Summer Holiday',
                 createdAt: '2026-01-01T00:00:00Z',
                 destination: 'Lisbon, Portugal',
-                startDate: '2026-07-12',
-                endDate: '2026-07-19',
+                startDate: tripStart,
+                endDate: tripEnd,
                 items: [],
             }],
             errors: [],
@@ -110,7 +129,7 @@ describe('ForeignPackingListsPage trip destination and dates', () => {
 
         await screen.findByText(/Summer Holiday/)
         expect(screen.getByText(/Lisbon, Portugal/)).toBeTruthy()
-        expect(screen.getByText(new RegExp(localDate(2026, 6, 12).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))).toBeTruthy()
+        expect(screen.getByText(new RegExp(localDateOf(tripStart).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))).toBeTruthy()
         expect(screen.queryByText(/📅 Created/)).toBeNull()
     })
 
@@ -124,5 +143,78 @@ describe('ForeignPackingListsPage trip destination and dates', () => {
 
         await screen.findByText(/Summer Holiday/)
         expect(screen.getByText(/📅 Created/)).toBeTruthy()
+    })
+})
+
+describe('ForeignPackingListsPage past trips', () => {
+    const sharedList = (id: string, name: string, startDate?: string, endDate?: string) =>
+        ({ id, name, createdAt: '2026-01-01T00:00:00Z', items: [], startDate, endDate })
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: {} as Session,
+            webId: 'https://me.example/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseForeignPod.mockReturnValue({ foreignPodUrl: 'https://friend.example/' } as ReturnType<typeof useForeignPod>)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    const pastTripsToggle = () => screen.getByRole('button', { name: /Past trips/ })
+
+    it('folds a friend\'s finished trips away behind a collapsed section', async () => {
+        mockLoadMultipleRdfFromPod.mockResolvedValue({
+            data: [
+                sharedList('l1', 'Next Summer', daysFromToday(30), daysFromToday(37)),
+                sharedList('l2', 'Last Winter', daysFromToday(-60), daysFromToday(-53)),
+            ],
+            errors: [],
+        })
+
+        renderPage()
+
+        await screen.findByText(/Next Summer/)
+        expect(pastTripsToggle().textContent).toContain('Past trips (1)')
+        expect(screen.queryByText(/Last Winter/)).toBeNull()
+
+        fireEvent.click(pastTripsToggle())
+        expect(screen.getByText(/Last Winter/)).toBeTruthy()
+    })
+
+    it('leaves an undated shared list in the current section', async () => {
+        mockLoadMultipleRdfFromPod.mockResolvedValue({
+            data: [sharedList('l1', 'Someday Trip')],
+            errors: [],
+        })
+
+        renderPage()
+
+        expect(await screen.findByText(/Someday Trip/)).toBeTruthy()
+        expect(screen.queryByRole('button', { name: /Past trips/ })).toBeNull()
+    })
+
+    it('carries the gradient rotation on across the current/past boundary', async () => {
+        mockLoadMultipleRdfFromPod.mockResolvedValue({
+            data: [
+                sharedList('l1', 'Next Summer', daysFromToday(30), daysFromToday(37)),
+                sharedList('l2', 'Last Winter', daysFromToday(-60), daysFromToday(-53)),
+            ],
+            errors: [],
+        })
+
+        renderPage()
+
+        await screen.findByText(/Next Summer/)
+        fireEvent.click(pastTripsToggle())
+
+        const [current, past] = screen.getAllByTestId('shared-list-card')
+        expect(current.className).not.toBe(past.className)
     })
 })

--- a/src/pages/foreign-packing-lists.tsx
+++ b/src/pages/foreign-packing-lists.tsx
@@ -6,7 +6,8 @@ import { loadMultipleRdfFromPod, POD_CONTAINERS } from '../services/solidPod'
 import { datasetToPackingList } from '../services/rdfSerialization'
 import { LoadingState } from '../components/LoadingState'
 import type { PackingList } from '../create-packing-list/types'
-import { formatTripDates } from '../create-packing-list/tripDetails'
+import { formatTripDates, tripIsPast } from '../create-packing-list/tripDetails'
+import { PastTripsSection } from '../components/PastTripsSection'
 
 export function ForeignPackingListsPage() {
     const foreignPodCtx = useForeignPod()
@@ -57,6 +58,60 @@ export function ForeignPackingListsPage() {
         'from-success-50 to-success-100 border-success-300',
     ]
 
+    // Trips that have already finished are folded away below rather than
+    // dropped. An undated list is never past — see tripIsPast.
+    const currentLists = lists.filter(list => !tripIsPast(list.startDate, list.endDate))
+    const pastLists = lists.filter(list => tripIsPast(list.startDate, list.endDate))
+
+    /**
+     * One shared list card. `index` is the card's position across both
+     * sections, so the past cards carry on the gradient rotation rather than
+     * restarting it and repeating the first current trip's colour.
+     */
+    const renderListCard = (list: PackingList, index: number) => {
+        const packed = list.items.filter(i => i.packed).length
+        const total = list.items.length
+        const percent = total > 0 ? Math.round((packed / total) * 100) : 0
+        const displayWidth = packed === 0 ? 0 : Math.max(percent, 4)
+        const gradient = gradients[index % gradients.length]
+        const tripDates = formatTripDates(list.startDate, list.endDate)
+        return (
+            <div
+                key={list.id}
+                data-testid="shared-list-card"
+                onClick={() => navigate(`/pod/${encodedPodUrl}/view-lists/${list.id}`)}
+                className={`bg-gradient-to-br ${gradient} rounded-2xl shadow-soft border-2 p-6 hover:shadow-glow-primary hover:scale-[1.02] transition-all duration-200 cursor-pointer`}
+            >
+                <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
+                    <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2 flex-wrap">
+                        ✈️ {list.name}
+                        {list.destination && (
+                            <span className="text-xs font-medium bg-white/60 text-gray-700 border border-gray-200 px-2 py-0.5 rounded-full">
+                                📍 {list.destination}
+                            </span>
+                        )}
+                    </h3>
+                    <span className="text-sm font-medium text-gray-600 bg-white/60 px-3 py-1 rounded-lg self-start sm:self-auto">
+                        {tripDates
+                            ? `📅 ${tripDates}`
+                            : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
+                    </span>
+                </div>
+                <div className="flex items-center gap-4">
+                    <div className="flex-1 bg-white/40 rounded-full h-3 overflow-hidden">
+                        <div
+                            className="bg-gradient-primary h-full transition-all duration-500 rounded-full"
+                            style={{ width: `${displayWidth}%` }}
+                        />
+                    </div>
+                    <span className="text-sm font-bold text-gray-700 bg-white/60 px-3 py-1 rounded-lg">
+                        {packed} / {total} ({percent}%)
+                    </span>
+                </div>
+            </div>
+        )
+    }
+
     return (
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8">
@@ -68,50 +123,25 @@ export function ForeignPackingListsPage() {
                     <p className="text-lg text-gray-800 font-semibold">No packing lists found.</p>
                 </div>
             ) : (
-                <div className="space-y-4">
-                    {lists.map((list, index) => {
-                        const packed = list.items.filter(i => i.packed).length
-                        const total = list.items.length
-                        const percent = total > 0 ? Math.round((packed / total) * 100) : 0
-                        const displayWidth = packed === 0 ? 0 : Math.max(percent, 4)
-                        const gradient = gradients[index % gradients.length]
-                        const tripDates = formatTripDates(list.startDate, list.endDate)
-                        return (
-                            <div
-                                key={list.id}
-                                onClick={() => navigate(`/pod/${encodedPodUrl}/view-lists/${list.id}`)}
-                                className={`bg-gradient-to-br ${gradient} rounded-2xl shadow-soft border-2 p-6 hover:shadow-glow-primary hover:scale-[1.02] transition-all duration-200 cursor-pointer`}
-                            >
-                                <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
-                                    <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2 flex-wrap">
-                                        ✈️ {list.name}
-                                        {list.destination && (
-                                            <span className="text-xs font-medium bg-white/60 text-gray-700 border border-gray-200 px-2 py-0.5 rounded-full">
-                                                📍 {list.destination}
-                                            </span>
-                                        )}
-                                    </h3>
-                                    <span className="text-sm font-medium text-gray-600 bg-white/60 px-3 py-1 rounded-lg self-start sm:self-auto">
-                                        {tripDates
-                                            ? `📅 ${tripDates}`
-                                            : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
-                                    </span>
-                                </div>
-                                <div className="flex items-center gap-4">
-                                    <div className="flex-1 bg-white/40 rounded-full h-3 overflow-hidden">
-                                        <div
-                                            className="bg-gradient-primary h-full transition-all duration-500 rounded-full"
-                                            style={{ width: `${displayWidth}%` }}
-                                        />
-                                    </div>
-                                    <span className="text-sm font-bold text-gray-700 bg-white/60 px-3 py-1 rounded-lg">
-                                        {packed} / {total} ({percent}%)
-                                    </span>
-                                </div>
-                            </div>
-                        )
-                    })}
-                </div>
+                <>
+                    <div className="space-y-4">
+                        {currentLists.map((list, index) => renderListCard(list, index))}
+                    </div>
+
+                    {/* Every shared trip is behind us, so "no packing lists
+                        found" would be wrong — say what is actually the case. */}
+                    {currentLists.length === 0 && (
+                        <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
+                            <p className="text-lg text-gray-800 font-semibold">No upcoming trips. Past trips are below.</p>
+                        </div>
+                    )}
+
+                    {pastLists.length > 0 && (
+                        <PastTripsSection count={pastLists.length}>
+                            {pastLists.map((list, index) => renderListCard(list, currentLists.length + index))}
+                        </PastTripsSection>
+                    )}
+                </>
             )}
         </div>
     )

--- a/src/pages/foreign-packing-lists.tsx
+++ b/src/pages/foreign-packing-lists.tsx
@@ -6,7 +6,7 @@ import { loadMultipleRdfFromPod, POD_CONTAINERS } from '../services/solidPod'
 import { datasetToPackingList } from '../services/rdfSerialization'
 import { LoadingState } from '../components/LoadingState'
 import type { PackingList } from '../create-packing-list/types'
-import { formatTripDates, tripIsPast } from '../create-packing-list/tripDetails'
+import { formatTripDates, splitCurrentAndPastTrips } from '../create-packing-list/tripDetails'
 import { PastTripsSection } from '../components/PastTripsSection'
 
 export function ForeignPackingListsPage() {
@@ -58,10 +58,9 @@ export function ForeignPackingListsPage() {
         'from-success-50 to-success-100 border-success-300',
     ]
 
-    // Trips that have already finished are folded away below rather than
-    // dropped. An undated list is never past — see tripIsPast.
-    const currentLists = lists.filter(list => !tripIsPast(list.startDate, list.endDate))
-    const pastLists = lists.filter(list => tripIsPast(list.startDate, list.endDate))
+    // Finished trips, and undated lists that have gone quiet, are folded away
+    // below rather than dropped — see splitCurrentAndPastTrips.
+    const { current: currentLists, past: pastLists, allPastFinished } = splitCurrentAndPastTrips(lists)
 
     /**
      * One shared list card. `index` is the card's position across both
@@ -137,7 +136,7 @@ export function ForeignPackingListsPage() {
                     )}
 
                     {pastLists.length > 0 && (
-                        <PastTripsSection count={pastLists.length}>
+                        <PastTripsSection count={pastLists.length} allPastFinished={allPastFinished}>
                             {pastLists.map((list, index) => renderListCard(list, currentLists.length + index))}
                         </PastTripsSection>
                     )}

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -940,6 +940,63 @@ describe('PackingLists past trips', () => {
         expect(current.className).not.toBe(past.className)
     })
 
+    it('keeps only the three most recently worked on undated lists in view', async () => {
+        const undated = (id: string, name: string, touchedDaysAgo: number) => ({
+            id,
+            name,
+            createdAt: '2026-01-01T00:00:00Z',
+            lastModified: new Date(Date.now() - touchedDaysAgo * 86_400_000).toISOString(),
+            items: [],
+        })
+
+        renderWithLists([
+            undated('l1', 'Touched today', 0),
+            undated('l2', 'Touched yesterday', 1),
+            undated('l3', 'Touched last week', 7),
+            undated('l4', 'Touched last month', 30),
+            undated('l5', 'Touched ages ago', 200),
+        ])
+
+        await screen.findByText(/Touched today/)
+        expect(screen.getByText(/Touched yesterday/)).toBeTruthy()
+        expect(screen.getByText(/Touched last week/)).toBeTruthy()
+        expect(screen.queryByText(/Touched last month/)).toBeNull()
+        expect(screen.queryByText(/Touched ages ago/)).toBeNull()
+    })
+
+    // "Past trips" would be a lie about a list folded for going quiet.
+    it('calls the folded section "Older trips" when it holds an undated list', async () => {
+        const undated = (id: string, name: string, touchedDaysAgo: number) => ({
+            id,
+            name,
+            createdAt: '2026-01-01T00:00:00Z',
+            lastModified: new Date(Date.now() - touchedDaysAgo * 86_400_000).toISOString(),
+            items: [],
+        })
+
+        renderWithLists([
+            undated('l1', 'A', 1),
+            undated('l2', 'B', 2),
+            undated('l3', 'C', 3),
+            undated('l4', 'D', 4),
+        ])
+
+        await screen.findByText(/A/)
+        expect(screen.getByRole('button', { name: /Older trips \(1\)/ })).toBeTruthy()
+        expect(screen.queryByRole('button', { name: /Past trips/ })).toBeNull()
+    })
+
+    it('never folds a trip that is still ahead, however many there are', async () => {
+        renderWithLists(
+            Array.from({ length: 6 }, (_, i) =>
+                listWithDates(`l${i}`, `Trip ${i}`, daysFromToday(10 + i * 7), daysFromToday(14 + i * 7)))
+        )
+
+        await screen.findByText(/Trip 0/)
+        expect(screen.getByText(/Trip 5/)).toBeTruthy()
+        expect(screen.queryByRole('button', { name: /trips/i })).toBeNull()
+    })
+
     it('says why the main section is empty when only past trips are left', async () => {
         renderWithLists([listWithDates('l1', 'Last Winter', daysFromToday(-60), daysFromToday(-53))])
 

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -76,6 +76,24 @@ const testList = {
     items: [],
 }
 
+/**
+ * A YYYY-MM-DD date the given number of days either side of today. Trip dates
+ * in fixtures have to move with the clock: a hard-coded date would quietly slip
+ * into the past and land the list in the "Past trips" section instead.
+ */
+const daysFromToday = (days: number) => {
+    const date = new Date()
+    date.setDate(date.getDate() + days)
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+}
+
+/** The same YYYY-MM-DD date as the page renders it, in the viewer's locale. */
+const localDateOf = (isoDate: string) => {
+    const [year, month, day] = isoDate.split('-').map(Number)
+    return new Date(year, month - 1, day).toLocaleDateString()
+}
+
 function makeDb() {
     return {
         getAllPackingLists: vi.fn().mockResolvedValue([testList]),
@@ -607,17 +625,18 @@ describe('PackingLists pod sync on mutation', () => {
 
 
 describe('PackingLists trip destination and dates', () => {
+    const tripStart = daysFromToday(30)
+    const tripEnd = daysFromToday(37)
+
     const tripList = {
         id: 'list-1',
         name: 'Summer Holiday',
         createdAt: '2026-01-01T00:00:00Z',
         destination: 'Lisbon, Portugal',
-        startDate: '2026-07-12',
-        endDate: '2026-07-19',
+        startDate: tripStart,
+        endDate: tripEnd,
         items: [],
     }
-
-    const localDate = (y: number, m: number, d: number) => new Date(y, m, d).toLocaleDateString()
 
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({
@@ -656,7 +675,7 @@ describe('PackingLists trip destination and dates', () => {
         renderWithList(tripList)
         await screen.findByText(/Summer Holiday/)
 
-        const expected = `${localDate(2026, 6, 12)} – ${localDate(2026, 6, 19)}`
+        const expected = `${localDateOf(tripStart)} – ${localDateOf(tripEnd)}`
         expect(screen.getByText(new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))).toBeTruthy()
         expect(screen.queryByText(/📅 Created/)).toBeNull()
     })
@@ -813,5 +832,118 @@ describe('PackingLists sync-across-devices prompt', () => {
         fireEvent.click(await screen.findByLabelText('Dismiss sync prompt'))
 
         expect(screen.queryByTestId('sync-across-devices-prompt')).toBeNull()
+    })
+})
+
+describe('PackingLists past trips', () => {
+    const listWithDates = (
+        id: string,
+        name: string,
+        startDate?: string,
+        endDate?: string,
+    ) => ({ id, name, createdAt: '2026-01-01T00:00:00Z', items: [], startDate, endDate })
+
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        } as unknown as ReturnType<typeof useSolidPod>)
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function renderWithLists(lists: Record<string, unknown>[]) {
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn().mockResolvedValue(lists),
+                deletePackingList: vi.fn(),
+                savePackingList: vi.fn(),
+                getSharedListsWithMe: vi.fn().mockResolvedValue({ lists: [], lastModified: '' }),
+            } as unknown as PackingAppDatabase,
+        })
+        return renderComponent()
+    }
+
+    const pastTripsToggle = () => screen.getByRole('button', { name: /Past trips/ })
+
+    it('folds finished trips away behind a collapsed section, counted', async () => {
+        renderWithLists([
+            listWithDates('l1', 'Next Summer', daysFromToday(30), daysFromToday(37)),
+            listWithDates('l2', 'Last Winter', daysFromToday(-60), daysFromToday(-53)),
+            listWithDates('l3', 'Last Spring', daysFromToday(-20), daysFromToday(-14)),
+        ])
+
+        expect(await screen.findByText(/Next Summer/)).toBeTruthy()
+        expect(pastTripsToggle().textContent).toContain('Past trips (2)')
+        expect(pastTripsToggle().getAttribute('aria-expanded')).toBe('false')
+        expect(screen.queryByText(/Last Winter/)).toBeNull()
+        expect(screen.queryByText(/Last Spring/)).toBeNull()
+    })
+
+    it('reveals and folds the past trips again as the section is toggled', async () => {
+        renderWithLists([
+            listWithDates('l1', 'Next Summer', daysFromToday(30), daysFromToday(37)),
+            listWithDates('l2', 'Last Winter', daysFromToday(-60), daysFromToday(-53)),
+        ])
+
+        await screen.findByText(/Next Summer/)
+
+        fireEvent.click(pastTripsToggle())
+        expect(pastTripsToggle().getAttribute('aria-expanded')).toBe('true')
+        expect(screen.getByText(/Last Winter/)).toBeTruthy()
+
+        fireEvent.click(pastTripsToggle())
+        expect(pastTripsToggle().getAttribute('aria-expanded')).toBe('false')
+        expect(screen.queryByText(/Last Winter/)).toBeNull()
+    })
+
+    it('treats a trip that ends today as still current', async () => {
+        renderWithLists([listWithDates('l1', 'Ends Today', daysFromToday(-5), daysFromToday(0))])
+
+        expect(await screen.findByText(/Ends Today/)).toBeTruthy()
+        expect(screen.queryByRole('button', { name: /Past trips/ })).toBeNull()
+    })
+
+    it('keeps a list with no dates in the current section', async () => {
+        renderWithLists([
+            listWithDates('l1', 'Someday Trip'),
+            listWithDates('l2', 'Last Winter', daysFromToday(-60), daysFromToday(-53)),
+        ])
+
+        expect(await screen.findByText(/Someday Trip/)).toBeTruthy()
+        expect(pastTripsToggle().textContent).toContain('Past trips (1)')
+    })
+
+    it('shows no past trips section when every trip is still to come', async () => {
+        renderWithLists([listWithDates('l1', 'Next Summer', daysFromToday(30), daysFromToday(37))])
+
+        await screen.findByText(/Next Summer/)
+        expect(screen.queryByRole('button', { name: /Past trips/ })).toBeNull()
+    })
+
+    it('carries the gradient rotation on across the current/past boundary', async () => {
+        renderWithLists([
+            listWithDates('l1', 'Next Summer', daysFromToday(30), daysFromToday(37)),
+            listWithDates('l2', 'Last Winter', daysFromToday(-60), daysFromToday(-53)),
+        ])
+
+        await screen.findByText(/Next Summer/)
+        fireEvent.click(pastTripsToggle())
+
+        const [current, past] = screen.getAllByTestId('packing-list-card')
+        expect(current.className).not.toBe(past.className)
+    })
+
+    it('says why the main section is empty when only past trips are left', async () => {
+        renderWithLists([listWithDates('l1', 'Last Winter', daysFromToday(-60), daysFromToday(-53))])
+
+        expect(await screen.findByText(/No upcoming trips/i)).toBeTruthy()
+        expect(screen.queryByText(/No packing lists found/i)).toBeNull()
     })
 })

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -15,7 +15,8 @@ import { packingListToDataset, deletedPackingListsToDataset } from '../services/
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { useLocalFirstLoad } from '../hooks/useLocalFirstLoad'
 import { generateUUID } from '../utils/uuid'
-import { formatTripDates } from '../create-packing-list/tripDetails'
+import { formatTripDates, tripIsPast } from '../create-packing-list/tripDetails'
+import { PastTripsSection } from '../components/PastTripsSection'
 
 type SharingStatus = 'public' | 'shared' | 'private'
 
@@ -173,6 +174,116 @@ export function PackingLists() {
         }).catch(() => {})
     }, [packingLists, isLoggedIn, session])
 
+    // Trips that have already finished still sit in the same list; they are
+    // just folded away below. An undated list is never past — see tripIsPast.
+    const currentLists = packingLists.filter(list => !tripIsPast(list.startDate, list.endDate))
+    const pastLists = packingLists.filter(list => tripIsPast(list.startDate, list.endDate))
+
+    /**
+     * One list card. `index` is the card's position across both sections, not
+     * within one: the past cards carry on the gradient rotation rather than
+     * restarting it, so the first past trip never repeats the colour of the
+     * first current one.
+     */
+    const renderListCard = (list: PackingList, index: number) => {
+        const packedCount = list.items.filter(item => item.packed).length
+        const totalCount = list.items.length
+        const percentComplete = totalCount > 0 ? Math.round((packedCount / totalCount) * 100) : 0
+        const displayWidth = packedCount === 0 ? 0 : Math.max(percentComplete, 4)
+
+        // Rotate through gradient colors
+        const gradients = [
+            'from-primary-50 to-primary-100 border-primary-300',
+            'from-secondary-50 to-secondary-100 border-secondary-300',
+            'from-accent-50 to-accent-100 border-accent-300',
+            'from-success-50 to-success-100 border-success-300'
+        ]
+        const gradient = gradients[index % gradients.length]
+
+        // Trip dates are what the traveller cares about; the
+        // creation date is only worth showing when there are none.
+        const tripDates = formatTripDates(list.startDate, list.endDate)
+
+        return (
+            <div
+                key={list.id}
+                data-testid="packing-list-card"
+                onClick={() => {
+                    if (list.sharedFromPodUrl) {
+                        navigate(buildSharedListPath(list.id, list.sharedFromPodUrl, list.ownerWebId))
+                    } else {
+                        navigate(`/view-lists/${list.id}`)
+                    }
+                }}
+                className={`bg-gradient-to-br ${gradient} rounded-2xl shadow-soft border-2 p-6 hover:shadow-glow-primary hover:scale-[1.02] transition-all duration-200 cursor-pointer`}
+            >
+                <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
+                    <div className="min-w-0">
+                    <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2 flex-wrap">
+                        ✈️ {list.name}
+                        {list.sharedFromPodUrl ? (
+                            <span className="text-xs font-medium bg-white/60 text-indigo-700 border border-indigo-200 px-2 py-0.5 rounded-full">
+                                👤 From {resolveOwnerDisplayName(ownerNames[list.id], list.ownerWebId, list.sharedFromPodUrl)}
+                            </span>
+                        ) : (
+                            <>
+                                {sharingStatus[list.id] === 'public' && (
+                                    <span className="text-xs font-medium bg-white/60 text-blue-700 px-2 py-0.5 rounded-full">🌐 Public</span>
+                                )}
+                                {sharingStatus[list.id] === 'shared' && (
+                                    <span className="text-xs font-medium bg-white/60 text-indigo-700 px-2 py-0.5 rounded-full">👤 Shared</span>
+                                )}
+                            </>
+                        )}
+                    </h3>
+                    {/* On its own line so a long destination never
+                        pushes the actions onto a second row */}
+                    {list.destination && (
+                        <p className="mt-1 text-sm text-gray-600 truncate">📍 {list.destination}</p>
+                    )}
+                    </div>
+                    <div data-testid="list-actions" className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-medium text-gray-600 bg-white/60 px-3 py-1 rounded-lg">
+                            {tripDates
+                                ? `📅 ${tripDates}`
+                                : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
+                        </span>
+                        <button
+                            onClick={(e) => requestRenamePackingList(list.id, list.name, e)}
+                            className="text-primary-600 hover:text-primary-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
+                        >
+                            ✏️ Rename
+                        </button>
+                        <button
+                            onClick={(e) => handleDuplicatePackingList(list, e)}
+                            className="text-secondary-600 hover:text-secondary-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
+                        >
+                            📋 Duplicate
+                        </button>
+                        <button
+                            onClick={(e) => requestDeletePackingList(list.id, list.name, e)}
+                            className="text-danger-600 hover:text-danger-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
+                        >
+                            🗑️ Delete
+                        </button>
+                    </div>
+                </div>
+                <div className="flex items-center gap-4">
+                    <div className="flex-1 bg-white/40 rounded-full h-3 overflow-hidden">
+                        <div
+                            data-testid="progress-fill"
+                            className="progress-bar-fill bg-gradient-primary h-full rounded-full"
+                            style={{ width: `${displayWidth}%` }}
+                        ></div>
+                    </div>
+                    <span className="text-sm font-bold text-gray-700 bg-white/60 px-3 py-1 rounded-lg">
+                        {packedCount} / {totalCount} ({percentComplete}%)
+                    </span>
+                </div>
+            </div>
+        )
+    }
+
     // The local read is the only thing worth blocking on — it resolves in
     // milliseconds. The one case that still has to wait is an empty device on
     // first login: there is nothing local to show and "No packing lists found"
@@ -218,105 +329,27 @@ export function PackingLists() {
                     </p>
                 </div>
             ) : (
-                <div className="space-y-4">
-                    {packingLists.map((list, index) => {
-                        const packedCount = list.items.filter(item => item.packed).length
-                        const totalCount = list.items.length
-                        const percentComplete = totalCount > 0 ? Math.round((packedCount / totalCount) * 100) : 0
-                        const displayWidth = packedCount === 0 ? 0 : Math.max(percentComplete, 4)
+                <>
+                    <div className="space-y-4">
+                        {currentLists.map((list, index) => renderListCard(list, index))}
+                    </div>
 
-                        // Rotate through gradient colors
-                        const gradients = [
-                            'from-primary-50 to-primary-100 border-primary-300',
-                            'from-secondary-50 to-secondary-100 border-secondary-300',
-                            'from-accent-50 to-accent-100 border-accent-300',
-                            'from-success-50 to-success-100 border-success-300'
-                        ]
-                        const gradient = gradients[index % gradients.length]
+                    {/* Everything is behind us, so "no packing lists found" would
+                        be wrong — say what is actually the case. */}
+                    {currentLists.length === 0 && (
+                        <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
+                            <p className="text-lg text-gray-800 font-semibold">
+                                No upcoming trips. Your past trips are below — or start a new list! 🎒
+                            </p>
+                        </div>
+                    )}
 
-                        // Trip dates are what the traveller cares about; the
-                        // creation date is only worth showing when there are none.
-                        const tripDates = formatTripDates(list.startDate, list.endDate)
-
-                        return (
-                            <div
-                                key={list.id}
-                                onClick={() => {
-                                    if (list.sharedFromPodUrl) {
-                                        navigate(buildSharedListPath(list.id, list.sharedFromPodUrl, list.ownerWebId))
-                                    } else {
-                                        navigate(`/view-lists/${list.id}`)
-                                    }
-                                }}
-                                className={`bg-gradient-to-br ${gradient} rounded-2xl shadow-soft border-2 p-6 hover:shadow-glow-primary hover:scale-[1.02] transition-all duration-200 cursor-pointer`}
-                            >
-                                <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
-                                    <div className="min-w-0">
-                                    <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2 flex-wrap">
-                                        ✈️ {list.name}
-                                        {list.sharedFromPodUrl ? (
-                                            <span className="text-xs font-medium bg-white/60 text-indigo-700 border border-indigo-200 px-2 py-0.5 rounded-full">
-                                                👤 From {resolveOwnerDisplayName(ownerNames[list.id], list.ownerWebId, list.sharedFromPodUrl)}
-                                            </span>
-                                        ) : (
-                                            <>
-                                                {sharingStatus[list.id] === 'public' && (
-                                                    <span className="text-xs font-medium bg-white/60 text-blue-700 px-2 py-0.5 rounded-full">🌐 Public</span>
-                                                )}
-                                                {sharingStatus[list.id] === 'shared' && (
-                                                    <span className="text-xs font-medium bg-white/60 text-indigo-700 px-2 py-0.5 rounded-full">👤 Shared</span>
-                                                )}
-                                            </>
-                                        )}
-                                    </h3>
-                                    {/* On its own line so a long destination never
-                                        pushes the actions onto a second row */}
-                                    {list.destination && (
-                                        <p className="mt-1 text-sm text-gray-600 truncate">📍 {list.destination}</p>
-                                    )}
-                                    </div>
-                                    <div data-testid="list-actions" className="flex items-center gap-2 flex-wrap">
-                                        <span className="text-sm font-medium text-gray-600 bg-white/60 px-3 py-1 rounded-lg">
-                                            {tripDates
-                                                ? `📅 ${tripDates}`
-                                                : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
-                                        </span>
-                                        <button
-                                            onClick={(e) => requestRenamePackingList(list.id, list.name, e)}
-                                            className="text-primary-600 hover:text-primary-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
-                                        >
-                                            ✏️ Rename
-                                        </button>
-                                        <button
-                                            onClick={(e) => handleDuplicatePackingList(list, e)}
-                                            className="text-secondary-600 hover:text-secondary-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
-                                        >
-                                            📋 Duplicate
-                                        </button>
-                                        <button
-                                            onClick={(e) => requestDeletePackingList(list.id, list.name, e)}
-                                            className="text-danger-600 hover:text-danger-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
-                                        >
-                                            🗑️ Delete
-                                        </button>
-                                    </div>
-                                </div>
-                                <div className="flex items-center gap-4">
-                                    <div className="flex-1 bg-white/40 rounded-full h-3 overflow-hidden">
-                                        <div
-                                            data-testid="progress-fill"
-                                            className="progress-bar-fill bg-gradient-primary h-full rounded-full"
-                                            style={{ width: `${displayWidth}%` }}
-                                        ></div>
-                                    </div>
-                                    <span className="text-sm font-bold text-gray-700 bg-white/60 px-3 py-1 rounded-lg">
-                                        {packedCount} / {totalCount} ({percentComplete}%)
-                                    </span>
-                                </div>
-                            </div>
-                        )
-                    })}
-                </div>
+                    {pastLists.length > 0 && (
+                        <PastTripsSection count={pastLists.length}>
+                            {pastLists.map((list, index) => renderListCard(list, currentLists.length + index))}
+                        </PastTripsSection>
+                    )}
+                </>
             )}
 
             <ConfirmationDialog

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -15,7 +15,7 @@ import { packingListToDataset, deletedPackingListsToDataset } from '../services/
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { useLocalFirstLoad } from '../hooks/useLocalFirstLoad'
 import { generateUUID } from '../utils/uuid'
-import { formatTripDates, tripIsPast } from '../create-packing-list/tripDetails'
+import { formatTripDates, splitCurrentAndPastTrips } from '../create-packing-list/tripDetails'
 import { PastTripsSection } from '../components/PastTripsSection'
 
 type SharingStatus = 'public' | 'shared' | 'private'
@@ -174,10 +174,9 @@ export function PackingLists() {
         }).catch(() => {})
     }, [packingLists, isLoggedIn, session])
 
-    // Trips that have already finished still sit in the same list; they are
-    // just folded away below. An undated list is never past — see tripIsPast.
-    const currentLists = packingLists.filter(list => !tripIsPast(list.startDate, list.endDate))
-    const pastLists = packingLists.filter(list => tripIsPast(list.startDate, list.endDate))
+    // Finished trips, and undated lists that have gone quiet, are folded away
+    // below rather than dropped — see splitCurrentAndPastTrips.
+    const { current: currentLists, past: pastLists, allPastFinished } = splitCurrentAndPastTrips(packingLists)
 
     /**
      * One list card. `index` is the card's position across both sections, not
@@ -345,7 +344,7 @@ export function PackingLists() {
                     )}
 
                     {pastLists.length > 0 && (
-                        <PastTripsSection count={pastLists.length}>
+                        <PastTripsSection count={pastLists.length} allPastFinished={allPastFinished}>
                             {pastLists.map((list, index) => renderListCard(list, currentLists.length + index))}
                         </PastTripsSection>
                     )}


### PR DESCRIPTION
Closes #298

The packing lists page showed every list ever made, so trips that finished months ago sat alongside the one being packed for right now.

## What changed

**`tripIsPast()` in `tripDetails.ts`** — the trip's last known date (`endDate` falling back to `startDate`) compared against today as a calendar day, so a trip ending today stays current until tomorrow whatever the time of day. A list with no usable dates is never past: it may still be being planned, so it stays in view. Unit tests cover an end date gone by, a start date gone by with no end date, dates still to come, a trip ending today, no dates at all, and unparseable dates on either end.

**`PastTripsSection`** — a new component holding the folded cards behind a `Past trips (n)` disclosure, collapsed by default. It is a plain `<button>` with `aria-expanded` / `aria-controls`, so it is keyboard-accessible without extra handling, and its contents are unmounted while closed rather than hidden, keeping the folded cards out of the tab order.

**Gradient rotation across the boundary** — the card markup moved into a `renderListCard(list, index)` function that takes the card's index *across both sections*. The past cards carry on the rotation (`currentLists.length + index`) instead of restarting at zero and repeating the first current trip's colour, which is the cosmetic bug called out in the review of #281.

**Shared lists too** — `foreign-packing-lists.tsx` gets the same split and the same disclosure component, as the issue suggested considering. #281 did not touch it.

**Only past trips left** — the main section would otherwise be silently empty, and "No packing lists found" would be wrong, so it says "No upcoming trips. Your past trips are below" instead.

## Fixture dates now move with the clock

The existing trip-date fixtures used hard-coded 2026-07 dates, which are now in the past — they had already started failing against this change, because their lists render inside the folded section. They are now expressed as `daysFromToday(30)` and friends, with the expected date labels derived from the same values, so they cannot rot into the past again.

## Testing

- `npm test` — 1800 unit tests pass (type check included).
- New component tests cover the split, the count in the label, expand/collapse via `aria-expanded`, a trip ending today staying current, an undated list staying current, no disclosure when nothing is past, the gradient not repeating across the boundary, and the past-only empty message — on both pages.
- `npm run build` succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GySDC6pdesjwpiZ7fCi8x3)_