### PR TITLE
Name the signed-in account in the nav, and put the WebID behind it

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,6 +1,6 @@
 import { test as base, BrowserContext, Page } from '@playwright/test'
 import { CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD, SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD } from '../playwright.config'
-import { loginToCss } from './helpers/login'
+import { accountMenu, loginToCss } from './helpers/login'
 
 type MyFixtures = {
   /** A page with a fresh (empty) browser context — no auth, no local data */
@@ -38,9 +38,9 @@ export const test = base.extend<MyFixtures>({
     // The context already has a valid session from authedContext's fresh login.
     // The app will try to restore the session (prompt=none), but since the same
     // CSS process is running and consent was just given, this should succeed quickly.
-    // Wait up to 30 seconds for "Logout" to appear.
+    // Wait up to 30 seconds for the account menu — the signed-in sentinel — to appear.
     await page.goto('/')
-    await page.getByRole('button', { name: 'Logout' }).first().waitFor({ state: 'visible', timeout: 30_000 })
+    await accountMenu(page).first().waitFor({ state: 'visible', timeout: 30_000 })
     await use(page)
   },
 

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,4 +1,24 @@
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
+
+/**
+ * The signed-in sentinel. Logout used to be a button in the nav bar and was
+ * what every helper waited for; it now lives inside the account menu (#302),
+ * so the trigger is what stays visible once you are signed in.
+ */
+export function accountMenu(page: Page): Locator {
+  return page.getByRole('button', { name: /account menu/i })
+}
+
+/** Opens the account menu, so its Backups link and Logout button are reachable. */
+export async function openAccountMenu(page: Page): Promise<void> {
+  await accountMenu(page).first().click()
+}
+
+/** Signs out the way a user does now: open the account menu, then Logout. */
+export async function logoutViaAccountMenu(page: Page): Promise<void> {
+  await openAccountMenu(page)
+  await page.getByRole('button', { name: 'Logout' }).click()
+}
 
 /**
  * Automates the full Solid Pod OAuth login flow through the app's UI.
@@ -69,6 +89,6 @@ export async function loginToCss(
   await page.waitForURL(/localhost:4173/, { timeout: 20_000 })
   // Wait for logged-in state (skip if the caller expects a migration prompt to block the nav)
   if (options?.waitForLoggedIn !== false) {
-    await page.getByRole('button', { name: 'Logout' }).first().waitFor({ timeout: 20_000 })
+    await accountMenu(page).first().waitFor({ timeout: 20_000 })
   }
 }

--- a/e2e/tests/d-navigation.spec.ts
+++ b/e2e/tests/d-navigation.spec.ts
@@ -6,11 +6,19 @@ test.describe('D – Navigation & UI', () => {
     await page.getByRole('link', { name: /My Questions & Items/i }).click()
     await expect(page).toHaveURL(/#\/manage-questions/)
 
-    await page.getByRole('link', { name: /Create List/i }).click()
-    await expect(page).toHaveURL(/#\/create-packing-list/)
-
-    await page.getByRole('link', { name: /View Lists/i }).click()
+    await page.getByRole('link', { name: 'Lists' }).click()
     await expect(page).toHaveURL(/#\/view-lists/)
+  })
+
+  // Creating a list starts from Lists now, not from the nav. See #302.
+  test('D1b: Create List has left the nav, and Lists carries New List', async ({ freshPage: page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('link', { name: /Create List/i })).toHaveCount(0)
+
+    await page.getByRole('link', { name: 'Lists' }).click()
+    await page.getByRole('button', { name: /New List/i }).first().click()
+
+    await expect(page).toHaveURL(/#\/create-packing-list/)
   })
 
   test('D2: Backups nav link is hidden when not logged in', async ({ freshPage: page }) => {

--- a/e2e/tests/e-auth.spec.ts
+++ b/e2e/tests/e-auth.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures'
-import { loginToCss } from '../helpers/login'
+import { accountMenu, loginToCss, logoutViaAccountMenu, openAccountMenu } from '../helpers/login'
 
 const CSS_ISSUER = process.env.CSS_ISSUER ?? 'http://localhost:4001'
 const TEST_EMAIL = 'test@example.com'
@@ -10,30 +10,51 @@ test.describe('E – Solid Pod Authentication', () => {
     await page.goto('/')
     await expect(page.getByRole('button', { name: 'Sync & Share' })).toBeVisible()
     await loginToCss(page, CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD)
+    await expect(accountMenu(page)).toBeVisible()
+  })
+
+  // The nav bar names the account rather than printing its WebID; the WebID is
+  // still reachable, one click into the account menu. See #302.
+  test('E1b: the nav bar names the account, with the WebID inside the menu', async ({ authedPage: page }) => {
+    const bar = page.getByTestId('nav-bar')
+    await expect(bar.getByText(/profile\/card#me/)).toHaveCount(0)
+
+    await openAccountMenu(page)
+
+    await expect(bar.getByText(/testuser\/profile\/card#me/)).toBeVisible()
+  })
+
+  test('E1c: the account menu closes on Escape', async ({ authedPage: page }) => {
+    await openAccountMenu(page)
     await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
-    // webId should be displayed (use .first() to avoid strict mode violations when multiple elements match)
-    await expect(page.getByText(/testuser.*profile|profile.*testuser/i).or(
-      page.locator('span:has-text("localhost:4001/testuser")')
-    ).first()).toBeVisible()
+
+    await page.keyboard.press('Escape')
+
+    await expect(page.getByRole('button', { name: 'Logout' })).not.toBeVisible()
+    await expect(accountMenu(page)).toBeFocused()
   })
 
   test('E2: logout returns to unauthenticated state', async ({ authedPage: page }) => {
-    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
-    await page.getByRole('button', { name: 'Logout' }).click()
+    await expect(accountMenu(page)).toBeVisible()
+    await logoutViaAccountMenu(page)
     await expect(page.getByRole('button', { name: 'Sync & Share' })).toBeVisible({ timeout: 8_000 })
-    await expect(page.getByRole('button', { name: 'Logout' })).not.toBeVisible()
+    await expect(accountMenu(page)).not.toBeVisible()
   })
 
-  test('E3: Backups nav link appears only when logged in', async ({ authedPage: page }) => {
+  test('E3: Backups link appears only when logged in', async ({ authedPage: page }) => {
+    await openAccountMenu(page)
     await expect(page.getByRole('link', { name: 'Backups' })).toBeVisible()
+
     await page.getByRole('button', { name: 'Logout' }).click()
+
     await expect(page.getByRole('link', { name: 'Backups' })).not.toBeVisible({ timeout: 8_000 })
+    await expect(accountMenu(page)).not.toBeVisible()
   })
 
   test('E4: session restored on page reload', async ({ authedPage: page }) => {
-    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
+    await expect(accountMenu(page)).toBeVisible()
     await page.reload()
     // Session should be restored from storage
-    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible({ timeout: 15_000 })
+    await expect(accountMenu(page)).toBeVisible({ timeout: 15_000 })
   })
 })

--- a/e2e/tests/k-schema-compat.spec.ts
+++ b/e2e/tests/k-schema-compat.spec.ts
@@ -79,11 +79,12 @@ test.describe('K – JSON Schema Compatibility', () => {
   })
 
   test('K3: new packing list can be created when question set is loaded from v1 JSON', async () => {
-    // Navigate to create-packing-list via nav link (hash change, no OIDC re-auth needed)
+    // Navigate to create-packing-list from the Lists page (hash change, no OIDC
+    // re-auth needed) — the nav no longer carries a Create List link (#302).
     await page.goto('/#/view-lists')
     await page.waitForLoadState('networkidle')
 
-    await page.getByRole('link', { name: 'Create List' }).first().click()
+    await page.getByRole('button', { name: /New List/i }).first().click()
     await page.waitForURL(/#\/create-packing-list/, { timeout: 10_000 })
 
     // The question from the fixture should appear (local DB already has it from beforeAll sync)

--- a/e2e/tests/z-verify-offline-share.spec.ts
+++ b/e2e/tests/z-verify-offline-share.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures'
-import { loginToCss } from '../helpers/login'
+import { accountMenu, loginToCss } from '../helpers/login'
 import { fillPersonRequiredFields } from '../helpers/wizard'
 import { CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD } from '../../playwright.config'
 
@@ -35,7 +35,7 @@ test.describe('Z – Offline list → login → share (regression for 404 fix)',
         try {
             await page.getByRole('button', { name: /use.*local/i }).click({ timeout: 3_000 })
         } catch { /* no modal */ }
-        await page.getByRole('button', { name: 'Logout' }).waitFor({ timeout: 15_000 })
+        await accountMenu(page).first().waitFor({ timeout: 15_000 })
         console.log('Logged in')
 
         // ── 3. Navigate to the list ──────────────────────────────────────────

--- a/scripts/perf/lib/css.mjs
+++ b/scripts/perf/lib/css.mjs
@@ -62,7 +62,7 @@ export async function authenticateForPod(cssOrigin, { email, password, webId }) 
  * Drive the app's real Solid login UI (same flow as e2e/helpers/login.ts).
  */
 export async function loginToCss(page, { appOrigin, cssOrigin, email, password }) {
-  await page.getByRole('button', { name: 'Login with Solid Pod' }).click()
+  await page.getByRole('button', { name: 'Sync & Share' }).click()
   await page.getByRole('dialog').waitFor()
   await page.getByText('Other providers').click()
   await page.getByRole('button', { name: 'Use Custom Provider' }).click()
@@ -93,5 +93,6 @@ export async function loginToCss(page, { appOrigin, cssOrigin, email, password }
   await authorizeBtn.click()
 
   await page.waitForURL(new RegExp(new URL(appOrigin).host), { timeout: 20_000 })
-  await page.getByRole('button', { name: 'Logout' }).first().waitFor({ timeout: 20_000 })
+  // The signed-in sentinel: Logout moved inside the account menu (#302).
+  await page.getByRole('button', { name: /account menu/i }).first().waitFor({ timeout: 20_000 })
 }

--- a/scripts/perf/mobile-repro.mjs
+++ b/scripts/perf/mobile-repro.mjs
@@ -90,8 +90,9 @@ async function main() {
     // then log out so PouchDB keeps the data but pod polling is disabled.
     await loginToCss(page, { appOrigin: APP_ORIGIN, cssOrigin: CSS_ORIGIN, email: EMAIL, password: PASSWORD })
     await restoreSeededBackup(page)
+    await page.getByRole('button', { name: /account menu/i }).first().click()
     await page.getByRole('button', { name: 'Logout' }).first().click()
-    await page.getByRole('button', { name: 'Login with Solid Pod' }).first().waitFor({ timeout: 10_000 })
+    await page.getByRole('button', { name: 'Sync & Share' }).first().waitFor({ timeout: 10_000 })
   }
 
   await page.setViewportSize(MOBILE_VIEWPORT)

--- a/src/components/AccountMenu.test.tsx
+++ b/src/components/AccountMenu.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { AccountMenu, ProfileBadge } from './AccountMenu'
+
+const WEB_ID = 'http://localhost:4000/testuser/profile/card#me'
+
+function renderMenu(overrides: Partial<Parameters<typeof AccountMenu>[0]> = {}) {
+    const onLogout = vi.fn()
+    render(
+        <MemoryRouter>
+            <AccountMenu webId={WEB_ID} displayName="Alice" photoUrl={null} onLogout={onLogout} {...overrides} />
+        </MemoryRouter>
+    )
+    return { onLogout, trigger: screen.getByRole('button', { name: /account menu/i }) }
+}
+
+describe('ProfileBadge', () => {
+    it('shows the profile photo when the card names one', () => {
+        render(<ProfileBadge name="Alice" photoUrl="https://alice.example/me.png" />)
+
+        expect(screen.getByTestId('profile-photo').getAttribute('src')).toBe('https://alice.example/me.png')
+        expect(screen.getByText('Alice')).toBeTruthy()
+    })
+
+    it('falls back to a generic icon when the card has no photo', () => {
+        render(<ProfileBadge name="testuser" photoUrl={null} />)
+
+        expect(screen.queryByTestId('profile-photo')).toBeNull()
+        expect(screen.getByTestId('profile-icon')).toBeTruthy()
+        expect(screen.getByText('testuser')).toBeTruthy()
+    })
+
+    it('falls back to the icon when the photo fails to load', () => {
+        render(<ProfileBadge name="Alice" photoUrl="https://alice.example/gone.png" />)
+
+        fireEvent.error(screen.getByTestId('profile-photo'))
+
+        expect(screen.queryByTestId('profile-photo')).toBeNull()
+        expect(screen.getByTestId('profile-icon')).toBeTruthy()
+    })
+})
+
+describe('AccountMenu', () => {
+    it('names the signed-in user on the trigger rather than their WebID', () => {
+        renderMenu()
+
+        expect(screen.getByText('Alice')).toBeTruthy()
+        expect(screen.queryByText(WEB_ID)).toBeNull()
+    })
+
+    it('keeps the panel shut until the trigger is used', () => {
+        const { trigger } = renderMenu()
+
+        expect(trigger.getAttribute('aria-expanded')).toBe('false')
+        expect(screen.queryByRole('link', { name: 'Backups' })).toBeNull()
+        expect(screen.queryByRole('button', { name: 'Logout' })).toBeNull()
+    })
+
+    it('holds the WebID, Backups and Logout once open', () => {
+        const { trigger } = renderMenu()
+
+        fireEvent.click(trigger)
+
+        expect(trigger.getAttribute('aria-expanded')).toBe('true')
+        expect(screen.getByText(WEB_ID)).toBeTruthy()
+        expect(screen.getByText(/signed in as/i)).toBeTruthy()
+        expect(screen.getByRole('link', { name: 'Backups' }).getAttribute('href')).toBe('/backups')
+        expect(screen.getByRole('button', { name: 'Logout' })).toBeTruthy()
+    })
+
+    it('closes on Escape and puts focus back on the trigger', () => {
+        const { trigger } = renderMenu()
+        fireEvent.click(trigger)
+
+        fireEvent.keyDown(screen.getByRole('button', { name: 'Logout' }), { key: 'Escape' })
+
+        expect(trigger.getAttribute('aria-expanded')).toBe('false')
+        expect(screen.queryByRole('button', { name: 'Logout' })).toBeNull()
+        expect(document.activeElement).toBe(trigger)
+    })
+
+    it('closes on Escape from the trigger itself', () => {
+        const { trigger } = renderMenu()
+        fireEvent.click(trigger)
+
+        fireEvent.keyDown(trigger, { key: 'Escape' })
+
+        expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    })
+
+    it('closes when you click away from it', () => {
+        const { trigger } = renderMenu()
+        fireEvent.click(trigger)
+
+        fireEvent.pointerDown(document.body)
+
+        expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    })
+
+    it('logs out and closes when Logout is chosen', () => {
+        const { trigger, onLogout } = renderMenu()
+        fireEvent.click(trigger)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Logout' }))
+
+        expect(onLogout).toHaveBeenCalledOnce()
+        expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    })
+
+    it('closes when a link inside it is followed', () => {
+        const { trigger } = renderMenu()
+        fireEvent.click(trigger)
+
+        fireEvent.click(screen.getByRole('link', { name: 'Backups' }))
+
+        expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    })
+})

--- a/src/components/AccountMenu.tsx
+++ b/src/components/AccountMenu.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+/**
+ * The signed-in user, drawn the way a signed-in state should be: their face and
+ * their name. A WebID in the nav bar is developer output — true, unreadable,
+ * and no help at all in telling you *which* account you are in.
+ *
+ * Degrades in two steps, because both cases are real: a profile card with a
+ * photo gets the photo, one without gets a generic icon, and a card with no
+ * name at all leaves the caller to fall back to the pod username (see
+ * `podUsernameFromWebId`). The photo can also fail *after* it loads clean —
+ * a 404 on a URL the card still names — so `onError` drops back to the icon
+ * rather than leaving a broken image where a face should be.
+ */
+export function ProfileBadge({ name, photoUrl }: { name: string; photoUrl?: string | null }) {
+    // Keyed to the URL, so a person whose photo 404s falls back but still picks
+    // up a *later* working one. Same reasoning as PersonAvatar.
+    const [failed, setFailed] = useState<string | null>(null)
+    const showPhoto = !!photoUrl && failed !== photoUrl
+
+    return (
+        <>
+            {showPhoto ? (
+                <img
+                    data-testid="profile-photo"
+                    src={photoUrl}
+                    alt=""
+                    aria-hidden="true"
+                    onError={() => setFailed(photoUrl)}
+                    className="w-7 h-7 rounded-full object-cover shrink-0 ring-2 ring-white/40"
+                />
+            ) : (
+                <svg
+                    data-testid="profile-icon"
+                    aria-hidden="true"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    className="w-7 h-7 rounded-full shrink-0 bg-white/20 p-1"
+                >
+                    <path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0 2c-4.42 0-8 2.24-8 5v1h16v-1c0-2.76-3.58-5-8-5Z" />
+                </svg>
+            )}
+            <span className="text-sm font-medium truncate max-w-[10rem]">{name}</span>
+        </>
+    )
+}
+
+/**
+ * Everything about *your account* rather than about your packing: which account
+ * you are in, its WebID, your backups, and the way out.
+ *
+ * A disclosure, not an ARIA `menu`. A `role="menu"` promises arrow-key roving
+ * focus and a typeahead; this is three controls reached by Tab, which is what a
+ * dropdown of links actually is. Escape closes it and hands focus back to the
+ * trigger, so the keyboard never ends up stranded on a panel that has gone.
+ *
+ * The trigger's accessible name is "Account menu <name>": the hidden half says
+ * what the control does, the visible half stays inside the accessible name, so
+ * "click the button that says Alice" and "press the Account menu button" are
+ * the same instruction (WCAG 2.5.3).
+ */
+export function AccountMenu({ webId, displayName, photoUrl, onLogout }: {
+    webId: string
+    displayName: string
+    photoUrl?: string | null
+    onLogout: () => void
+}) {
+    const [isOpen, setIsOpen] = useState(false)
+    const containerRef = useRef<HTMLDivElement>(null)
+    const triggerRef = useRef<HTMLButtonElement>(null)
+
+    useEffect(() => {
+        if (!isOpen) return
+        const onPointerDown = (e: PointerEvent | MouseEvent) => {
+            if (!containerRef.current?.contains(e.target as Node)) setIsOpen(false)
+        }
+        document.addEventListener('pointerdown', onPointerDown)
+        return () => document.removeEventListener('pointerdown', onPointerDown)
+    }, [isOpen])
+
+    const closeAndRefocus = () => {
+        setIsOpen(false)
+        triggerRef.current?.focus()
+    }
+
+    return (
+        <div
+            ref={containerRef}
+            className="relative"
+            // On the container rather than the panel: Escape has to work while
+            // focus is still on the trigger, which is where it is the moment
+            // the panel opens.
+            onKeyDown={e => { if (e.key === 'Escape' && isOpen) closeAndRefocus() }}
+        >
+            <button
+                ref={triggerRef}
+                type="button"
+                onClick={() => setIsOpen(open => !open)}
+                aria-expanded={isOpen}
+                className="flex items-center gap-2 bg-white/10 backdrop-blur-sm px-3 py-1.5 rounded-xl hover:bg-white/20 transition-all duration-200"
+            >
+                <span className="sr-only">Account menu</span>
+                <ProfileBadge name={displayName} photoUrl={photoUrl} />
+                <svg
+                    aria-hidden="true"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    className={`w-4 h-4 shrink-0 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+                >
+                    <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.17l3.71-3.94a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clipRule="evenodd" />
+                </svg>
+            </button>
+
+            {isOpen && (
+                <div className="absolute right-0 mt-2 w-72 z-50 rounded-xl bg-white text-gray-900 shadow-soft ring-1 ring-black/10 overflow-hidden">
+                    <div className="px-4 py-3 border-b border-gray-100">
+                        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Signed in as</p>
+                        {/* Reachable, but no longer the thing the nav bar shouts */}
+                        <p className="mt-1 text-xs text-gray-700 break-all" title={webId}>{webId}</p>
+                    </div>
+                    <Link
+                        to="/backups"
+                        onClick={() => setIsOpen(false)}
+                        className="block px-4 py-3 text-sm font-semibold hover:bg-primary-50 transition-colors duration-200"
+                    >
+                        Backups
+                    </Link>
+                    <button
+                        type="button"
+                        onClick={() => { setIsOpen(false); onLogout() }}
+                        className="w-full text-left px-4 py-3 text-sm font-semibold border-t border-gray-100 hover:bg-primary-50 transition-colors duration-200"
+                    >
+                        Logout
+                    </button>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { Navigation } from './Navigation'
@@ -12,6 +12,13 @@ vi.mock('./SolidProviderSelector', () => ({
     SolidProviderSelector: () => null,
 }))
 
+// Only the profile read is faked: podUsernameFromWebId is the real one, so the
+// fallback these tests assert on is the fallback the nav actually ships.
+vi.mock('../services/solidPod', async importOriginal => ({
+    ...(await importOriginal<typeof import('../services/solidPod')>()),
+    getSolidProfile: vi.fn().mockResolvedValue({ name: null, photo: null }),
+}))
+
 vi.mock('./DatabaseContext', () => ({
     useDatabase: vi.fn().mockReturnValue({
         db: { getSharedWithMe: vi.fn().mockResolvedValue({ contexts: [], lastModified: '' }) },
@@ -21,8 +28,38 @@ vi.mock('./DatabaseContext', () => ({
 }))
 
 import { useSolidPod } from './SolidPodContext'
+import { getSolidProfile } from '../services/solidPod'
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockGetSolidProfile = vi.mocked(getSolidProfile)
+
+const WEB_ID = 'https://user.solidpod.example/profile/card#me'
+
+function signedIn() {
+    mockUseSolidPod.mockReturnValue({
+        session: null,
+        isLoggedIn: true,
+        sessionExpired: false,
+        clearSessionExpired: vi.fn(),
+        webId: WEB_ID,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+    })
+}
+
+function renderNav() {
+    return render(
+        <MemoryRouter>
+            <Navigation />
+        </MemoryRouter>
+    )
+}
+
+/** The top row — what "the nav bar" means, as opposed to the mobile menu below it. */
+const navBar = () => screen.getByTestId('nav-bar')
+
+const openAccountMenu = () => fireEvent.click(within(navBar()).getByRole('button', { name: /account menu/i }))
 
 describe('Navigation', () => {
     beforeEach(() => {
@@ -114,24 +151,95 @@ describe('Navigation', () => {
     })
 
     it('shows Backups link when logged in', () => {
-        mockUseSolidPod.mockReturnValue({
-            session: null,
-            isLoggedIn: true,
-            sessionExpired: false,
-            clearSessionExpired: vi.fn(),
-            webId: 'https://user.solidpod.example/profile/card#me',
-            isLoading: false,
-            login: vi.fn(),
-            logout: vi.fn(),
-        })
+        signedIn()
 
-        render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
+        renderNav()
+        openAccountMenu()
 
         expect(screen.getAllByText('Backups').length).toBeGreaterThan(0)
+    })
+
+    // Creating a list starts from Lists now — "New List" is the button on that
+    // page, in your own pod and in someone else's. See #302.
+    it('keeps Create List out of the nav', () => {
+        renderNav()
+
+        expect(screen.queryByRole('link', { name: /create list/i })).toBeNull()
+    })
+
+    it('calls the lists destination "Lists"', () => {
+        renderNav()
+
+        expect(within(navBar()).getByRole('link', { name: 'Lists' })).toBeTruthy()
+        expect(screen.queryByText('View Lists')).toBeNull()
+    })
+
+    // #204 promoted sharing deliberately; it does not get demoted into the
+    // account menu a release later.
+    it('keeps Sharing in the nav bar rather than the account menu', () => {
+        signedIn()
+
+        renderNav()
+
+        expect(within(navBar()).getByRole('link', { name: 'Sharing' })).toBeTruthy()
+    })
+})
+
+describe('Navigation – signed-in account menu', () => {
+    beforeEach(() => {
+        mockGetSolidProfile.mockResolvedValue({ name: null, photo: null })
+        signedIn()
+    })
+
+    it('does not print the raw WebID in the nav bar', async () => {
+        renderNav()
+
+        await waitFor(() => expect(mockGetSolidProfile).toHaveBeenCalled())
+        expect(within(navBar()).queryByText(WEB_ID)).toBeNull()
+    })
+
+    it('names the signed-in user from their profile card', async () => {
+        mockGetSolidProfile.mockResolvedValue({ name: 'Alice Adams', photo: 'https://user.solidpod.example/me.png' })
+
+        renderNav()
+
+        await waitFor(() => expect(within(navBar()).getByText('Alice Adams')).toBeTruthy())
+        expect(within(navBar()).getByTestId('profile-photo').getAttribute('src'))
+            .toBe('https://user.solidpod.example/me.png')
+    })
+
+    it('falls back to the pod username and a generic icon when the card names neither', async () => {
+        renderNav()
+
+        await waitFor(() => expect(mockGetSolidProfile).toHaveBeenCalled())
+        expect(within(navBar()).getAllByText('user').length).toBeGreaterThan(0)
+        expect(within(navBar()).getByTestId('profile-icon')).toBeTruthy()
+    })
+
+    it('keeps the WebID reachable inside the account menu', () => {
+        renderNav()
+
+        openAccountMenu()
+
+        expect(within(navBar()).getByText(WEB_ID)).toBeTruthy()
+        expect(within(navBar()).getByRole('button', { name: 'Logout' })).toBeTruthy()
+        expect(within(navBar()).getByRole('link', { name: 'Backups' })).toBeTruthy()
+    })
+
+    it('reads the profile through the shared cached path', async () => {
+        renderNav()
+
+        await waitFor(() => expect(mockGetSolidProfile).toHaveBeenCalledWith(null, WEB_ID))
+    })
+
+    it('gives the mobile menu the same affordances without a dropdown', () => {
+        renderNav()
+
+        const mobile = screen.getByTestId('mobile-menu')
+        expect(within(mobile).getByText(WEB_ID)).toBeTruthy()
+        expect(within(mobile).getByRole('link', { name: 'Backups' })).toBeTruthy()
+        expect(within(mobile).getByRole('button', { name: 'Logout' })).toBeTruthy()
+        expect(within(mobile).queryByRole('button', { name: /account menu/i })).toBeNull()
     })
 })
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,8 +4,7 @@ import { useSolidPod } from './SolidPodContext'
 import { useDatabase } from './DatabaseContext'
 import { SolidProviderSelector } from './SolidProviderSelector'
 import { AccountMenu, ProfileBadge } from './AccountMenu'
-import { useSolidProfile } from '../hooks/useSolidProfile'
-import { podUsernameFromWebId } from '../services/solidPod'
+import { profileDisplayName, useSolidProfile } from '../hooks/useSolidProfile'
 import type { SharedContext } from '../services/rdfSerialization'
 
 export const Navigation = () => {
@@ -24,9 +23,7 @@ export const Navigation = () => {
     }, [db, loginSyncVersion])
 
     const profile = useSolidProfile(webId, session)
-    // Their name if their card has one, otherwise the username their WebID
-    // carries. Both beat printing the WebID, which is what used to sit here.
-    const displayName = profile.name ?? (webId ? podUsernameFromWebId(webId) : null) ?? 'Your account'
+    const displayName = profileDisplayName(profile, webId)
 
     const podMatch = /^\/pod\/([^/]+)/.exec(location.pathname)
     const currentForeignEncoded = podMatch?.[1] ?? null

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,12 +3,15 @@ import { useState, useEffect } from 'react'
 import { useSolidPod } from './SolidPodContext'
 import { useDatabase } from './DatabaseContext'
 import { SolidProviderSelector } from './SolidProviderSelector'
+import { AccountMenu, ProfileBadge } from './AccountMenu'
+import { useSolidProfile } from '../hooks/useSolidProfile'
+import { podUsernameFromWebId } from '../services/solidPod'
 import type { SharedContext } from '../services/rdfSerialization'
 
 export const Navigation = () => {
     const [isOpen, setIsOpen] = useState(false)
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
-    const { login, logout, isLoggedIn, webId } = useSolidPod()
+    const { login, logout, isLoggedIn, webId, session } = useSolidPod()
     const { db, loginSyncVersion } = useDatabase()
     const location = useLocation()
     const navigate = useNavigate()
@@ -20,6 +23,11 @@ export const Navigation = () => {
             .catch(() => {})
     }, [db, loginSyncVersion])
 
+    const profile = useSolidProfile(webId, session)
+    // Their name if their card has one, otherwise the username their WebID
+    // carries. Both beat printing the WebID, which is what used to sit here.
+    const displayName = profile.name ?? (webId ? podUsernameFromWebId(webId) : null) ?? 'Your account'
+
     const podMatch = /^\/pod\/([^/]+)/.exec(location.pathname)
     const currentForeignEncoded = podMatch?.[1] ?? null
     const inForeignContext = currentForeignEncoded !== null
@@ -27,7 +35,6 @@ export const Navigation = () => {
     // When viewing a foreign pod, contextual links stay inside that pod's routes
     const viewListsPath = inForeignContext ? `/pod/${currentForeignEncoded}/view-lists` : '/view-lists'
     const manageQuestionsPath = inForeignContext ? `/pod/${currentForeignEncoded}/manage-questions` : '/manage-questions'
-    const createListPath = inForeignContext ? `/pod/${currentForeignEncoded}/create-packing-list` : '/create-packing-list'
 
     const handleSolidLogin = () => {
         setIsProviderSelectorOpen(true)
@@ -45,7 +52,7 @@ export const Navigation = () => {
         <>
             <nav className="bg-primary-950 text-white shadow-soft safe-area-top">
                 <div className="max-w-7xl mx-auto px-4">
-                    <div className="flex items-center justify-between h-14 md:h-16">
+                    <div data-testid="nav-bar" className="flex items-center justify-between h-14 md:h-16">
                         <div className="flex items-center">
                             <div className="flex-shrink-0">
                                 <Link to="/home" className="flex items-center gap-2 text-xl md:text-2xl font-bold hover:scale-105 transition-transform duration-200 drop-shadow-md">
@@ -61,26 +68,20 @@ export const Navigation = () => {
                                     >
                                         {inForeignContext ? 'Questions & Items' : 'My Questions & Items'}
                                     </Link>
-                                    <Link
-                                        to={createListPath}
-                                        className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
-                                    >
-                                        Create List
-                                    </Link>
+                                    {/*
+                                      * No "Create List" here: creating starts from
+                                      * Lists, where the "New List" button sits, in
+                                      * your own pod and in someone else's alike.
+                                      * Backups lives in the account menu — it is a
+                                      * once-in-a-while destination, not an everyday
+                                      * one. See #302.
+                                      */}
                                     <Link
                                         to={viewListsPath}
                                         className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
                                     >
-                                        View Lists
+                                        Lists
                                     </Link>
-                                    {isLoggedIn && (
-                                        <Link
-                                            to="/backups"
-                                            className="px-4 py-2 rounded-xl text-sm font-semibold hover:bg-white/20 transition-all duration-200 hover:scale-105"
-                                        >
-                                            Backups
-                                        </Link>
-                                    )}
                                     {/*
                                       * Sharing stays visible logged out: the page's own
                                       * benefit-framed sign-in handles that case, and hiding
@@ -98,7 +99,13 @@ export const Navigation = () => {
                         {/* Solid Login/Logout section */}
                         <div className="hidden md:flex items-center gap-4">
                             {isLoggedIn ? (
-                                <div className="flex items-center gap-3 bg-white/10 backdrop-blur-sm px-4 py-2 rounded-xl">
+                                <div className="flex items-center gap-3">
+                                    {/*
+                                      * The context switcher stays out here rather than
+                                      * inside the account menu: whose data you are
+                                      * looking at has to be answerable at a glance,
+                                      * without opening anything.
+                                      */}
                                     {sharedContexts.length > 0 && (
                                         <select
                                             value={currentForeignEncoded ?? '__own__'}
@@ -122,15 +129,12 @@ export const Navigation = () => {
                                             ))}
                                         </select>
                                     )}
-                                    <span className="text-sm font-medium truncate max-w-xs" title={webId}>
-                                        {webId}
-                                    </span>
-                                    <button
-                                        onClick={handleLogout}
-                                        className="px-3 py-1.5 rounded-lg text-sm font-semibold bg-white/20 hover:bg-white/30 transition-all duration-200 hover:scale-105"
-                                    >
-                                        Logout
-                                    </button>
+                                    <AccountMenu
+                                        webId={webId ?? ''}
+                                        displayName={displayName}
+                                        photoUrl={profile.photo}
+                                        onLogout={handleLogout}
+                                    />
                                 </div>
                             ) : (
                                 <div className="flex flex-col items-end">
@@ -179,7 +183,7 @@ export const Navigation = () => {
                 </div>
 
                 {/* Mobile menu */}
-                <div className={`${isOpen ? 'block' : 'hidden'} md:hidden bg-primary-950`}>
+                <div data-testid="mobile-menu" className={`${isOpen ? 'block' : 'hidden'} md:hidden bg-primary-950`}>
                     <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
                         <Link
                             to={manageQuestionsPath}
@@ -189,28 +193,12 @@ export const Navigation = () => {
                             {inForeignContext ? 'Questions & Items' : 'My Questions & Items'}
                         </Link>
                         <Link
-                            to={createListPath}
-                            className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
-                            onClick={() => setIsOpen(false)}
-                        >
-                            Create List
-                        </Link>
-                        <Link
                             to={viewListsPath}
                             className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
                             onClick={() => setIsOpen(false)}
                         >
-                            View Lists
+                            Lists
                         </Link>
-                        {isLoggedIn && (
-                            <Link
-                                to="/backups"
-                                className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
-                                onClick={() => setIsOpen(false)}
-                            >
-                                Backups
-                            </Link>
-                        )}
                         <Link
                             to="/sharing"
                             className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
@@ -222,9 +210,25 @@ export const Navigation = () => {
                         <div className="border-t border-white/20 pt-2 mt-2">
                             {isLoggedIn ? (
                                 <>
-                                    <div className="px-3 py-2 text-sm font-medium truncate" title={webId}>
-                                        {webId}
+                                    {/*
+                                      * The same things the desktop account menu holds,
+                                      * flat: the mobile menu is already a disclosure,
+                                      * and a dropdown inside a dropdown buys nothing.
+                                      */}
+                                    <div className="flex items-center gap-2 px-3 py-2">
+                                        <ProfileBadge name={displayName} photoUrl={profile.photo} />
                                     </div>
+                                    <div className="px-3 pb-2">
+                                        <p className="text-xs font-semibold text-white/70 uppercase tracking-wide">Signed in as</p>
+                                        <p className="mt-0.5 text-xs text-white/80 break-all" title={webId}>{webId}</p>
+                                    </div>
+                                    <Link
+                                        to="/backups"
+                                        className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"
+                                        onClick={() => setIsOpen(false)}
+                                    >
+                                        Backups
+                                    </Link>
                                     <button
                                         onClick={() => {
                                             handleLogout()

--- a/src/hooks/useSolidProfile.test.ts
+++ b/src/hooks/useSolidProfile.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import type { AppSession } from '../types/AppSession'
-import { useSolidProfile } from './useSolidProfile'
+import { profileDisplayName, useSolidProfile } from './useSolidProfile'
 
-vi.mock('../services/solidPod', () => ({
+// podUsernameFromWebId stays real: the fallback these tests assert on should be
+// the fallback that ships.
+vi.mock('../services/solidPod', async importOriginal => ({
+    ...(await importOriginal<typeof import('../services/solidPod')>()),
     getSolidProfile: vi.fn(),
 }))
 
@@ -72,5 +75,26 @@ describe('useSolidProfile', () => {
 
         expect(errors).not.toHaveBeenCalled()
         errors.mockRestore()
+    })
+})
+
+describe('profileDisplayName', () => {
+    const WEB_ID = 'http://localhost:4000/testuser/profile/card#me'
+
+    it('prefers the name the profile card gives', () => {
+        expect(profileDisplayName({ name: 'Alice Adams', photo: null }, WEB_ID)).toBe('Alice Adams')
+    })
+
+    it('falls back to the username the WebID carries', () => {
+        expect(profileDisplayName({ name: null, photo: null }, WEB_ID)).toBe('testuser')
+    })
+
+    // Signed in, but the WebID has not landed yet — better than an empty gap.
+    it('falls back again when there is no WebID to read', () => {
+        expect(profileDisplayName({ name: null, photo: null }, undefined)).toBe('Your account')
+    })
+
+    it('falls back again when the WebID cannot be parsed', () => {
+        expect(profileDisplayName({ name: null, photo: null }, 'not-a-url')).toBe('Your account')
     })
 })

--- a/src/hooks/useSolidProfile.test.ts
+++ b/src/hooks/useSolidProfile.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { AppSession } from '../types/AppSession'
+import { useSolidProfile } from './useSolidProfile'
+
+vi.mock('../services/solidPod', () => ({
+    getSolidProfile: vi.fn(),
+}))
+
+import { getSolidProfile } from '../services/solidPod'
+
+const mockGetSolidProfile = vi.mocked(getSolidProfile)
+
+const session = { fetch: globalThis.fetch, info: { isLoggedIn: true } } as AppSession
+
+describe('useSolidProfile', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('reports nothing until the profile card has been read', () => {
+        mockGetSolidProfile.mockReturnValue(new Promise(() => {}))
+
+        const { result } = renderHook(() => useSolidProfile('https://alice.example/profile/card#me', session))
+
+        expect(result.current).toEqual({ name: null, photo: null })
+    })
+
+    it('reports the name and photo the card names', async () => {
+        mockGetSolidProfile.mockResolvedValue({ name: 'Alice', photo: 'https://alice.example/me.png' })
+
+        const { result } = renderHook(() => useSolidProfile('https://alice.example/profile/card#me', session))
+
+        await waitFor(() => expect(result.current).toEqual({ name: 'Alice', photo: 'https://alice.example/me.png' }))
+    })
+
+    it('reads nothing when there is no WebID to read', () => {
+        renderHook(() => useSolidProfile(undefined, session))
+
+        expect(mockGetSolidProfile).not.toHaveBeenCalled()
+    })
+
+    // A profile card is public by convention, and getSolidProfile reads it
+    // unauthenticated when there is no session — same as usePersonPhotos.
+    it('still reads the card when there is no session', async () => {
+        mockGetSolidProfile.mockResolvedValue({ name: 'Alice', photo: null })
+
+        const { result } = renderHook(() => useSolidProfile('https://alice.example/profile/card#me', null))
+
+        await waitFor(() => expect(result.current.name).toBe('Alice'))
+        expect(mockGetSolidProfile).toHaveBeenCalledWith(null, 'https://alice.example/profile/card#me')
+    })
+
+    it('keeps a card that cannot be read from breaking the caller', async () => {
+        mockGetSolidProfile.mockRejectedValue(new Error('404'))
+
+        const { result } = renderHook(() => useSolidProfile('https://gone.example/profile/card#me', session))
+
+        await waitFor(() => expect(mockGetSolidProfile).toHaveBeenCalled())
+        expect(result.current).toEqual({ name: null, photo: null })
+    })
+
+    it('does not write state for a profile that lands after unmount', async () => {
+        let resolve!: (p: { name: string | null; photo: string | null }) => void
+        mockGetSolidProfile.mockReturnValue(new Promise(r => { resolve = r }))
+        const errors = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        const { unmount } = renderHook(() => useSolidProfile('https://alice.example/profile/card#me', session))
+        unmount()
+        resolve({ name: 'Alice', photo: null })
+        await Promise.resolve()
+
+        expect(errors).not.toHaveBeenCalled()
+        errors.mockRestore()
+    })
+})

--- a/src/hooks/useSolidProfile.ts
+++ b/src/hooks/useSolidProfile.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { getSolidProfile, type SolidProfile } from '../services/solidPod'
+import { getSolidProfile, podUsernameFromWebId, type SolidProfile } from '../services/solidPod'
 import type { AppSession } from '../types/AppSession'
 
 const UNREAD: SolidProfile = { name: null, photo: null }
@@ -38,4 +38,16 @@ export function useSolidProfile(
     }, [webId, session])
 
     return profile
+}
+
+/**
+ * What to call the person behind a WebID, in the two places that name the
+ * signed-in user: the nav's account menu and the landing page's greeting.
+ *
+ * Their card's name if it has one, otherwise the username the WebID carries,
+ * and only failing both a generic label. Never the WebID itself — printing that
+ * at a person is what #302 was opened about.
+ */
+export function profileDisplayName(profile: SolidProfile, webId: string | undefined): string {
+    return profile.name ?? (webId ? podUsernameFromWebId(webId) : null) ?? 'Your account'
 }

--- a/src/hooks/useSolidProfile.ts
+++ b/src/hooks/useSolidProfile.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import { getSolidProfile, type SolidProfile } from '../services/solidPod'
+import type { AppSession } from '../types/AppSession'
+
+const UNREAD: SolidProfile = { name: null, photo: null }
+
+/**
+ * One WebID's profile card — their name, and their photo.
+ *
+ * The fetch is `getSolidProfile`, which is the same cached, deduped path the
+ * person avatars go through (see `usePersonPhotos`). So the nav asking for the
+ * signed-in user's card costs nothing when a packing list has already drawn
+ * them, and the app reads any one card once however many components want it.
+ *
+ * No abort on unmount, for the same reason: the request belongs to the cache,
+ * not to this component, and cancelling it would take it away from whoever else
+ * is waiting. Unmounting only stops us writing state.
+ */
+export function useSolidProfile(
+    webId: string | undefined,
+    session: AppSession | null | undefined,
+): SolidProfile {
+    const [profile, setProfile] = useState<SolidProfile>(UNREAD)
+
+    useEffect(() => {
+        if (!webId) {
+            setProfile(UNREAD)
+            return
+        }
+        let cancelled = false
+        // Reset first: a different WebID must not wear the last one's face
+        // while its own card is still in flight.
+        setProfile(UNREAD)
+        getSolidProfile(session, webId)
+            .then(p => { if (!cancelled) setProfile(p) })
+            .catch(() => { /* unreadable card: the caller's fallback stands */ })
+        return () => { cancelled = true }
+    }, [webId, session])
+
+    return profile
+}

--- a/src/pages/foreign-packing-lists.test.tsx
+++ b/src/pages/foreign-packing-lists.test.tsx
@@ -16,6 +16,12 @@ vi.mock('../services/rdfSerialization', () => ({
     datasetToPackingList: vi.fn(),
 }))
 
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react-router-dom')>()
+    return { ...actual, useNavigate: () => mockNavigate }
+})
+
 import { ForeignPackingListsPage } from './foreign-packing-lists'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useForeignPod } from '../components/ForeignPodContext'
@@ -216,5 +222,46 @@ describe('ForeignPackingListsPage past trips', () => {
 
         const [current, past] = screen.getAllByTestId('shared-list-card')
         expect(current.className).not.toBe(past.className)
+    })
+})
+
+// The nav no longer carries "Create List" (#302), so this page is the only
+// create-list entry point in foreign-pod context — it did not have one before.
+describe('ForeignPackingListsPage create entry point', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: {} as Session,
+            webId: 'https://me.example/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseForeignPod.mockReturnValue({ foreignPodUrl: 'https://friend.example/' } as ReturnType<typeof useForeignPod>)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('offers a New List button while the shared lists are still loading', async () => {
+        mockLoadMultipleRdfFromPod.mockReturnValue(new Promise(() => {}))
+
+        renderPage()
+
+        await waitFor(() => expect(screen.getByRole('button', { name: /New List/i })).toBeTruthy())
+    })
+
+    it('creates the list into the pod being viewed, not your own', async () => {
+        mockLoadMultipleRdfFromPod.mockResolvedValue({ data: [], errors: [] })
+
+        renderPage()
+
+        fireEvent.click(await screen.findByRole('button', { name: /New List/i }))
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+            `/pod/${encodeURIComponent('https://friend.example/')}/create-packing-list`
+        )
     })
 })

--- a/src/pages/foreign-packing-lists.tsx
+++ b/src/pages/foreign-packing-lists.tsx
@@ -5,6 +5,7 @@ import { useSolidPod } from '../components/SolidPodContext'
 import { loadMultipleRdfFromPod, POD_CONTAINERS } from '../services/solidPod'
 import { datasetToPackingList } from '../services/rdfSerialization'
 import { LoadingState } from '../components/LoadingState'
+import { Button } from '../components/Button'
 import type { PackingList } from '../create-packing-list/types'
 import { formatTripDates, splitCurrentAndPastTrips } from '../create-packing-list/tripDetails'
 import { PastTripsSection } from '../components/PastTripsSection'
@@ -39,13 +40,15 @@ export function ForeignPackingListsPage() {
 
     const encodedPodUrl = encodeURIComponent(foreignPodUrl ?? '')
 
+    // The only way to start a list in someone else's pod. The nav dropped
+    // "Create List" (#302), and until then this page had no create affordance
+    // at all — so a collaborator could edit a shared list but never add one.
+    const createList = () => navigate(`/pod/${encodedPodUrl}/create-packing-list`)
+
     if (isLoading) {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
-                <div className="mb-8">
-                    <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
-                    <p className="mt-2 text-lg text-gray-700 font-medium">Shared packing lists.</p>
-                </div>
+                <Header onCreate={createList} />
                 <LoadingState message="Loading packing lists..." rows={3} />
             </div>
         )
@@ -113,10 +116,7 @@ export function ForeignPackingListsPage() {
 
     return (
         <div className="max-w-4xl mx-auto py-8 px-4">
-            <div className="mb-8">
-                <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
-                <p className="mt-2 text-lg text-gray-700 font-medium">Shared packing lists.</p>
-            </div>
+            <Header onCreate={createList} />
             {lists.length === 0 ? (
                 <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
                     <p className="text-lg text-gray-800 font-semibold">No packing lists found.</p>
@@ -142,6 +142,18 @@ export function ForeignPackingListsPage() {
                     )}
                 </>
             )}
+        </div>
+    )
+}
+
+function Header({ onCreate }: { onCreate: () => void }) {
+    return (
+        <div className="mb-8 flex justify-between items-start gap-4">
+            <div className="mb-2">
+                <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
+                <p className="mt-2 text-lg text-gray-700 font-medium">Shared packing lists.</p>
+            </div>
+            <Button variant="primary" onClick={onCreate}>➕ New List</Button>
         </div>
     )
 }

--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { LandingPage } from './landing-page'
@@ -12,11 +12,18 @@ vi.mock('../components/SolidPodContext', () => ({
     useSolidPod: vi.fn(),
 }))
 
+vi.mock('../services/solidPod', async importOriginal => ({
+    ...(await importOriginal<typeof import('../services/solidPod')>()),
+    getSolidProfile: vi.fn().mockResolvedValue({ name: null, photo: null }),
+}))
+
 import { useHasQuestions } from '../hooks/useHasQuestions'
 import { useSolidPod } from '../components/SolidPodContext'
+import { getSolidProfile } from '../services/solidPod'
 
 const mockUseHasQuestions = vi.mocked(useHasQuestions)
 const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockGetSolidProfile = vi.mocked(getSolidProfile)
 
 describe('LandingPage', () => {
     beforeEach(() => {
@@ -148,5 +155,74 @@ describe('LandingPage', () => {
         const loginButton = screen.getByRole('button', { name: /get a free solid pod/i })
         fireEvent.click(loginButton)
         expect(screen.getByRole('dialog')).toBeTruthy()
+    })
+})
+
+// The nav stopped printing the raw WebID in #302; this banner sat right under it
+// still doing exactly that.
+describe('LandingPage – signed-in greeting', () => {
+    const WEB_ID = 'https://user.solidpod.example/profile/card#me'
+
+    beforeEach(() => {
+        mockUseHasQuestions.mockReturnValue(false)
+        mockGetSolidProfile.mockResolvedValue({ name: null, photo: null })
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: true,
+            webId: WEB_ID,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+    })
+
+    function renderPage() {
+        return render(
+            <MemoryRouter>
+                <LandingPage />
+            </MemoryRouter>
+        )
+    }
+
+    it('greets you by the name on your profile card', async () => {
+        mockGetSolidProfile.mockResolvedValue({ name: 'Alice Adams', photo: null })
+
+        renderPage()
+
+        expect(await screen.findByText('Alice Adams')).toBeTruthy()
+    })
+
+    it('never prints the raw WebID', async () => {
+        renderPage()
+
+        await waitFor(() => expect(mockGetSolidProfile).toHaveBeenCalled())
+        expect(screen.queryByText(WEB_ID)).toBeNull()
+    })
+
+    it('falls back to the pod username when the card has no name', async () => {
+        renderPage()
+
+        expect(await screen.findByText('user')).toBeTruthy()
+    })
+
+    it('reads the profile through the shared cached path', async () => {
+        renderPage()
+
+        await waitFor(() => expect(mockGetSolidProfile).toHaveBeenCalledWith(null, WEB_ID))
+    })
+
+    it('says nothing at all when signed out', () => {
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+
+        renderPage()
+
+        expect(screen.queryByText(/signed in as/i)).toBeNull()
     })
 })

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -2,10 +2,12 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useHasQuestions } from '../hooks/useHasQuestions'
+import { profileDisplayName, useSolidProfile } from '../hooks/useSolidProfile'
 import { SolidProviderSelector } from '../components/SolidProviderSelector'
 
 export const LandingPage = () => {
-    const { isLoggedIn, webId, login } = useSolidPod()
+    const { isLoggedIn, webId, session, login } = useSolidPod()
+    const profile = useSolidProfile(webId, session)
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
     const hasQuestions = useHasQuestions()
     const primaryCta = hasQuestions ? (
@@ -27,8 +29,14 @@ export const LandingPage = () => {
         <>
             {isLoggedIn && (
                 <div className="mb-6 p-4 bg-gradient-to-r from-success-50 to-primary-50 border-2 border-success-300 rounded-2xl shadow-soft animate-fade-in">
+                    {/*
+                      * Their name, not their WebID. The nav stopped printing the
+                      * raw WebID in #302 and this greeting sits right under it —
+                      * a URL is not what being signed in looks like. The photo
+                      * stays in the nav rather than being repeated an inch away.
+                      */}
                     <p className="text-success-800 font-semibold">
-                        🎉 Logged in as: <span className="font-bold">{webId}</span>
+                        🎉 Signed in as <span className="font-bold">{profileDisplayName(profile, webId)}</span>
                     </p>
                 </div>
             )}

--- a/src/services/solidPod.test.ts
+++ b/src/services/solidPod.test.ts
@@ -23,6 +23,7 @@ import {
     friendlyPodName,
     getPrimaryPodUrl,
     derivePodUrlFromWebId,
+    podUsernameFromWebId,
     resetPodSessionCaches,
 } from './solidPod'
 import { AuthenticationError } from './solidPod'
@@ -1748,5 +1749,33 @@ describe('derivePodUrlFromWebId', () => {
 
     it('returns null for an invalid URL', () => {
         expect(derivePodUrlFromWebId('not-a-url')).toBeNull()
+    })
+})
+
+// ─── podUsernameFromWebId ────────────────────────────────────────────────────
+
+describe('podUsernameFromWebId', () => {
+    it('reads the username out of a WebID stored inside its Pod', () => {
+        expect(podUsernameFromWebId('http://localhost:4000/testuser/profile/card#me')).toBe('testuser')
+    })
+
+    it('reads the username off the subdomain when the profile sits at the host root', () => {
+        expect(podUsernameFromWebId('https://alice.solidcommunity.net/profile/card#me')).toBe('alice')
+    })
+
+    it('reads the username off an identity-provider WebID', () => {
+        expect(podUsernameFromWebId('https://id.inrupt.com/hannahwprior')).toBe('hannahwprior')
+    })
+
+    it('falls back to the host when nothing in the WebID names a user', () => {
+        expect(podUsernameFromWebId('https://example.org/profile/card#me')).toBe('example.org')
+    })
+
+    it('ignores a service subdomain rather than calling the user "storage"', () => {
+        expect(podUsernameFromWebId('https://storage.inrupt.com/profile/card#me')).toBe('inrupt.com')
+    })
+
+    it('returns null for an invalid URL', () => {
+        expect(podUsernameFromWebId('not-a-url')).toBeNull()
     })
 })

--- a/src/services/solidPod.ts
+++ b/src/services/solidPod.ts
@@ -286,6 +286,45 @@ export function derivePodUrlFromWebId(webId: string): string | null {
     return null
 }
 
+/**
+ * The username a WebID carries, for the places that need to name the signed-in
+ * user when their profile card does not — the nav bar's account menu, which
+ * would otherwise have a raw WebID to show and nothing else.
+ *
+ * Not `friendlyPodName`: fed a WebID rather than a Pod root, that reads the
+ * first path segment and calls the user "profile on solidcommunity.net".
+ *
+ * The username lives in a different place on each kind of WebID, so each is
+ * tried in turn: the segment before `/profile/card` for a WebID stored inside
+ * its own Pod, the last path segment for one minted by an identity provider,
+ * then the subdomain for a per-user host. A host with no user in it anywhere is
+ * the host itself — "example.org" says less than a name, but it is true, and it
+ * is shorter than the WebID it stands in for.
+ */
+export function podUsernameFromWebId(webId: string): string | null {
+    try {
+        const url = new URL(webId)
+        const segments = url.pathname.split('/').filter(s => s.length > 0)
+
+        const last = segments[segments.length - 1]
+        // .../<username>/profile/card#me — the CSS and NSS convention
+        if (segments.length >= 3 && segments[segments.length - 2] === 'profile' && last === 'card') {
+            return segments[segments.length - 3]
+        }
+        // https://id.inrupt.com/<username> — no Pod in the WebID at all
+        if (segments.length >= 1 && last !== 'card') {
+            return last
+        }
+
+        const parts = url.hostname.split('.')
+        if (parts.length >= 3 && !SERVICE_SUBDOMAINS.has(parts[0])) return parts[0]
+        if (parts.length >= 3 && SERVICE_SUBDOMAINS.has(parts[0])) return parts.slice(1).join('.')
+        return url.hostname
+    } catch {
+        return null
+    }
+}
+
 export async function grantCollaboratorAccess(
     session: Session,
     resourceUrl: string,


### PR DESCRIPTION
Closes #302

The nav bar printed a raw WebID where a signed-in state belongs. It now shows the pod profile's photo and name, degrading to a generic icon and the username the WebID carries when the card has neither. The WebID itself stays reachable, one click into an account menu, alongside Backups and Logout.

📋 **[Manual test report — 2026-08-23, with screenshots](https://github.com/timgent/pack-me-up/blob/agent-testing/2026-08-23-issue-302-nav-account-menu/README.md)** (on the `agent-testing` branch)

## Product decisions

#302 flagged three calls as the owner's to make, and asked for them to be settled before any code landed. They were, and are [recorded on the issue](https://github.com/timgent/pack-me-up/issues/302#issuecomment-5388359591):

1. **Create List leaves the nav.** Creating starts from Lists — so `foreign-packing-lists.tsx` gains the "➕ New List" button it never had. Until now there was no way at all to start a list in a pod you collaborate on: you could edit a shared list but never add one. That was the gap #281 left when it deleted `createListPath`.
2. **Backups moves into the account menu; Sharing does not.** #204 promoted sharing deliberately, and the nav already carried a comment explaining why it stays visible when logged out. It is not being demoted a release later.
3. **"View Lists" → "Lists".**

The issue also mentions moving a theme toggle into the mobile menu. There is no theme toggle in this repo — it existed only on #281's branch — so there was nothing to move.

## What changed

**`podUsernameFromWebId`** (`src/services/solidPod.ts`) — the fallback name when a profile card has none. `friendlyPodName` could not be reused: fed a WebID rather than a pod root it reads the first path segment and calls the user "profile on solidcommunity.net".

**`useSolidProfile`** (`src/hooks/useSolidProfile.ts`) — one WebID's name and photo, read through `getSolidProfile`, the same promise-caching path the person avatars use via `usePersonPhotos`. So the signed-in user's card is fetched once for the whole app, not once per mount (AC 6). Alongside it, `profileDisplayName` holds the single rule for what to call someone.

**`AccountMenu` / `ProfileBadge`** (`src/components/AccountMenu.tsx`) — a disclosure, not an ARIA `menu`: `role="menu"` would promise roving arrow keys and a typeahead this does not implement. Three controls reached by Tab, Escape closing it and handing focus back to the trigger. The trigger's accessible name is "Account menu &lt;name&gt;" — the hidden half says what the control does, the visible half stays inside the accessible name, so it does not trip WCAG 2.5.3 the way a bare `aria-label` over visible text would.

**`Navigation.tsx`** — assembles the above; the mobile menu gets the same affordances flat, since it is already a disclosure.

**`landing-page.tsx`** — see below.

## The landing page, found in testing

Manual testing turned up the landing page still printing **"🎉 Logged in as: &lt;WebID&gt;"** in a banner directly under the now-fixed nav bar — the same "developer output standing in for a signed-in state" problem, one component over. It was outside #302's acceptance criteria, so it was reported rather than fixed unilaterally; @timgent asked for it, and it is in this PR.

The banner now reads **"🎉 Signed in as &lt;name&gt;"**, using the same rule as the nav — which is why `profileDisplayName` is a shared function rather than an expression duplicated in two places. The photo deliberately stays in the nav rather than being repeated an inch below it.

Verified by walking the DOM for every visible element containing `profile/card#me`, in all three cases:

```
[named]             landing banner: 🎉 Signed in as Alice Adams   VISIBLE raw WebIDs: []
[username-fallback] landing banner: 🎉 Signed in as test          VISIBLE raw WebIDs: []
[named-mobile]      landing banner: 🎉 Signed in as Alice Adams   VISIBLE raw WebIDs: []
```

## Test-suite plumbing

Logout was the signed-in sentinel that `e2e/fixtures.ts`, `e2e/helpers/login.ts`, `z-verify-offline-share` and the perf scripts all waited for. Those now wait on the account-menu trigger, which stays visible; `logoutViaAccountMenu` / `openAccountMenu` helpers keep the flow in one place.

## Rebased on `main`

Rebased onto `be53d5a`, picking up #303 (one search box in the provider selector) and #298 (past trips folded away). One conflict, in `foreign-packing-lists.test.tsx`, where both branches appended a new `describe` to the same file — resolved by keeping both suites. The page component itself merged cleanly and correctly: the shared `Header` with "New List" sits above #298's current/past split in both the loading and loaded states.

Re-verified after the rebase: `npm test` ✅ **1856 passed** · `npm run lint` ✅ 0 errors · full e2e ✅ **88 passed**.

> **Known, not fixed here:** `scripts/perf/lib/css.mjs` still drives the provider selector through "Other providers" → "Use Custom Provider" → "Custom Provider URL", which #303 replaced with a single search box. #303 updated `e2e/helpers/login.ts` but not the perf script's copy of the same flow. It is unrelated to this change and left alone rather than widened into during a rebase — worth a follow-up.

## Verification

| Check | Result |
|---|---|
| `npm test` (type check + vitest) | ✅ 1856 passed, 97 files |
| `npm run lint` | ✅ 0 errors |
| `npx playwright test` (full e2e) | ✅ 88 passed |
| Manual pass, desktop 1280×900 + mobile 390×844, real CSS | ✅ all 7 acceptance criteria — see report |

Manual testing used two pod accounts to exercise both sides of the degradation: one card with a name and photo, one exactly as CSS creates it (neither), plus a real collaborator grant so foreign-pod context was tested against an actual shared pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9zJF2xjw8MacG8xddDBAE