### PR TITLE
Make the folded "Past trips" row look like a row you can press

### DIFF
--- a/src/components/PastTripsSection.tsx
+++ b/src/components/PastTripsSection.tsx
@@ -24,12 +24,15 @@ export function PastTripsSection({ count, allPastFinished, children }: PastTrips
 
     return (
         <div className="mt-8">
+            {/* Understated next to the list cards — it is not a trip — but still
+                a row that looks pressable, since it is the only thing on the
+                page that reveals anything. */}
             <button
                 type="button"
                 onClick={() => setIsExpanded(expanded => !expanded)}
                 aria-expanded={isExpanded}
                 aria-controls={panelId}
-                className="flex items-center gap-2 w-full text-left py-2 text-gray-600 hover:text-gray-900 transition-colors"
+                className="flex items-center gap-2 w-full text-left px-4 py-3 rounded-xl border-2 border-gray-200 bg-white/60 text-gray-600 hover:bg-white hover:border-gray-300 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-400 transition-colors"
             >
                 <span className="shrink-0 text-sm text-gray-400">{isExpanded ? '▼' : '▶'}</span>
                 <span className="text-lg font-semibold">{label} ({count})</span>


### PR DESCRIPTION
Follow-up to #316. This commit was pushed a few minutes after that PR merged, so it missed the merge — it has been rebased onto the new main and is unchanged otherwise.

## What changed

Driving the built app in a browser (rather than reading the tests) showed the disclosure reading as a caption rather than a control: small grey text and a bare triangle floating below the cards, with nothing to say it could be clicked. It is the only thing on the page that reveals anything, so it now sits in a bordered, rounded row with hover and focus states — in the cards' rhythm without competing with them, since it is not itself a trip.

CSS only: one `className` on the existing `<button>` in `PastTripsSection.tsx`. No change to the markup, the ARIA attributes, or the split logic.

## Testing

- `npm test` — 1813 unit tests pass on the rebased branch (type check included).
- Verified in a browser against the built app, seeded with two dated trips (one ahead, one finished) and five undated lists: four cards visible, three folded, `aria-expanded` flips on both click and Enter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GySDC6pdesjwpiZ7fCi8x3)_