### PR TITLE
App-wide dark mode with a system default and a manual toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,29 @@
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Pack Me Up</title>
+  <!--
+    Applies the theme before the first paint, so the page never flashes light
+    then swaps to dark. It has to be inline and synchronous to beat the paint;
+    localStorage can throw outright in a cookie-blocked or sandboxed context,
+    so the whole thing is guarded and simply falls back to the OS preference.
+    Kept in step with src/components/ThemeContext.tsx (same storage key).
+  -->
+  <script>
+    (function () {
+      var theme = null;
+      try {
+        var stored = localStorage.getItem('theme');
+        if (stored === 'light' || stored === 'dark') theme = stored;
+      } catch (e) { /* storage unavailable — fall back to the OS */ }
+      try {
+        if (!theme) {
+          theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        document.documentElement.classList.toggle('dark', theme === 'dark');
+        document.documentElement.style.colorScheme = theme;
+      } catch (e) { /* never let the theme break the page */ }
+    })();
+  </script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <!-- The nav is the same dark teal in both themes, so the browser and native
+       shells get one colour rather than a pair that would have to be kept in
+       step with the theme. -->
+  <meta name="theme-color" content="#042f2e" />
   <title>Pack Me Up</title>
   <!--
     Applies the theme before the first paint, so the page never flashes light

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Navigation } from './components/Navigation'
 import { Footer } from './components/Footer'
 import { SessionExpiredBanner } from './components/SessionExpiredBanner'
 import { ToastProvider } from './components/ToastContext'
+import { ThemeProvider } from './components/ThemeContext'
 import { LandingPage } from './pages/landing-page'
 import { CreatePackingList } from './pages/create-packing-list'
 import { PackingLists } from './pages/packing-lists'
@@ -32,45 +33,47 @@ function DefaultRedirect() {
 
 function App() {
   return (
-    <ToastProvider>
-      <SolidPodProvider>
-        <DatabaseProvider>
-        <HashRouter>
-            <Analytics />
-          {/* Column layout keeps the footer at the bottom of short pages rather
-              than floating it under the content. */}
-          <div className="min-h-screen flex flex-col bg-gradient-to-br from-primary-50 via-white to-accent-50">
-            <Navigation />
-            <SessionExpiredBanner />
-            <div className="flex-1 container mx-auto px-4 py-8">
-              <Routes>
-                <Route path="/" element={<DefaultRedirect />} />
-                <Route path="/home" element={<LandingPage />} />
-                <Route path="/wizard" element={<Wizard />} />
-                <Route path="/manage-questions" element={<QuestionsPage />} />
-                <Route path="/create-packing-list" element={<CreatePackingList />} />
-                <Route path="/view-lists" element={<PackingLists />} />
-                <Route path="/view-lists/:id" element={<ViewPackingList />} />
-                <Route path="/solid-pod-handle-redirect" element={<SolidPodHandleRedirectPage />} />
-                <Route path="/backups" element={<BackupsPage />} />
-                <Route path="/sharing" element={<SharingSettingsPage />} />
-                <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
-                <Route path="/your-data" element={<YourDataPage />} />
-                <Route path="/pod/:encodedPodUrl" element={<ForeignPodLayout />}>
-                  <Route index element={<Navigate to="view-lists" replace />} />
-                  <Route path="view-lists" element={<ForeignPackingListsPage />} />
-                  <Route path="view-lists/:id" element={<ViewPackingList />} />
-                  <Route path="manage-questions" element={<QuestionsPage />} />
-                  <Route path="create-packing-list" element={<CreatePackingList />} />
-                </Route>
-              </Routes>
-            </div>
-            <Footer />
-          </div>
-        </HashRouter>
-        </DatabaseProvider>
-      </SolidPodProvider>
-    </ToastProvider>
+    <ThemeProvider>
+      <ToastProvider>
+        <SolidPodProvider>
+          <DatabaseProvider>
+            <HashRouter>
+              <Analytics />
+              {/* Column layout keeps the footer at the bottom of short pages rather
+                  than floating it under the content. */}
+              <div className="min-h-screen flex flex-col bg-gradient-to-br from-primary-50 via-white to-accent-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950">
+                <Navigation />
+                <SessionExpiredBanner />
+                <div className="flex-1 container mx-auto px-4 py-8">
+                  <Routes>
+                    <Route path="/" element={<DefaultRedirect />} />
+                    <Route path="/home" element={<LandingPage />} />
+                    <Route path="/wizard" element={<Wizard />} />
+                    <Route path="/manage-questions" element={<QuestionsPage />} />
+                    <Route path="/create-packing-list" element={<CreatePackingList />} />
+                    <Route path="/view-lists" element={<PackingLists />} />
+                    <Route path="/view-lists/:id" element={<ViewPackingList />} />
+                    <Route path="/solid-pod-handle-redirect" element={<SolidPodHandleRedirectPage />} />
+                    <Route path="/backups" element={<BackupsPage />} />
+                    <Route path="/sharing" element={<SharingSettingsPage />} />
+                    <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
+                    <Route path="/your-data" element={<YourDataPage />} />
+                    <Route path="/pod/:encodedPodUrl" element={<ForeignPodLayout />}>
+                      <Route index element={<Navigate to="view-lists" replace />} />
+                      <Route path="view-lists" element={<ForeignPackingListsPage />} />
+                      <Route path="view-lists/:id" element={<ViewPackingList />} />
+                      <Route path="manage-questions" element={<QuestionsPage />} />
+                      <Route path="create-packing-list" element={<CreatePackingList />} />
+                    </Route>
+                  </Routes>
+                </div>
+                <Footer />
+              </div>
+            </HashRouter>
+          </DatabaseProvider>
+        </SolidPodProvider>
+      </ToastProvider>
+    </ThemeProvider>
   )
 }
 

--- a/src/components/AccountMenu.tsx
+++ b/src/components/AccountMenu.tsx
@@ -113,23 +113,23 @@ export function AccountMenu({ webId, displayName, photoUrl, onLogout }: {
             </button>
 
             {isOpen && (
-                <div className="absolute right-0 mt-2 w-72 z-50 rounded-xl bg-white text-gray-900 shadow-soft ring-1 ring-black/10 overflow-hidden">
-                    <div className="px-4 py-3 border-b border-gray-100">
-                        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Signed in as</p>
+                <div className="absolute right-0 mt-2 w-72 z-50 rounded-xl bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 shadow-soft ring-1 ring-black/10 overflow-hidden">
+                    <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-800">
+                        <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Signed in as</p>
                         {/* Reachable, but no longer the thing the nav bar shouts */}
-                        <p className="mt-1 text-xs text-gray-700 break-all" title={webId}>{webId}</p>
+                        <p className="mt-1 text-xs text-gray-700 dark:text-gray-300 break-all" title={webId}>{webId}</p>
                     </div>
                     <Link
                         to="/backups"
                         onClick={() => setIsOpen(false)}
-                        className="block px-4 py-3 text-sm font-semibold hover:bg-primary-50 transition-colors duration-200"
+                        className="block px-4 py-3 text-sm font-semibold hover:bg-primary-50 dark:hover:bg-primary-950/40 transition-colors duration-200"
                     >
                         Backups
                     </Link>
                     <button
                         type="button"
                         onClick={() => { setIsOpen(false); onLogout() }}
-                        className="w-full text-left px-4 py-3 text-sm font-semibold border-t border-gray-100 hover:bg-primary-50 transition-colors duration-200"
+                        className="w-full text-left px-4 py-3 text-sm font-semibold border-t border-gray-100 dark:border-gray-800 hover:bg-primary-50 dark:hover:bg-primary-950/40 transition-colors duration-200"
                     >
                         Logout
                     </button>

--- a/src/components/AgePromotionCard.tsx
+++ b/src/components/AgePromotionCard.tsx
@@ -116,30 +116,30 @@ export function AgePromotionCard({ questionSet, onApply, manualTransitions, onMa
         .join(', ')
 
     const renderSuggestion = (s: PromotionSuggestion) => (
-        <label key={s.key} className="flex items-start gap-2 text-sm text-gray-700 bg-white rounded border border-violet-200 px-3 py-2">
+        <label key={s.key} className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-900 rounded border border-violet-200 dark:border-violet-800 px-3 py-2">
             <input
                 type="checkbox"
                 checked={!unchecked.has(s.key)}
                 onChange={() => toggleChecked(s.key)}
-                className="mt-0.5 h-4 w-4 text-violet-600 rounded focus:ring-2 focus:ring-violet-500"
+                className="mt-0.5 h-4 w-4 text-violet-600 dark:text-violet-400 rounded focus:ring-2 focus:ring-violet-500"
             />
             <span>
-                <span className="font-medium text-gray-900">{s.itemText}</span>
-                <span className="ml-2 text-xs text-gray-500">{s.contextLabel}</span>
+                <span className="font-medium text-gray-900 dark:text-gray-100">{s.itemText}</span>
+                <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">{s.contextLabel}</span>
             </span>
         </label>
     )
 
     return (
-        <div className="bg-violet-50 rounded-lg border border-violet-200 p-4">
+        <div className="bg-violet-50 dark:bg-violet-950/40 rounded-lg border border-violet-200 dark:border-violet-800 p-4">
             <div className="flex items-start justify-between gap-4">
-                <p className="text-violet-900 font-medium">🎂 Time flies — {summary}! Want to update their packing items?</p>
+                <p className="text-violet-900 dark:text-violet-200 font-medium">🎂 Time flies — {summary}! Want to update their packing items?</p>
                 <button
                     type="button"
                     aria-label="Dismiss age update"
                     title="Don't ask again for this age change"
                     onClick={handleDismiss}
-                    className="text-violet-600 hover:text-violet-900 text-xl leading-none flex-shrink-0"
+                    className="text-violet-600 dark:text-violet-400 hover:text-violet-900 dark:hover:text-violet-200 text-xl leading-none flex-shrink-0"
                 >
                     ×
                 </button>
@@ -148,7 +148,7 @@ export function AgePromotionCard({ questionSet, onApply, manualTransitions, onMa
                 <button
                     type="button"
                     onClick={() => setIsExpanded(true)}
-                    className="mt-2 text-sm text-violet-700 underline"
+                    className="mt-2 text-sm text-violet-700 dark:text-violet-300 underline"
                 >
                     Review changes
                 </button>
@@ -156,21 +156,21 @@ export function AgePromotionCard({ questionSet, onApply, manualTransitions, onMa
                 <div className="mt-4 space-y-5">
                     {byPerson.map(({ transition, ageOut, ageIn }) => (
                         <div key={transition.person.id}>
-                            <p className="text-sm text-violet-800 font-semibold">
+                            <p className="text-sm text-violet-800 dark:text-violet-200 font-semibold">
                                 {transition.person.name}: {bracketLabel(transition.from)} → {bracketLabel(transition.to)}
                             </p>
                             {ageOut.length === 0 && ageIn.length === 0 && (
-                                <p className="mt-1 text-sm text-violet-700">No item changes suggested — we'll just remember the new age bracket.</p>
+                                <p className="mt-1 text-sm text-violet-700 dark:text-violet-300">No item changes suggested — we'll just remember the new age bracket.</p>
                             )}
                             {ageOut.length > 0 && (
                                 <div className="mt-2">
-                                    <p className="text-xs uppercase tracking-wide text-violet-600 font-semibold mb-1">Outgrown — untick to keep</p>
+                                    <p className="text-xs uppercase tracking-wide text-violet-600 dark:text-violet-400 font-semibold mb-1">Outgrown — untick to keep</p>
                                     <div className="space-y-1.5">{ageOut.map(renderSuggestion)}</div>
                                 </div>
                             )}
                             {ageIn.length > 0 && (
                                 <div className="mt-2">
-                                    <p className="text-xs uppercase tracking-wide text-violet-600 font-semibold mb-1">Suggested for their new age</p>
+                                    <p className="text-xs uppercase tracking-wide text-violet-600 dark:text-violet-400 font-semibold mb-1">Suggested for their new age</p>
                                     <div className="space-y-1.5">{ageIn.map(renderSuggestion)}</div>
                                 </div>
                             )}
@@ -180,7 +180,7 @@ export function AgePromotionCard({ questionSet, onApply, manualTransitions, onMa
                         <button
                             type="button"
                             onClick={() => setIsExpanded(false)}
-                            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-violet-100"
+                            className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100 rounded-lg hover:bg-violet-100 dark:hover:bg-violet-900/40"
                         >
                             Not now
                         </button>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -11,7 +11,7 @@ export function Button({ variant = 'primary', ...props }: ButtonProps) {
         primary: 'bg-gradient-primary text-white shadow-soft hover:shadow-glow-primary focus:ring-primary-500',
         secondary: 'bg-gradient-secondary text-white shadow-soft hover:shadow-glow-secondary focus:ring-secondary-500',
         danger: 'bg-gradient-to-r from-danger-500 to-danger-600 text-white shadow-soft hover:shadow-lg focus:ring-danger-500',
-        ghost: 'text-primary-700 hover:bg-primary-50 border-2 border-primary-200 hover:border-primary-400 focus:ring-primary-500'
+        ghost: 'text-primary-700 dark:text-primary-300 hover:bg-primary-50 dark:hover:bg-primary-950/40 border-2 border-primary-200 dark:border-primary-800 hover:border-primary-400 dark:hover:border-primary-600 focus:ring-primary-500'
     }[variant]
 
     return (

--- a/src/components/Callout.tsx
+++ b/src/components/Callout.tsx
@@ -11,11 +11,11 @@ interface CalloutProps {
 
 export function Callout({ title, description, action }: CalloutProps) {
     return (
-        <div className="rounded-2xl bg-gradient-to-br from-primary-50 to-accent-50 p-6 border-2 border-primary-200 shadow-soft hover:shadow-glow-primary transition-all duration-300">
+        <div className="rounded-2xl bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 p-6 border-2 border-primary-200 dark:border-primary-800 shadow-soft hover:shadow-glow-primary transition-all duration-300">
             <div className="flex">
                 <div className="flex-1">
-                    <h3 className="text-lg font-bold text-primary-900">{title}</h3>
-                    <div className="mt-3 text-sm text-gray-700 leading-relaxed">
+                    <h3 className="text-lg font-bold text-primary-900 dark:text-primary-200">{title}</h3>
+                    <div className="mt-3 text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
                         <p>{description}</p>
                     </div>
                     {action && (

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -206,7 +206,7 @@ export function CategoryItemGrid({
     const visibleRows = foldShared ? visible.filter(row => !row.communal) : visible
 
     if (visibleRows.length === 0 && sharedRows.length === 0) {
-        return <p className="text-sm font-medium text-emerald-700">Nothing left to pack 🎒</p>
+        return <p className="text-sm font-medium text-emerald-700 dark:text-emerald-300">Nothing left to pack 🎒</p>
     }
 
     // One width for every row in the card, so the chips land in the same places
@@ -220,7 +220,7 @@ export function CategoryItemGrid({
                     key={flourish.nonce}
                     data-testid={`item-tick-${item.id}`}
                     aria-hidden="true"
-                    className="item-packed-tick pointer-events-none absolute left-1/2 top-1/2 z-10 text-xl font-bold text-success-600"
+                    className="item-packed-tick pointer-events-none absolute left-1/2 top-1/2 z-10 text-xl font-bold text-success-600 dark:text-success-400"
                 >
                     ✓
                 </span>
@@ -244,9 +244,9 @@ export function CategoryItemGrid({
                 onClick={() => onOpenRow(row)}
                 aria-label={`Edit ${row.label}`}
                 title="Rename, quantities, and who needs it"
-                className="group block w-full cursor-pointer rounded-md px-1 py-2 text-left transition-colors active:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+                className="group block w-full cursor-pointer rounded-md px-1 py-2 text-left transition-colors active:bg-blue-100 dark:active:bg-blue-900/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
             >
-                <span className={`break-words ${complete ? 'text-gray-400 line-through' : 'text-gray-800 group-hover:text-blue-800'}`}>
+                <span className={`break-words ${complete ? 'text-gray-400 dark:text-gray-500 line-through' : 'text-gray-800 dark:text-gray-100 group-hover:text-blue-800 dark:group-hover:text-blue-200'}`}>
                     {head && `${head} `}
                     {/* The last word, the quantity and the chevron travel
                         together, so the chevron is never left pointing at
@@ -254,7 +254,7 @@ export function CategoryItemGrid({
                     <span className="whitespace-nowrap">
                         {lastWord}
                         {row.quantity !== undefined && (
-                            <span className="ml-1.5 inline-block rounded-full bg-blue-100 px-1.5 py-0.5 align-middle text-xs font-semibold text-blue-700">
+                            <span className="ml-1.5 inline-block rounded-full bg-blue-100 dark:bg-blue-900/40 px-1.5 py-0.5 align-middle text-xs font-semibold text-blue-700 dark:text-blue-300">
                                 ×{row.quantity}
                             </span>
                         )}
@@ -270,7 +270,7 @@ export function CategoryItemGrid({
                             strokeWidth={2.5}
                             strokeLinecap="round"
                             strokeLinejoin="round"
-                            className="ml-1.5 inline-block h-3.5 w-3.5 align-[-0.15em] text-gray-500 transition-transform group-hover:translate-x-0.5 group-hover:text-blue-600"
+                            className="ml-1.5 inline-block h-3.5 w-3.5 align-[-0.15em] text-gray-500 dark:text-gray-400 transition-transform group-hover:translate-x-0.5 group-hover:text-blue-600 dark:group-hover:text-blue-400"
                         >
                             <path d="M7.5 4.5 13 10l-5.5 5.5" />
                         </svg>
@@ -307,7 +307,7 @@ export function CategoryItemGrid({
                 ref={(element) => registerCellRef(item.id, element)}
                 title={`${row.label} for ${column.name}`}
                 className={`relative flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full text-xs font-bold transition-colors before:absolute before:-inset-1.5 before:content-[''] has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 has-[:focus-visible]:ring-offset-1 ${
-                    packed ? color.avatar : `border-2 bg-white ${color.border} ${color.text}`
+                    packed ? color.avatar : `border-2 bg-white dark:bg-gray-900 ${color.border} ${color.text}`
                 } ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
             >
                 <input
@@ -321,7 +321,7 @@ export function CategoryItemGrid({
                     {packed ? '✓' : (emoji ?? column.initial)}
                 </span>
                 {row.mixedQuantities && quantity && (
-                    <span className="pointer-events-none absolute -bottom-1 -right-1 rounded-full bg-blue-100 px-1 text-[10px] font-semibold text-blue-700">
+                    <span className="pointer-events-none absolute -bottom-1 -right-1 rounded-full bg-blue-100 dark:bg-blue-900/40 px-1 text-[10px] font-semibold text-blue-700 dark:text-blue-300">
                         ×{quantity}
                     </span>
                 )}
@@ -349,9 +349,9 @@ export function CategoryItemGrid({
             aria-hidden="true"
             onClick={() => onOpenRow(row)}
             title={`${column.name} doesn't need this — open to change`}
-            className="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-blue-50"
+            className="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-blue-50 dark:hover:bg-blue-950/40"
         >
-            <span className="block h-1 w-1 rounded-full bg-gray-200" />
+            <span className="block h-1 w-1 rounded-full bg-gray-200 dark:bg-gray-700" />
         </button>
     )
 
@@ -363,14 +363,14 @@ export function CategoryItemGrid({
             <label
                 data-testid={`grid-cell-${item.id}`}
                 ref={(element) => registerCellRef(item.id, element)}
-                className={`relative flex h-8 cursor-pointer items-center gap-2 rounded-full px-3 text-xs font-medium transition-colors before:absolute before:-inset-y-1.5 before:inset-x-0 before:content-[''] has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 ${packed ? 'bg-emerald-100 text-emerald-800' : 'bg-blue-50 text-blue-800 hover:bg-blue-100'} ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
+                className={`relative flex h-8 cursor-pointer items-center gap-2 rounded-full px-3 text-xs font-medium transition-colors before:absolute before:-inset-y-1.5 before:inset-x-0 before:content-[''] has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 ${packed ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200' : 'bg-blue-50 dark:bg-blue-950/40 text-blue-800 dark:text-blue-200 hover:bg-blue-100 dark:hover:bg-blue-900/40'} ${item.id === highlightedItemId ? 'ring-2 ring-green-400' : ''} ${item.id === flourish?.itemId ? 'grid-cell-packed' : ''}`}
             >
                 <input
                     type="checkbox"
                     checked={packed}
                     onChange={(e) => onToggleItem(item, e.target.checked)}
                     aria-label={`${row.label} for the whole group`}
-                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                    className="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 dark:text-blue-400 focus:ring-blue-500"
                 />
                 <span className="whitespace-nowrap">👥 Shared</span>
                 {renderFlourish(item)}
@@ -380,14 +380,14 @@ export function CategoryItemGrid({
 
     return (
         <div ref={containerRef}>
-            <ul className="divide-y divide-gray-100">
+            <ul className="divide-y divide-gray-100 dark:divide-gray-800">
                 {visibleRows.map(row => {
                     const complete = rowComplete(row)
                     return (
                         <li
                             key={row.key}
                             data-testid="grid-row"
-                            className={`flex items-start gap-1 rounded-md transition-colors ${complete ? 'bg-emerald-50' : 'hover:bg-gray-50'} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
+                            className={`flex items-start gap-1 rounded-md transition-colors ${complete ? 'bg-emerald-50 dark:bg-emerald-950/40' : 'hover:bg-gray-50 dark:hover:bg-gray-800'} ${hidePacked && complete ? 'grid-row-leaving' : ''}`}
                         >
                             {/* Capped, so a wide card doesn't strand the chips
                                 an inch and a half from the name they belong to. */}
@@ -423,24 +423,24 @@ export function CategoryItemGrid({
                 category's business, and a line saying how many there are is
                 enough to remember that while packing one person's bag. */}
             {sharedRows.length > 0 && (
-                <div className="mt-1 border-t border-gray-100 pt-1">
+                <div className="mt-1 border-t border-gray-100 dark:border-gray-800 pt-1">
                     <button
                         type="button"
                         aria-expanded={sharedOpen}
                         onClick={() => setSharedOpen(open => !open)}
-                        className="flex w-full items-center gap-1.5 rounded-md px-1 py-2 text-left text-xs font-semibold text-blue-800 transition-colors hover:bg-blue-50"
+                        className="flex w-full items-center gap-1.5 rounded-md px-1 py-2 text-left text-xs font-semibold text-blue-800 dark:text-blue-200 transition-colors hover:bg-blue-50 dark:hover:bg-blue-950/40"
                     >
-                        <span aria-hidden="true" className="text-gray-400">{sharedOpen ? '▼' : '▶'}</span>
+                        <span aria-hidden="true" className="text-gray-400 dark:text-gray-500">{sharedOpen ? '▼' : '▶'}</span>
                         <span aria-hidden="true">👥</span>
                         Shared ({sharedRows.length})
                     </button>
                     {sharedOpen && (
-                        <ul className="divide-y divide-gray-100">
+                        <ul className="divide-y divide-gray-100 dark:divide-gray-800">
                             {sharedRows.map(row => (
                                 <li
                                     key={row.key}
                                     data-testid="grid-row"
-                                    className="flex items-start gap-1 rounded-md transition-colors hover:bg-gray-50"
+                                    className="flex items-start gap-1 rounded-md transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
                                 >
                                     <span className="min-w-0 flex-1" style={{ maxWidth: `${NAME_MAX_WIDTH}px` }}>
                                         {renderName(row, rowComplete(row))}

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -13,8 +13,8 @@ export function CloseButton({ label, className, ...props }: CloseButtonProps) {
                 inline-flex items-center justify-center
                 w-8 h-8
                 rounded-full
-                text-gray-400 hover:text-gray-600
-                hover:bg-gray-100
+                text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400
+                hover:bg-gray-100 dark:hover:bg-gray-800
                 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2
                 transition-colors duration-200
                 ${className || ''}

--- a/src/components/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog.tsx
@@ -25,7 +25,7 @@ export function ConfirmationDialog({
     return (
         <Modal isOpen={isOpen} onClose={onClose} title={title}>
             <div className="space-y-4">
-                <p className="text-gray-700 whitespace-pre-line">{message}</p>
+                <p className="text-gray-700 dark:text-gray-300 whitespace-pre-line">{message}</p>
                 <div className="flex gap-3 justify-end mt-6">
                     <Button variant="ghost" onClick={onClose}>
                         {cancelText}

--- a/src/components/CreatableSelect.tsx
+++ b/src/components/CreatableSelect.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useRef } from 'react';
 import CreatableSelect from 'react-select/creatable';
 import { ActionMeta, OnChangeValue } from 'react-select';
+import { useIsDarkMode } from './ThemeContext';
 
 interface Option {
     label: string;
@@ -15,27 +16,42 @@ interface CreatableSelectProps {
     menuPortalTarget?: HTMLElement | null;
 }
 
-const selectStyles = {
+/*
+ * react-select paints its control and menu with inline styles, so `dark:`
+ * classes cannot reach them — the palette has to be handed over in JS. Values
+ * match the Tailwind greys the rest of the app uses in each theme.
+ */
+const buildSelectStyles = (isDark: boolean) => ({
     control: (base: object) => ({
         ...base,
         minHeight: '42px',
-        borderColor: '#e5e7eb',
-        '&:hover': { borderColor: '#9ca3af' }
+        backgroundColor: isDark ? '#111827' : 'white',
+        borderColor: isDark ? '#374151' : '#e5e7eb',
+        '&:hover': { borderColor: isDark ? '#6b7280' : '#9ca3af' }
     }),
+    input: (base: object) => ({ ...base, color: isDark ? '#f3f4f6' : '#111827' }),
+    singleValue: (base: object) => ({ ...base, color: isDark ? '#f3f4f6' : '#111827' }),
+    placeholder: (base: object) => ({ ...base, color: isDark ? '#6b7280' : '#9ca3af' }),
     option: (base: object, state: { isSelected: boolean; isFocused: boolean }) => ({
         ...base,
-        backgroundColor: state.isSelected ? '#e5e7eb' : state.isFocused ? '#f3f4f6' : 'white',
-        color: state.isSelected ? '#111827' : '#374151',
-        '&:hover': { backgroundColor: '#f3f4f6' }
+        backgroundColor: isDark
+            ? (state.isSelected ? '#374151' : state.isFocused ? '#1f2937' : '#111827')
+            : (state.isSelected ? '#e5e7eb' : state.isFocused ? '#f3f4f6' : 'white'),
+        color: isDark
+            ? (state.isSelected ? '#f9fafb' : '#e5e7eb')
+            : (state.isSelected ? '#111827' : '#374151'),
+        '&:hover': { backgroundColor: isDark ? '#1f2937' : '#f3f4f6' }
     }),
     menu: (base: object) => ({
         ...base,
+        backgroundColor: isDark ? '#111827' : 'white',
+        border: isDark ? '1px solid #374151' : undefined,
         boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
         borderRadius: '0.375rem',
         marginTop: '0.25rem'
     }),
     menuList: (base: object) => ({ ...base, padding: '0.25rem' })
-};
+});
 
 // The full react-select — only mounts when the user actually interacts with this item.
 export function ActiveSelect({ value, onChange, options, placeholder, menuPortalTarget }: CreatableSelectProps) {
@@ -44,6 +60,8 @@ export function ActiveSelect({ value, onChange, options, placeholder, menuPortal
     const [inputValue, setInputValue] = useState(value);
     const [menuIsOpen, setMenuIsOpen] = useState(false);
     const justSelectedRef = useRef(false);
+    const isDark = useIsDarkMode();
+    const selectStyles = useMemo(() => buildSelectStyles(isDark), [isDark]);
 
     const selectOptions = useMemo(() => options.map(option => ({
         label: option,
@@ -101,9 +119,9 @@ export function CustomCreatableSelect({ value, onChange, options, placeholder = 
                 tabIndex={0}
                 onClick={() => setIsActive(true)}
                 onFocus={() => setIsActive(true)}
-                className="flex items-center min-h-[42px] border border-gray-200 hover:border-gray-400 rounded px-3 cursor-text"
+                className="flex items-center min-h-[42px] border border-gray-200 dark:border-gray-700 hover:border-gray-400 dark:hover:border-gray-500 rounded px-3 cursor-text"
             >
-                <span className={`flex-1 text-sm ${value ? 'text-gray-700' : 'text-gray-400'}`}>
+                <span className={`flex-1 text-sm ${value ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'}`}>
                     {value || placeholder}
                 </span>
                 {value && (
@@ -112,13 +130,13 @@ export function CustomCreatableSelect({ value, onChange, options, placeholder = 
                         tabIndex={-1}
                         onMouseDown={(e) => e.preventDefault()}
                         onClick={(e) => { e.stopPropagation(); onChange(''); }}
-                        className="text-gray-300 hover:text-gray-500 text-lg leading-none ml-1"
+                        className="text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 text-lg leading-none ml-1"
                         aria-label="Clear"
                     >
                         ×
                     </button>
                 )}
-                <svg className="w-4 h-4 text-gray-300 ml-1 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <svg className="w-4 h-4 text-gray-300 dark:text-gray-600 ml-1 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                 </svg>
             </div>

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -6,10 +6,10 @@ interface ErrorFallbackProps {
 
 export function ErrorFallback({ resetError }: ErrorFallbackProps) {
     return (
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-50 via-white to-accent-50 px-4">
-            <div className="max-w-md w-full text-center bg-white rounded-2xl shadow-soft p-8">
-                <h1 className="text-xl font-bold text-gray-900 mb-2">Something went wrong</h1>
-                <p className="text-gray-600 mb-6">
+        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-50 dark:from-primary-950/40 via-white to-accent-50 dark:to-accent-950/40 px-4">
+            <div className="max-w-md w-full text-center bg-white dark:bg-gray-900 rounded-2xl shadow-soft p-8">
+                <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">Something went wrong</h1>
+                <p className="text-gray-600 dark:text-gray-400 mb-6">
                     We've been notified about this error. A report dialog should appear where you can add details
                     about what happened — that helps us fix it faster.
                 </p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 
 export const FEEDBACK_EMAIL = 'tim.packmeup@gmail.com'
 
-const linkStyles = 'text-gray-500 hover:text-primary-700 hover:underline transition-colors duration-200'
+const linkStyles = 'text-gray-500 dark:text-gray-400 hover:text-primary-700 dark:hover:text-primary-300 hover:underline transition-colors duration-200'
 
 /**
  * Where the things you need once belong — the policy, the data-deletion page, a
@@ -15,7 +15,7 @@ const linkStyles = 'text-gray-500 hover:text-primary-700 hover:underline transit
  */
 export function Footer() {
     return (
-        <footer className="border-t border-primary-100 bg-white/40 safe-area-bottom">
+        <footer className="border-t border-primary-100 dark:border-primary-900 bg-white/40 safe-area-bottom">
             {/*
               * pb-24 on mobile keeps the last row above Sentry's fixed feedback
               * widget, which otherwise sits on top of the "Feedback" link once you

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,7 +15,7 @@ const linkStyles = 'text-gray-500 dark:text-gray-400 hover:text-primary-700 dark
  */
 export function Footer() {
     return (
-        <footer className="border-t border-primary-100 dark:border-primary-900 bg-white/40 safe-area-bottom">
+        <footer className="border-t border-primary-100 dark:border-primary-900 bg-white/40 dark:bg-gray-900/40 safe-area-bottom">
             {/*
               * pb-24 on mobile keeps the last row above Sentry's fixed feedback
               * widget, which otherwise sits on top of the "Feedback" link once you

--- a/src/components/ForeignPodLayout.tsx
+++ b/src/components/ForeignPodLayout.tsx
@@ -98,7 +98,7 @@ export function ForeignPodLayout() {
     if (!isLoggedIn) {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
-                <p className="text-gray-700">Please log in to view shared content.</p>
+                <p className="text-gray-700 dark:text-gray-300">Please log in to view shared content.</p>
             </div>
         )
     }
@@ -106,7 +106,7 @@ export function ForeignPodLayout() {
     if (accessState === 'denied') {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
-                <p className="text-red-700">Access denied to this pod. The owner may have revoked access.</p>
+                <p className="text-red-700 dark:text-red-300">Access denied to this pod. The owner may have revoked access.</p>
             </div>
         )
     }
@@ -114,14 +114,14 @@ export function ForeignPodLayout() {
     if (accessState === 'pending') {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
-                <p className="text-gray-500">Verifying access…</p>
+                <p className="text-gray-500 dark:text-gray-400">Verifying access…</p>
             </div>
         )
     }
 
     return (
         <ForeignPodContext.Provider value={{ foreignPodUrl }}>
-            <div className="bg-blue-50 border-b border-blue-200 px-4 py-2 text-sm text-blue-800 -mx-4 -mt-8 mb-6">
+            <div className="bg-blue-50 dark:bg-blue-950/40 border-b border-blue-200 dark:border-blue-800 px-4 py-2 text-sm text-blue-800 dark:text-blue-200 -mx-4 -mt-8 mb-6">
                 Viewing <span className="font-semibold" title={foreignPodUrl}>{ownerName ?? (resolvedWebId ? friendlyPodName(resolvedWebId) : null) ?? friendlyPodName(foreignPodUrl)}</span>'s data
             </div>
             <Outlet />

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -10,7 +10,7 @@ export function Input({ label, ...props }: InputProps) {
     return (
         <div className="flex-1">
             {label && (
-                <label htmlFor={inputId} className="block text-sm font-semibold text-gray-800 mb-2">
+                <label htmlFor={inputId} className="block text-sm font-semibold text-gray-800 dark:text-gray-100 mb-2">
                     {label}
                 </label>
             )}
@@ -22,16 +22,16 @@ export function Input({ label, ...props }: InputProps) {
                     px-4
                     py-2.5
                     border-2
-                    border-primary-200
+                    border-primary-200 dark:border-primary-800
                     rounded-xl
                     shadow-soft
-                    text-gray-900
+                    text-gray-900 dark:text-gray-100
                     placeholder-gray-400
                     focus:outline-none
                     focus:ring-2
                     focus:ring-primary-500
-                    focus:border-primary-500
-                    hover:border-primary-300
+                    focus:border-primary-500 dark:focus:border-primary-600
+                    hover:border-primary-300 dark:hover:border-primary-700
                     transition-all
                     duration-200
                     ${props.className || ''}

--- a/src/components/ItemEditorControls.tsx
+++ b/src/components/ItemEditorControls.tsx
@@ -80,7 +80,7 @@ export const PersonToggles = memo(function PersonToggles({ item, people, layout,
                             onClick={() => onTogglePerson(personIdx)}
                             title={personTitle(person.name)}
                             aria-pressed={selected}
-                            className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold transition-colors ${selected ? personColorFor(person, personIdx).avatar : PERSON_COLOR_OFF} ${isCommunal && selected ? 'ring-2 ring-blue-300 ring-offset-1' : ''}`}
+                            className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold transition-colors ${selected ? personColorFor(person, personIdx).avatar : PERSON_COLOR_OFF} ${isCommunal && selected ? 'ring-2 ring-blue-300 dark:ring-blue-700 ring-offset-1' : ''}`}
                         >
                             {person.name.charAt(0).toUpperCase()}
                         </button>
@@ -98,7 +98,7 @@ export const PersonToggles = memo(function PersonToggles({ item, people, layout,
                 title={communalTitle}
                 aria-label={`Toggle shared for ${item.text || 'item'}`}
                 aria-pressed={isCommunal}
-                className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${isCommunal ? 'bg-blue-600 text-white border-transparent' : 'bg-white border-gray-200 text-gray-400'}`}
+                className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${isCommunal ? 'bg-blue-600 text-white border-transparent' : 'bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500'}`}
             >
                 <span className="text-lg font-bold leading-none">👥</span>
                 <span className="text-[10px] font-medium leading-none truncate w-full text-center px-1">
@@ -114,7 +114,7 @@ export const PersonToggles = memo(function PersonToggles({ item, people, layout,
                         onClick={() => onTogglePerson(personIdx)}
                         title={personTitle(person.name)}
                         aria-pressed={selected}
-                        className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${selected ? `${personColorFor(person, personIdx).avatar} border-transparent` : 'bg-white border-gray-200 text-gray-400'}`}
+                        className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${selected ? `${personColorFor(person, personIdx).avatar} border-transparent` : 'bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500'}`}
                     >
                         <span className="text-lg font-bold leading-none">
                             {person.name.charAt(0).toUpperCase()}
@@ -142,7 +142,7 @@ export const QuantityPanel = memo(function QuantityPanel({ item, onPerNight, onP
 }) {
     const hasRate = item.perNight !== undefined
     return (
-        <div className="w-full flex items-center gap-3 flex-wrap text-xs text-gray-600 bg-emerald-50 border border-emerald-100 rounded-lg px-2.5 py-1.5">
+        <div className="w-full flex items-center gap-3 flex-wrap text-xs text-gray-600 dark:text-gray-400 bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-100 dark:border-emerald-900 rounded-lg px-2.5 py-1.5">
             <span className="flex items-center gap-1.5">
                 Pack
                 <input
@@ -151,7 +151,7 @@ export const QuantityPanel = memo(function QuantityPanel({ item, onPerNight, onP
                     value={item.perNight ?? ''}
                     onChange={e => onPerNight(parseQty(e.target.value))}
                     aria-label={`Quantity to pack for ${item.text || 'item'}`}
-                    className="w-12 border border-gray-300 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                    className="w-12 border border-gray-300 dark:border-gray-600 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400"
                 />
                 per
                 <input
@@ -162,7 +162,7 @@ export const QuantityPanel = memo(function QuantityPanel({ item, onPerNight, onP
                     onChange={e => onPerNights(parseQty(e.target.value))}
                     disabled={!hasRate}
                     aria-label={`Number of nights per ${item.text || 'item'}`}
-                    className="w-12 border border-gray-300 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400 disabled:opacity-40"
+                    className="w-12 border border-gray-300 dark:border-gray-600 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400 disabled:opacity-40"
                 />
                 night{(item.perNights ?? 1) > 1 ? 's' : ''}
             </span>
@@ -175,10 +175,10 @@ export const QuantityPanel = memo(function QuantityPanel({ item, onPerNight, onP
                     onChange={e => onMaxQuantity(parseQty(e.target.value))}
                     disabled={!hasRate}
                     aria-label={`Maximum quantity for ${item.text || 'item'}`}
-                    className="w-12 border border-gray-300 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                    className="w-12 border border-gray-300 dark:border-gray-600 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-emerald-400"
                 />
             </label>
-            <span className="text-gray-400">
+            <span className="text-gray-400 dark:text-gray-500">
                 e.g. socks: 1 per night; a jumper: 1 per 4 nights. Suggests a
                 quantity when a list has nights away — leave blank to skip
             </span>

--- a/src/components/ItemInlineEditor.tsx
+++ b/src/components/ItemInlineEditor.tsx
@@ -18,7 +18,7 @@ import { CustomCreatableSelect } from './CreatableSelect'
 import { PersonToggles, QuantityPanel } from './ItemEditorControls'
 import type { Item, Person } from '../edit-questions/types'
 
-const FIELD_LABEL = 'block text-[11px] font-semibold text-gray-400 uppercase tracking-wide mb-1'
+const FIELD_LABEL = 'block text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1'
 
 export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, allItemNames, sectionNames, sectionDefaultLabel, onChange, onDelete, onClose }: {
     item: Item
@@ -78,7 +78,7 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
         <div
             data-testid="item-inline-editor"
             onKeyDown={e => { if (e.key === 'Escape') onClose() }}
-            className="mt-1 mb-2 rounded-lg border border-primary-200 bg-white p-3 space-y-3 shadow-sm"
+            className="mt-1 mb-2 rounded-lg border border-primary-200 dark:border-primary-800 bg-white dark:bg-gray-900 p-3 space-y-3 shadow-sm"
         >
             <div data-testid="item-name-field">
                 <span className={FIELD_LABEL}>Item</span>
@@ -101,7 +101,7 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
                     onToggleCommunal={toggleCommunal}
                 />
                 {item.communal && people.length > 1 && (
-                    <p className="mt-1 text-[11px] text-blue-600">
+                    <p className="mt-1 text-[11px] text-blue-600 dark:text-blue-400">
                         Packed once for the group — included when a highlighted person is going
                     </p>
                 )}
@@ -129,7 +129,7 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
                     aria-label="Section"
                     value={item.category ?? sectionDefaultLabel}
                     onChange={e => setSection(e.target.value)}
-                    className="w-full border border-gray-200 rounded px-3 py-2.5 text-sm text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    className="w-full border border-gray-200 dark:border-gray-700 rounded px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
                 >
                     {sectionOptions.map(label => (
                         <option key={label} value={label}>{label}</option>
@@ -146,7 +146,7 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
                         type="button"
                         onClick={onDelete}
                         aria-label={item.text ? `Delete ${item.text}` : 'Delete item'}
-                        className="px-2 py-1.5 text-sm font-medium text-gray-400 rounded-lg hover:text-red-600 hover:bg-red-50"
+                        className="px-2 py-1.5 text-sm font-medium text-gray-400 dark:text-gray-500 rounded-lg hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40"
                     >
                         Delete
                     </button>
@@ -154,7 +154,7 @@ export const ItemInlineEditor = memo(function ItemInlineEditor({ item, people, a
                 <button
                     type="button"
                     onClick={onClose}
-                    className="px-4 py-1.5 text-sm font-medium text-primary-700 bg-primary-50 rounded-lg hover:bg-primary-100"
+                    className="px-4 py-1.5 text-sm font-medium text-primary-700 dark:text-primary-300 bg-primary-50 dark:bg-primary-950/40 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-900/40"
                 >
                     Done
                 </button>

--- a/src/components/ItemNameField.tsx
+++ b/src/components/ItemNameField.tsx
@@ -17,7 +17,7 @@ import { useMemo, useState } from 'react'
 import { suggestFor, type ItemSuggestion, type SuggestionIndex } from '../utils/itemSuggestions'
 
 /** A composer field, bar the focus ring — each page brings its own accent. */
-export const FIELD_BASE = 'px-3 py-2 border border-gray-300 rounded-md bg-white text-sm text-gray-700 focus:outline-none focus:ring-2'
+export const FIELD_BASE = 'px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-sm text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2'
 export const FIELD = `${FIELD_BASE} focus:ring-blue-500`
 
 interface ItemNameFieldProps {
@@ -144,7 +144,7 @@ export function ItemNameField({
                 <ul
                     id={listboxId}
                     role="listbox"
-                    className="absolute left-0 right-0 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+                    className="absolute left-0 right-0 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 py-1 shadow-lg"
                 >
                     {matches.map((suggestion, i) => (
                         <li key={suggestion.text}>
@@ -155,11 +155,11 @@ export function ItemNameField({
                                 // Blur would close the list before the click landed.
                                 onMouseDown={e => e.preventDefault()}
                                 onClick={() => applySuggestion(suggestion)}
-                                className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm ${i === highlighted ? 'bg-blue-50 text-blue-900' : 'text-gray-700 hover:bg-gray-50'}`}
+                                className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm ${i === highlighted ? 'bg-blue-50 dark:bg-blue-950/40 text-blue-900 dark:text-blue-200' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'}`}
                             >
                                 <span className="truncate">{suggestion.text}</span>
                                 {suggestion.category && (
-                                    <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[11px] text-gray-500">
+                                    <span className="shrink-0 rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-[11px] text-gray-500 dark:text-gray-400">
                                         {suggestion.category}
                                     </span>
                                 )}

--- a/src/components/ItemRow.tsx
+++ b/src/components/ItemRow.tsx
@@ -39,7 +39,7 @@ function ItemText({ text, highlight }: { text: string; highlight?: TextHighlight
     return (
         <>
             {text.slice(0, highlight.start)}
-            <mark className="bg-amber-200 text-gray-900 rounded-sm px-0.5">{text.slice(highlight.start, end)}</mark>
+            <mark className="bg-amber-200 dark:bg-amber-900/60 text-gray-900 dark:text-gray-100 rounded-sm px-0.5">{text.slice(highlight.start, end)}</mark>
             {text.slice(end)}
         </>
     )
@@ -57,13 +57,13 @@ export const ItemRow = memo(function ItemRow({ item, people, index, isOpen, high
     const showDots = people.length > 1
     const content = (
         <>
-            <span className={`flex-1 min-w-0 text-left ${item.text ? 'text-gray-700' : 'text-gray-400 italic'}`}>
+            <span className={`flex-1 min-w-0 text-left ${item.text ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500 italic'}`}>
                 <ItemText text={item.text} highlight={highlight} />
             </span>
             {item.communal && (
                 <span
                     title="Shared — packed once for the whole group"
-                    className="inline-flex items-center justify-center h-5 rounded-full px-1.5 text-[10px] font-medium bg-blue-100 text-blue-700 select-none shrink-0"
+                    className="inline-flex items-center justify-center h-5 rounded-full px-1.5 text-[10px] font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 select-none shrink-0"
                 >
                     👥
                 </span>
@@ -71,7 +71,7 @@ export const ItemRow = memo(function ItemRow({ item, people, index, isOpen, high
             {item.perNight !== undefined && (
                 <span
                     title={quantityTitle(item)}
-                    className="inline-flex items-center justify-center h-5 rounded-full px-1.5 text-[10px] font-medium bg-emerald-100 text-emerald-700 select-none shrink-0"
+                    className="inline-flex items-center justify-center h-5 rounded-full px-1.5 text-[10px] font-medium bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 select-none shrink-0"
                 >
                     ×{rateLabel(item).replace(' per ', '/')}
                 </span>
@@ -100,7 +100,7 @@ export const ItemRow = memo(function ItemRow({ item, people, index, isOpen, high
             onClick={() => onOpen(index)}
             aria-expanded={isOpen ?? false}
             title={`Edit ${item.text || 'item'}`}
-            className={`group w-full flex items-center gap-2 py-1 px-2 text-sm rounded transition-colors ${isOpen ? 'bg-primary-50' : 'hover:bg-gray-100'}`}
+            className={`group w-full flex items-center gap-2 py-1 px-2 text-sm rounded transition-colors ${isOpen ? 'bg-primary-50 dark:bg-primary-950/40' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}`}
         >
             {content}
             {/* Decorative, not a button of its own: the whole row is the target,
@@ -110,7 +110,7 @@ export const ItemRow = memo(function ItemRow({ item, people, index, isOpen, high
             <svg
                 data-testid="item-edit-icon"
                 aria-hidden="true"
-                className={`w-3.5 h-3.5 shrink-0 transition-colors ${isOpen ? 'text-primary-500' : 'text-gray-400 group-hover:text-gray-700'}`}
+                className={`w-3.5 h-3.5 shrink-0 transition-colors ${isOpen ? 'text-primary-500 dark:text-primary-400' : 'text-gray-400 dark:text-gray-500 group-hover:text-gray-700 dark:group-hover:text-gray-300'}`}
                 fill="none" viewBox="0 0 24 24" stroke="currentColor"
             >
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />

--- a/src/components/ItemRowPanel.tsx
+++ b/src/components/ItemRowPanel.tsx
@@ -95,7 +95,7 @@ export function ItemRowPanel({
                 title={item.lastMinute
                     ? 'Packed with everything else after all'
                     : "Can't be packed until just before you go"}
-                className={`rounded-md p-1.5 transition-colors hover:bg-amber-50 hover:text-amber-600 ${item.lastMinute ? 'text-amber-600' : 'text-gray-400'}`}
+                className={`rounded-md p-1.5 transition-colors hover:bg-amber-50 dark:hover:bg-amber-950/40 hover:text-amber-600 dark:hover:text-amber-400 ${item.lastMinute ? 'text-amber-600 dark:text-amber-400' : 'text-gray-400 dark:text-gray-500'}`}
             >
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                     <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.5 2.5a1 1 0 101.414-1.414L11 9.586V6z" clipRule="evenodd" />
@@ -113,11 +113,11 @@ export function ItemRowPanel({
             {/* The modal centres its content on a phone, which is right for a
                 message and wrong for a form. */}
             <div className="space-y-4 text-left">
-                <p className="-mt-2 text-sm text-gray-500">
+                <p className="-mt-2 text-sm text-gray-500 dark:text-gray-400">
                     In {sectionTitle} · rename it, choose who needs one and how many, or remove it.
                 </p>
                 <div>
-                    <label htmlFor="item-row-name" className="block text-sm font-medium text-gray-700">
+                    <label htmlFor="item-row-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                         Name
                     </label>
                     <input
@@ -130,25 +130,25 @@ export function ItemRowPanel({
                             if (e.key === 'Enter') { e.preventDefault(); commitName() }
                             if (e.key === 'Escape') { e.preventDefault(); setDraftName(row.label) }
                         }}
-                        className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        className="mt-1 w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     />
                     {row.items.length > 1 && (
-                        <p className="mt-1 text-xs text-gray-500">
+                        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                             Renaming changes it for everyone below
                         </p>
                     )}
                 </div>
 
                 {row.communal ? (
-                    <div className="flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2">
+                    <div className="flex items-center gap-2 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/40 px-3 py-2">
                         <span aria-hidden="true">👥</span>
-                        <span className="flex-1 text-sm font-medium text-blue-900">
+                        <span className="flex-1 text-sm font-medium text-blue-900 dark:text-blue-200">
                             Shared — packed once for the whole group
                         </span>
                         {renderItemControls(row.items[0], 'the group')}
                     </div>
                 ) : (
-                    <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200">
+                    <ul className="divide-y divide-gray-100 dark:divide-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
                         {columns.map((column, index) => {
                             const item = row.cells[index]
                             const packed = item !== undefined && packedById[item.id]
@@ -167,7 +167,7 @@ export function ItemRowPanel({
                                             // This one decides whether she has
                                             // one at all.
                                             aria-label={`${column.name} needs ${row.label}`}
-                                            className="h-5 w-5 shrink-0 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                                            className="h-5 w-5 shrink-0 rounded border-gray-300 dark:border-gray-600 text-blue-600 dark:text-blue-400 focus:ring-blue-500"
                                         />
                                         {!column.unassigned && (
                                             <PersonAvatar
@@ -177,11 +177,11 @@ export function ItemRowPanel({
                                                 size="sm"
                                             />
                                         )}
-                                        <span className={`truncate text-sm font-medium ${item ? 'text-gray-800' : 'text-gray-400'}`}>
+                                        <span className={`truncate text-sm font-medium ${item ? 'text-gray-800 dark:text-gray-100' : 'text-gray-400 dark:text-gray-500'}`}>
                                             {column.name}
                                         </span>
                                         {packed && (
-                                            <span className="shrink-0 rounded-full bg-emerald-100 px-1.5 py-0.5 text-[11px] font-medium text-emerald-700">
+                                            <span className="shrink-0 rounded-full bg-emerald-100 dark:bg-emerald-900/40 px-1.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
                                                 packed
                                             </span>
                                         )}
@@ -197,14 +197,14 @@ export function ItemRowPanel({
                     <button
                         type="button"
                         onClick={() => onDeleteRow(row)}
-                        className="rounded-md px-3 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50"
+                        className="rounded-md px-3 py-2 text-sm font-medium text-red-600 dark:text-red-400 transition-colors hover:bg-red-50 dark:hover:bg-red-950/40"
                     >
                         {row.items.length > 1 ? `Remove for all ${row.items.length}` : 'Remove item'}
                     </button>
                     <button
                         type="button"
                         onClick={onClose}
-                        className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                        className="rounded-md border border-gray-300 dark:border-gray-600 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
                     >
                         Done
                     </button>
@@ -248,7 +248,7 @@ function QuantityField({ item, label, onCommit }: {
             placeholder="Qty"
             aria-label={label}
             title="How many to pack (leave blank for one)"
-            className="w-14 shrink-0 rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-14 shrink-0 rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 text-sm text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
     )
 }

--- a/src/components/ItemSearch.tsx
+++ b/src/components/ItemSearch.tsx
@@ -32,7 +32,7 @@ export function ItemSearchBar({ value, onChange }: {
             <div className="relative">
                 <svg
                     aria-hidden="true"
-                    className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none"
+                    className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-gray-500 pointer-events-none"
                     fill="none" viewBox="0 0 24 24" stroke="currentColor"
                 >
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z" />
@@ -51,7 +51,7 @@ export function ItemSearchBar({ value, onChange }: {
                     // and the one people already expect from a search field.
                     onKeyDown={e => { if (e.key === 'Escape') onChange('') }}
                     placeholder="Search items — e.g. sun cream"
-                    className="w-full border border-gray-300 rounded-lg pl-9 pr-9 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    className="w-full border border-gray-300 dark:border-gray-600 rounded-lg pl-9 pr-9 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
                 />
                 {typed > 0 && (
                     <button
@@ -59,7 +59,7 @@ export function ItemSearchBar({ value, onChange }: {
                         onClick={() => onChange('')}
                         aria-label="Clear search"
                         title="Clear search"
-                        className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-700 rounded"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 rounded"
                     >
                         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -70,7 +70,7 @@ export function ItemSearchBar({ value, onChange }: {
             {/* One letter matches most of a question set, so the page keeps
                 showing the set and says what it is waiting for. */}
             {typed > 0 && typed < MIN_QUERY_LENGTH && (
-                <p className="mt-1 text-xs text-gray-400">
+                <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
                     Keep typing — search starts at {MIN_QUERY_LENGTH} letters
                 </p>
             )}
@@ -125,10 +125,10 @@ export function ItemSearchResults({ questionSet, query, people, allItemNames, se
     return (
         <div data-testid="item-search-results" className="space-y-2">
             {found ? (
-                <p data-testid="item-search-summary" role="status" className="text-sm text-gray-500">
+                <p data-testid="item-search-summary" role="status" className="text-sm text-gray-500 dark:text-gray-400">
                     {results.total} item{results.total === 1 ? '' : 's'} match{results.total === 1 ? 'es' : ''} “{needle}”
                     {results.shown < results.total && (
-                        <span className="text-gray-400"> — showing the first {results.shown}. Try a longer search.</span>
+                        <span className="text-gray-400 dark:text-gray-500"> — showing the first {results.shown}. Try a longer search.</span>
                     )}
                 </p>
             ) : (
@@ -137,10 +137,10 @@ export function ItemSearchResults({ questionSet, query, people, allItemNames, se
                 <div
                     data-testid="item-search-summary"
                     role="status"
-                    className="rounded-lg border border-dashed border-gray-200 bg-white px-4 py-6 text-center"
+                    className="rounded-lg border border-dashed border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-6 text-center"
                 >
-                    <p className="text-sm text-gray-500">No items match “{needle}”</p>
-                    <p className="mt-1 text-xs text-gray-400">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">No items match “{needle}”</p>
+                    <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
                         Search looks at item names — try part of a word, or check the spelling.
                     </p>
                 </div>
@@ -150,17 +150,17 @@ export function ItemSearchResults({ questionSet, query, people, allItemNames, se
                 <div
                     key={group.key}
                     data-testid="search-group"
-                    className="rounded-lg border border-gray-200 bg-white"
+                    className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
                 >
-                    <div className="flex items-center gap-2 rounded-t-lg bg-gray-50 px-2.5 py-1.5">
+                    <div className="flex items-center gap-2 rounded-t-lg bg-gray-50 dark:bg-gray-800 px-2.5 py-1.5">
                         <span
                             data-testid="search-group-crumbs"
-                            className="flex items-baseline text-sm min-w-0 text-gray-700"
+                            className="flex items-baseline text-sm min-w-0 text-gray-700 dark:text-gray-300"
                         >
                             {group.crumbs.map((crumb, i) => (
                                 <Fragment key={`${group.key}-crumb-${i}`}>
                                     {i > 0 && (
-                                        <span aria-hidden="true" className="shrink-0 whitespace-pre text-gray-400">{' \u203a '}</span>
+                                        <span aria-hidden="true" className="shrink-0 whitespace-pre text-gray-400 dark:text-gray-500">{' \u203a '}</span>
                                     )}
                                     {/* The answer is what holds the items and what
                                         tells two cards of the same question apart,
@@ -172,7 +172,7 @@ export function ItemSearchResults({ questionSet, query, people, allItemNames, se
                                 </Fragment>
                             ))}
                         </span>
-                        <span className="ml-auto shrink-0 text-[11px] font-medium text-gray-400">
+                        <span className="ml-auto shrink-0 text-[11px] font-medium text-gray-400 dark:text-gray-500">
                             {group.count} match{group.count === 1 ? '' : 'es'}
                         </span>
                     </div>

--- a/src/components/LoadingState.tsx
+++ b/src/components/LoadingState.tsx
@@ -15,7 +15,7 @@ export function LoadingState({ message, rows = 3 }: LoadingStateProps) {
         <div role="status" aria-live="polite">
             <div className="flex flex-col items-center gap-3 py-6">
                 <span aria-hidden="true" className="loading-suitcase text-5xl leading-none">🧳</span>
-                <p className="text-lg font-semibold text-gray-700">{message}</p>
+                <p className="text-lg font-semibold text-gray-700 dark:text-gray-300">{message}</p>
             </div>
 
             <div data-testid="loading-skeleton" aria-hidden="true" className="space-y-4">
@@ -23,7 +23,7 @@ export function LoadingState({ message, rows = 3 }: LoadingStateProps) {
                     <div
                         key={index}
                         data-testid="loading-skeleton-card"
-                        className="rounded-2xl border-2 border-primary-100 bg-white p-5 shadow-soft"
+                        className="rounded-2xl border-2 border-primary-100 dark:border-primary-900 bg-white dark:bg-gray-900 p-5 shadow-soft"
                     >
                         <div className="loading-skeleton-bar h-5 w-1/2 rounded-full" />
                         <div className="loading-skeleton-bar mt-3 h-4 w-1/3 rounded-full" />

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -15,11 +15,11 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
             <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
                 <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={onClose} />
 
-                <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 w-full sm:max-w-lg sm:p-6">
+                <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white dark:bg-gray-900 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 w-full sm:max-w-lg sm:p-6">
                     <div className="absolute right-0 top-0 pr-4 pt-4">
                         <button
                             type="button"
-                            className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
+                            className="rounded-md bg-white dark:bg-gray-900 text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-400 focus:outline-none"
                             onClick={onClose}
                         >
                             <span className="sr-only">Close</span>
@@ -30,7 +30,7 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
                     </div>
                     <div className="sm:flex sm:items-start">
                         <div className="mt-3 text-center sm:mt-0 sm:text-left w-full">
-                            <h3 className="text-lg font-semibold leading-6 text-gray-900 mb-4">
+                            <h3 className="text-lg font-semibold leading-6 text-gray-900 dark:text-gray-100 mb-4">
                                 {title}
                             </h3>
                             <div className="mt-2">

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -13,7 +13,7 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
     return (
         <div className="fixed inset-0 z-50 overflow-y-auto">
             <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
-                <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={onClose} />
+                <div className="fixed inset-0 bg-gray-500/75 dark:bg-black/70 transition-opacity" onClick={onClose} />
 
                 <div role="dialog" aria-modal="true" className="relative transform overflow-hidden rounded-lg bg-white dark:bg-gray-900 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 w-full sm:max-w-lg sm:p-6">
                     <div className="absolute right-0 top-0 pr-4 pt-4">

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, within } from '@testing-library/rea
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { Navigation } from './Navigation'
+import { ThemeProvider } from './ThemeContext'
 
 vi.mock('./SolidPodContext', () => ({
     useSolidPod: vi.fn(),
@@ -51,7 +52,9 @@ function signedIn() {
 function renderNav() {
     return render(
         <MemoryRouter>
-            <Navigation />
+            <ThemeProvider>
+                <Navigation />
+            </ThemeProvider>
         </MemoryRouter>
     )
 }
@@ -76,32 +79,20 @@ describe('Navigation', () => {
     })
 
     it('hides Backups link when not logged in', () => {
-        render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
+        renderNav()
 
         expect(screen.queryByText('Backups')).toBeNull()
     })
 
     it('keeps the Sharing link reachable when logged out so sharing is discoverable', () => {
-        render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
+        renderNav()
 
         // Desktop and mobile menus each render one
         expect(screen.getAllByText('Sharing').length).toBeGreaterThan(0)
     })
 
     it('shows "My Questions & Items" nav link instead of "Edit Questions"', () => {
-        render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
+        renderNav()
 
         expect(screen.getAllByText('My Questions & Items').length).toBeGreaterThan(0)
         expect(screen.queryByText('Edit Questions')).toBeNull()
@@ -111,11 +102,7 @@ describe('Navigation', () => {
     // they're once-in-a-while links, and the nav is for everyday ones. See
     // Footer.test.tsx for their coverage.
     it('keeps once-in-a-while links out of the nav', () => {
-        render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
+        renderNav()
 
         expect(screen.queryByRole('link', { name: /feedback/i })).toBeNull()
         expect(screen.queryByRole('link', { name: /privacy/i })).toBeNull()
@@ -127,11 +114,7 @@ describe('Navigation', () => {
     // a tall empty band above the logo. The inset is applied through a class so
     // CSS can limit it to the cases that actually draw under the status bar.
     it('leaves the status-bar inset to CSS rather than an inline style', () => {
-        const { container } = render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
+        const { container } = renderNav()
 
         const nav = container.querySelector('nav')!
         expect(nav.style.paddingTop).toBe('')
@@ -139,11 +122,7 @@ describe('Navigation', () => {
     })
 
     it('uses a shorter header row on mobile than on desktop', () => {
-        const { container } = render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
+        const { container } = renderNav()
 
         const row = container.querySelector('nav .flex.items-center.justify-between')!
         expect(row.className).toContain('h-14')
@@ -258,31 +237,19 @@ describe('Navigation – signed-out auth control', () => {
     })
 
     it('labels the auth control with the benefit in both desktop nav and mobile menu', () => {
-        render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
+        renderNav()
 
         expect(screen.getAllByRole('button', { name: 'Sync & Share' })).toHaveLength(2)
     })
 
     it('does not lead with "Solid Pod" on the auth control', () => {
-        render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
+        renderNav()
 
         expect(screen.queryByRole('button', { name: /solid pod/i })).toBeNull()
     })
 
     it('notes the payoff alongside the auth control', () => {
-        render(
-            <MemoryRouter>
-                <Navigation />
-            </MemoryRouter>
-        )
+        renderNav()
 
         expect(screen.getAllByText(/sync across devices/i).length).toBeGreaterThanOrEqual(2)
     })

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,6 +4,7 @@ import { useSolidPod } from './SolidPodContext'
 import { useDatabase } from './DatabaseContext'
 import { SolidProviderSelector } from './SolidProviderSelector'
 import { AccountMenu, ProfileBadge } from './AccountMenu'
+import { ThemeToggle } from './ThemeToggle'
 import { profileDisplayName, useSolidProfile } from '../hooks/useSolidProfile'
 import type { SharedContext } from '../services/rdfSerialization'
 
@@ -95,6 +96,7 @@ export const Navigation = () => {
                         </div>
                         {/* Solid Login/Logout section */}
                         <div className="hidden md:flex items-center gap-4">
+                            <ThemeToggle />
                             {isLoggedIn ? (
                                 <div className="flex items-center gap-3">
                                     {/*
@@ -114,12 +116,12 @@ export const Navigation = () => {
                                             className="text-sm font-medium bg-white/20 text-white rounded-lg px-2 py-1 border-0 focus:ring-0 cursor-pointer"
                                             aria-label="Switch context"
                                         >
-                                            <option value="__own__" className="text-gray-900">Your data</option>
+                                            <option value="__own__" className="text-gray-900 dark:text-gray-100">Your data</option>
                                             {sharedContexts.map(ctx => (
                                                 <option
                                                     key={ctx.podUrl}
                                                     value={encodeURIComponent(ctx.podUrl)}
-                                                    className="text-gray-900"
+                                                    className="text-gray-900 dark:text-gray-100"
                                                 >
                                                     {ctx.label ?? ctx.podUrl}
                                                 </option>
@@ -147,7 +149,8 @@ export const Navigation = () => {
                             )}
                         </div>
                         {/* Mobile menu button */}
-                        <div className="md:hidden">
+                        <div className="md:hidden flex items-center gap-1">
+                            <ThemeToggle />
                             <button
                                 onClick={() => setIsOpen(!isOpen)}
                                 className="inline-flex items-center justify-center p-2.5 rounded-lg text-white hover:bg-white/20 focus:outline-none transition-all duration-200"
@@ -203,6 +206,7 @@ export const Navigation = () => {
                         >
                             Sharing
                         </Link>
+                        <ThemeToggle showLabel />
                         {/* Mobile Solid Login/Logout */}
                         <div className="border-t border-white/20 pt-2 mt-2">
                             {isLoggedIn ? (

--- a/src/components/PastTripsSection.tsx
+++ b/src/components/PastTripsSection.tsx
@@ -32,7 +32,7 @@ export function PastTripsSection({ count, allPastFinished, children }: PastTrips
                 onClick={() => setIsExpanded(expanded => !expanded)}
                 aria-expanded={isExpanded}
                 aria-controls={panelId}
-                className="flex items-center gap-2 w-full text-left px-4 py-3 rounded-xl border-2 border-gray-200 dark:border-gray-700 bg-white/60 text-gray-600 dark:text-gray-400 hover:bg-white dark:hover:bg-gray-900 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-400 transition-colors"
+                className="flex items-center gap-2 w-full text-left px-4 py-3 rounded-xl border-2 border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 text-gray-600 dark:text-gray-400 hover:bg-white dark:hover:bg-gray-900 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-400 transition-colors"
             >
                 <span className="shrink-0 text-sm text-gray-400 dark:text-gray-500">{isExpanded ? '▼' : '▶'}</span>
                 <span className="text-lg font-semibold">{label} ({count})</span>

--- a/src/components/PastTripsSection.tsx
+++ b/src/components/PastTripsSection.tsx
@@ -32,9 +32,9 @@ export function PastTripsSection({ count, allPastFinished, children }: PastTrips
                 onClick={() => setIsExpanded(expanded => !expanded)}
                 aria-expanded={isExpanded}
                 aria-controls={panelId}
-                className="flex items-center gap-2 w-full text-left px-4 py-3 rounded-xl border-2 border-gray-200 bg-white/60 text-gray-600 hover:bg-white hover:border-gray-300 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-400 transition-colors"
+                className="flex items-center gap-2 w-full text-left px-4 py-3 rounded-xl border-2 border-gray-200 dark:border-gray-700 bg-white/60 text-gray-600 dark:text-gray-400 hover:bg-white dark:hover:bg-gray-900 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-400 transition-colors"
             >
-                <span className="shrink-0 text-sm text-gray-400">{isExpanded ? '▼' : '▶'}</span>
+                <span className="shrink-0 text-sm text-gray-400 dark:text-gray-500">{isExpanded ? '▼' : '▶'}</span>
                 <span className="text-lg font-semibold">{label} ({count})</span>
             </button>
             {/* Unmounted rather than hidden: a closed section shouldn't put its

--- a/src/components/PeopleFilterBar.tsx
+++ b/src/components/PeopleFilterBar.tsx
@@ -142,15 +142,15 @@ export function PeopleFilterBar({
     if (columns.length <= 1 && sharedStat === undefined) return null
 
     return (
-        <div className="mt-1.5 flex items-center gap-2 border-t border-gray-100 pt-1.5">
+        <div className="mt-1.5 flex items-center gap-2 border-t border-gray-100 dark:border-gray-800 pt-1.5">
             {/* The words are worth 87px of a 390px screen, which is most of a
                 chip — so the phone gets the funnel and the room instead. */}
-            <span aria-hidden="true" className="shrink-0 text-gray-400 sm:hidden">
+            <span aria-hidden="true" className="shrink-0 text-gray-400 dark:text-gray-500 sm:hidden">
                 <svg viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
                     <path fillRule="evenodd" d="M2.6 4.2A1 1 0 0 1 3.5 3.6h13a1 1 0 0 1 .77 1.64l-4.77 5.6v4.2a1 1 0 0 1-.55.9l-2.4 1.2a1 1 0 0 1-1.45-.9v-5.4L2.33 5.24a1 1 0 0 1 .27-1.04Z" clipRule="evenodd" />
                 </svg>
             </span>
-            <span className="hidden shrink-0 text-[11px] font-semibold uppercase tracking-wide text-gray-400 sm:inline">
+            <span className="hidden shrink-0 text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 sm:inline">
                 Packing for
             </span>
             <div className="relative min-w-0 flex-1">
@@ -177,13 +177,13 @@ export function PeopleFilterBar({
                             onClick={() => { if (!swallowLongPress()) onToggle(column.key) }}
                             className={`flex min-h-[44px] shrink-0 items-center justify-center gap-1.5 rounded-full border p-2 text-xs font-medium transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 ${
                                 isSelected
-                                    ? 'border-blue-500 bg-blue-600 text-white'
-                                    : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+                                    ? 'border-blue-500 dark:border-blue-600 bg-blue-600 text-white'
+                                    : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
                             }`}
                         >
                             <span className="relative shrink-0">
                                 {column.unassigned
-                                    ? <span aria-hidden="true" className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gray-200 text-xs font-bold text-gray-600">?</span>
+                                    ? <span aria-hidden="true" className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gray-200 dark:bg-gray-700 text-xs font-bold text-gray-600 dark:text-gray-400">?</span>
                                     : <PersonAvatar name={column.name} identity={identity} initial={column.initial} />}
                                 {done && <DoneTick />}
                             </span>
@@ -215,8 +215,8 @@ export function PeopleFilterBar({
                             onClick={() => { if (!swallowLongPress()) onToggle(SHARED_FILTER_KEY) }}
                             className={`flex min-h-[44px] min-w-[44px] shrink-0 items-center justify-center gap-1.5 rounded-full border p-2 text-base transition-colors sm:py-1.5 sm:pl-2 sm:pr-2.5 sm:text-xs sm:font-medium ${
                                 isSelected
-                                    ? 'border-blue-500 bg-blue-600 text-white'
-                                    : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+                                    ? 'border-blue-500 dark:border-blue-600 bg-blue-600 text-white'
+                                    : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
                             }`}
                         >
                             <span className="relative shrink-0">

--- a/src/components/PersonIdentityPicker.tsx
+++ b/src/components/PersonIdentityPicker.tsx
@@ -27,9 +27,9 @@ export function PersonIdentityPicker({ personName, selectedColor, selectedEmoji,
 }) {
     const emojiChoices = [...PERSON_EMOJI, ...EXTRA_PERSON_EMOJI]
     return (
-        <div className="mt-2 ml-9 space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+        <div className="mt-2 ml-9 space-y-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 p-3">
             <div>
-                <p className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-400">Colour</p>
+                <p className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">Colour</p>
                 <div role="group" aria-label={`Colour for ${personName}`} className="grid grid-cols-6 gap-1.5">
                     {PERSON_COLORS.map(color => {
                         const isSelected = color.id === selectedColor.id
@@ -51,7 +51,7 @@ export function PersonIdentityPicker({ personName, selectedColor, selectedEmoji,
             </div>
 
             <div>
-                <p className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-400">Emoji</p>
+                <p className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">Emoji</p>
                 <div role="group" aria-label={`Emoji for ${personName}`} className="grid grid-cols-6 gap-1.5">
                     {/* First, so the way back to a plain initial is where the eye
                         lands rather than at the end of two dozen creatures. */}
@@ -75,7 +75,7 @@ export function PersonIdentityPicker({ personName, selectedColor, selectedEmoji,
                                 aria-label={choice.label}
                                 aria-pressed={isSelected}
                                 title={choice.label}
-                                className={`h-7 w-7 rounded-full flex items-center justify-center text-sm bg-white border transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-gray-400 ${isSelected ? `border-transparent ring-2 ring-offset-1 ${selectedColor.ring}` : 'border-gray-200'}`}
+                                className={`h-7 w-7 rounded-full flex items-center justify-center text-sm bg-white dark:bg-gray-900 border transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-gray-400 ${isSelected ? `border-transparent ring-2 ring-offset-1 ${selectedColor.ring}` : 'border-gray-200 dark:border-gray-700'}`}
                             >
                                 {choice.emoji}
                             </button>
@@ -85,7 +85,7 @@ export function PersonIdentityPicker({ personName, selectedColor, selectedEmoji,
             </div>
 
             <div>
-                <label className="mb-1.5 block text-[11px] font-medium uppercase tracking-wide text-gray-400">
+                <label className="mb-1.5 block text-[11px] font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
                     Solid WebID
                     <input
                         type="url"
@@ -94,10 +94,10 @@ export function PersonIdentityPicker({ personName, selectedColor, selectedEmoji,
                         onChange={event => onChangeWebId(event.target.value)}
                         placeholder="https://example.org/profile/card#me"
                         aria-label={`Solid WebID for ${personName}`}
-                        className="mt-1 w-full rounded-lg border border-gray-300 px-2 py-1.5 text-sm font-normal normal-case tracking-normal text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                        className="mt-1 w-full rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1.5 text-sm font-normal normal-case tracking-normal text-gray-600 dark:text-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500"
                     />
                 </label>
-                <p className="text-[11px] text-gray-400">
+                <p className="text-[11px] text-gray-400 dark:text-gray-500">
                     Has their own pod? Paste their WebID and their profile photo becomes their avatar.
                 </p>
             </div>

--- a/src/components/PodSyncIndicator.tsx
+++ b/src/components/PodSyncIndicator.tsx
@@ -22,7 +22,7 @@ export function PodSyncIndicator({ subject }: PodSyncIndicatorProps) {
             data-testid="pod-sync-indicator"
             role="status"
             aria-live="polite"
-            className="mb-4 flex items-center gap-2 text-sm font-medium text-gray-600"
+            className="mb-4 flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-400"
         >
             <span aria-hidden="true" className="loading-suitcase text-base leading-none">🧳</span>
             Checking your Pod for changes{subject ? ` to ${subject}` : ''}...

--- a/src/components/SectionOrderEditor.tsx
+++ b/src/components/SectionOrderEditor.tsx
@@ -67,7 +67,7 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
             {/* On a phone the caption costs a third of the row it introduces,
                 and the names beside a "Reorder" button say what it would have
                 said. Still read out, just not drawn. */}
-            <span className="sr-only sm:not-sr-only sm:text-xs sm:text-gray-400 sm:shrink-0">List order</span>
+            <span className="sr-only sm:not-sr-only sm:text-xs sm:text-gray-400 dark:sm:text-gray-500 sm:shrink-0">List order</span>
             <div className="hidden sm:flex sm:flex-wrap sm:items-center sm:gap-1.5 sm:min-w-0">
                 {shown.map((label, i) => {
                     const accent = sectionAccent(label, false)
@@ -82,9 +82,9 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
                         </span>
                     )
                 })}
-                {hidden > 0 && <span className="text-[11px] text-gray-400">+{hidden} more</span>}
+                {hidden > 0 && <span className="text-[11px] text-gray-400 dark:text-gray-500">+{hidden} more</span>}
             </div>
-            <span className="sm:hidden flex-1 min-w-0 truncate text-[11px] text-gray-400">
+            <span className="sm:hidden flex-1 min-w-0 truncate text-[11px] text-gray-400 dark:text-gray-500">
                 {labels.join(' · ')}
             </span>
             {onEdit && (
@@ -95,7 +95,7 @@ export const SectionOrderLegend = memo(function SectionOrderLegend({ labels, onE
                     // A full-size touch target, like every other control the
                     // page expects a thumb to find. At the strip's own scale it
                     // was 24px tall, and missing it looked like a dead button.
-                    className="inline-flex items-center justify-center gap-1 shrink-0 h-11 px-3 text-[11px] font-medium rounded-lg text-primary-600 hover:bg-primary-50 active:bg-primary-100 transition-colors"
+                    className="inline-flex items-center justify-center gap-1 shrink-0 h-11 px-3 text-[11px] font-medium rounded-lg text-primary-600 dark:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-950/40 active:bg-primary-100 dark:active:bg-primary-900/40 transition-colors"
                 >
                     <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
@@ -119,14 +119,14 @@ function SortableSectionRow({ label, position, total, onMove }: {
         <div
             ref={setNodeRef}
             style={{ transform: CSS.Transform.toString(transform), transition }}
-            className={`flex items-center gap-1 rounded-lg border bg-white p-2 ${isDragging ? 'relative z-10 border-primary-400 shadow-md opacity-95' : accent.border}`}
+            className={`flex items-center gap-1 rounded-lg border bg-white dark:bg-gray-900 p-2 ${isDragging ? 'relative z-10 border-primary-400 dark:border-primary-600 shadow-md opacity-95' : accent.border}`}
         >
             <button
                 type="button"
                 ref={setActivatorNodeRef}
                 {...attributes}
                 {...listeners}
-                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-50 cursor-grab active:cursor-grabbing touch-none"
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-grab active:cursor-grabbing touch-none"
                 title="Drag to reorder"
                 aria-label={`Drag ${label} to reorder`}
             >
@@ -135,7 +135,7 @@ function SortableSectionRow({ label, position, total, onMove }: {
                 </svg>
             </button>
             <span className={`w-1.5 h-5 rounded-full shrink-0 ${accent.rail}`} aria-hidden="true" />
-            <span className="flex-1 min-w-0 truncate text-sm text-gray-800 px-1">{label}</span>
+            <span className="flex-1 min-w-0 truncate text-sm text-gray-800 dark:text-gray-100 px-1">{label}</span>
             {/* Named destinations rather than bare arrows: this is the path that
                 works from the keyboard, and "move up" alone doesn't say where. */}
             <button
@@ -143,7 +143,7 @@ function SortableSectionRow({ label, position, total, onMove }: {
                 disabled={position === 0}
                 onClick={() => onMove(position - 1)}
                 aria-label={`Move ${label} up`}
-                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:text-gray-200 disabled:border-gray-100 disabled:hover:bg-transparent transition-colors"
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:text-gray-200 disabled:border-gray-100 dark:disabled:border-gray-800 disabled:hover:bg-transparent transition-colors"
             >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
@@ -154,7 +154,7 @@ function SortableSectionRow({ label, position, total, onMove }: {
                 disabled={position === total - 1}
                 onClick={() => onMove(position + 1)}
                 aria-label={`Move ${label} down`}
-                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:text-gray-200 disabled:border-gray-100 disabled:hover:bg-transparent transition-colors"
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:text-gray-200 disabled:border-gray-100 dark:disabled:border-gray-800 disabled:hover:bg-transparent transition-colors"
             >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
@@ -199,17 +199,17 @@ export function SectionOrderModal({ labels, onChange, onClose }: {
             <div
                 role="dialog"
                 aria-label="Reorder list sections"
-                className="bg-white rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
+                className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
                 onClick={e => e.stopPropagation()}
             >
-                <div className="p-5 border-b border-gray-100 flex-shrink-0">
-                    <h2 className="text-lg font-semibold text-gray-900">Reorder sections</h2>
-                    <p className="mt-0.5 text-sm text-gray-500">
+                <div className="p-5 border-b border-gray-100 dark:border-gray-800 flex-shrink-0">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Reorder sections</h2>
+                    <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
                         The order your packing lists are grouped in — every list, including the ones you already have.
                     </p>
                 </div>
                 <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
-                    <div className="text-[11px] text-gray-400 mb-2 px-0.5">
+                    <div className="text-[11px] text-gray-400 dark:text-gray-500 mb-2 px-0.5">
                         Drag the handle (press and hold on touch) to reorder, or use the arrows.
                     </div>
                     <DndContext
@@ -254,7 +254,7 @@ export function SectionOrderModal({ labels, onChange, onClose }: {
                         </SortableContext>
                     </DndContext>
                 </div>
-                <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex justify-end">
+                <div className="px-5 py-4 border-t border-gray-100 dark:border-gray-800 flex-shrink-0 flex justify-end">
                     <button
                         type="button"
                         onClick={onClose}

--- a/src/components/SectionedItemReorder.tsx
+++ b/src/components/SectionedItemReorder.tsx
@@ -87,7 +87,7 @@ function SectionHeaderRow({ id, label, isDefault, onRename, onRemove }: {
                         if (e.key === 'Escape') { setDraft(label); setEditing(false) }
                     }}
                     aria-label={`Rename section ${label}`}
-                    className="w-full border border-primary-300 rounded-lg px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    className="w-full border border-primary-300 dark:border-primary-700 rounded-lg px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-primary-500"
                 />
             ) : (
                 <div className={`flex items-center gap-2 rounded-lg border ${accent.border} ${accent.header} px-3 py-2`}>
@@ -101,7 +101,7 @@ function SectionHeaderRow({ id, label, isDefault, onRename, onRemove }: {
                                 type="button"
                                 onClick={() => { setDraft(label); setEditing(true) }}
                                 aria-label={`Rename section ${label}`}
-                                className={`ml-auto text-[11px] px-1 ${accent.muted} hover:text-primary-700`}
+                                className={`ml-auto text-[11px] px-1 ${accent.muted} hover:text-primary-700 dark:hover:text-primary-300`}
                             >
                                 Rename
                             </button>
@@ -109,7 +109,7 @@ function SectionHeaderRow({ id, label, isDefault, onRename, onRemove }: {
                                 type="button"
                                 onClick={onRemove}
                                 aria-label={`Remove section ${label}`}
-                                className={`text-[11px] px-1 ${accent.muted} hover:text-red-600`}
+                                className={`text-[11px] px-1 ${accent.muted} hover:text-red-600 dark:hover:text-red-400`}
                             >
                                 Remove
                             </button>
@@ -144,7 +144,7 @@ function MoveMenu({ label, canMoveToTop, canMoveToBottom, otherSections, onMoveW
                     disabled={!hasMoves}
                     title="Move item"
                     aria-label={`Move ${label}`}
-                    className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 active:bg-gray-100 disabled:text-gray-200 disabled:border-gray-100 disabled:hover:bg-transparent transition-colors"
+                    className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 active:bg-gray-100 dark:active:bg-gray-800 disabled:text-gray-200 disabled:border-gray-100 dark:disabled:border-gray-800 disabled:hover:bg-transparent transition-colors"
                 >
                     <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                         <circle cx="12" cy="5" r="1.5" />
@@ -157,12 +157,12 @@ function MoveMenu({ label, canMoveToTop, canMoveToBottom, otherSections, onMoveW
                 <DropdownMenu.Content
                     align="end"
                     sideOffset={4}
-                    className="min-w-52 max-w-72 bg-white rounded-lg shadow-lg border border-gray-100 py-1 z-50"
+                    className="min-w-52 max-w-72 bg-white dark:bg-gray-900 rounded-lg shadow-lg border border-gray-100 dark:border-gray-800 py-1 z-50"
                 >
                     {canMoveToTop && (
                         <DropdownMenu.Item
                             onSelect={() => onMoveWithinSection('top')}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 cursor-default outline-none"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 focus:bg-gray-50 dark:focus:bg-gray-800 cursor-default outline-none"
                         >
                             Move to top of section
                         </DropdownMenu.Item>
@@ -170,19 +170,19 @@ function MoveMenu({ label, canMoveToTop, canMoveToBottom, otherSections, onMoveW
                     {canMoveToBottom && (
                         <DropdownMenu.Item
                             onSelect={() => onMoveWithinSection('bottom')}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 cursor-default outline-none"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 focus:bg-gray-50 dark:focus:bg-gray-800 cursor-default outline-none"
                         >
                             Move to bottom of section
                         </DropdownMenu.Item>
                     )}
                     {otherSections.length > 0 && (canMoveToTop || canMoveToBottom) && (
-                        <DropdownMenu.Separator className="my-1 h-px bg-gray-100" />
+                        <DropdownMenu.Separator className="my-1 h-px bg-gray-100 dark:bg-gray-800" />
                     )}
                     {otherSections.map(section => (
                         <DropdownMenu.Item
                             key={section}
                             onSelect={() => onMoveToSection(section)}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 cursor-default outline-none truncate"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 focus:bg-gray-50 dark:focus:bg-gray-800 cursor-default outline-none truncate"
                         >
                             Move to {section}
                         </DropdownMenu.Item>
@@ -208,14 +208,14 @@ function SortableSectionItem({ id, item, canMoveToTop, canMoveToBottom, otherSec
             ref={setNodeRef}
             style={{ transform: CSS.Transform.toString(transform), transition }}
             data-reorder-row
-            className={`flex items-center gap-1 rounded-lg border bg-white p-2 ${isDragging ? 'relative z-10 border-primary-400 shadow-md opacity-95' : 'border-gray-200'}`}
+            className={`flex items-center gap-1 rounded-lg border bg-white dark:bg-gray-900 p-2 ${isDragging ? 'relative z-10 border-primary-400 dark:border-primary-600 shadow-md opacity-95' : 'border-gray-200 dark:border-gray-700'}`}
         >
             <button
                 type="button"
                 ref={setActivatorNodeRef}
                 {...attributes}
                 {...listeners}
-                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-50 cursor-grab active:cursor-grabbing touch-none"
+                className="inline-flex items-center justify-center w-11 h-11 shrink-0 rounded-lg text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-grab active:cursor-grabbing touch-none"
                 title="Drag to reorder or move between sections"
                 aria-label={`Drag ${item.text || 'item'} to reorder`}
             >
@@ -223,8 +223,8 @@ function SortableSectionItem({ id, item, canMoveToTop, canMoveToBottom, otherSec
                     <path d="M7 4a1 1 0 100 2 1 1 0 000-2zM7 9a1 1 0 100 2 1 1 0 000-2zM7 14a1 1 0 100 2 1 1 0 000-2zM13 4a1 1 0 100 2 1 1 0 000-2zM13 9a1 1 0 100 2 1 1 0 000-2zM13 14a1 1 0 100 2 1 1 0 000-2z" />
                 </svg>
             </button>
-            <span className="flex-1 min-w-0 truncate text-sm text-gray-800 px-1">
-                {item.text || <span className="text-gray-400 italic">Unnamed item</span>}
+            <span className="flex-1 min-w-0 truncate text-sm text-gray-800 dark:text-gray-100 px-1">
+                {item.text || <span className="text-gray-400 dark:text-gray-500 italic">Unnamed item</span>}
             </span>
             <MoveMenu
                 label={item.text || 'item'}
@@ -336,7 +336,7 @@ export function SectionedItemReorder({ items, defaultLabel, emptySections, scrol
 
     return (
         <>
-            <div className="text-[11px] text-gray-400 mb-2 px-0.5">
+            <div className="text-[11px] text-gray-400 dark:text-gray-500 mb-2 px-0.5">
                 Drag the handle (press and hold on touch) to reorder, or focus it and press
                 space, then the arrow keys. Each item's move menu jumps it to the top or
                 bottom of its section, or into another section.

--- a/src/components/SessionExpiredBanner.tsx
+++ b/src/components/SessionExpiredBanner.tsx
@@ -11,19 +11,19 @@ export function SessionExpiredBanner() {
 
     return (
         <>
-            <div className="bg-amber-50 border-b border-amber-200 px-4 py-3 flex items-center justify-between">
-                <p className="text-amber-800 text-sm font-medium">
+            <div className="bg-amber-50 dark:bg-amber-950/40 border-b border-amber-200 dark:border-amber-800 px-4 py-3 flex items-center justify-between">
+                <p className="text-amber-800 dark:text-amber-200 text-sm font-medium">
                     Your session has expired. Your data is saved locally.
                 </p>
                 <div className="flex items-center gap-3">
                     <button
                         onClick={() => setIsProviderSelectorOpen(true)}
-                        className="text-sm font-semibold text-amber-900 underline hover:no-underline"
+                        className="text-sm font-semibold text-amber-900 dark:text-amber-200 underline hover:no-underline"
                     >
                         Log in again
                     </button>
                     <button onClick={clearSessionExpired} aria-label="Dismiss">
-                        <XMarkIcon className="h-4 w-4 text-amber-700 hover:text-amber-900" />
+                        <XMarkIcon className="h-4 w-4 text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-200" />
                     </button>
                 </div>
             </div>

--- a/src/components/SharePackingListModal.tsx
+++ b/src/components/SharePackingListModal.tsx
@@ -147,36 +147,36 @@ export function SharePackingListModal({
             <div className="space-y-5">
                 {/* Current access section */}
                 <div>
-                    <h3 className="text-sm font-semibold text-gray-700 mb-2">Current access</h3>
+                    <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Current access</h3>
                     {isLoadingAccess ? (
-                        <p className="text-sm text-gray-500">Loading…</p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
                     ) : !hasAnyAccess ? (
-                        <p className="text-sm text-gray-500">No one else has access yet.</p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">No one else has access yet.</p>
                     ) : (
                         <ul className="space-y-2">
                             {isPublic && (
-                                <li className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
-                                    <span className="text-sm text-gray-800">🌐 Anyone with the link</span>
+                                <li className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
+                                    <span className="text-sm text-gray-800 dark:text-gray-100">🌐 Anyone with the link</span>
                                     <button
                                         type="button"
                                         onClick={handleRevokePublic}
                                         disabled={isRevokingPublic}
                                         aria-label="Revoke public access"
-                                        className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-red-100 text-red-700 hover:bg-red-200 disabled:opacity-50 transition-colors"
+                                        className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-900/60 disabled:opacity-50 transition-colors"
                                     >
                                         {isRevokingPublic ? 'Revoking…' : 'Revoke'}
                                     </button>
                                 </li>
                             )}
                             {currentCollaborators.map(webId => (
-                                <li key={webId} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
-                                    <span className="text-sm text-gray-800 truncate flex-1" title={webId}>{webId}</span>
+                                <li key={webId} className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
+                                    <span className="text-sm text-gray-800 dark:text-gray-100 truncate flex-1" title={webId}>{webId}</span>
                                     <button
                                         type="button"
                                         onClick={() => handleRevokeCollaborator(webId)}
                                         disabled={revokingWebId === webId}
                                         aria-label={`Revoke access for ${webId}`}
-                                        className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-red-100 text-red-700 hover:bg-red-200 disabled:opacity-50 transition-colors"
+                                        className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-900/60 disabled:opacity-50 transition-colors"
                                     >
                                         {revokingWebId === webId ? 'Revoking…' : 'Revoke'}
                                     </button>
@@ -186,21 +186,21 @@ export function SharePackingListModal({
                     )}
                 </div>
 
-                <hr className="border-gray-200" />
+                <hr className="border-gray-200 dark:border-gray-700" />
 
                 {/* Add access section */}
                 <div>
-                    <h3 className="text-sm font-semibold text-gray-700 mb-3">Add access</h3>
+                    <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Add access</h3>
 
                     {/* Mode tabs */}
-                    <div className="flex rounded-lg border border-gray-200 overflow-hidden mb-4">
+                    <div className="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden mb-4">
                         <button
                             type="button"
                             onClick={() => handleModeChange('person')}
                             className={`flex-1 py-2 px-3 text-sm font-medium transition-colors ${
                                 shareMode === 'person'
                                     ? 'bg-blue-600 text-white'
-                                    : 'bg-white text-gray-600 hover:bg-gray-50'
+                                    : 'bg-white dark:bg-gray-900 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
                             }`}
                         >
                             With a person
@@ -211,7 +211,7 @@ export function SharePackingListModal({
                             className={`flex-1 py-2 px-3 text-sm font-medium transition-colors ${
                                 shareMode === 'public'
                                     ? 'bg-blue-600 text-white'
-                                    : 'bg-white text-gray-600 hover:bg-gray-50'
+                                    : 'bg-white dark:bg-gray-900 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
                             }`}
                         >
                             Anyone with the link
@@ -234,13 +234,13 @@ export function SharePackingListModal({
                     )}
 
                     {shareMode === 'public' && !generatedLink && (
-                        <p className="text-sm text-gray-600">
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
                             Anyone who follows this link can view and edit this list — no sign-in required to view.
                         </p>
                     )}
 
                     {error && (
-                        <p className="text-sm text-red-600 mt-2">{error}</p>
+                        <p className="text-sm text-red-600 dark:text-red-400 mt-2">{error}</p>
                     )}
 
                     {shareMode === 'person' && (
@@ -267,14 +267,14 @@ export function SharePackingListModal({
 
                     {generatedLink && (
                         <div className="space-y-2 mt-3">
-                            <label className="block text-sm font-medium text-gray-700">
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                                 Shareable link
                                 <input
                                     aria-label="Shareable link"
                                     type="text"
                                     readOnly
                                     value={generatedLink}
-                                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 bg-gray-50"
+                                    className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-800"
                                 />
                             </label>
                             <Button type="button" variant="secondary" onClick={handleCopy}>

--- a/src/components/SolidPodPrompt.tsx
+++ b/src/components/SolidPodPrompt.tsx
@@ -74,11 +74,11 @@ export function SolidPodPrompt({
     <>
       <Modal isOpen={isOpen} onClose={handleMaybeLater} title={title}>
         <div className="space-y-4">
-          <p className="text-gray-700 leading-relaxed">{message}</p>
+          <p className="text-gray-700 dark:text-gray-300 leading-relaxed">{message}</p>
 
-          <div className="bg-gradient-to-br from-primary-50 to-accent-50 border-2 border-primary-200 rounded-xl p-4 space-y-2">
-            <h4 className="font-bold text-primary-900 text-sm">{benefitsTitle}</h4>
-            <ul className="text-sm text-gray-700 space-y-1.5 ml-4 list-disc">
+          <div className="bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 border-2 border-primary-200 dark:border-primary-800 rounded-xl p-4 space-y-2">
+            <h4 className="font-bold text-primary-900 dark:text-primary-200 text-sm">{benefitsTitle}</h4>
+            <ul className="text-sm text-gray-700 dark:text-gray-300 space-y-1.5 ml-4 list-disc">
               {benefits.map(benefit => (
                 <li key={benefit.label}>
                   <strong>{benefit.label}</strong> - {benefit.text}
@@ -106,7 +106,7 @@ export function SolidPodPrompt({
             </Button>
           </div>
 
-          <p className="text-xs text-gray-500 text-center">
+          <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
             You can always set this up later from the navigation menu
           </p>
         </div>

--- a/src/components/SolidProviderSelector.tsx
+++ b/src/components/SolidProviderSelector.tsx
@@ -143,21 +143,21 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
     <Modal isOpen={isOpen} onClose={handleClose} title="Sync &amp; Share your lists">
       <div className="space-y-4">
         {/* Payoff first, mechanism second — signing in is what unlocks these */}
-        <div className="bg-blue-50 border border-blue-200 rounded-md p-4 space-y-2">
-          <p className="text-sm text-gray-700">
+        <div className="bg-blue-50 dark:bg-blue-950/40 border border-blue-200 dark:border-blue-800 rounded-md p-4 space-y-2">
+          <p className="text-sm text-gray-700 dark:text-gray-300">
             Signing in lets you <strong>sync across your devices</strong> and <strong>share lists</strong> — a single list with a friend, or your whole question set with the person you travel with.
           </p>
           <details className="group">
-            <summary className="text-sm font-semibold text-gray-900 cursor-pointer list-none marker:content-none">
+            <summary className="text-sm font-semibold text-gray-900 dark:text-gray-100 cursor-pointer list-none marker:content-none">
               <span className="group-open:hidden">▸ </span>
               <span className="hidden group-open:inline">▾ </span>
               What is a Solid Pod?
             </summary>
             <div className="mt-2 space-y-2">
-              <p className="text-sm text-gray-700">
+              <p className="text-sm text-gray-700 dark:text-gray-300">
                 Signing in uses a Solid Pod: personal data storage that <strong>you control</strong>. Instead of storing your packing lists on our servers, they're stored in your own secure space.
               </p>
-              <ul className="text-sm text-gray-700 space-y-1 ml-4 list-disc">
+              <ul className="text-sm text-gray-700 dark:text-gray-300 space-y-1 ml-4 list-disc">
                 <li><strong>You own your data</strong> - it stays in your Pod</li>
                 <li><strong>Privacy-focused</strong> - you choose who can access it</li>
                 <li><strong>Portable</strong> - use your Pod with any Solid app</li>
@@ -167,18 +167,18 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
         </div>
 
         {connectingTo ? (
-          <div className="border-t border-gray-200 pt-6 pb-4 flex flex-col items-center gap-3" aria-live="polite">
-            <svg className="h-8 w-8 animate-spin text-blue-500" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <div className="border-t border-gray-200 dark:border-gray-700 pt-6 pb-4 flex flex-col items-center gap-3" aria-live="polite">
+            <svg className="h-8 w-8 animate-spin text-blue-500 dark:text-blue-400" viewBox="0 0 24 24" fill="none" aria-hidden="true">
               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
             </svg>
-            <p className="text-sm text-gray-700">Connecting to {connectingTo.name}…</p>
-            <p className="text-xs text-gray-500 text-center">
+            <p className="text-sm text-gray-700 dark:text-gray-300">Connecting to {connectingTo.name}…</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
               You'll be taken to your provider to sign in.
             </p>
           </div>
         ) : (
-          <div className="border-t border-gray-200 pt-4 space-y-3">
+          <div className="border-t border-gray-200 dark:border-gray-700 pt-4 space-y-3">
             <Input
               label="Search providers or paste your Pod URL"
               type="text"
@@ -193,7 +193,7 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
             />
 
             {error && (
-              <p role="alert" className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2">
+              <p role="alert" className="text-sm text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-800 rounded-md px-3 py-2">
                 {error}
               </p>
             )}
@@ -205,10 +205,10 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
                   data-provider-option
                   aria-label={`Connect to ${typedUrl}`}
                   onClick={() => void connect(providerForIssuer(typedUrl))}
-                  className="w-full text-left px-4 py-3 border-2 border-blue-400 bg-blue-50 hover:bg-blue-100 hover:border-blue-500 rounded-md transition-colors"
+                  className="w-full text-left px-4 py-3 border-2 border-blue-400 dark:border-blue-600 bg-blue-50 dark:bg-blue-950/40 hover:bg-blue-100 dark:hover:bg-blue-900/40 hover:border-blue-500 dark:hover:border-blue-600 rounded-md transition-colors"
                 >
-                  <div className="font-medium text-gray-900 break-all">{typedUrl}</div>
-                  <div className="text-xs text-blue-700 font-medium">Use this Pod URL</div>
+                  <div className="font-medium text-gray-900 dark:text-gray-100 break-all">{typedUrl}</div>
+                  <div className="text-xs text-blue-700 dark:text-blue-300 font-medium">Use this Pod URL</div>
                 </button>
               )}
 
@@ -221,18 +221,18 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
                     data-provider-option
                     aria-label={provider.name}
                     onClick={() => void connect(provider)}
-                    className="w-full text-left px-4 py-3 border border-gray-300 hover:bg-gray-50 hover:border-gray-400 rounded-md transition-colors"
+                    className="w-full text-left px-4 py-3 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-400 dark:hover:border-gray-500 rounded-md transition-colors"
                   >
-                    <div className="font-medium text-gray-900 break-all">{provider.name}</div>
+                    <div className="font-medium text-gray-900 dark:text-gray-100 break-all">{provider.name}</div>
                     {provider.description && (
-                      <div className="text-xs text-green-700 font-medium">{provider.description}</div>
+                      <div className="text-xs text-green-700 dark:text-green-300 font-medium">{provider.description}</div>
                     )}
                     <div className="flex items-baseline justify-between gap-2">
                       {provider.name === provider.issuer
                         ? <span />
-                        : <span className="text-xs text-gray-400 break-all">{provider.issuer}</span>}
+                        : <span className="text-xs text-gray-400 dark:text-gray-500 break-all">{provider.issuer}</span>}
                       {isLastUsed && (
-                        <span className="text-xs font-medium text-blue-700 whitespace-nowrap">Last used</span>
+                        <span className="text-xs font-medium text-blue-700 dark:text-blue-300 whitespace-nowrap">Last used</span>
                       )}
                     </div>
                   </button>
@@ -240,7 +240,7 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
               })}
 
               {providers.length === 0 && !typedUrl && (
-                <p className="text-sm text-gray-500 text-center py-2">
+                <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-2">
                   No matching providers. Paste your Pod's URL to connect to it directly.
                 </p>
               )}
@@ -248,7 +248,7 @@ export function SolidProviderSelector({ isOpen, onClose, onSelect }: SolidProvid
           </div>
         )}
 
-        <p className="text-xs text-gray-500 text-center">
+        <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
           No Pod? No problem — your data saves locally in your browser automatically.
         </p>
       </div>

--- a/src/components/SyncAcrossDevicesPrompt.tsx
+++ b/src/components/SyncAcrossDevicesPrompt.tsx
@@ -42,10 +42,10 @@ export function SyncAcrossDevicesPrompt() {
         <>
             <div
                 data-testid="sync-across-devices-prompt"
-                className="mb-6 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-primary-200 bg-primary-50/70 px-4 py-3"
+                className="mb-6 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-primary-200 dark:border-primary-800 bg-primary-50/70 px-4 py-3"
             >
-                <p className="flex-1 min-w-50 text-sm text-gray-700">
-                    <span className="font-bold text-primary-900">📱 Sync across devices</span>
+                <p className="flex-1 min-w-50 text-sm text-gray-700 dark:text-gray-300">
+                    <span className="font-bold text-primary-900 dark:text-primary-200">📱 Sync across devices</span>
                     {' — '}
                     sign in to pick these lists up on your phone or laptop, and keep them safe if you clear your browser.
                 </p>
@@ -53,7 +53,7 @@ export function SyncAcrossDevicesPrompt() {
                     <button
                         type="button"
                         onClick={() => setIsProviderSelectorOpen(true)}
-                        className="text-sm font-bold text-primary-700 underline hover:no-underline px-2 py-1"
+                        className="text-sm font-bold text-primary-700 dark:text-primary-300 underline hover:no-underline px-2 py-1"
                     >
                         Sign in
                     </button>
@@ -61,9 +61,9 @@ export function SyncAcrossDevicesPrompt() {
                         type="button"
                         onClick={handleDismiss}
                         aria-label="Dismiss sync prompt"
-                        className="p-2 rounded-lg hover:bg-primary-100 transition-colors"
+                        className="p-2 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-900/40 transition-colors"
                     >
-                        <XMarkIcon className="h-4 w-4 text-primary-700" />
+                        <XMarkIcon className="h-4 w-4 text-primary-700 dark:text-primary-300" />
                     </button>
                 </div>
             </div>

--- a/src/components/SyncAcrossDevicesPrompt.tsx
+++ b/src/components/SyncAcrossDevicesPrompt.tsx
@@ -42,7 +42,7 @@ export function SyncAcrossDevicesPrompt() {
         <>
             <div
                 data-testid="sync-across-devices-prompt"
-                className="mb-6 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-primary-200 dark:border-primary-800 bg-primary-50/70 px-4 py-3"
+                className="mb-6 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-primary-200 dark:border-primary-800 bg-primary-50/70 dark:bg-primary-950/40 px-4 py-3"
             >
                 <p className="flex-1 min-w-50 text-sm text-gray-700 dark:text-gray-300">
                     <span className="font-bold text-primary-900 dark:text-primary-200">📱 Sync across devices</span>

--- a/src/components/TemplateUpdatesCard.tsx
+++ b/src/components/TemplateUpdatesCard.tsx
@@ -77,9 +77,9 @@ export function TemplateUpdatesCard({ questionSet, onApply }: TemplateUpdatesCar
     const count = suggestions.length
 
     return (
-        <div className="bg-emerald-50 rounded-lg border border-emerald-200 p-4">
+        <div className="bg-emerald-50 dark:bg-emerald-950/40 rounded-lg border border-emerald-200 dark:border-emerald-800 p-4">
             <div className="flex items-start justify-between gap-4">
-                <p className="text-emerald-900 font-medium">
+                <p className="text-emerald-900 dark:text-emerald-200 font-medium">
                     ✨ We've added to the starter suggestions since you set up — {count} new suggestion{count === 1 ? '' : 's'} available.
                 </p>
                 <button
@@ -88,7 +88,7 @@ export function TemplateUpdatesCard({ questionSet, onApply }: TemplateUpdatesCar
                     title="No thanks — don't show these again"
                     disabled={isApplying}
                     onClick={handleDismiss}
-                    className="text-emerald-600 hover:text-emerald-900 text-xl leading-none flex-shrink-0 disabled:opacity-50"
+                    className="text-emerald-600 dark:text-emerald-400 hover:text-emerald-900 dark:hover:text-emerald-200 text-xl leading-none flex-shrink-0 disabled:opacity-50"
                 >
                     ×
                 </button>
@@ -98,7 +98,7 @@ export function TemplateUpdatesCard({ questionSet, onApply }: TemplateUpdatesCar
                 <button
                     type="button"
                     onClick={() => setIsExpanded(true)}
-                    className="mt-2 text-sm text-emerald-700 underline"
+                    className="mt-2 text-sm text-emerald-700 dark:text-emerald-300 underline"
                 >
                     Review suggestions
                 </button>
@@ -106,23 +106,23 @@ export function TemplateUpdatesCard({ questionSet, onApply }: TemplateUpdatesCar
                 <div className="mt-4 space-y-4">
                     {groups.map(group => (
                         <div key={group.label}>
-                            <p className="text-xs uppercase tracking-wide text-emerald-600 font-semibold mb-1">{group.label}</p>
+                            <p className="text-xs uppercase tracking-wide text-emerald-600 dark:text-emerald-400 font-semibold mb-1">{group.label}</p>
                             <div className="space-y-1.5">
                                 {group.items.map(s => (
                                     <label
                                         key={s.key}
-                                        className="flex items-start gap-2 text-sm text-gray-700 bg-white rounded border border-emerald-200 px-3 py-2"
+                                        className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-900 rounded border border-emerald-200 dark:border-emerald-800 px-3 py-2"
                                     >
                                         <input
                                             type="checkbox"
                                             checked={!unchecked.has(s.key)}
                                             onChange={() => toggleChecked(s.key)}
-                                            className="mt-0.5 h-4 w-4 text-emerald-600 rounded focus:ring-2 focus:ring-emerald-500"
+                                            className="mt-0.5 h-4 w-4 text-emerald-600 dark:text-emerald-400 rounded focus:ring-2 focus:ring-emerald-500"
                                         />
                                         <span>
-                                            <span className="font-medium text-gray-900">{s.label}</span>
+                                            <span className="font-medium text-gray-900 dark:text-gray-100">{s.label}</span>
                                             {KIND_HINT[s.kind] && (
-                                                <span className="ml-2 text-xs text-emerald-600">{KIND_HINT[s.kind]}</span>
+                                                <span className="ml-2 text-xs text-emerald-600 dark:text-emerald-400">{KIND_HINT[s.kind]}</span>
                                             )}
                                         </span>
                                     </label>
@@ -134,7 +134,7 @@ export function TemplateUpdatesCard({ questionSet, onApply }: TemplateUpdatesCar
                         <button
                             type="button"
                             onClick={() => setIsExpanded(false)}
-                            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-emerald-100"
+                            className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100 rounded-lg hover:bg-emerald-100 dark:hover:bg-emerald-900/40"
                         >
                             Not now
                         </button>

--- a/src/components/ThemeContext.test.tsx
+++ b/src/components/ThemeContext.test.tsx
@@ -1,0 +1,290 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import React from 'react'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { ThemeProvider, useIsDarkMode, useTheme, THEME_STORAGE_KEY } from './ThemeContext'
+
+/**
+ * A fake `matchMedia` we can drive: the OS theme can be set up front and
+ * changed mid-test, which is the case the previous attempt at dark mode
+ * (#281) got wrong.
+ */
+function installMatchMedia(initialPrefersDark: boolean) {
+    let prefersDark = initialPrefersDark
+    const listeners = new Set<(e: MediaQueryListEvent) => void>()
+
+    const mql = {
+        get matches() {
+            return prefersDark
+        },
+        media: '(prefers-color-scheme: dark)',
+        addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => {
+            listeners.add(cb)
+        },
+        removeEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => {
+            listeners.delete(cb)
+        },
+    }
+
+    window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia
+
+    return {
+        setOsTheme(dark: boolean) {
+            prefersDark = dark
+            act(() => {
+                listeners.forEach(cb => cb({ matches: dark } as MediaQueryListEvent))
+            })
+        },
+        get listenerCount() {
+            return listeners.size
+        },
+    }
+}
+
+function ThemeProbe() {
+    const { theme, preference, setTheme, toggleTheme } = useTheme()
+    return (
+        <div>
+            <span data-testid="theme">{theme}</span>
+            <span data-testid="preference">{preference ?? 'system'}</span>
+            <button onClick={() => setTheme('dark')}>choose dark</button>
+            <button onClick={() => setTheme('light')}>choose light</button>
+            <button onClick={toggleTheme}>toggle</button>
+        </div>
+    )
+}
+
+function renderProbe() {
+    return render(
+        <ThemeProvider>
+            <ThemeProbe />
+        </ThemeProvider>
+    )
+}
+
+const storedTheme = () => window.localStorage.getItem(THEME_STORAGE_KEY)
+const resolvedTheme = () => screen.getByTestId('theme').textContent
+const chosenPreference = () => screen.getByTestId('preference').textContent
+const htmlIsDark = () => document.documentElement.classList.contains('dark')
+
+describe('ThemeContext', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+        document.documentElement.classList.remove('dark')
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('follows the OS preference when nothing is stored', () => {
+        installMatchMedia(true)
+        renderProbe()
+
+        expect(resolvedTheme()).toBe('dark')
+        expect(chosenPreference()).toBe('system')
+        expect(htmlIsDark()).toBe(true)
+    })
+
+    it('keeps following the OS while the user has made no choice', () => {
+        const media = installMatchMedia(false)
+        renderProbe()
+
+        expect(resolvedTheme()).toBe('light')
+
+        media.setOsTheme(true)
+
+        expect(resolvedTheme()).toBe('dark')
+        expect(htmlIsDark()).toBe(true)
+        // Following the OS is not a choice, so nothing is written.
+        expect(storedTheme()).toBeNull()
+    })
+
+    it('prefers a stored choice over the OS preference', () => {
+        installMatchMedia(true)
+        window.localStorage.setItem(THEME_STORAGE_KEY, 'light')
+        renderProbe()
+
+        expect(resolvedTheme()).toBe('light')
+        expect(chosenPreference()).toBe('light')
+        expect(htmlIsDark()).toBe(false)
+    })
+
+    it('stops following the OS once the user chooses, including when the OS changes mid-session', () => {
+        // The #281 bug: a first-time visitor's media listener was attached with
+        // `[]` deps, so it kept overriding the choice made after mount.
+        const media = installMatchMedia(false)
+        renderProbe()
+
+        act(() => {
+            screen.getByText('choose dark').click()
+        })
+
+        expect(resolvedTheme()).toBe('dark')
+        expect(storedTheme()).toBe('dark')
+
+        media.setOsTheme(true)
+        expect(resolvedTheme()).toBe('dark')
+
+        // The OS going back to light must not undo the choice either.
+        media.setOsTheme(false)
+        expect(resolvedTheme()).toBe('dark')
+        expect(htmlIsDark()).toBe(true)
+        expect(storedTheme()).toBe('dark')
+    })
+
+    it('never lets the rendered theme and localStorage disagree', () => {
+        const media = installMatchMedia(true)
+        renderProbe()
+
+        act(() => {
+            screen.getByText('choose light').click()
+        })
+        expect(resolvedTheme()).toBe('light')
+        expect(storedTheme()).toBe('light')
+
+        media.setOsTheme(false)
+        media.setOsTheme(true)
+        expect(resolvedTheme()).toBe('light')
+        expect(storedTheme()).toBe('light')
+
+        act(() => {
+            screen.getByText('toggle').click()
+        })
+        expect(resolvedTheme()).toBe('dark')
+        expect(storedTheme()).toBe('dark')
+    })
+
+    it('toggles from the currently resolved theme', () => {
+        installMatchMedia(true)
+        renderProbe()
+
+        act(() => {
+            screen.getByText('toggle').click()
+        })
+
+        expect(resolvedTheme()).toBe('light')
+        expect(storedTheme()).toBe('light')
+    })
+
+    it('ignores an unrecognised stored value and falls back to the OS', () => {
+        installMatchMedia(true)
+        window.localStorage.setItem(THEME_STORAGE_KEY, 'aubergine')
+        renderProbe()
+
+        expect(resolvedTheme()).toBe('dark')
+        expect(chosenPreference()).toBe('system')
+    })
+
+    it('still works when localStorage is unavailable', () => {
+        installMatchMedia(true)
+        const denied = () => {
+            throw new Error('The operation is insecure.')
+        }
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(denied)
+        vi.spyOn(Storage.prototype, 'setItem').mockImplementation(denied)
+
+        expect(() => renderProbe()).not.toThrow()
+        expect(resolvedTheme()).toBe('dark')
+
+        expect(() =>
+            act(() => {
+                screen.getByText('choose light').click()
+            })
+        ).not.toThrow()
+        expect(resolvedTheme()).toBe('light')
+        expect(htmlIsDark()).toBe(false)
+    })
+
+    it('removes its media listener when unmounted', () => {
+        const media = installMatchMedia(false)
+        const { unmount } = renderProbe()
+
+        expect(media.listenerCount).toBeGreaterThan(0)
+        unmount()
+        expect(media.listenerCount).toBe(0)
+    })
+})
+
+describe('useIsDarkMode', () => {
+    function DarkProbe() {
+        return <span data-testid="is-dark">{String(useIsDarkMode())}</span>
+    }
+
+    beforeEach(() => {
+        document.documentElement.classList.remove('dark')
+    })
+
+    it('reads the theme off <html> without needing a provider', () => {
+        document.documentElement.classList.add('dark')
+
+        render(<DarkProbe />)
+
+        expect(screen.getByTestId('is-dark').textContent).toBe('true')
+    })
+
+    it('follows the class when the theme changes', async () => {
+        render(<DarkProbe />)
+        expect(screen.getByTestId('is-dark').textContent).toBe('false')
+
+        // The hook watches <html> for the class ThemeProvider toggles.
+        document.documentElement.classList.add('dark')
+
+        await waitFor(() => expect(screen.getByTestId('is-dark').textContent).toBe('true'))
+    })
+})
+
+/**
+ * The theme has to be on `<html>` before the first paint or the page flashes
+ * the wrong colours, which means a small inline script rather than React. It
+ * runs on every page load in every browser, so it must never throw — a
+ * cookie-blocked or sandboxed context makes `localStorage` itself throw.
+ */
+describe('pre-paint theme script in index.html', () => {
+    const html = readFileSync(resolve(__dirname, '../../index.html'), 'utf-8')
+    const inlineScript = /<script>([\s\S]*?)<\/script>/.exec(html)?.[1] ?? ''
+
+    beforeEach(() => {
+        window.localStorage.clear()
+        document.documentElement.classList.remove('dark')
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    const runScript = () => new Function(inlineScript)()
+
+    it('is present in index.html', () => {
+        expect(inlineScript).toContain('classList')
+    })
+
+    it('applies the stored theme', () => {
+        installMatchMedia(false)
+        window.localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+
+        runScript()
+
+        expect(htmlIsDark()).toBe(true)
+    })
+
+    it('falls back to the OS preference', () => {
+        installMatchMedia(true)
+
+        runScript()
+
+        expect(htmlIsDark()).toBe(true)
+    })
+
+    it('does not throw when localStorage is unavailable', () => {
+        installMatchMedia(true)
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            throw new Error('The operation is insecure.')
+        })
+
+        expect(() => runScript()).not.toThrow()
+        // Still gets the OS preference right despite the failure.
+        expect(htmlIsDark()).toBe(true)
+    })
+})

--- a/src/components/ThemeContext.tsx
+++ b/src/components/ThemeContext.tsx
@@ -1,0 +1,153 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, ReactNode } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+/**
+ * What the user has asked for. `null` means they have not asked for anything,
+ * so the OS decides — and keeps deciding, every time it changes.
+ */
+export type ThemePreference = Theme | null
+
+export const THEME_STORAGE_KEY = 'theme'
+
+const DARK_QUERY = '(prefers-color-scheme: dark)'
+
+const isTheme = (value: unknown): value is Theme => value === 'light' || value === 'dark'
+
+/**
+ * Storage access throws outright — not returns null — when cookies are blocked
+ * or the page is sandboxed, so every read and write is guarded. A theme is a
+ * nicety; losing it must never take the app down with it.
+ */
+function readStoredPreference(): ThemePreference {
+    try {
+        const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+        return isTheme(stored) ? stored : null
+    } catch {
+        return null
+    }
+}
+
+function writeStoredPreference(theme: Theme): void {
+    try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, theme)
+    } catch {
+        // Nothing to do: the choice still applies for this session.
+    }
+}
+
+function osPrefersDark(): boolean {
+    try {
+        return window.matchMedia(DARK_QUERY).matches
+    } catch {
+        return false
+    }
+}
+
+interface ThemeContextType {
+    /** The theme actually being rendered — a choice if there is one, else the OS. */
+    theme: Theme
+    /** The user's explicit choice, or `null` while the OS is in charge. */
+    preference: ThemePreference
+    setTheme: (theme: Theme) => void
+    toggleTheme: () => void
+    /** Hand control back to the OS. */
+    useSystemTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+    const [preference, setPreference] = useState<ThemePreference>(readStoredPreference)
+    const [systemTheme, setSystemTheme] = useState<Theme>(() => (osPrefersDark() ? 'dark' : 'light'))
+
+    /*
+     * The resolved theme is derived, not stored: a stored choice wins over the
+     * OS by construction, so an OS change arriving mid-session cannot overwrite
+     * it. #281 instead decided once at mount whether to listen to the OS, which
+     * left a first-time visitor's listener attached after they picked a theme —
+     * and it wrote only to state, so the app and localStorage then disagreed.
+     */
+    const theme: Theme = preference ?? systemTheme
+
+    useEffect(() => {
+        let media: MediaQueryList
+        try {
+            media = window.matchMedia(DARK_QUERY)
+        } catch {
+            return
+        }
+
+        const onChange = (event: MediaQueryListEvent) => {
+            setSystemTheme(event.matches ? 'dark' : 'light')
+        }
+
+        // The OS may have changed between the initial state and this effect.
+        setSystemTheme(media.matches ? 'dark' : 'light')
+        media.addEventListener('change', onChange)
+        return () => media.removeEventListener('change', onChange)
+    }, [])
+
+    useEffect(() => {
+        document.documentElement.classList.toggle('dark', theme === 'dark')
+        // Lets the browser paint form controls, scrollbars and the like to match.
+        document.documentElement.style.colorScheme = theme
+    }, [theme])
+
+    // A choice is written and held together, so the two can never drift apart.
+    const setTheme = useCallback((next: Theme) => {
+        writeStoredPreference(next)
+        setPreference(next)
+    }, [])
+
+    const toggleTheme = useCallback(() => {
+        setTheme(theme === 'dark' ? 'light' : 'dark')
+    }, [setTheme, theme])
+
+    const useSystemTheme = useCallback(() => {
+        try {
+            window.localStorage.removeItem(THEME_STORAGE_KEY)
+        } catch {
+            // See writeStoredPreference.
+        }
+        setPreference(null)
+    }, [])
+
+    const value = useMemo(
+        () => ({ theme, preference, setTheme, toggleTheme, useSystemTheme }),
+        [theme, preference, setTheme, toggleTheme, useSystemTheme]
+    )
+
+    return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+/**
+ * The current theme read straight off `<html>`, for components that need the
+ * colour in JavaScript rather than in a `dark:` class — react-select's inline
+ * styles, chiefly. It works without a provider, so a component using it can
+ * still be rendered on its own in a test, and follows the class rather than the
+ * context so it cannot drift from what the CSS is doing.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useIsDarkMode(): boolean {
+    const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'))
+
+    useEffect(() => {
+        const read = () => setIsDark(document.documentElement.classList.contains('dark'))
+        read()
+        const observer = new MutationObserver(read)
+        observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+        return () => observer.disconnect()
+    }, [])
+
+    return isDark
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useTheme() {
+    const context = useContext(ThemeContext)
+    if (context === undefined) {
+        throw new Error('useTheme must be used within a ThemeProvider')
+    }
+    return context
+}

--- a/src/components/ThemeToggle.test.tsx
+++ b/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { ThemeProvider, THEME_STORAGE_KEY } from './ThemeContext'
+import { ThemeToggle } from './ThemeToggle'
+
+function renderToggle(props: Partial<React.ComponentProps<typeof ThemeToggle>> = {}) {
+    return render(
+        <ThemeProvider>
+            <ThemeToggle {...props} />
+        </ThemeProvider>
+    )
+}
+
+describe('ThemeToggle', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+        document.documentElement.classList.remove('dark')
+        window.matchMedia = vi.fn().mockReturnValue({
+            matches: false,
+            media: '(prefers-color-scheme: dark)',
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        }) as unknown as typeof window.matchMedia
+    })
+
+    it('offers to switch to dark while the app is light', () => {
+        renderToggle()
+
+        expect(screen.getByRole('button', { name: /switch to dark mode/i })).toBeTruthy()
+    })
+
+    it('switches the theme when clicked, and then offers the way back', () => {
+        renderToggle()
+
+        fireEvent.click(screen.getByRole('button', { name: /switch to dark mode/i }))
+
+        expect(document.documentElement.classList.contains('dark')).toBe(true)
+        expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+
+        fireEvent.click(screen.getByRole('button', { name: /switch to light mode/i }))
+
+        expect(document.documentElement.classList.contains('dark')).toBe(false)
+        expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light')
+    })
+
+    it('shows a visible label when asked, for the mobile menu', () => {
+        renderToggle({ showLabel: true })
+
+        expect(screen.getByText('Dark mode')).toBeTruthy()
+    })
+
+    it('has no visible label by default, for the icon-only desktop nav', () => {
+        renderToggle()
+
+        expect(screen.queryByText('Dark mode')).toBeNull()
+    })
+})

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+import { MoonIcon, SunIcon } from '@heroicons/react/24/outline'
+import { useTheme } from './ThemeContext'
+
+interface ThemeToggleProps {
+    /** The mobile menu is a list of labelled rows, so the icon alone won't do. */
+    showLabel?: boolean
+    className?: string
+}
+
+/**
+ * Switches between light and dark. Clicking it is an explicit choice, so from
+ * then on the OS setting no longer has a say — see ThemeContext.
+ */
+export const ThemeToggle = ({ showLabel = false, className = '' }: ThemeToggleProps) => {
+    const { theme, toggleTheme } = useTheme()
+    const goingDark = theme === 'light'
+    const label = goingDark ? 'Switch to dark mode' : 'Switch to light mode'
+
+    return (
+        <button
+            type="button"
+            onClick={toggleTheme}
+            aria-label={label}
+            title={label}
+            className={
+                showLabel
+                    ? `w-full flex items-center gap-3 px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200 ${className}`
+                    : `p-2 rounded-lg text-white hover:bg-white/20 transition-all duration-200 ${className}`
+            }
+        >
+            {goingDark ? <MoonIcon className="h-5 w-5" aria-hidden="true" /> : <SunIcon className="h-5 w-5" aria-hidden="true" />}
+            {showLabel && <span>{goingDark ? 'Dark mode' : 'Light mode'}</span>}
+        </button>
+    )
+}

--- a/src/components/UpdateFromQuestionsModal.tsx
+++ b/src/components/UpdateFromQuestionsModal.tsx
@@ -59,27 +59,27 @@ export function UpdateFromQuestionsModal({
 
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Update from questions">
-            <p className="text-sm text-gray-600 mb-4">
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                 Your questions have new items that match this trip. Choose which to add.
             </p>
             <div className="max-h-96 overflow-y-auto space-y-4">
                 {groups.map(group => (
                     <div key={group.label}>
-                        <p className="text-sm font-semibold text-gray-700 mb-2">{group.label}</p>
+                        <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{group.label}</p>
                         <div className="space-y-1">
                             {group.items.map(item => (
-                                <label key={item.id} className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer">
+                                <label key={item.id} className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer">
                                     <input
                                         type="checkbox"
                                         aria-label={`Add ${item.itemText}${item.personName ? ` for ${item.personName}` : ''}`}
                                         checked={!excludedIds.has(item.id)}
                                         onChange={() => toggle(item.id)}
-                                        className="h-4 w-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+                                        className="h-4 w-4 text-blue-600 dark:text-blue-400 rounded focus:ring-2 focus:ring-blue-500"
                                     />
-                                    <span className="text-gray-900">
+                                    <span className="text-gray-900 dark:text-gray-100">
                                         {item.itemText}
                                         {item.quantity !== undefined && (
-                                            <span className="ml-1.5 text-sm text-gray-500">×{item.quantity}</span>
+                                            <span className="ml-1.5 text-sm text-gray-500 dark:text-gray-400">×{item.quantity}</span>
                                         )}
                                     </span>
                                 </label>

--- a/src/edit-questions/person-colors.ts
+++ b/src/edit-questions/person-colors.ts
@@ -57,19 +57,19 @@ export interface PersonColor {
 }
 
 export const PERSON_COLORS: readonly PersonColor[] = [
-    { id: 'blue', label: 'Blue', avatar: 'bg-blue-500 text-white', border: 'border-blue-300', soft: 'bg-blue-50', text: 'text-blue-900', ring: 'ring-blue-400' },
-    { id: 'violet', label: 'Violet', avatar: 'bg-violet-500 text-white', border: 'border-violet-300', soft: 'bg-violet-50', text: 'text-violet-900', ring: 'ring-violet-400' },
-    { id: 'emerald', label: 'Emerald', avatar: 'bg-emerald-500 text-white', border: 'border-emerald-300', soft: 'bg-emerald-50', text: 'text-emerald-900', ring: 'ring-emerald-400' },
-    { id: 'amber', label: 'Amber', avatar: 'bg-amber-500 text-white', border: 'border-amber-300', soft: 'bg-amber-50', text: 'text-amber-900', ring: 'ring-amber-400' },
-    { id: 'rose', label: 'Rose', avatar: 'bg-rose-500 text-white', border: 'border-rose-300', soft: 'bg-rose-50', text: 'text-rose-900', ring: 'ring-rose-400' },
-    { id: 'cyan', label: 'Cyan', avatar: 'bg-cyan-500 text-white', border: 'border-cyan-300', soft: 'bg-cyan-50', text: 'text-cyan-900', ring: 'ring-cyan-400' },
-    { id: 'orange', label: 'Orange', avatar: 'bg-orange-500 text-white', border: 'border-orange-300', soft: 'bg-orange-50', text: 'text-orange-900', ring: 'ring-orange-400' },
-    { id: 'indigo', label: 'Indigo', avatar: 'bg-indigo-500 text-white', border: 'border-indigo-300', soft: 'bg-indigo-50', text: 'text-indigo-900', ring: 'ring-indigo-400' },
-    { id: 'teal', label: 'Teal', avatar: 'bg-teal-500 text-white', border: 'border-teal-300', soft: 'bg-teal-50', text: 'text-teal-900', ring: 'ring-teal-400' },
-    { id: 'fuchsia', label: 'Fuchsia', avatar: 'bg-fuchsia-500 text-white', border: 'border-fuchsia-300', soft: 'bg-fuchsia-50', text: 'text-fuchsia-900', ring: 'ring-fuchsia-400' },
+    { id: 'blue', label: 'Blue', avatar: 'bg-blue-500 text-white', border: 'border-blue-300 dark:border-blue-700', soft: 'bg-blue-50 dark:bg-blue-950/40', text: 'text-blue-900 dark:text-blue-200', ring: 'ring-blue-400' },
+    { id: 'violet', label: 'Violet', avatar: 'bg-violet-500 text-white', border: 'border-violet-300 dark:border-violet-700', soft: 'bg-violet-50 dark:bg-violet-950/40', text: 'text-violet-900 dark:text-violet-200', ring: 'ring-violet-400' },
+    { id: 'emerald', label: 'Emerald', avatar: 'bg-emerald-500 text-white', border: 'border-emerald-300 dark:border-emerald-700', soft: 'bg-emerald-50 dark:bg-emerald-950/40', text: 'text-emerald-900 dark:text-emerald-200', ring: 'ring-emerald-400' },
+    { id: 'amber', label: 'Amber', avatar: 'bg-amber-500 text-white', border: 'border-amber-300 dark:border-amber-700', soft: 'bg-amber-50 dark:bg-amber-950/40', text: 'text-amber-900 dark:text-amber-200', ring: 'ring-amber-400' },
+    { id: 'rose', label: 'Rose', avatar: 'bg-rose-500 text-white', border: 'border-rose-300 dark:border-rose-700', soft: 'bg-rose-50 dark:bg-rose-950/40', text: 'text-rose-900 dark:text-rose-200', ring: 'ring-rose-400' },
+    { id: 'cyan', label: 'Cyan', avatar: 'bg-cyan-500 text-white', border: 'border-cyan-300 dark:border-cyan-700', soft: 'bg-cyan-50 dark:bg-cyan-950/40', text: 'text-cyan-900 dark:text-cyan-200', ring: 'ring-cyan-400' },
+    { id: 'orange', label: 'Orange', avatar: 'bg-orange-500 text-white', border: 'border-orange-300 dark:border-orange-700', soft: 'bg-orange-50 dark:bg-orange-950/40', text: 'text-orange-900 dark:text-orange-200', ring: 'ring-orange-400' },
+    { id: 'indigo', label: 'Indigo', avatar: 'bg-indigo-500 text-white', border: 'border-indigo-300 dark:border-indigo-700', soft: 'bg-indigo-50 dark:bg-indigo-950/40', text: 'text-indigo-900 dark:text-indigo-200', ring: 'ring-indigo-400' },
+    { id: 'teal', label: 'Teal', avatar: 'bg-teal-500 text-white', border: 'border-teal-300 dark:border-teal-700', soft: 'bg-teal-50 dark:bg-teal-950/40', text: 'text-teal-900 dark:text-teal-200', ring: 'ring-teal-400' },
+    { id: 'fuchsia', label: 'Fuchsia', avatar: 'bg-fuchsia-500 text-white', border: 'border-fuchsia-300 dark:border-fuchsia-700', soft: 'bg-fuchsia-50 dark:bg-fuchsia-950/40', text: 'text-fuchsia-900 dark:text-fuchsia-200', ring: 'ring-fuchsia-400' },
     // The one initial not written in white: lime is too bright to carry it.
-    { id: 'lime', label: 'Lime', avatar: 'bg-lime-400 text-lime-950', border: 'border-lime-300', soft: 'bg-lime-50', text: 'text-lime-900', ring: 'ring-lime-500' },
-    { id: 'pink', label: 'Pink', avatar: 'bg-pink-500 text-white', border: 'border-pink-300', soft: 'bg-pink-50', text: 'text-pink-900', ring: 'ring-pink-400' },
+    { id: 'lime', label: 'Lime', avatar: 'bg-lime-400 text-lime-950', border: 'border-lime-300 dark:border-lime-700', soft: 'bg-lime-50 dark:bg-lime-950/40', text: 'text-lime-900 dark:text-lime-200', ring: 'ring-lime-500' },
+    { id: 'pink', label: 'Pink', avatar: 'bg-pink-500 text-white', border: 'border-pink-300 dark:border-pink-700', soft: 'bg-pink-50 dark:bg-pink-950/40', text: 'text-pink-900 dark:text-pink-200', ring: 'ring-pink-400' },
 ]
 
 /**
@@ -88,7 +88,7 @@ export const LEGACY_AVATAR_ROTATION: readonly string[] = [
 ]
 
 /** An avatar for someone this item isn't for: present, but plainly off. */
-export const PERSON_COLOR_OFF = 'bg-gray-100 text-gray-300'
+export const PERSON_COLOR_OFF = 'bg-gray-100 dark:bg-gray-800 text-gray-300 dark:text-gray-600'
 
 const BY_ID = new Map<string, PersonColor>(PERSON_COLORS.map(color => [color.id, color]))
 

--- a/src/edit-questions/section-accent.ts
+++ b/src/edit-questions/section-accent.ts
@@ -36,14 +36,14 @@ export interface SectionAccent {
  * the same colour would suggest a link that isn't there.
  */
 export const SECTION_ACCENTS: readonly SectionAccent[] = [
-    { border: 'border-violet-200', header: 'bg-violet-50', text: 'text-violet-900', muted: 'text-violet-500', rail: 'bg-violet-400' },
-    { border: 'border-amber-200', header: 'bg-amber-50', text: 'text-amber-900', muted: 'text-amber-600', rail: 'bg-amber-400' },
-    { border: 'border-rose-200', header: 'bg-rose-50', text: 'text-rose-900', muted: 'text-rose-500', rail: 'bg-rose-400' },
-    { border: 'border-cyan-200', header: 'bg-cyan-50', text: 'text-cyan-900', muted: 'text-cyan-600', rail: 'bg-cyan-400' },
-    { border: 'border-lime-200', header: 'bg-lime-50', text: 'text-lime-900', muted: 'text-lime-600', rail: 'bg-lime-500' },
-    { border: 'border-fuchsia-200', header: 'bg-fuchsia-50', text: 'text-fuchsia-900', muted: 'text-fuchsia-500', rail: 'bg-fuchsia-400' },
-    { border: 'border-indigo-200', header: 'bg-indigo-50', text: 'text-indigo-900', muted: 'text-indigo-500', rail: 'bg-indigo-400' },
-    { border: 'border-orange-200', header: 'bg-orange-50', text: 'text-orange-900', muted: 'text-orange-600', rail: 'bg-orange-400' },
+    { border: 'border-violet-200 dark:border-violet-800', header: 'bg-violet-50 dark:bg-violet-950/40', text: 'text-violet-900 dark:text-violet-200', muted: 'text-violet-500 dark:text-violet-400', rail: 'bg-violet-400' },
+    { border: 'border-amber-200 dark:border-amber-800', header: 'bg-amber-50 dark:bg-amber-950/40', text: 'text-amber-900 dark:text-amber-200', muted: 'text-amber-600 dark:text-amber-400', rail: 'bg-amber-400' },
+    { border: 'border-rose-200 dark:border-rose-800', header: 'bg-rose-50 dark:bg-rose-950/40', text: 'text-rose-900 dark:text-rose-200', muted: 'text-rose-500 dark:text-rose-400', rail: 'bg-rose-400' },
+    { border: 'border-cyan-200 dark:border-cyan-800', header: 'bg-cyan-50 dark:bg-cyan-950/40', text: 'text-cyan-900 dark:text-cyan-200', muted: 'text-cyan-600 dark:text-cyan-400', rail: 'bg-cyan-400' },
+    { border: 'border-lime-200 dark:border-lime-800', header: 'bg-lime-50 dark:bg-lime-950/40', text: 'text-lime-900 dark:text-lime-200', muted: 'text-lime-600 dark:text-lime-400', rail: 'bg-lime-500' },
+    { border: 'border-fuchsia-200 dark:border-fuchsia-800', header: 'bg-fuchsia-50 dark:bg-fuchsia-950/40', text: 'text-fuchsia-900 dark:text-fuchsia-200', muted: 'text-fuchsia-500 dark:text-fuchsia-400', rail: 'bg-fuchsia-400' },
+    { border: 'border-indigo-200 dark:border-indigo-800', header: 'bg-indigo-50 dark:bg-indigo-950/40', text: 'text-indigo-900 dark:text-indigo-200', muted: 'text-indigo-500 dark:text-indigo-400', rail: 'bg-indigo-400' },
+    { border: 'border-orange-200 dark:border-orange-800', header: 'bg-orange-50 dark:bg-orange-950/40', text: 'text-orange-900 dark:text-orange-200', muted: 'text-orange-600 dark:text-orange-400', rail: 'bg-orange-400' },
 ]
 
 /**
@@ -52,10 +52,10 @@ export const SECTION_ACCENTS: readonly SectionAccent[] = [
  * That way colour on this page always means "someone named this group".
  */
 export const DEFAULT_SECTION_ACCENT: SectionAccent = {
-    border: 'border-gray-200',
-    header: 'bg-gray-100',
-    text: 'text-gray-700',
-    muted: 'text-gray-400',
+    border: 'border-gray-200 dark:border-gray-700',
+    header: 'bg-gray-100 dark:bg-gray-800',
+    text: 'text-gray-700 dark:text-gray-300',
+    muted: 'text-gray-400 dark:text-gray-500',
     rail: 'bg-gray-300',
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,12 @@
 @import "tailwindcss";
 
+/*
+ * Dark mode follows a class on <html> rather than the media query, so a theme
+ * the user picked outlives the OS setting. ThemeContext puts the class there;
+ * the inline script in index.html gets it there before the first paint.
+ */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   /* Primary - Very Dark Teal for navigation */
   --color-primary-950: #042f2e;
@@ -269,6 +276,11 @@ body {
   animation: loading-skeleton-sweep 1.6s ease-in-out infinite;
 }
 
+.dark .loading-skeleton-bar {
+  background-color: #1f2937;
+  background-image: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.12) 50%, transparent 100%);
+}
+
 /* Ticking an item is the move the user repeats hundreds of times a trip, so it
    gets a beat of acknowledgement — a green swell and a tick lifting out of the
    checkbox — before the row is whisked out of the unpacked list. Kept in step
@@ -289,8 +301,30 @@ body {
   100% { transform: translate(-50%, -135%) scale(1); opacity: 0; }
 }
 
+@keyframes item-packed-swell-dark {
+  0% { transform: scale(1); background-color: rgb(17 24 39); }
+  30% { transform: scale(1.02); background-color: rgb(6 78 59); }
+  70% { transform: scale(1); background-color: rgb(6 78 59); }
+  100% { transform: scale(1); background-color: rgb(17 24 39); }
+}
+
+@keyframes grid-cell-packed-dark {
+  0% { transform: scale(1); background-color: transparent; }
+  30% { transform: scale(1.06); background-color: rgb(6 78 59); }
+  70% { transform: scale(1); background-color: rgb(6 78 59); }
+  100% { transform: scale(1); background-color: transparent; }
+}
+
 .item-row-packed {
   animation: item-packed-swell 0.45s ease-out;
+}
+
+.dark .item-row-packed {
+  animation-name: item-packed-swell-dark;
+}
+
+.dark .grid-cell-packed {
+  animation-name: grid-cell-packed-dark;
 }
 
 .item-packed-tick {

--- a/src/index.css
+++ b/src/index.css
@@ -130,6 +130,20 @@ body {
   overscroll-behavior: none;
 }
 
+/*
+ * The page's own ground colour, painted before React mounts. Without it the
+ * browser — and the Capacitor WebView especially — shows white while the
+ * bundle loads, which is the flash the pre-paint script in index.html exists
+ * to avoid.
+ */
+html {
+  background-color: #ffffff;
+}
+
+html.dark {
+  background-color: #030712;
+}
+
 /* Wizard generation reveal: each line eases in as it is added */
 @keyframes reveal-line-in {
   from { opacity: 0; transform: translateY(6px); }

--- a/src/pages/backups.tsx
+++ b/src/pages/backups.tsx
@@ -102,8 +102,8 @@ export function BackupsPage() {
     if (!isLoggedIn) {
         return (
             <div className="max-w-4xl mx-auto py-8 px-4">
-                <h1 className="text-4xl font-bold text-primary-900 mb-4">Backups</h1>
-                <p className="text-lg text-gray-700 font-medium">
+                <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200 mb-4">Backups</h1>
+                <p className="text-lg text-gray-700 dark:text-gray-300 font-medium">
                     Backups require a Solid Pod login. Please log in to manage your backups.
                 </p>
             </div>
@@ -114,8 +114,8 @@ export function BackupsPage() {
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8 flex justify-between items-start">
                 <div>
-                    <h1 className="text-4xl font-bold text-primary-900">Backups</h1>
-                    <p className="mt-2 text-lg text-gray-700 font-medium">
+                    <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">Backups</h1>
+                    <p className="mt-2 text-lg text-gray-700 dark:text-gray-300 font-medium">
                         Create and restore backups of your packing data.
                     </p>
                 </div>
@@ -132,22 +132,22 @@ export function BackupsPage() {
             {isLoadingBackups ? (
                 <LoadingState message="Loading backups..." rows={2} />
             ) : backups.length === 0 ? (
-                <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
-                    <p className="text-lg text-gray-800 font-semibold">No backups yet</p>
+                <div className="text-center py-12 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft">
+                    <p className="text-lg text-gray-800 dark:text-gray-100 font-semibold">No backups yet</p>
                 </div>
             ) : (
                 <div className="space-y-4">
                     {backups.map(backup => (
                         <div
                             key={backup.url}
-                            className="bg-white rounded-2xl border-2 border-primary-200 shadow-soft p-5"
+                            className="bg-white dark:bg-gray-900 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft p-5"
                         >
                             <div className="flex justify-between items-center">
                                 <div>
-                                    <p className="font-semibold text-gray-900">
+                                    <p className="font-semibold text-gray-900 dark:text-gray-100">
                                         {new Date(backup.createdAt).toLocaleString()}
                                     </p>
-                                    <p className="text-sm text-gray-600 mt-1">
+                                    <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
                                         {backup.packingListCount} packing list{backup.packingListCount !== 1 ? 's' : ''}
                                         {backup.hasQuestionSet ? ' · question set included' : ''}
                                     </p>
@@ -163,7 +163,7 @@ export function BackupsPage() {
                                     <button
                                         type="button"
                                         onClick={() => handleDelete(backup)}
-                                        className="px-4 py-2 rounded-xl font-semibold text-sm text-danger-600 hover:bg-danger-50 border-2 border-danger-200 hover:border-danger-400 transition-all duration-200"
+                                        className="px-4 py-2 rounded-xl font-semibold text-sm text-danger-600 dark:text-danger-400 hover:bg-danger-50 dark:hover:bg-danger-950/40 border-2 border-danger-200 dark:border-danger-800 hover:border-danger-400 dark:hover:border-danger-600 transition-all duration-200"
                                     >
                                         Delete
                                     </button>

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -121,16 +121,16 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
     }, [suggestions])
 
     return (
-        <div className="bg-amber-50 rounded-lg border border-amber-200 p-4">
+        <div className="bg-amber-50 dark:bg-amber-950/40 rounded-lg border border-amber-200 dark:border-amber-800 p-4">
             <div className="flex items-start justify-between gap-4">
-                <p className="text-amber-900 font-medium">
+                <p className="text-amber-900 dark:text-amber-200 font-medium">
                     On past trips you added items that aren't in your question set yet. Want to add any for next time?
                 </p>
                 <button
                     type="button"
                     aria-label="Dismiss suggestions"
                     onClick={onDismiss}
-                    className="text-amber-600 hover:text-amber-900 text-xl leading-none flex-shrink-0"
+                    className="text-amber-600 dark:text-amber-400 hover:text-amber-900 dark:hover:text-amber-200 text-xl leading-none flex-shrink-0"
                 >
                     ×
                 </button>
@@ -139,7 +139,7 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                 <button
                     type="button"
                     onClick={() => setIsExpanded(true)}
-                    className="mt-2 text-sm text-amber-700 underline"
+                    className="mt-2 text-sm text-amber-700 dark:text-amber-300 underline"
                     aria-label="Review suggestions"
                 >
                     Review suggestions
@@ -148,7 +148,7 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                 <div className="mt-4 space-y-4">
                     {grouped.map(({ listName, items }) => (
                         <div key={listName}>
-                            <p className="text-sm text-amber-700 font-semibold mb-2">From: {listName}</p>
+                            <p className="text-sm text-amber-700 dark:text-amber-300 font-semibold mb-2">From: {listName}</p>
                             <div className="space-y-2">
                                 {items.map(({ listId, item }) => {
                                     const destValue = destinations[item.id] ?? 'always'
@@ -160,11 +160,11 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                         })()
                                     const isShared = communalFlags[item.id] ?? item.communal ?? false
                                     return (
-                                    <div key={item.id} className="flex flex-col gap-2 bg-white rounded border border-amber-200 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+                                    <div key={item.id} className="flex flex-col gap-2 bg-white dark:bg-gray-900 rounded border border-amber-200 dark:border-amber-800 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
                                         <div>
-                                            <span className="font-medium text-gray-900">{item.itemText}</span>
+                                            <span className="font-medium text-gray-900 dark:text-gray-100">{item.itemText}</span>
                                             {item.personName && (
-                                                <span className="ml-2 text-sm text-gray-500">for {item.personName}</span>
+                                                <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">for {item.personName}</span>
                                             )}
                                         </div>
                                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -172,7 +172,7 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                                 aria-label={`Destination for ${item.itemText}`}
                                                 value={destValue}
                                                 onChange={(e) => setDestinations(prev => ({ ...prev, [item.id]: e.target.value }))}
-                                                className="w-full text-sm border border-amber-300 rounded px-2 py-1 sm:flex-1 sm:min-w-0"
+                                                className="w-full text-sm border border-amber-300 dark:border-amber-700 rounded px-2 py-1 sm:flex-1 sm:min-w-0"
                                             >
                                                 <option value="always">Always Needed Items</option>
                                                 {questionSet.questions.flatMap(q =>
@@ -183,13 +183,13 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                                     ))
                                                 )}
                                             </select>
-                                            <label className="flex items-center gap-1.5 text-sm text-gray-600 shrink-0" title="Packed once for the whole group instead of per person">
+                                            <label className="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 shrink-0" title="Packed once for the whole group instead of per person">
                                                 <input
                                                     type="checkbox"
                                                     aria-label={`Save ${item.itemText} as a shared item`}
                                                     checked={isShared}
                                                     onChange={(e) => setCommunalFlags(prev => ({ ...prev, [item.id]: e.target.checked }))}
-                                                    className="h-4 w-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+                                                    className="h-4 w-4 text-blue-600 dark:text-blue-400 rounded focus:ring-2 focus:ring-blue-500"
                                                 />
                                                 👥 Shared
                                             </label>
@@ -244,16 +244,16 @@ function DeletionSuggestionCard({ suggestions, onRemovePermanently, onKeep, onDi
     }, [suggestions])
 
     return (
-        <div className="bg-red-50 rounded-lg border border-red-200 p-4">
+        <div className="bg-red-50 dark:bg-red-950/40 rounded-lg border border-red-200 dark:border-red-800 p-4">
             <div className="flex items-start justify-between gap-4">
-                <p className="text-red-900 font-medium">
+                <p className="text-red-900 dark:text-red-200 font-medium">
                     On past trips you previously removed items that are still in your question set. Want to stop including them?
                 </p>
                 <button
                     type="button"
                     aria-label="Dismiss removals"
                     onClick={onDismiss}
-                    className="text-red-600 hover:text-red-900 text-xl leading-none flex-shrink-0"
+                    className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-200 text-xl leading-none flex-shrink-0"
                 >
                     ×
                 </button>
@@ -262,7 +262,7 @@ function DeletionSuggestionCard({ suggestions, onRemovePermanently, onKeep, onDi
                 <button
                     type="button"
                     onClick={() => setIsExpanded(true)}
-                    className="mt-2 text-sm text-red-700 underline"
+                    className="mt-2 text-sm text-red-700 dark:text-red-300 underline"
                     aria-label="Review removals"
                 >
                     Review removals
@@ -271,14 +271,14 @@ function DeletionSuggestionCard({ suggestions, onRemovePermanently, onKeep, onDi
                 <div className="mt-4 space-y-4">
                     {grouped.map(({ listName, items }) => (
                         <div key={listName}>
-                            <p className="text-sm text-red-700 font-semibold mb-2">From: {listName}</p>
+                            <p className="text-sm text-red-700 dark:text-red-300 font-semibold mb-2">From: {listName}</p>
                             <div className="space-y-2">
                                 {items.map(({ listId, item }) => (
-                                    <div key={item.id} className="flex flex-col gap-2 bg-white rounded border border-red-200 px-3 py-2">
+                                    <div key={item.id} className="flex flex-col gap-2 bg-white dark:bg-gray-900 rounded border border-red-200 dark:border-red-800 px-3 py-2">
                                         <div>
-                                            <span className="font-medium text-gray-900">{item.itemText}</span>
+                                            <span className="font-medium text-gray-900 dark:text-gray-100">{item.itemText}</span>
                                             {item.personName && (
-                                                <span className="ml-2 text-sm text-gray-500">for {item.personName}</span>
+                                                <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">for {item.personName}</span>
                                             )}
                                         </div>
                                         <div className="flex gap-2">
@@ -692,23 +692,23 @@ export function CreatePackingList() {
             <>
                 <div className="max-w-4xl mx-auto py-8 px-4">
                     <div className="mb-8">
-                        <h1 className="text-2xl font-bold text-gray-900">Create New Packing List</h1>
-                        <p className="mt-2 text-gray-600">Let's set up your packing list questions first!</p>
+                        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Create New Packing List</h1>
+                        <p className="mt-2 text-gray-600 dark:text-gray-400">Let's set up your packing list questions first!</p>
                     </div>
 
-                    <div className="bg-white rounded-2xl shadow-soft border-2 border-primary-200 p-8">
+                    <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-soft border-2 border-primary-200 dark:border-primary-800 p-8">
                         <div className="text-center mb-6">
                             <div className="text-6xl mb-4">📋</div>
-                            <h2 className="text-2xl font-bold text-gray-900 mb-2">No Questions Found</h2>
-                            <p className="text-gray-600">
+                            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">No Questions Found</h2>
+                            <p className="text-gray-600 dark:text-gray-400">
                                 Before you can create a packing list, you need to set up your packing list questions.
                             </p>
                         </div>
 
                         <div className="space-y-4 max-w-2xl mx-auto">
-                            <div className="bg-gradient-to-br from-primary-50 to-primary-100 p-6 rounded-xl border-2 border-primary-200">
-                                <h3 className="text-lg font-bold text-primary-900 mb-2">✨ Quick Start with Wizard</h3>
-                                <p className="text-gray-700 mb-4">
+                            <div className="bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-primary-100 dark:to-primary-900/40 p-6 rounded-xl border-2 border-primary-200 dark:border-primary-800">
+                                <h3 className="text-lg font-bold text-primary-900 dark:text-primary-200 mb-2">✨ Quick Start with Wizard</h3>
+                                <p className="text-gray-700 dark:text-gray-300 mb-4">
                                     Answer a few simple questions and we'll generate a personalized question set for you.
                                 </p>
                                 <Link to="/wizard">
@@ -719,13 +719,13 @@ export function CreatePackingList() {
                             </div>
 
                             {!isLoggedIn && (
-                                <div className="bg-gradient-to-br from-accent-50 to-accent-100 p-6 rounded-xl border-2 border-accent-200">
-                                    <h3 className="text-lg font-bold text-accent-900 mb-2">🔄 Sync Questions From Another Device</h3>
-                                    <p className="text-gray-700 mb-4">
+                                <div className="bg-gradient-to-br from-accent-50 dark:from-accent-950/40 to-accent-100 dark:to-accent-900/40 p-6 rounded-xl border-2 border-accent-200 dark:border-accent-800">
+                                    <h3 className="text-lg font-bold text-accent-900 dark:text-accent-200 mb-2">🔄 Sync Questions From Another Device</h3>
+                                    <p className="text-gray-700 dark:text-gray-300 mb-4">
                                         If you've already created questions on another device, sign in to sync them here. Signing in uses your Solid Pod.
                                     </p>
                                     <button
-                                        className="text-sm font-semibold text-accent-700 underline hover:text-accent-900"
+                                        className="text-sm font-semibold text-accent-700 dark:text-accent-300 underline hover:text-accent-900 dark:hover:text-accent-200"
                                         onClick={() => setIsProviderSelectorOpen(true)}
                                     >
                                         Sync &amp; Share
@@ -733,9 +733,9 @@ export function CreatePackingList() {
                                 </div>
                             )}
 
-                            <div className="bg-gradient-to-br from-secondary-50 to-secondary-100 p-6 rounded-xl border-2 border-secondary-200">
-                                <h3 className="text-lg font-bold text-secondary-900 mb-2">✏️ Create Manually</h3>
-                                <p className="text-gray-700 mb-4">
+                            <div className="bg-gradient-to-br from-secondary-50 dark:from-secondary-950/40 to-secondary-100 dark:to-secondary-900/40 p-6 rounded-xl border-2 border-secondary-200 dark:border-secondary-800">
+                                <h3 className="text-lg font-bold text-secondary-900 dark:text-secondary-200 mb-2">✏️ Create Manually</h3>
+                                <p className="text-gray-700 dark:text-gray-300 mb-4">
                                     Prefer full control? Create your packing list questions from scratch.
                                 </p>
                                 <Link to="/manage-questions">
@@ -763,8 +763,8 @@ export function CreatePackingList() {
     return (
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8">
-                <h1 className="text-2xl font-bold text-gray-900">Create New Packing List</h1>
-                <p className="mt-2 text-gray-600">Answer the questions below to create your packing list.</p>
+                <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Create New Packing List</h1>
+                <p className="mt-2 text-gray-600 dark:text-gray-400">Answer the questions below to create your packing list.</p>
             </div>
 
             {/* The questions below are this device's copy; say so while the pod
@@ -815,7 +815,7 @@ export function CreatePackingList() {
                         placeholder="e.g. 3"
                         {...register('nights', { valueAsNumber: true, min: 1 })}
                     />
-                    <p className="mt-1 text-xs text-gray-500">
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                         We'll suggest quantities for items with a per-night amount, like socks — e.g. 3 nights → Socks ×3.
                     </p>
                 </div>
@@ -840,16 +840,16 @@ export function CreatePackingList() {
                             {...register('endDate')}
                         />
                     </div>
-                    <p className="mt-1 text-xs text-gray-500">
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                         Where you're going and when — shown on your lists so you can tell trips apart.
                     </p>
                 </div>
 
                 {/* Person Selection */}
                 {questionSet.people.length > 0 && (
-                    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+                    <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
                         <div className="flex items-center justify-between mb-4">
-                            <h3 className="text-lg font-medium text-gray-900">
+                            <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
                                 Who is going on this trip?
                             </h3>
                             <button
@@ -859,7 +859,7 @@ export function CreatePackingList() {
                                         ? setSelectedPeopleIds([])
                                         : setSelectedPeopleIds(questionSet.people.map(p => p.id))
                                 }
-                                className="text-sm text-blue-600 underline hover:text-blue-800"
+                                className="text-sm text-blue-600 dark:text-blue-400 underline hover:text-blue-800 dark:hover:text-blue-200"
                             >
                                 {selectedPeopleIds.length === questionSet.people.length ? 'Select none' : 'Select all'}
                             </button>
@@ -877,7 +877,7 @@ export function CreatePackingList() {
                                                 setSelectedPeopleIds(selectedPeopleIds.filter(id => id !== person.id))
                                             }
                                         }}
-                                        className="h-4 w-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+                                        className="h-4 w-4 text-blue-600 dark:text-blue-400 rounded focus:ring-2 focus:ring-blue-500"
                                     />
                                     {/* The same mark they'll carry on the list this makes */}
                                     <PersonAvatar
@@ -885,10 +885,10 @@ export function CreatePackingList() {
                                         identity={personIdentityAt(person, personIndex, personPhoto)}
                                         size="sm"
                                     />
-                                    <span className="text-gray-700">
+                                    <span className="text-gray-700 dark:text-gray-300">
                                         {person.name}
                                         {person.ageRange && (
-                                            <span className="ml-2 text-sm text-gray-500">({person.ageRange})</span>
+                                            <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">({person.ageRange})</span>
                                         )}
                                     </span>
                                 </label>
@@ -902,11 +902,11 @@ export function CreatePackingList() {
                     const questionType = question.questionType || "single-choice"
 
                     return (
-                    <div key={question.id} className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-                        <h3 className="text-lg font-medium text-gray-900 mb-4">
+                    <div key={question.id} className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
+                        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
                             {question.text}
                             {questionType === "multiple-choice" && (
-                                <span className="ml-2 text-sm text-gray-500">(select all that apply)</span>
+                                <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">(select all that apply)</span>
                             )}
                         </h3>
                         <input
@@ -923,9 +923,9 @@ export function CreatePackingList() {
                                             type="radio"
                                             value={option.id}
                                             {...register(`questionAnswers.${index}.selectedOptionIds.0`)}
-                                            className="h-4 w-4 text-blue-600"
+                                            className="h-4 w-4 text-blue-600 dark:text-blue-400"
                                         />
-                                        <span className="text-gray-700">{option.text}</span>
+                                        <span className="text-gray-700 dark:text-gray-300">{option.text}</span>
                                     </label>
                                 ))
                             ) : (
@@ -950,9 +950,9 @@ export function CreatePackingList() {
                                                     setValue(`questionAnswers.${index}.selectedOptionIds`, currentIds.filter((id: string) => id !== option.id))
                                                 }
                                             }}
-                                            className="h-4 w-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+                                            className="h-4 w-4 text-blue-600 dark:text-blue-400 rounded focus:ring-2 focus:ring-blue-500"
                                         />
-                                        <span className="text-gray-700">{option.text}</span>
+                                        <span className="text-gray-700 dark:text-gray-300">{option.text}</span>
                                     </label>
                                     )
                                 })

--- a/src/pages/foreign-packing-lists.tsx
+++ b/src/pages/foreign-packing-lists.tsx
@@ -55,10 +55,10 @@ export function ForeignPackingListsPage() {
     }
 
     const gradients = [
-        'from-primary-50 to-primary-100 border-primary-300',
-        'from-secondary-50 to-secondary-100 border-secondary-300',
-        'from-accent-50 to-accent-100 border-accent-300',
-        'from-success-50 to-success-100 border-success-300',
+        'from-primary-50 dark:from-primary-950/40 to-primary-100 dark:to-primary-900/40 border-primary-300 dark:border-primary-700',
+        'from-secondary-50 dark:from-secondary-950/40 to-secondary-100 dark:to-secondary-900/40 border-secondary-300 dark:border-secondary-700',
+        'from-accent-50 dark:from-accent-950/40 to-accent-100 dark:to-accent-900/40 border-accent-300 dark:border-accent-700',
+        'from-success-50 dark:from-success-950/40 to-success-100 dark:to-success-900/40 border-success-300 dark:border-success-700',
     ]
 
     // Finished trips, and undated lists that have gone quiet, are folded away
@@ -85,28 +85,28 @@ export function ForeignPackingListsPage() {
                 className={`bg-gradient-to-br ${gradient} rounded-2xl shadow-soft border-2 p-6 hover:shadow-glow-primary hover:scale-[1.02] transition-all duration-200 cursor-pointer`}
             >
                 <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
-                    <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2 flex-wrap">
+                    <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2 flex-wrap">
                         ✈️ {list.name}
                         {list.destination && (
-                            <span className="text-xs font-medium bg-white/60 text-gray-700 border border-gray-200 px-2 py-0.5 rounded-full">
+                            <span className="text-xs font-medium bg-white/60 dark:bg-white/10 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700 px-2 py-0.5 rounded-full">
                                 📍 {list.destination}
                             </span>
                         )}
                     </h3>
-                    <span className="text-sm font-medium text-gray-600 bg-white/60 px-3 py-1 rounded-lg self-start sm:self-auto">
+                    <span className="text-sm font-medium text-gray-600 dark:text-gray-400 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg self-start sm:self-auto">
                         {tripDates
                             ? `📅 ${tripDates}`
                             : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
                     </span>
                 </div>
                 <div className="flex items-center gap-4">
-                    <div className="flex-1 bg-white/40 rounded-full h-3 overflow-hidden">
+                    <div className="flex-1 bg-white/40 dark:bg-white/10 rounded-full h-3 overflow-hidden">
                         <div
                             className="bg-gradient-primary h-full transition-all duration-500 rounded-full"
                             style={{ width: `${displayWidth}%` }}
                         />
                     </div>
-                    <span className="text-sm font-bold text-gray-700 bg-white/60 px-3 py-1 rounded-lg">
+                    <span className="text-sm font-bold text-gray-700 dark:text-gray-300 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg">
                         {packed} / {total} ({percent}%)
                     </span>
                 </div>
@@ -118,8 +118,8 @@ export function ForeignPackingListsPage() {
         <div className="max-w-4xl mx-auto py-8 px-4">
             <Header onCreate={createList} />
             {lists.length === 0 ? (
-                <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
-                    <p className="text-lg text-gray-800 font-semibold">No packing lists found.</p>
+                <div className="text-center py-12 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft">
+                    <p className="text-lg text-gray-800 dark:text-gray-100 font-semibold">No packing lists found.</p>
                 </div>
             ) : (
                 <>
@@ -130,8 +130,8 @@ export function ForeignPackingListsPage() {
                     {/* Every shared trip is behind us, so "no packing lists
                         found" would be wrong — say what is actually the case. */}
                     {currentLists.length === 0 && (
-                        <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
-                            <p className="text-lg text-gray-800 font-semibold">No upcoming trips. Past trips are below.</p>
+                        <div className="text-center py-12 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft">
+                            <p className="text-lg text-gray-800 dark:text-gray-100 font-semibold">No upcoming trips. Past trips are below.</p>
                         </div>
                     )}
 
@@ -150,8 +150,8 @@ function Header({ onCreate }: { onCreate: () => void }) {
     return (
         <div className="mb-8 flex justify-between items-start gap-4">
             <div className="mb-2">
-                <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
-                <p className="mt-2 text-lg text-gray-700 font-medium">Shared packing lists.</p>
+                <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">📦 Packing Lists</h1>
+                <p className="mt-2 text-lg text-gray-700 dark:text-gray-300 font-medium">Shared packing lists.</p>
             </div>
             <Button variant="primary" onClick={onCreate}>➕ New List</Button>
         </div>

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -28,14 +28,14 @@ export const LandingPage = () => {
     return (
         <>
             {isLoggedIn && (
-                <div className="mb-6 p-4 bg-gradient-to-r from-success-50 to-primary-50 border-2 border-success-300 rounded-2xl shadow-soft animate-fade-in">
+                <div className="mb-6 p-4 bg-gradient-to-r from-success-50 dark:from-success-950/40 to-primary-50 dark:to-primary-950/40 border-2 border-success-300 dark:border-success-700 rounded-2xl shadow-soft animate-fade-in">
                     {/*
                       * Their name, not their WebID. The nav stopped printing the
                       * raw WebID in #302 and this greeting sits right under it —
                       * a URL is not what being signed in looks like. The photo
                       * stays in the nav rather than being repeated an inch away.
                       */}
-                    <p className="text-success-800 font-semibold">
+                    <p className="text-success-800 dark:text-success-200 font-semibold">
                         🎉 Signed in as <span className="font-bold">{profileDisplayName(profile, webId)}</span>
                     </p>
                 </div>
@@ -44,10 +44,10 @@ export const LandingPage = () => {
                 {/* Hero leads with the travel benefit and keeps the primary CTA above the
                     fold — the data-ownership story lives in the trust section further down. */}
                 <div className="text-center mb-10 animate-slide-up">
-                    <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-primary-900 text-balance">
+                    <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-primary-900 dark:text-primary-200 text-balance">
                         Packing lists that learn how you travel
                     </h1>
-                    <p className="text-lg sm:text-xl text-gray-700 max-w-2xl mx-auto">
+                    <p className="text-lg sm:text-xl text-gray-700 dark:text-gray-300 max-w-2xl mx-auto">
                         Set up your questions once, then get a personalised list for every trip. Share one list with your partner or the whole family and pack as a team.
                     </p>
                 </div>
@@ -57,41 +57,41 @@ export const LandingPage = () => {
                 </div>
 
                 <div className="mb-12">
-                    <h2 className="text-center text-sm font-semibold uppercase tracking-widest text-gray-500 mb-6">How it works</h2>
+                    <h2 className="text-center text-sm font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400 mb-6">How it works</h2>
                     <div className="grid md:grid-cols-3 gap-6">
-                        <div className="bg-gradient-to-br from-primary-50 to-primary-100 p-6 rounded-2xl shadow-soft hover:shadow-glow-primary transition-all duration-300 hover:scale-105 border-2 border-primary-200">
+                        <div className="bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-primary-100 dark:to-primary-900/40 p-6 rounded-2xl shadow-soft hover:shadow-glow-primary transition-all duration-300 hover:scale-105 border-2 border-primary-200 dark:border-primary-800">
                             <div className="text-3xl mb-2">✨</div>
-                            <h3 className="text-xl font-bold mb-3 text-primary-900">1. Set up in a minute</h3>
-                            <p className="text-gray-700">
+                            <h3 className="text-xl font-bold mb-3 text-primary-900 dark:text-primary-200">1. Set up in a minute</h3>
+                            <p className="text-gray-700 dark:text-gray-300">
                                 One screen — tell us who you travel with, and we'll generate a starter set of packing questions for your group.
                             </p>
                         </div>
 
-                        <div className="bg-gradient-to-br from-secondary-50 to-secondary-100 p-6 rounded-2xl shadow-soft hover:shadow-glow-secondary transition-all duration-300 hover:scale-105 border-2 border-secondary-200">
+                        <div className="bg-gradient-to-br from-secondary-50 dark:from-secondary-950/40 to-secondary-100 dark:to-secondary-900/40 p-6 rounded-2xl shadow-soft hover:shadow-glow-secondary transition-all duration-300 hover:scale-105 border-2 border-secondary-200 dark:border-secondary-800">
                             <div className="text-3xl mb-2">✏️</div>
-                            <h3 className="text-xl font-bold mb-3 text-secondary-900">2. Fine-tune your questions</h3>
-                            <p className="text-gray-700">
+                            <h3 className="text-xl font-bold mb-3 text-secondary-900 dark:text-secondary-200">2. Fine-tune your questions</h3>
+                            <p className="text-gray-700 dark:text-gray-300">
                                 Add, remove, and customise questions and packing items until they perfectly match how you travel.
                             </p>
                         </div>
 
-                        <div className="bg-gradient-to-br from-success-50 to-success-100 p-6 rounded-2xl shadow-soft hover:shadow-lg transition-all duration-300 hover:scale-105 border-2 border-success-200">
+                        <div className="bg-gradient-to-br from-success-50 dark:from-success-950/40 to-success-100 dark:to-success-900/40 p-6 rounded-2xl shadow-soft hover:shadow-lg transition-all duration-300 hover:scale-105 border-2 border-success-200 dark:border-success-800">
                             <div className="text-3xl mb-2">📋</div>
-                            <h3 className="text-xl font-bold mb-3 text-success-900">3. Pack for every trip</h3>
-                            <p className="text-gray-700">
+                            <h3 className="text-xl font-bold mb-3 text-success-900 dark:text-success-200">3. Pack for every trip</h3>
+                            <p className="text-gray-700 dark:text-gray-300">
                                 Before each trip, answer your questions to instantly generate a personalised packing list.
                             </p>
                         </div>
                     </div>
                 </div>
 
-                <div className="mt-10 p-4 rounded-xl border border-gray-200 bg-gray-50 text-center text-sm text-gray-500">
-                    <h2 className="font-semibold text-gray-600 inline">Own Your Data</h2>
+                <div className="mt-10 p-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-center text-sm text-gray-500 dark:text-gray-400">
+                    <h2 className="font-semibold text-gray-600 dark:text-gray-400 inline">Own Your Data</h2>
                     {' '}— Your lists live in storage you control, never on our servers. They save to this device automatically, even without an account.
                     {!isLoggedIn && (
                         <span className="block mt-1">
                             <button
-                                className="font-semibold text-primary-700 underline hover:text-primary-900"
+                                className="font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-200"
                                 onClick={() => setIsProviderSelectorOpen(true)}
                             >
                                 Get a free Solid Pod

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -192,10 +192,10 @@ export function PackingLists() {
 
         // Rotate through gradient colors
         const gradients = [
-            'from-primary-50 to-primary-100 border-primary-300',
-            'from-secondary-50 to-secondary-100 border-secondary-300',
-            'from-accent-50 to-accent-100 border-accent-300',
-            'from-success-50 to-success-100 border-success-300'
+            'from-primary-50 dark:from-primary-950/40 to-primary-100 dark:to-primary-900/40 border-primary-300 dark:border-primary-700',
+            'from-secondary-50 dark:from-secondary-950/40 to-secondary-100 dark:to-secondary-900/40 border-secondary-300 dark:border-secondary-700',
+            'from-accent-50 dark:from-accent-950/40 to-accent-100 dark:to-accent-900/40 border-accent-300 dark:border-accent-700',
+            'from-success-50 dark:from-success-950/40 to-success-100 dark:to-success-900/40 border-success-300 dark:border-success-700'
         ]
         const gradient = gradients[index % gradients.length]
 
@@ -218,19 +218,19 @@ export function PackingLists() {
             >
                 <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
                     <div className="min-w-0">
-                    <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2 flex-wrap">
+                    <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2 flex-wrap">
                         ✈️ {list.name}
                         {list.sharedFromPodUrl ? (
-                            <span className="text-xs font-medium bg-white/60 text-indigo-700 border border-indigo-200 px-2 py-0.5 rounded-full">
+                            <span className="text-xs font-medium bg-white/60 dark:bg-white/10 text-indigo-700 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-800 px-2 py-0.5 rounded-full">
                                 👤 From {resolveOwnerDisplayName(ownerNames[list.id], list.ownerWebId, list.sharedFromPodUrl)}
                             </span>
                         ) : (
                             <>
                                 {sharingStatus[list.id] === 'public' && (
-                                    <span className="text-xs font-medium bg-white/60 text-blue-700 px-2 py-0.5 rounded-full">🌐 Public</span>
+                                    <span className="text-xs font-medium bg-white/60 dark:bg-white/10 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded-full">🌐 Public</span>
                                 )}
                                 {sharingStatus[list.id] === 'shared' && (
-                                    <span className="text-xs font-medium bg-white/60 text-indigo-700 px-2 py-0.5 rounded-full">👤 Shared</span>
+                                    <span className="text-xs font-medium bg-white/60 dark:bg-white/10 text-indigo-700 dark:text-indigo-300 px-2 py-0.5 rounded-full">👤 Shared</span>
                                 )}
                             </>
                         )}
@@ -238,44 +238,44 @@ export function PackingLists() {
                     {/* On its own line so a long destination never
                         pushes the actions onto a second row */}
                     {list.destination && (
-                        <p className="mt-1 text-sm text-gray-600 truncate">📍 {list.destination}</p>
+                        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 truncate">📍 {list.destination}</p>
                     )}
                     </div>
                     <div data-testid="list-actions" className="flex items-center gap-2 flex-wrap">
-                        <span className="text-sm font-medium text-gray-600 bg-white/60 px-3 py-1 rounded-lg">
+                        <span className="text-sm font-medium text-gray-600 dark:text-gray-400 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg">
                             {tripDates
                                 ? `📅 ${tripDates}`
                                 : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
                         </span>
                         <button
                             onClick={(e) => requestRenamePackingList(list.id, list.name, e)}
-                            className="text-primary-600 hover:text-primary-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
+                            className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg"
                         >
                             ✏️ Rename
                         </button>
                         <button
                             onClick={(e) => handleDuplicatePackingList(list, e)}
-                            className="text-secondary-600 hover:text-secondary-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
+                            className="text-secondary-600 dark:text-secondary-400 hover:text-secondary-800 dark:hover:text-secondary-200 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg"
                         >
                             📋 Duplicate
                         </button>
                         <button
                             onClick={(e) => requestDeletePackingList(list.id, list.name, e)}
-                            className="text-danger-600 hover:text-danger-800 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 px-3 py-1 rounded-lg"
+                            className="text-danger-600 dark:text-danger-400 hover:text-danger-800 dark:hover:text-danger-200 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg"
                         >
                             🗑️ Delete
                         </button>
                     </div>
                 </div>
                 <div className="flex items-center gap-4">
-                    <div className="flex-1 bg-white/40 rounded-full h-3 overflow-hidden">
+                    <div className="flex-1 bg-white/40 dark:bg-white/10 rounded-full h-3 overflow-hidden">
                         <div
                             data-testid="progress-fill"
                             className="progress-bar-fill bg-gradient-primary h-full rounded-full"
                             style={{ width: `${displayWidth}%` }}
                         ></div>
                     </div>
-                    <span className="text-sm font-bold text-gray-700 bg-white/60 px-3 py-1 rounded-lg">
+                    <span className="text-sm font-bold text-gray-700 dark:text-gray-300 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg">
                         {packedCount} / {totalCount} ({percentComplete}%)
                     </span>
                 </div>
@@ -294,8 +294,8 @@ export function PackingLists() {
             <div className="max-w-4xl mx-auto py-8 px-4">
                 <div className="mb-8 flex justify-between items-start">
                     <div className="mb-2">
-                        <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
-                        <p className="mt-2 text-lg text-gray-700 font-medium">View all your created packing lists.</p>
+                        <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">📦 Packing Lists</h1>
+                        <p className="mt-2 text-lg text-gray-700 dark:text-gray-300 font-medium">View all your created packing lists.</p>
                     </div>
                     <Button variant="primary" onClick={() => navigate('/create-packing-list')}>➕ New List</Button>
                 </div>
@@ -308,8 +308,8 @@ export function PackingLists() {
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8 flex justify-between items-start">
                 <div className="mb-2">
-                    <h1 className="text-4xl font-bold text-primary-900">📦 Packing Lists</h1>
-                    <p className="mt-2 text-lg text-gray-700 font-medium">View all your created packing lists.</p>
+                    <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">📦 Packing Lists</h1>
+                    <p className="mt-2 text-lg text-gray-700 dark:text-gray-300 font-medium">View all your created packing lists.</p>
                 </div>
                 <Button variant="primary" onClick={() => navigate('/create-packing-list')}>➕ New List</Button>
             </div>
@@ -322,8 +322,8 @@ export function PackingLists() {
             {packingLists.length > 0 && <SyncAcrossDevicesPrompt />}
 
             {packingLists.length === 0 ? (
-                <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
-                    <p className="text-lg text-gray-800 font-semibold">
+                <div className="text-center py-12 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft">
+                    <p className="text-lg text-gray-800 dark:text-gray-100 font-semibold">
                         No packing lists found. Create your first packing list to get started! 🎒
                     </p>
                 </div>
@@ -336,8 +336,8 @@ export function PackingLists() {
                     {/* Everything is behind us, so "no packing lists found" would
                         be wrong — say what is actually the case. */}
                     {currentLists.length === 0 && (
-                        <div className="text-center py-12 bg-gradient-to-br from-primary-50 to-accent-50 rounded-2xl border-2 border-primary-200 shadow-soft">
-                            <p className="text-lg text-gray-800 font-semibold">
+                        <div className="text-center py-12 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft">
+                            <p className="text-lg text-gray-800 dark:text-gray-100 font-semibold">
                                 No upcoming trips. Your past trips are below — or start a new list! 🎒
                             </p>
                         </div>
@@ -368,7 +368,7 @@ export function PackingLists() {
                         type="text"
                         value={renameValue}
                         onChange={e => setRenameValue(e.target.value)}
-                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-400"
+                        className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-400"
                     />
                     <div className="flex gap-3 justify-end mt-4">
                         <Button variant="ghost" onClick={() => setListToRename(null)}>Cancel</Button>

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -4,20 +4,20 @@ const LAST_UPDATED = '30 July 2026'
 
 export const PrivacyPolicyPage = () => {
     return (
-        <div className="max-w-3xl mx-auto bg-white/60 rounded-2xl shadow-soft p-6 md:p-10 space-y-6">
+        <div className="max-w-3xl mx-auto bg-white/60 dark:bg-gray-900/60 rounded-2xl shadow-soft p-6 md:p-10 space-y-6">
             <div>
-                <h1 className="text-3xl font-bold text-primary-900 mb-1">Privacy Policy</h1>
-                <p className="text-sm text-gray-500">Last updated: {LAST_UPDATED}</p>
+                <h1 className="text-3xl font-bold text-primary-900 dark:text-primary-200 mb-1">Privacy Policy</h1>
+                <p className="text-sm text-gray-500 dark:text-gray-400">Last updated: {LAST_UPDATED}</p>
             </div>
 
-            <p className="text-gray-700">
+            <p className="text-gray-700 dark:text-gray-300">
                 Pack Me Up ("the app") helps you build and manage packing lists for your trips. This
                 policy explains what information the app handles, where it is stored, and who can see it.
             </p>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Information you provide</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Information you provide</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     The app stores the packing questions, items, and packing lists you create, including
                     any trip or traveller details you choose to enter (such as names or age brackets for
                     the people you're packing for). This information is provided directly by you and is
@@ -26,19 +26,19 @@ export const PrivacyPolicyPage = () => {
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Where your data is stored</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Where your data is stored</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     By default, your data is stored locally on your device, in your browser's or app's
                     local storage. It is not sent to any server we control.
                 </p>
-                <p className="text-gray-700">
+                <p className="text-gray-700 dark:text-gray-300">
                     If you choose to log in with a Solid Pod, your data is also saved to the personal Pod
                     you connect — storage that you own and control, hosted by the Pod provider you select.
                     We do not have our own servers that store your packing data; the app talks directly to
                     your Pod. You can revoke access or delete your data from your Pod at any time through
                     your Pod provider.
                 </p>
-                <p className="text-gray-700">
+                <p className="text-gray-700 dark:text-gray-300">
                     If you use the sharing feature, the packing lists or questions you choose to share are
                     made accessible to the specific people you share them with, via your Pod's access
                     controls.
@@ -46,13 +46,13 @@ export const PrivacyPolicyPage = () => {
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Deleting your data</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Deleting your data</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     You can delete everything the app has stored at any time — from this device, from
                     your Solid Pod, or both — on the{' '}
                     <Link
                         to="/your-data"
-                        className="font-semibold text-primary-700 underline hover:text-primary-900"
+                        className="font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-200"
                     >
                         Your data
                     </Link>{' '}
@@ -61,14 +61,14 @@ export const PrivacyPolicyPage = () => {
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Analytics and error reporting</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Analytics and error reporting</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     We use privacy-friendly, cookie-free analytics to understand overall app usage (such as
                     which pages are visited), and an error-reporting tool to help us diagnose crashes and
                     bugs. Error reports may include technical details like error messages, stack traces,
                     and device/browser information, but do not include the contents of your packing lists.
                 </p>
-                <p className="text-gray-700">
+                <p className="text-gray-700 dark:text-gray-300">
                     Neither is linked to you: we don't attach a name, email or account to them, and we
                     don't collect your IP address. That also means we have no way to single out one
                     person's crash reports or page views on request — there is no identifier to search
@@ -76,7 +76,7 @@ export const PrivacyPolicyPage = () => {
                     asks for your name and email, and emailing us tells us your address; see the{' '}
                     <Link
                         to="/your-data"
-                        className="font-semibold text-primary-700 underline hover:text-primary-900"
+                        className="font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-200"
                     >
                         Your data
                     </Link>{' '}
@@ -85,8 +85,8 @@ export const PrivacyPolicyPage = () => {
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">What we don't do</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">What we don't do</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     We do not sell your data, and we do not use your packing list contents for advertising.
                     We do not have accounts or passwords of our own — authentication, when used, is handled
                     by your chosen Solid Pod provider.
@@ -94,28 +94,28 @@ export const PrivacyPolicyPage = () => {
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Children's privacy</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Children's privacy</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     The app is not directed at children and is not designed to knowingly collect personal
                     information from children.
                 </p>
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Changes to this policy</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Changes to this policy</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     We may update this policy from time to time. Changes will be posted on this page with
                     an updated "Last updated" date.
                 </p>
             </section>
 
             <section className="space-y-2">
-                <h2 className="text-xl font-bold text-primary-900">Contact us</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Contact us</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     If you have questions about this policy or your data, contact us at{' '}
                     <a
                         href="mailto:tim.packmeup@gmail.com"
-                        className="font-semibold text-primary-700 underline hover:text-primary-900"
+                        className="font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-200"
                     >
                         tim.packmeup@gmail.com
                     </a>

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -52,10 +52,10 @@ const PersonLegend = memo(function PersonLegend({ people, onEdit, personPhoto }:
     return (
         <div className="flex items-center gap-2 flex-wrap mb-4">
             {people.length === 0 && onEdit && (
-                <span className="text-xs text-gray-400">No people added</span>
+                <span className="text-xs text-gray-400 dark:text-gray-500">No people added</span>
             )}
             {people.map((person, i) => (
-                <span key={person.id} className="flex items-center gap-1 text-xs text-gray-500">
+                <span key={person.id} className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
                     <PersonAvatar
                         name={person.name}
                         identity={personIdentityAt(person, i, personPhoto)}
@@ -68,7 +68,7 @@ const PersonLegend = memo(function PersonLegend({ people, onEdit, personPhoto }:
                 <button
                     type="button"
                     onClick={onEdit}
-                    className="p-1 text-gray-300 hover:text-gray-600 rounded"
+                    className="p-1 text-gray-300 dark:text-gray-600 hover:text-gray-600 dark:hover:text-gray-400 rounded"
                     title="Edit people"
                 >
                     <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -119,12 +119,12 @@ function ReorganiseModal({ items, defaultLabel, emptySections, onChange, onClose
             <div
                 role="dialog"
                 aria-label={`Organise ${defaultLabel} items`}
-                className="bg-white rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
+                className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[85vh]"
                 onClick={e => e.stopPropagation()}
             >
-                <div className="p-5 border-b border-gray-100 flex-shrink-0">
-                    <h2 className="text-lg font-semibold text-gray-900">Organise items</h2>
-                    <p className="mt-0.5 text-sm text-gray-500 truncate">{defaultLabel}</p>
+                <div className="p-5 border-b border-gray-100 dark:border-gray-800 flex-shrink-0">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Organise items</h2>
+                    <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400 truncate">{defaultLabel}</p>
                 </div>
                 <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
                     <SectionedItemReorder
@@ -135,7 +135,7 @@ function ReorganiseModal({ items, defaultLabel, emptySections, onChange, onClose
                         onChange={onChange}
                     />
                 </div>
-                <div className="px-5 py-4 border-t border-gray-100 flex-shrink-0 flex justify-end">
+                <div className="px-5 py-4 border-t border-gray-100 dark:border-gray-800 flex-shrink-0 flex justify-end">
                     <button
                         type="button"
                         onClick={onClose}
@@ -207,7 +207,7 @@ function useDeferredReorder(onReorder?: (items: Item[], emptySections: string[] 
     return { draft, onChange, flush: stop }
 }
 
-const FOOT_BUTTON = 'py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors'
+const FOOT_BUTTON = 'py-2 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg text-xs text-gray-400 dark:text-gray-500 hover:border-primary-300 dark:hover:border-primary-700 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-950/40 transition-colors'
 
 /**
  * Name a new section. Offers the names already used elsewhere in the set, so
@@ -243,7 +243,7 @@ function AddSection({ suggestions, onAdd, onClose }: {
                 }}
                 aria-label="New section name"
                 placeholder="Section name (e.g. Toiletries)"
-                className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
             />
             <datalist id={listId}>
                 {suggestions.map(label => <option key={label} value={label} />)}
@@ -473,7 +473,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
             <button
                 type="button"
                 onClick={() => setOrganising(true)}
-                className="inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 text-primary-600 hover:bg-primary-50 transition-colors"
+                className="inline-flex items-center gap-1 text-xs font-medium rounded-full px-2.5 py-1 text-primary-600 dark:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-950/40 transition-colors"
             >
                 <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
@@ -538,7 +538,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                             // clipped away to nothing. The heading rounds its own
                             // top corners instead of relying on the card to crop
                             // them.
-                            className={`rounded-lg border ${accent.border} bg-white`}
+                            className={`rounded-lg border ${accent.border} bg-white dark:bg-gray-900`}
                         >
                             <div className={`flex items-center gap-2 rounded-t-lg px-2.5 py-1.5 ${accent.header}`}>
                                 <span
@@ -566,7 +566,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                                         onClick={() => handleSectionBin(group.label, group.entries.length)}
                                         aria-label={`Delete section ${group.label}`}
                                         title={`Delete section ${group.label} — its items move to ${defaultLabel}`}
-                                        className={`shrink-0 -my-1 rounded p-1.5 ${accent.muted} hover:bg-white/70 hover:text-red-600 transition-colors`}
+                                        className={`shrink-0 -my-1 rounded p-1.5 ${accent.muted} hover:bg-white/70 hover:text-red-600 dark:hover:text-red-400 transition-colors`}
                                     >
                                         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -581,7 +581,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                                         aria-expanded={openComposer === group.label}
                                         aria-label={`Add an item to ${group.label}`}
                                         title={`Add an item to ${group.label}`}
-                                        className={`shrink-0 -my-1 rounded p-1.5 ${accent.text} hover:bg-white/70 transition-colors`}
+                                        className={`shrink-0 -my-1 rounded p-1.5 ${accent.text} hover:bg-white/70 dark:hover:bg-white/10 transition-colors`}
                                     >
                                         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v14M5 12h14" />
@@ -594,7 +594,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                                     // A section you have just made, before anything is
                                     // in it. Says so rather than drawing a card with a
                                     // blank body, which reads as a rendering fault.
-                                    <p className="px-1.5 py-1 text-xs text-gray-400 italic">
+                                    <p className="px-1.5 py-1 text-xs text-gray-400 dark:text-gray-500 italic">
                                         Nothing here yet — use ＋ to add the first item
                                     </p>
                                 )}
@@ -650,7 +650,7 @@ function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete:
             <DropdownMenu.Trigger asChild>
                 <button
                     type="button"
-                    className="p-2 text-gray-400 hover:text-gray-700 rounded"
+                    className="p-2 text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 rounded"
                     title="More actions"
                 >
                     <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
@@ -664,17 +664,17 @@ function OptionContextMenu({ onEdit, onDelete }: { onEdit: () => void; onDelete:
                 <DropdownMenu.Content
                     align="end"
                     sideOffset={4}
-                    className="w-32 bg-white rounded-lg shadow-lg border border-gray-100 py-1 z-50"
+                    className="w-32 bg-white dark:bg-gray-900 rounded-lg shadow-lg border border-gray-100 dark:border-gray-800 py-1 z-50"
                 >
                     <DropdownMenu.Item
                         onSelect={onEdit}
-                        className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 cursor-default outline-none"
+                        className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none"
                     >
                         Edit
                     </DropdownMenu.Item>
                     <DropdownMenu.Item
                         onSelect={onDelete}
-                        className="px-4 py-2.5 text-sm text-red-500 hover:bg-red-50 cursor-default outline-none"
+                        className="px-4 py-2.5 text-sm text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 cursor-default outline-none"
                     >
                         Delete
                     </DropdownMenu.Item>
@@ -767,24 +767,24 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
             ) : (
                 <svg
                     data-testid="option-expand-chevron"
-                    className={`w-4 h-4 text-gray-400 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                    className={`w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
                     fill="none" viewBox="0 0 24 24" stroke="currentColor"
                 >
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                 </svg>
             )}
-            <span className="text-sm font-medium text-gray-800 flex-1 min-w-0">
-                {option.text || <em className="text-gray-400 font-normal">Untitled option</em>}
+            <span className="text-sm font-medium text-gray-800 dark:text-gray-100 flex-1 min-w-0">
+                {option.text || <em className="text-gray-400 dark:text-gray-500 font-normal">Untitled option</em>}
             </span>
             {isEmpty ? (
-                <span className="text-xs text-gray-400 italic flex-shrink-0 mr-1">No items</span>
+                <span className="text-xs text-gray-400 dark:text-gray-500 italic flex-shrink-0 mr-1">No items</span>
             ) : (
-                <span className="hidden sm:inline text-xs text-gray-400 flex-shrink-0 mr-1">{option.items.length} items</span>
+                <span className="hidden sm:inline text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 mr-1">{option.items.length} items</span>
             )}
         </>
     )
     return (
-        <div data-testid="option-section" className="bg-gray-50 rounded-lg p-3">
+        <div data-testid="option-section" className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3">
             <div className={`flex items-center${isExpanded ? ' mb-2' : ''}`}>
                 {!canExpand ? (
                     <div className="flex items-center gap-2 flex-1 text-left min-w-0">
@@ -812,7 +812,7 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
                         <button
                             type="button"
                             onClick={onEdit}
-                            className="p-1 text-gray-300 hover:text-gray-600 rounded"
+                            className="p-1 text-gray-300 dark:text-gray-600 hover:text-gray-600 dark:hover:text-gray-400 rounded"
                             title="Edit option"
                         >
                             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -822,7 +822,7 @@ export function OptionSection({ option, people, sectionDefaultLabel, allItemName
                         <button
                             type="button"
                             onClick={() => setShowDeleteModal(true)}
-                            className="p-1 text-gray-300 hover:text-red-400 rounded"
+                            className="p-1 text-gray-300 dark:text-gray-600 hover:text-red-400 rounded"
                             title="Delete option"
                         >
                             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -874,16 +874,16 @@ function DeleteConfirmModal({ title = 'Delete question?', body = 'This will perm
             onKeyDown={e => { if (e.key === 'Escape') onCancel() }}
         >
             <div
-                className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6"
+                className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6"
                 onClick={e => e.stopPropagation()}
             >
-                <h2 className="text-lg font-semibold text-gray-900 mb-2">{title}</h2>
-                <p className="text-sm text-gray-500 mb-6">{body}</p>
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">{title}</h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">{body}</p>
                 <div className="flex justify-end gap-3">
                     <button
                         type="button"
                         onClick={onCancel}
-                        className="px-4 py-2 text-sm text-gray-600 rounded-lg hover:bg-gray-100"
+                        className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
                     >
                         Cancel
                     </button>
@@ -914,7 +914,7 @@ function QuestionContextMenu({ onMoveUp, onMoveDown, onEdit, onDelete }: {
                 <DropdownMenu.Trigger asChild>
                     <button
                         type="button"
-                        className="p-2 text-gray-400 hover:text-gray-700 rounded"
+                        className="p-2 text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 rounded"
                         title="More actions"
                     >
                         <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -928,31 +928,31 @@ function QuestionContextMenu({ onMoveUp, onMoveDown, onEdit, onDelete }: {
                     <DropdownMenu.Content
                         align="end"
                         sideOffset={4}
-                        className="w-40 bg-white rounded-lg shadow-lg border border-gray-100 py-1 z-50"
+                        className="w-40 bg-white dark:bg-gray-900 rounded-lg shadow-lg border border-gray-100 dark:border-gray-800 py-1 z-50"
                     >
                         <DropdownMenu.Item
                             onSelect={onEdit}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 cursor-default outline-none"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none"
                         >
                             Edit
                         </DropdownMenu.Item>
                         <DropdownMenu.Item
                             onSelect={onMoveUp}
                             disabled={!onMoveUp}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 cursor-default outline-none data-[disabled]:text-gray-300 data-[disabled]:pointer-events-none"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none data-[disabled]:text-gray-300 data-[disabled]:pointer-events-none"
                         >
                             Move Up
                         </DropdownMenu.Item>
                         <DropdownMenu.Item
                             onSelect={onMoveDown}
                             disabled={!onMoveDown}
-                            className="px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 cursor-default outline-none data-[disabled]:text-gray-300 data-[disabled]:pointer-events-none"
+                            className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none data-[disabled]:text-gray-300 data-[disabled]:pointer-events-none"
                         >
                             Move Down
                         </DropdownMenu.Item>
                         <DropdownMenu.Item
                             onSelect={e => { e.preventDefault(); setShowDeleteModal(true) }}
-                            className="px-4 py-2.5 text-sm text-red-500 hover:bg-red-50 cursor-default outline-none"
+                            className="px-4 py-2.5 text-sm text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 cursor-default outline-none"
                         >
                             Delete
                         </DropdownMenu.Item>
@@ -1002,23 +1002,23 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
     const moveUp = canMoveUp ? () => onMove(question.id, 'up') : undefined
     const moveDown = canMoveDown ? () => onMove(question.id, 'down') : undefined
     return (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
             <div className="flex items-stretch">
                 <button
                     type="button"
                     onClick={() => setIsExpanded(e => !e)}
-                    className="flex items-center gap-3 flex-1 text-left px-4 py-4 sm:px-6 min-w-0 hover:bg-gray-50 transition-colors duration-150"
+                    className="flex items-center gap-3 flex-1 text-left px-4 py-4 sm:px-6 min-w-0 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors duration-150"
                 >
                     <svg
-                        className={`w-5 h-5 text-gray-400 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                        className={`w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
                         fill="none" viewBox="0 0 24 24" stroke="currentColor"
                     >
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                     </svg>
-                    <span className="font-medium text-gray-900 flex-1 min-w-0">
-                        {question.text || <em className="text-gray-400 font-normal">Untitled question</em>}
+                    <span className="font-medium text-gray-900 dark:text-gray-100 flex-1 min-w-0">
+                        {question.text || <em className="text-gray-400 dark:text-gray-500 font-normal">Untitled question</em>}
                     </span>
-                    <span className="hidden sm:inline text-xs text-gray-400 flex-shrink-0 mr-2">{question.options.length} options</span>
+                    <span className="hidden sm:inline text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 mr-2">{question.options.length} options</span>
                 </button>
                 <div className="flex items-center pr-3 flex-shrink-0">
                     {/* Mobile: context menu */}
@@ -1036,7 +1036,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                             type="button"
                             onClick={moveUp}
                             disabled={!canMoveUp}
-                            className={`p-1.5 rounded ${canMoveUp ? 'text-gray-300 hover:text-gray-600' : 'text-gray-100 cursor-not-allowed'}`}
+                            className={`p-1.5 rounded ${canMoveUp ? 'text-gray-300 dark:text-gray-600 hover:text-gray-600 dark:hover:text-gray-400' : 'text-gray-100 cursor-not-allowed'}`}
                             title="Move up"
                         >
                             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1047,7 +1047,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                             type="button"
                             onClick={moveDown}
                             disabled={!canMoveDown}
-                            className={`p-1.5 rounded ${canMoveDown ? 'text-gray-300 hover:text-gray-600' : 'text-gray-100 cursor-not-allowed'}`}
+                            className={`p-1.5 rounded ${canMoveDown ? 'text-gray-300 dark:text-gray-600 hover:text-gray-600 dark:hover:text-gray-400' : 'text-gray-100 cursor-not-allowed'}`}
                             title="Move down"
                         >
                             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1057,7 +1057,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                         <button
                             type="button"
                             onClick={handleEdit}
-                            className="p-1.5 text-gray-300 hover:text-gray-600 rounded"
+                            className="p-1.5 text-gray-300 dark:text-gray-600 hover:text-gray-600 dark:hover:text-gray-400 rounded"
                             title="Edit question"
                         >
                             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1067,7 +1067,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                         <button
                             type="button"
                             onClick={() => setShowDeleteModal(true)}
-                            className="p-1.5 text-gray-300 hover:text-red-400 rounded"
+                            className="p-1.5 text-gray-300 dark:text-gray-600 hover:text-red-400 rounded"
                             title="Delete question"
                         >
                             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1102,7 +1102,7 @@ const QuestionSection = memo(function QuestionSection({ question, people, canMov
                     <button
                         type="button"
                         onClick={() => onAddOption(question.id)}
-                        className="w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
+                        className="w-full py-2 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg text-xs text-gray-400 dark:text-gray-500 hover:border-primary-300 dark:hover:border-primary-700 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-950/40 transition-colors"
                     >
                         + Add Option
                     </button>
@@ -1140,7 +1140,7 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections
     const hasExpandedRef = useRef(isExpanded)
     if (isExpanded) hasExpandedRef.current = true
     return (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6">
+        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 sm:p-6">
             <div className="flex items-center">
                 <button
                     type="button"
@@ -1148,14 +1148,14 @@ const AlwaysSection = memo(function AlwaysSection({ items, people, emptySections
                     className="flex items-center gap-2 flex-1 text-left min-w-0"
                 >
                     <svg
-                        className={`w-5 h-5 text-gray-400 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                        className={`w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0 transform transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
                         fill="none" viewBox="0 0 24 24" stroke="currentColor"
                     >
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                     </svg>
                     <span className="flex flex-col min-w-0">
-                        <span className="font-medium text-gray-900">Always Needed Items</span>
-                        <span className="hidden sm:inline text-sm font-normal text-gray-500">{items.length} items</span>
+                        <span className="font-medium text-gray-900 dark:text-gray-100">Always Needed Items</span>
+                        <span className="hidden sm:inline text-sm font-normal text-gray-500 dark:text-gray-400">{items.length} items</span>
                     </span>
                 </button>
             </div>
@@ -1222,12 +1222,12 @@ function OptionEditModal({ option, onSave, onClose }: {
             onClick={onClose}
             onKeyDown={e => { if (e.key === 'Escape') onClose() }}
         >
-            <div className="bg-white rounded-xl shadow-xl w-full max-w-md" onClick={e => e.stopPropagation()}>
+            <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-md" onClick={e => e.stopPropagation()}>
                 <div className="p-5">
-                    <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
                         {option ? 'Edit Option' : 'Add Option'}
                     </h2>
-                    <label htmlFor={fieldId} className="block text-sm font-medium text-gray-700 mb-1">Answer text</label>
+                    <label htmlFor={fieldId} className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Answer text</label>
                     <input
                         id={fieldId}
                         autoFocus
@@ -1235,11 +1235,11 @@ function OptionEditModal({ option, onSave, onClose }: {
                         value={text}
                         onChange={e => setText(e.target.value)}
                         placeholder="e.g. Yes"
-                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 mb-5"
+                        className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 mb-5"
                         onKeyDown={e => { if (e.key === 'Enter') handleSave() }}
                     />
                     <div className="flex gap-2 justify-end">
-                        <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
+                        <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800">
                             Cancel
                         </button>
                         <button
@@ -1311,9 +1311,9 @@ export function PeopleModal({ people, onSave, onClose, session }: {
             {/* Bounded and scrollable: a household of five with an appearance
                 panel open is taller than a phone, and a modal that runs off the
                 bottom takes Save with it. */}
-            <div className="bg-white rounded-xl shadow-xl w-full max-w-sm max-h-[85vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+            <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm max-h-[85vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
                 <div className="p-5">
-                    <h2 className="text-lg font-semibold text-gray-900 mb-4">Edit People</h2>
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Edit People</h2>
                     <div className="space-y-2 mb-3">
                         {localPeople.map((person, i) => {
                             const identity = personIdentityAt(person, i, personPhoto)
@@ -1338,14 +1338,14 @@ export function PeopleModal({ people, onSave, onClose, session }: {
                                         value={person.name}
                                         onChange={e => updateName(i, e.target.value)}
                                         placeholder={`Person ${i + 1}`}
-                                        className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                        className="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
                                         onKeyDown={e => { if (e.key === 'Enter') addPerson() }}
                                     />
                                     {localPeople.length > 1 && (
                                         <button
                                             type="button"
                                             onClick={() => removePerson(i)}
-                                            className="text-gray-300 hover:text-red-400 text-xl leading-none shrink-0"
+                                            className="text-gray-300 dark:text-gray-600 hover:text-red-400 text-xl leading-none shrink-0"
                                             title="Remove person"
                                         >
                                             ×
@@ -1360,14 +1360,14 @@ export function PeopleModal({ people, onSave, onClose, session }: {
                                             title="Birthday (optional) — used to keep age-based items up to date"
                                             value={person.dateOfBirth ?? ''}
                                             onChange={e => updateDob(i, e.target.value)}
-                                            className="flex-1 min-w-0 border border-gray-300 rounded-lg px-2 py-1.5 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                            className="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-lg px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500"
                                         />
                                         <select
                                             aria-label={`Age group for ${person.name || `Person ${i + 1}`}`}
                                             title="Age group — change it manually if they're ready for the next one early"
                                             value={person.ageRange ?? ''}
                                             onChange={e => updateAgeRange(i, e.target.value)}
-                                            className="flex-1 min-w-0 border border-gray-300 rounded-lg px-2 py-1.5 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                            className="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-lg px-2 py-1.5 text-sm text-gray-600 dark:text-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500"
                                         >
                                             <option value="">Age group…</option>
                                             {AGE_RANGE_OPTIONS.map(option => (
@@ -1391,16 +1391,16 @@ export function PeopleModal({ people, onSave, onClose, session }: {
                             )
                         })}
                     </div>
-                    <p className="text-xs text-gray-400 mb-3">Tap someone's circle to change their colour, emoji or photo — it follows them onto every packing list. Birthdays are optional: add one and we'll suggest packing-item updates as they grow, or bump the age group early if they're ready for it.</p>
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-3">Tap someone's circle to change their colour, emoji or photo — it follows them onto every packing list. Birthdays are optional: add one and we'll suggest packing-item updates as they grow, or bump the age group early if they're ready for it.</p>
                     <button
                         type="button"
                         onClick={addPerson}
-                        className="w-full py-2 border-2 border-dashed border-gray-200 rounded-lg text-xs text-gray-400 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors mb-4"
+                        className="w-full py-2 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg text-xs text-gray-400 dark:text-gray-500 hover:border-primary-300 dark:hover:border-primary-700 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-950/40 transition-colors mb-4"
                     >
                         + Add Person
                     </button>
                     <div className="flex gap-2 justify-end">
-                        <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100">
+                        <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800">
                             Cancel
                         </button>
                         <button type="button" onClick={() => onSave(localPeople)} className="px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700">
@@ -1440,29 +1440,29 @@ function QuestionModal({ question, onSave, onClose }: {
             onClick={onClose}
             onKeyDown={e => { if (e.key === 'Escape') onClose() }}
         >
-            <div className="bg-white rounded-xl shadow-xl w-full max-w-md" onClick={e => e.stopPropagation()}>
+            <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-md" onClick={e => e.stopPropagation()}>
                 <div className="p-5">
-                    <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
                         {question ? 'Edit Question' : 'Add Question'}
                     </h2>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Question text</label>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Question text</label>
                     <input
                         autoFocus
                         type="text"
                         value={text}
                         onChange={e => setText(e.target.value)}
                         placeholder="e.g. Are you going to a hot climate?"
-                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 mb-4"
+                        className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 mb-4"
                         onKeyDown={e => { if (e.key === 'Enter' && text.trim()) onSave(text.trim(), type) }}
                     />
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Answer type</label>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Answer type</label>
                     <div className="flex gap-2 mb-5">
                         {(['single-choice', 'multiple-choice'] as QuestionType[]).map(t => (
                             <button
                                 key={t}
                                 type="button"
                                 onClick={() => setType(t)}
-                                className={`flex-1 py-2 rounded-lg text-sm border-2 transition-colors ${type === t ? 'border-primary-400 bg-primary-50 text-primary-900 font-medium' : 'border-gray-200 text-gray-600 hover:border-gray-300'}`}
+                                className={`flex-1 py-2 rounded-lg text-sm border-2 transition-colors ${type === t ? 'border-primary-400 dark:border-primary-600 bg-primary-50 dark:bg-primary-950/40 text-primary-900 dark:text-primary-200 font-medium' : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600'}`}
                             >
                                 {t === 'single-choice' ? 'Single choice' : 'Multiple choice'}
                             </button>
@@ -1472,7 +1472,7 @@ function QuestionModal({ question, onSave, onClose }: {
                         <button
                             type="button"
                             onClick={onClose}
-                            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100"
+                            className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
                         >
                             Cancel
                         </button>
@@ -1959,7 +1959,7 @@ export function QuestionsPage() {
     const activeQuestions = useMemo(() => (data?.questions ?? []).filter(q => !q.deletedAt), [data])
     const activeAlwaysNeededItems = useMemo(() => (data?.alwaysNeededItems ?? []).filter(i => !i.deletedAt), [data])
 
-    if (error) return <div className="p-8 text-red-600">Error: {error}</div>
+    if (error) return <div className="p-8 text-red-600 dark:text-red-400">Error: {error}</div>
     // An empty set on a device that has never synced isn't an answer yet: the
     // login sync may be about to bring the user's real questions. Showing them
     // "you have no questions" first, and a full set a moment later, would read
@@ -1980,9 +1980,9 @@ export function QuestionsPage() {
                     still being read, so anything that changes makes sense. */}
                 {isCheckingPod && <PodSyncIndicator />}
                 <div className="mb-2">
-                    <h1 className="text-2xl font-bold text-gray-900">{isForeign ? 'Questions & Items' : 'My Questions & Items'}</h1>
-                    <p className="mt-1 text-gray-600 text-sm">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>
-                    {!isForeign && <p className="mt-1 text-xs text-gray-400">Want to start from scratch? <Link to="/wizard" className="text-primary-600 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</p>}
+                    <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{isForeign ? 'Questions & Items' : 'My Questions & Items'}</h1>
+                    <p className="mt-1 text-gray-600 dark:text-gray-400 text-sm">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>
+                    {!isForeign && <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">Want to start from scratch? <Link to="/wizard" className="text-primary-600 dark:text-primary-400 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</p>}
                 </div>
                 {!isForeign && (
                     <AgePromotionCard
@@ -2056,7 +2056,7 @@ export function QuestionsPage() {
                     <button
                         type="button"
                         onClick={() => setQuestionModal({ question: null })}
-                        className="w-full py-3 border-2 border-dashed border-gray-200 rounded-lg text-sm text-gray-500 hover:border-primary-300 hover:text-primary-600 hover:bg-primary-50 transition-colors"
+                        className="w-full py-3 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-500 dark:text-gray-400 hover:border-primary-300 dark:hover:border-primary-700 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-950/40 transition-colors"
                     >
                         + Add Question
                     </button>

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -566,7 +566,7 @@ const SectionedItemRows = memo(function SectionedItemRows({ items, people, defau
                                         onClick={() => handleSectionBin(group.label, group.entries.length)}
                                         aria-label={`Delete section ${group.label}`}
                                         title={`Delete section ${group.label} — its items move to ${defaultLabel}`}
-                                        className={`shrink-0 -my-1 rounded p-1.5 ${accent.muted} hover:bg-white/70 hover:text-red-600 dark:hover:text-red-400 transition-colors`}
+                                        className={`shrink-0 -my-1 rounded p-1.5 ${accent.muted} hover:bg-white/70 dark:hover:bg-white/10 hover:text-red-600 dark:hover:text-red-400 transition-colors`}
                                     >
                                         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -44,14 +44,14 @@ const FULL_SETUP_TAGLINE = 'Let someone else use your questions and lists.'
 function FullSetupIntro() {
     return (
         <div className="space-y-2">
-            <p className="text-sm text-gray-700">{FULL_SETUP_TAGLINE}</p>
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-gray-700 dark:text-gray-300">{FULL_SETUP_TAGLINE}</p>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
                 They get your question set and every packing list you have — including the ones you
                 make later — and can view and edit them. Handy for anyone who packs with the same
                 people over and over: couples, families, sports clubs, scout troops, climbing
                 buddies.
             </p>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
                 Sharing just one list? Open that list and choose <strong>Share</strong> — that sends
                 a single list, not your whole setup.
             </p>
@@ -291,14 +291,14 @@ export function SharingSettingsPage() {
     if (!isLoggedIn) {
         return (
             <div className="max-w-2xl mx-auto py-8 px-4 space-y-6">
-                <h1 className="text-3xl font-bold text-primary-900">Sharing</h1>
+                <h1 className="text-3xl font-bold text-primary-900 dark:text-primary-200">Sharing</h1>
                 <section className="space-y-4">
-                    <h2 className="text-xl font-semibold text-gray-900">Share your full setup</h2>
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Share your full setup</h2>
                     <FullSetupIntro />
                     <Button type="button" variant="primary" onClick={() => setSignInPromptOpen(true)}>
                         Sign in to share your setup
                     </Button>
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
                         Everything you have made so far stays on this device until you sign in — nothing
                         is shared before you say who with.
                     </p>
@@ -327,12 +327,12 @@ export function SharingSettingsPage() {
     return (
         <div className="max-w-2xl mx-auto py-8 px-4 space-y-10">
             <div>
-                <h1 className="text-3xl font-bold text-primary-900">Sharing</h1>
+                <h1 className="text-3xl font-bold text-primary-900 dark:text-primary-200">Sharing</h1>
             </div>
 
             {/* Section 1: Share the whole setup — questions + every list */}
             <section className="space-y-4">
-                <h2 className="text-xl font-semibold text-gray-900">Share your full setup</h2>
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Share your full setup</h2>
                 <FullSetupIntro />
                 <div className="flex flex-col sm:flex-row gap-2">
                     <input
@@ -342,7 +342,7 @@ export function SharingSettingsPage() {
                         onChange={e => setCollaboratorWebId(e.target.value)}
                         placeholder="e.g. https://alice.solidcommunity.net/profile/card#me"
                         aria-label="Their WebID"
-                        className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                        className="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
                     />
                     <button
                         onClick={handleGrantAccess}
@@ -352,17 +352,17 @@ export function SharingSettingsPage() {
                         {isGranting ? 'Sharing…' : 'Share my setup'}
                     </button>
                 </div>
-                <p className="text-xs text-gray-500">
+                <p className="text-xs text-gray-500 dark:text-gray-400">
                     A WebID is the address of someone's Solid Pod — ask them to copy theirs from their
                     own sharing page.
                 </p>
 
                 {inviteLink && (
-                    <div className="mt-2 rounded-xl border-2 border-primary-200 bg-primary-50 p-4 space-y-2">
-                        <p className="text-sm font-semibold text-primary-900">
+                    <div className="mt-2 rounded-xl border-2 border-primary-200 dark:border-primary-800 bg-primary-50 dark:bg-primary-950/40 p-4 space-y-2">
+                        <p className="text-sm font-semibold text-primary-900 dark:text-primary-200">
                             ✅ Your full setup is shared{sharedWith ? ' with ' + sharedWith : ''}
                         </p>
-                        <p className="text-sm text-gray-700">
+                        <p className="text-sm text-gray-700 dark:text-gray-300">
                             They now have your question set and all your packing lists. Send them this
                             link so they can open it:
                         </p>
@@ -371,7 +371,7 @@ export function SharingSettingsPage() {
                             readOnly
                             value={inviteLink}
                             aria-label="Invite link"
-                            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none"
+                            className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-900 focus:outline-none"
                             onClick={e => (e.target as HTMLInputElement).select()}
                         />
                         <Button type="button" variant="secondary" onClick={handleCopyInviteLink}>
@@ -380,19 +380,19 @@ export function SharingSettingsPage() {
                     </div>
                 )}
 
-                <h3 className="text-sm font-semibold text-gray-700 pt-2">People with your full setup</h3>
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 pt-2">People with your full setup</h3>
                 {isLoadingCollaborators ? (
-                    <p className="text-sm text-gray-500">Loading…</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
                 ) : collaborators.length > 0 ? (
                     <ul className="space-y-2 mt-2">
                         {collaborators.map(webId => (
-                            <li key={webId} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
-                                <span className="text-sm text-gray-800 truncate flex-1" title={webId}>{webId}</span>
+                            <li key={webId} className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
+                                <span className="text-sm text-gray-800 dark:text-gray-100 truncate flex-1" title={webId}>{webId}</span>
                                 <button
                                     onClick={() => handleRevoke(webId)}
                                     disabled={revokingWebId === webId}
                                     aria-label={`Revoke access for ${webId}`}
-                                    className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-red-100 text-red-700 hover:bg-red-200 disabled:opacity-50 transition-colors"
+                                    className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-900/60 disabled:opacity-50 transition-colors"
                                 >
                                     {revokingWebId === webId ? 'Revoking…' : 'Revoke'}
                                 </button>
@@ -400,27 +400,27 @@ export function SharingSettingsPage() {
                         ))}
                     </ul>
                 ) : (
-                    <p className="text-sm text-gray-500">You haven't shared your full setup with anyone yet.</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">You haven't shared your full setup with anyone yet.</p>
                 )}
             </section>
 
             {/* Section 2: Pods shared with me */}
             <section className="space-y-4">
-                <h2 className="text-xl font-semibold text-gray-900">Data shared with me</h2>
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Data shared with me</h2>
                 {sharedContexts.length === 0 ? (
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
                         No shared pods yet. Visit an invite link to add one.
                     </p>
                 ) : (
                     <ul className="space-y-2">
                         {sharedContexts.map(ctx => (
-                            <li key={ctx.podUrl} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
-                                <span className="text-sm text-gray-800 truncate flex-1" title={ctx.podUrl}>
+                            <li key={ctx.podUrl} className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
+                                <span className="text-sm text-gray-800 dark:text-gray-100 truncate flex-1" title={ctx.podUrl}>
                                     {ctx.label ?? resolveOwnerDisplayName(podNames[ctx.podUrl], ctx.webId, ctx.podUrl)}
                                 </span>
                                 <button
                                     onClick={() => navigate(`/pod/${encodeURIComponent(ctx.podUrl)}/view-lists`)}
-                                    className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 text-primary-700 hover:bg-primary-200 transition-colors"
+                                    className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300 hover:bg-primary-200 dark:hover:bg-primary-900/60 transition-colors"
                                 >
                                     Open
                                 </button>
@@ -428,7 +428,7 @@ export function SharingSettingsPage() {
                                     onClick={() => handleRemoveSharedContext(ctx.podUrl)}
                                     disabled={removingPodUrl === ctx.podUrl}
                                     aria-label={`Remove shared pod`}
-                                    className="ml-2 px-3 py-1 text-xs font-semibold rounded-md bg-red-100 text-red-700 hover:bg-red-200 disabled:opacity-50 transition-colors"
+                                    className="ml-2 px-3 py-1 text-xs font-semibold rounded-md bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-900/60 disabled:opacity-50 transition-colors"
                                 >
                                     {removingPodUrl === ctx.podUrl ? 'Removing…' : 'Remove'}
                                 </button>
@@ -440,26 +440,26 @@ export function SharingSettingsPage() {
 
             {/* Section 3: Individual lists shared with me */}
             <section className="space-y-4">
-                <h2 className="text-xl font-semibold text-gray-900">Individual lists shared with me</h2>
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Individual lists shared with me</h2>
                 {sharedLists.length === 0 ? (
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
                         No individual lists yet. When someone shares a list link with you and you save it, it will appear here.
                     </p>
                 ) : (
                     <ul className="space-y-2">
                         {sharedLists.map(ctx => (
-                            <li key={`${ctx.listId}-${ctx.podUrl}`} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+                            <li key={`${ctx.listId}-${ctx.podUrl}`} className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
                                 <div className="flex flex-col flex-1 min-w-0">
-                                    <span className="text-sm font-medium text-gray-800 truncate">
+                                    <span className="text-sm font-medium text-gray-800 dark:text-gray-100 truncate">
                                         {ctx.label ?? ctx.listId}
                                     </span>
-                                    <span className="text-xs text-gray-500 truncate" title={ctx.podUrl}>
+                                    <span className="text-xs text-gray-500 dark:text-gray-400 truncate" title={ctx.podUrl}>
                                         {resolveOwnerDisplayName(listOwnerNames[ctx.listId], ctx.ownerWebId, ctx.podUrl)}
                                     </span>
                                 </div>
                                 <button
                                     onClick={() => navigate(buildSharedListPath(ctx.listId, ctx.podUrl, ctx.ownerWebId ?? undefined))}
-                                    className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 text-primary-700 hover:bg-primary-200 transition-colors"
+                                    className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300 hover:bg-primary-200 dark:hover:bg-primary-900/60 transition-colors"
                                 >
                                     Open
                                 </button>
@@ -467,7 +467,7 @@ export function SharingSettingsPage() {
                                     onClick={() => handleRemoveSharedList(ctx.listId)}
                                     disabled={removingListId === ctx.listId}
                                     aria-label={`Remove shared list ${ctx.label ?? ctx.listId}`}
-                                    className="ml-2 px-3 py-1 text-xs font-semibold rounded-md bg-red-100 text-red-700 hover:bg-red-200 disabled:opacity-50 transition-colors"
+                                    className="ml-2 px-3 py-1 text-xs font-semibold rounded-md bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-900/60 disabled:opacity-50 transition-colors"
                                 >
                                     {removingListId === ctx.listId ? 'Removing…' : 'Remove'}
                                 </button>
@@ -479,15 +479,15 @@ export function SharingSettingsPage() {
 
             {/* Section 4: Individual lists I've shared */}
             <section className="space-y-4">
-                <h2 className="text-xl font-semibold text-gray-900">Individual lists I've shared</h2>
-                <p className="text-sm text-gray-600">
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Individual lists I've shared</h2>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                     Lists you've shared on their own — with specific people or publicly. People who have
                     your full setup are not listed here; they already have every list.
                 </p>
                 {ownLists.length === 0 ? (
-                    <p className="text-sm text-gray-500">No packing lists yet.</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">No packing lists yet.</p>
                 ) : sharedOwnLists.length === 0 && Object.values(sharingStatusByListId).every(s => s !== 'loading') ? (
-                    <p className="text-sm text-gray-500">You haven't shared any individual lists yet.</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">You haven't shared any individual lists yet.</p>
                 ) : (
                     <ul className="space-y-2">
                         {ownLists
@@ -499,10 +499,10 @@ export function SharingSettingsPage() {
                             .map(list => {
                                 const status = sharingStatusByListId[list.id]
                                 return (
-                                    <li key={list.id} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+                                    <li key={list.id} className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
                                         <div className="flex flex-col flex-1 min-w-0">
-                                            <span className="text-sm font-medium text-gray-800 truncate">✈️ {list.name}</span>
-                                            <span className="text-xs text-gray-500">
+                                            <span className="text-sm font-medium text-gray-800 dark:text-gray-100 truncate">✈️ {list.name}</span>
+                                            <span className="text-xs text-gray-500 dark:text-gray-400">
                                                 {status === 'loading' ? 'Loading sharing info…' :
                                                     status === 'error' ? 'Could not load sharing info' :
                                                     [
@@ -517,7 +517,7 @@ export function SharingSettingsPage() {
                                                     fileUrl: `${ownPodUrl}${POD_CONTAINERS.PACKING_LISTS}${list.id}.ttl`,
                                                     listId: list.id,
                                                 })}
-                                                className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 text-primary-700 hover:bg-primary-200 transition-colors"
+                                                className="ml-3 px-3 py-1 text-xs font-semibold rounded-md bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300 hover:bg-primary-200 dark:hover:bg-primary-900/60 transition-colors"
                                             >
                                                 Manage sharing
                                             </button>

--- a/src/pages/solid-pod-handle-redirect-page.tsx
+++ b/src/pages/solid-pod-handle-redirect-page.tsx
@@ -23,7 +23,7 @@ export const SolidPodHandleRedirectPage = () => {
         <div className="flex items-center justify-center min-h-screen">
             <div className="text-center">
                 <h1 className="text-2xl font-bold mb-4">Logging in...</h1>
-                <p className="text-gray-600">Redirecting you back to the app...</p>
+                <p className="text-gray-600 dark:text-gray-400">Redirecting you back to the app...</p>
             </div>
         </div>
     );

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1590,19 +1590,19 @@ export function ViewPackingList() {
             <div className="w-full max-w-screen-2xl mb-3">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                     <div className="flex items-center gap-3 min-w-0">
-                        <h1 className="text-xl font-bold text-gray-900 truncate">{packingList.name}</h1>
+                        <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 truncate">{packingList.name}</h1>
                         {foreignPodUrl && (
-                            <span className="text-xs font-medium text-blue-700 bg-blue-100 border border-blue-200 rounded-full px-2 py-0.5 shrink-0">
+                            <span className="text-xs font-medium text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/40 border border-blue-200 dark:border-blue-800 rounded-full px-2 py-0.5 shrink-0">
                                 Shared list
                             </span>
                         )}
                         {isLoggedIn && syncingFromPod && (
-                            <span className="text-xs text-blue-600 shrink-0">Syncing…</span>
+                            <span className="text-xs text-blue-600 dark:text-blue-400 shrink-0">Syncing…</span>
                         )}
                         <div className={`flex items-center gap-1 transition-opacity duration-200 shrink-0 ${autoSaveStatus === 'idle' ? 'opacity-0' : 'opacity-100'}`}>
-                            {autoSaveStatus === 'saving' && <span className="text-xs text-blue-500">Saving…</span>}
-                            {autoSaveStatus === 'saved' && <span className="text-xs text-green-600">Saved</span>}
-                            {autoSaveStatus === 'error' && <span className="text-xs text-red-600">Error saving</span>}
+                            {autoSaveStatus === 'saving' && <span className="text-xs text-blue-500 dark:text-blue-400">Saving…</span>}
+                            {autoSaveStatus === 'saved' && <span className="text-xs text-green-600 dark:text-green-400">Saved</span>}
+                            {autoSaveStatus === 'error' && <span className="text-xs text-red-600 dark:text-red-400">Error saving</span>}
                         </div>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
@@ -1646,7 +1646,7 @@ export function ViewPackingList() {
                 {(packingList.destination || tripDates) && (
                     <div
                         data-testid="trip-details"
-                        className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600"
+                        className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600 dark:text-gray-400"
                     >
                         {packingList.destination && <span>📍 {packingList.destination}</span>}
                         {tripDates && <span>📅 {tripDates}</span>}
@@ -1665,8 +1665,8 @@ export function ViewPackingList() {
 
             {/* Persistent "viewing someone else's list" indicator */}
             {foreignPodUrl && !foreignPodCtx && (
-                <div className="w-full max-w-screen-2xl mb-2 bg-indigo-50 border border-indigo-200 rounded-xl px-4 py-3">
-                    <p className="text-sm text-indigo-800 font-medium">
+                <div className="w-full max-w-screen-2xl mb-2 bg-indigo-50 dark:bg-indigo-950/40 border border-indigo-200 dark:border-indigo-800 rounded-xl px-4 py-3">
+                    <p className="text-sm text-indigo-800 dark:text-indigo-200 font-medium">
                         👤 Viewing a list from <span className="font-semibold">{resolveOwnerDisplayName(ownerDisplayName, effectiveOwnerWebId, foreignPodUrl)}</span>
                     </p>
                 </div>
@@ -1675,12 +1675,12 @@ export function ViewPackingList() {
             {/* Slim sticky progress strip */}
             <div className="sticky top-0 z-50 w-full mb-4 flex justify-center">
                 <div className="w-full max-w-screen-2xl">
-                    <div className="backdrop-blur-md bg-white/90 border border-gray-200 shadow-sm rounded-lg px-4 py-2">
+                    <div className="backdrop-blur-md bg-white/90 dark:bg-gray-900/90 border border-gray-200 dark:border-gray-700 shadow-sm rounded-lg px-4 py-2">
                         {/* Counts and bar share a line with the controls where there is
                             room; at 390px the controls drop to a line of their own
                             rather than squeezing everything into wrapped fragments. */}
                         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-                            <span className={`text-sm font-medium whitespace-nowrap ${allPacked ? 'text-emerald-600' : 'text-gray-600'}`}>
+                            <span className={`text-sm font-medium whitespace-nowrap ${allPacked ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-600 dark:text-gray-400'}`}>
                                 {allPacked ? '🎉 All packed!' : `${packedCount} / ${totalCount} packed (${percentComplete}%)`}
                             </span>
                             {/* The bar shrinks to its minimum before the encouragement
@@ -1693,7 +1693,7 @@ export function ViewPackingList() {
                                     aria-valuenow={percentComplete}
                                     aria-valuemin={0}
                                     aria-valuemax={100}
-                                    className="flex-1 min-w-8 bg-gray-200 rounded-full h-1.5 overflow-hidden"
+                                    className="flex-1 min-w-8 bg-gray-200 dark:bg-gray-700 rounded-full h-1.5 overflow-hidden"
                                 >
                                     <div
                                         data-testid="packing-progress-fill"
@@ -1702,7 +1702,7 @@ export function ViewPackingList() {
                                     ></div>
                                 </div>
                                 {milestoneMessage && (
-                                    <span data-testid="progress-milestone" className="text-xs font-semibold text-primary-700 whitespace-nowrap">
+                                    <span data-testid="progress-milestone" className="text-xs font-semibold text-primary-700 dark:text-primary-300 whitespace-nowrap">
                                         {milestoneMessage}
                                     </span>
                                 )}
@@ -1713,12 +1713,12 @@ export function ViewPackingList() {
                                         type="button"
                                         onClick={toggleAllSections}
                                         title={everySectionFolded ? 'Open every section' : 'Fold every section down to its header'}
-                                        className="shrink-0 flex items-center gap-1 rounded-md border border-gray-300 bg-white px-2.5 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                                        className="shrink-0 flex items-center gap-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2.5 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
                                     >
                                         {/* Same glyph the section headers use for the same
                                             state, so the toolbar and the cards never point
                                             opposite ways at each other. */}
-                                        <span aria-hidden="true" className="text-xs text-gray-400">{everySectionFolded ? '▶' : '▼'}</span>
+                                        <span aria-hidden="true" className="text-xs text-gray-400 dark:text-gray-500">{everySectionFolded ? '▶' : '▼'}</span>
                                         {/* The word "all" is what tips this row onto a second
                                             line on a phone, and the icon already says it. */}
                                         {everySectionFolded ? (isDesktop ? 'Expand all' : 'Expand') : (isDesktop ? 'Collapse all' : 'Collapse')}
@@ -1755,11 +1755,11 @@ export function ViewPackingList() {
                             wraps for the same reason the strip does — a guest's
                             row of controls is wider than a phone. */}
                         {filtering && (
-                            <div className="mt-1.5 flex min-h-[2.75rem] items-center gap-2 overflow-x-auto border-t border-gray-100 pt-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                            <div className="mt-1.5 flex min-h-[2.75rem] items-center gap-2 overflow-x-auto border-t border-gray-100 dark:border-gray-800 pt-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                                 <button
                                     type="button"
                                     onClick={handleClearFilter}
-                                    className="shrink-0 rounded-full border border-blue-200 px-2.5 py-1 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-50"
+                                    className="shrink-0 rounded-full border border-blue-200 dark:border-blue-800 px-2.5 py-1 text-xs font-semibold text-blue-700 dark:text-blue-300 transition-colors hover:bg-blue-50 dark:hover:bg-blue-950/40"
                                 >
                                     Clear
                                 </button>
@@ -1777,36 +1777,36 @@ export function ViewPackingList() {
                                                 }}
                                                 onBlur={() => handleRenameGuest(soleGuest.id, renamingGuestName)}
                                                 autoFocus
-                                                className="w-40 shrink-0 rounded-md border border-blue-400 px-2 py-1 text-xs font-semibold text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                                className="w-40 shrink-0 rounded-md border border-blue-400 dark:border-blue-600 px-2 py-1 text-xs font-semibold text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                                             />
                                         ) : (
                                             <>
-                                                <span className="shrink-0 text-xs font-semibold text-gray-700">{solePerson.name}</span>
+                                                <span className="shrink-0 text-xs font-semibold text-gray-700 dark:text-gray-300">{solePerson.name}</span>
                                                 {/* On a phone the chips are faces
                                                     with no names on them, so the
                                                     numbers come off the chip and
                                                     land here beside the name. */}
-                                                <span className="shrink-0 text-xs tabular-nums text-gray-500 sm:hidden">
+                                                <span className="shrink-0 text-xs tabular-nums text-gray-500 dark:text-gray-400 sm:hidden">
                                                     {solePersonTotal - solePersonUnpacked}/{solePersonTotal}
                                                 </span>
                                             </>
                                         )}
                                         {soleGuest && renamingGuestId !== soleGuest.id && (
-                                            <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">Guest</span>
+                                            <span className="shrink-0 rounded-full bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-300">Guest</span>
                                         )}
                                         {/* One person finishing their bag is a
                                             real thing to have done. The trip's
                                             own celebration stays for the trip,
                                             but this shouldn't pass in silence. */}
                                         {solePersonUnpacked === 0 && solePersonTotal > 0 ? (
-                                            <span className="shrink-0 whitespace-nowrap rounded-full border border-emerald-200 bg-emerald-100 px-2.5 py-1 text-xs font-semibold text-emerald-700">
+                                            <span className="shrink-0 whitespace-nowrap rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-100 dark:bg-emerald-900/40 px-2.5 py-1 text-xs font-semibold text-emerald-700 dark:text-emerald-300">
                                                 🎉 {solePerson.name}'s bag is packed!
                                             </span>
                                         ) : solePersonUnpacked > 0 && (
                                             <button
                                                 type="button"
                                                 onClick={() => handlePackAllFor(solePerson.name)}
-                                                className="shrink-0 whitespace-nowrap rounded-full border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-100"
+                                                className="shrink-0 whitespace-nowrap rounded-full border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/40 px-2.5 py-1 text-xs font-semibold text-blue-700 dark:text-blue-300 transition-colors hover:bg-blue-100 dark:hover:bg-blue-900/40"
                                             >
                                                 {/* The number is in the button, where it
                                                     is read before the tap rather than in a
@@ -1819,14 +1819,14 @@ export function ViewPackingList() {
                                                 <button
                                                     type="button"
                                                     onClick={() => { setRenamingGuestId(soleGuest.id); setRenamingGuestName(soleGuest.name) }}
-                                                    className="shrink-0 rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                                                    className="shrink-0 rounded-full border border-gray-200 dark:border-gray-700 px-2.5 py-1 text-xs font-medium text-gray-600 dark:text-gray-400 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
                                                 >
                                                     Rename
                                                 </button>
                                                 <button
                                                     type="button"
                                                     onClick={() => setGuestToRemove(soleGuest.id)}
-                                                    className="shrink-0 rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-red-50 hover:text-red-700"
+                                                    className="shrink-0 rounded-full border border-gray-200 dark:border-gray-700 px-2.5 py-1 text-xs font-medium text-gray-600 dark:text-gray-400 transition-colors hover:bg-red-50 dark:hover:bg-red-950/40 hover:text-red-700 dark:hover:text-red-300"
                                                 >
                                                     Remove
                                                 </button>
@@ -1838,7 +1838,7 @@ export function ViewPackingList() {
                                     above says it in colour, which is no answer
                                     on a phone where the chips carry no names. */}
                                 {solePerson === undefined && (
-                                    <span className="shrink-0 text-xs font-semibold text-gray-700">
+                                    <span className="shrink-0 text-xs font-semibold text-gray-700 dark:text-gray-300">
                                         {filterNames(selectedPeople)}
                                     </span>
                                 )}
@@ -1884,14 +1884,14 @@ export function ViewPackingList() {
                 themselves, so it never becomes furniture. */}
             {foldedOnOpen && everySectionFolded && (
                 <div data-testid="folded-on-open-note" className="w-full max-w-screen-2xl mb-4">
-                    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3">
-                        <p className="text-sm text-blue-800">
+                    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-xl border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/40 px-4 py-3">
+                        <p className="text-sm text-blue-800 dark:text-blue-200">
                             A long list, so all {listSections.length} sections start folded — tap any heading to open one.
                         </p>
                         <button
                             type="button"
                             onClick={toggleAllSections}
-                            className="shrink-0 rounded-md border border-blue-300 bg-white px-3 py-1.5 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100"
+                            className="shrink-0 rounded-md border border-blue-300 dark:border-blue-700 bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-semibold text-blue-700 dark:text-blue-300 transition-colors hover:bg-blue-100 dark:hover:bg-blue-900/40"
                         >
                             Expand all
                         </button>
@@ -1903,8 +1903,8 @@ export function ViewPackingList() {
                 celebration, and the Show Packed button is right there anyway */}
             {hiddenPackedCount > 0 && !allPacked && (
                 <div className="w-full max-w-screen-2xl mb-4">
-                    <div className="bg-amber-50 border border-amber-200 rounded-xl px-4 py-3">
-                        <p className="text-sm text-amber-800">
+                    <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-800 rounded-xl px-4 py-3">
+                        <p className="text-sm text-amber-800 dark:text-amber-200">
                             {hiddenPackedCount} packed item{hiddenPackedCount !== 1 ? 's' : ''} hidden — tap <strong>Show Packed</strong> to see them.
                         </p>
                     </div>
@@ -1926,7 +1926,7 @@ export function ViewPackingList() {
                             }}
                             placeholder="Guest name..."
                             autoFocus
-                            className="flex-1 min-w-0 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                            className="flex-1 min-w-0 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
                         />
                         <button
                             type="button"
@@ -1938,7 +1938,7 @@ export function ViewPackingList() {
                         <button
                             type="button"
                             onClick={() => { setShowAddGuest(false); setNewGuestName('') }}
-                            className="shrink-0 px-3 py-2 text-gray-600 hover:text-gray-900 border border-gray-300 rounded-md text-sm"
+                            className="shrink-0 px-3 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 border border-gray-300 dark:border-gray-600 rounded-md text-sm"
                         >
                             Cancel
                         </button>
@@ -1982,18 +1982,18 @@ export function ViewPackingList() {
                             const isGridSection = true
                             const isSectionCollapsed = collapsedSections.has(sectionKey)
                             const sectionBorder = isComplete
-                                ? 'border-emerald-300 bg-emerald-50'
+                                ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40'
                                 // Amber, because the card is a reminder rather than
                                 // a pile: nothing in it can be dealt with yet.
                                 : isLastMinute
-                                    ? 'border-amber-300 bg-amber-50'
-                                    : 'bg-white border-gray-200'
+                                    ? 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40'
+                                    : 'bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700'
                             return (
                             <div key={sectionKey} data-testid="list-section" className={`border rounded-lg p-3 shadow-sm transition-colors duration-300 sm:p-4 ${sectionBorder}`} style={{ breakInside: 'avoid' }}>
                                 {/* The rule under the heading separates it from the items
                                     below; a folded card has none, so it would just be a
                                     line ruling off empty space. */}
-                                <div className={isSectionCollapsed ? undefined : 'mb-4 pb-2 border-b border-gray-200'}>
+                                <div className={isSectionCollapsed ? undefined : 'mb-4 pb-2 border-b border-gray-200 dark:border-gray-700'}>
                                     <div className="flex flex-wrap items-center gap-1 min-h-[2rem]">
                                         <button
                                             type="button"
@@ -2001,18 +2001,18 @@ export function ViewPackingList() {
                                             onClick={() => toggleSection(sectionKey)}
                                             className="flex items-center gap-2 flex-1 min-w-0 text-left"
                                         >
-                                            <span className="shrink-0 text-sm text-gray-400">{isSectionCollapsed ? '▶' : '▼'}</span>
-                                            <span className="text-xl font-semibold text-gray-800">{title}</span>
+                                            <span className="shrink-0 text-sm text-gray-400 dark:text-gray-500">{isSectionCollapsed ? '▶' : '▼'}</span>
+                                            <span className="text-xl font-semibold text-gray-800 dark:text-gray-100">{title}</span>
                                             {/* Never let a count break across lines — "9 /" above "9" is
                                                 a fraction the eye has to reassemble. */}
-                                            <span className="ml-1 shrink-0 whitespace-nowrap text-sm font-normal text-gray-500">
+                                            <span className="ml-1 shrink-0 whitespace-nowrap text-sm font-normal text-gray-500 dark:text-gray-400">
                                                 {stats.packed} / {stats.total}{filterQualifier}
                                             </span>
                                         </button>
                                         {isComplete && (
                                             <span
                                                 aria-label={`All packed for ${completeLabel}${filterQualifier}`}
-                                                className="animate-pop-in text-xs font-semibold text-emerald-700 bg-emerald-100 border border-emerald-200 rounded-full px-2 py-0.5 shrink-0"
+                                                className="animate-pop-in text-xs font-semibold text-emerald-700 dark:text-emerald-300 bg-emerald-100 dark:bg-emerald-900/40 border border-emerald-200 dark:border-emerald-800 rounded-full px-2 py-0.5 shrink-0"
                                             >
                                                 🎉 All packed!
                                             </span>
@@ -2026,7 +2026,7 @@ export function ViewPackingList() {
                                                 type="button"
                                                 aria-label={`Check all${filterQualifier} in ${title}`}
                                                 onClick={() => handleCheckAll(checkableItemsOf(section))}
-                                                className="shrink-0 rounded-full border border-gray-200 px-2.5 py-1 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-50"
+                                                className="shrink-0 rounded-full border border-gray-200 dark:border-gray-700 px-2.5 py-1 text-xs font-medium text-blue-700 dark:text-blue-300 transition-colors hover:bg-blue-50 dark:hover:bg-blue-950/40"
                                             >
                                                 Check all
                                             </button>
@@ -2037,13 +2037,13 @@ export function ViewPackingList() {
                                     {/* The card is the only one whose items can't be dealt with
                                         yet, so it says why rather than leaving that to the name. */}
                                     {isLastMinute && (
-                                        <p className="-mt-2 mb-3 text-sm text-amber-800">{LAST_MINUTE_HINT}</p>
+                                        <p className="-mt-2 mb-3 text-sm text-amber-800 dark:text-amber-200">{LAST_MINUTE_HINT}</p>
                                     )}
                                     {/* Every card can be typed into directly. What varies is which
                                         part of the target the card already knows: a person's card
                                         knows who, and asks which section; a section's card knows
                                         which section, and asks who. */}
-                                    <div className="mb-4 pb-4 border-b border-gray-200">
+                                    <div className="mb-4 pb-4 border-b border-gray-200 dark:border-gray-700">
                                         {/* The card knows which section it is;
                                             who it is for follows the filter when
                                             the filter names one person, so an
@@ -2062,7 +2062,7 @@ export function ViewPackingList() {
                                         />
                                     </div>
                                     {isComplete && items.length === 0 && !isGridSection && (
-                                        <p className="text-sm font-medium text-emerald-700">
+                                        <p className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
                                             Nothing left to pack 🎒
                                         </p>
                                     )}
@@ -2089,11 +2089,11 @@ export function ViewPackingList() {
                         )})}
                     </div>}
                     {!sectionsPackedAway && listSections.length === 0 && filtering && (
-                        <div className="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-center">
-                            <p className="text-sm font-medium text-gray-700">
+                        <div className="rounded-lg border border-dashed border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 p-6 text-center">
+                            <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
                                 Nothing on this list is{filterQualifier} yet.
                             </p>
-                            <p className="mt-1 text-sm text-gray-500">
+                            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
                                 Clear the filter to add the first thing{filterQualifier}, or pick somebody else.
                             </p>
                         </div>

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -148,23 +148,23 @@ export const Wizard = () => {
     return (
         <div className="max-w-3xl mx-auto">
             <div className="mb-8 text-center animate-slide-up">
-                <h1 className="text-4xl font-bold mb-4 text-primary-900">
+                <h1 className="text-4xl font-bold mb-4 text-primary-900 dark:text-primary-200">
                     Create Your Packing Questions
                 </h1>
-                <p className="text-lg text-gray-700">
+                <p className="text-lg text-gray-700 dark:text-gray-300">
                     Tell us who you travel with — we'll generate a starter set of packing questions tailored to your group.
                 </p>
-                <p className="text-sm text-gray-500 mt-2 italic">
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 italic">
                     Do this once to get started. Afterwards, fine-tune your questions and packing items from 'My Questions &amp; Items' to match exactly what you need.
                 </p>
             </div>
 
             {hasExistingData && (
-                <div className="mb-6 p-4 bg-warning-50 border-2 border-warning-300 rounded-2xl">
-                    <p className="text-warning-900 font-semibold">
+                <div className="mb-6 p-4 bg-warning-50 dark:bg-warning-950/40 border-2 border-warning-300 dark:border-warning-700 rounded-2xl">
+                    <p className="text-warning-900 dark:text-warning-200 font-semibold">
                         ⚠️ You already have packing list questions set up. Completing this wizard will replace them.
                     </p>
-                    <p className="text-sm text-warning-800 mt-1">
+                    <p className="text-sm text-warning-800 dark:text-warning-200 mt-1">
                         To keep your existing questions, go to{' '}
                         <Link to="/manage-questions" className="underline font-semibold">Edit Questions</Link> instead.
                     </p>
@@ -173,16 +173,16 @@ export const Wizard = () => {
 
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
                 {/* People Section */}
-                <div className="bg-white p-6 rounded-2xl shadow-soft border-2 border-primary-200">
+                <div className="bg-white dark:bg-gray-900 p-6 rounded-2xl shadow-soft border-2 border-primary-200 dark:border-primary-800">
                     <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-2xl font-bold text-primary-900">👥 Who's Packing?</h2>
-                        <span className="text-sm text-gray-600 font-medium">
+                        <h2 className="text-2xl font-bold text-primary-900 dark:text-primary-200">👥 Who's Packing?</h2>
+                        <span className="text-sm text-gray-600 dark:text-gray-400 font-medium">
                             {fields.length} in your group
                         </span>
                     </div>
 
                     {isPrefilled && (
-                        <p className="mb-4 text-sm text-gray-600">
+                        <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
                             We've filled in the people from your current setup — add, remove or change anyone before generating.
                         </p>
                     )}
@@ -192,32 +192,32 @@ export const Wizard = () => {
                             const dob = field.kind === 'person' ? watch(`people.${index}.dateOfBirth`) : undefined
                             const derivedAgeRange = dob ? deriveAgeRange(dob) : undefined
                             return (
-                            <div key={field.id} className="bg-primary-50 p-4 rounded-xl border border-primary-200">
+                            <div key={field.id} className="bg-primary-50 dark:bg-primary-950/40 p-4 rounded-xl border border-primary-200 dark:border-primary-800">
                                 <div className="flex items-start gap-4">
                                     <div className="flex-1 grid grid-cols-1 md:grid-cols-3 gap-4">
                                         <div>
-                                            <label htmlFor={`person-name-${index}`} className="block text-sm font-semibold text-gray-700 mb-2">
+                                            <label htmlFor={`person-name-${index}`} className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
                                                 Name
                                             </label>
                                             <input
                                                 id={`person-name-${index}`}
                                                 type="text"
                                                 {...register(`people.${index}.name`)}
-                                                className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                className="w-full px-4 py-2 border-2 border-gray-300 dark:border-gray-600 rounded-xl focus:border-primary-500 dark:focus:border-primary-600 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 transition-all"
                                             />
                                             {errors.people?.[index]?.name && (
-                                                <p className="text-danger-500 text-sm mt-1">{errors.people[index]?.name?.message}</p>
+                                                <p className="text-danger-500 dark:text-danger-400 text-sm mt-1">{errors.people[index]?.name?.message}</p>
                                             )}
                                         </div>
                                         {field.kind === 'pet' ? (
                                             <div>
-                                                <label htmlFor={`person-species-${index}`} className="block text-sm font-semibold text-gray-700 mb-2">
+                                                <label htmlFor={`person-species-${index}`} className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
                                                     Species
                                                 </label>
                                                 <select
                                                     id={`person-species-${index}`}
                                                     {...register(`people.${index}.species`)}
-                                                    className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                    className="w-full px-4 py-2 border-2 border-gray-300 dark:border-gray-600 rounded-xl focus:border-primary-500 dark:focus:border-primary-600 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 transition-all"
                                                 >
                                                     <option value="">Select species...</option>
                                                     {PET_SPECIES_OPTIONS.map(option => (
@@ -227,14 +227,14 @@ export const Wizard = () => {
                                                     ))}
                                                 </select>
                                                 {errors.people?.[index] && 'species' in errors.people[index]! && (
-                                                    <p className="text-danger-500 text-sm mt-1">Species is required</p>
+                                                    <p className="text-danger-500 dark:text-danger-400 text-sm mt-1">Species is required</p>
                                                 )}
                                             </div>
                                         ) : (
                                             <>
                                                 <div>
-                                                    <label htmlFor={`person-birthday-${index}`} className="block text-sm font-semibold text-gray-700 mb-2">
-                                                        Birthday <span className="text-gray-400 font-normal">(optional)</span>
+                                                    <label htmlFor={`person-birthday-${index}`} className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                                                        Birthday <span className="text-gray-400 dark:text-gray-500 font-normal">(optional)</span>
                                                     </label>
                                                     <input
                                                         id={`person-birthday-${index}`}
@@ -245,20 +245,20 @@ export const Wizard = () => {
                                                                 if (derived) setValue(`people.${index}.ageRange`, derived)
                                                             },
                                                         })}
-                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                        className="w-full px-4 py-2 border-2 border-gray-300 dark:border-gray-600 rounded-xl focus:border-primary-500 dark:focus:border-primary-600 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 transition-all"
                                                     />
                                                     {derivedAgeRange && (
-                                                        <p className="text-xs text-gray-500 mt-1">Age group filled in from birthday — adjust it if they're ahead or behind</p>
+                                                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Age group filled in from birthday — adjust it if they're ahead or behind</p>
                                                     )}
                                                 </div>
                                                 <div>
-                                                    <label htmlFor={`person-age-range-${index}`} className="block text-sm font-semibold text-gray-700 mb-2">
+                                                    <label htmlFor={`person-age-range-${index}`} className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
                                                         Age Range
                                                     </label>
                                                     <select
                                                         id={`person-age-range-${index}`}
                                                         {...register(`people.${index}.ageRange`)}
-                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                        className="w-full px-4 py-2 border-2 border-gray-300 dark:border-gray-600 rounded-xl focus:border-primary-500 dark:focus:border-primary-600 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 transition-all"
                                                     >
                                                         <option value="">Select age range...</option>
                                                         {AGE_RANGE_OPTIONS.map(option => (
@@ -268,17 +268,17 @@ export const Wizard = () => {
                                                         ))}
                                                     </select>
                                                     {errors.people?.[index] && 'ageRange' in errors.people[index]! && (
-                                                        <p className="text-danger-500 text-sm mt-1">{(errors.people[index] as { ageRange?: { message?: string } }).ageRange?.message}</p>
+                                                        <p className="text-danger-500 dark:text-danger-400 text-sm mt-1">{(errors.people[index] as { ageRange?: { message?: string } }).ageRange?.message}</p>
                                                     )}
                                                 </div>
                                                 <div>
-                                                    <label htmlFor={`person-gender-${index}`} className="block text-sm font-semibold text-gray-700 mb-2">
+                                                    <label htmlFor={`person-gender-${index}`} className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
                                                         Gender
                                                     </label>
                                                     <select
                                                         id={`person-gender-${index}`}
                                                         {...register(`people.${index}.gender`)}
-                                                        className="w-full px-4 py-2 border-2 border-gray-300 rounded-xl focus:border-primary-500 focus:ring-2 focus:ring-primary-200 transition-all"
+                                                        className="w-full px-4 py-2 border-2 border-gray-300 dark:border-gray-600 rounded-xl focus:border-primary-500 dark:focus:border-primary-600 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 transition-all"
                                                     >
                                                         <option value="">Select gender...</option>
                                                         {GENDER_OPTIONS.map(option => (
@@ -294,7 +294,7 @@ export const Wizard = () => {
                                     <button
                                         type="button"
                                         onClick={() => handleRemovePerson(index)}
-                                        className="mt-8 p-2 text-danger-500 hover:bg-danger-50 rounded-lg transition-colors"
+                                        className="mt-8 p-2 text-danger-500 dark:text-danger-400 hover:bg-danger-50 dark:hover:bg-danger-950/40 rounded-lg transition-colors"
                                         title={field.kind === 'pet' ? 'Remove pet' : 'Remove person'}
                                     >
                                         <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
@@ -311,7 +311,7 @@ export const Wizard = () => {
                         <button
                             type="button"
                             onClick={handleAddPerson}
-                            className="w-full py-3 px-4 border-2 border-dashed border-primary-300 rounded-xl text-primary-700 font-semibold hover:border-primary-500 hover:bg-primary-50 transition-all duration-200 flex items-center justify-center gap-2"
+                            className="w-full py-3 px-4 border-2 border-dashed border-primary-300 dark:border-primary-700 rounded-xl text-primary-700 dark:text-primary-300 font-semibold hover:border-primary-500 dark:hover:border-primary-600 hover:bg-primary-50 dark:hover:bg-primary-950/40 transition-all duration-200 flex items-center justify-center gap-2"
                         >
                             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                 <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
@@ -321,7 +321,7 @@ export const Wizard = () => {
                         <button
                             type="button"
                             onClick={handleAddPet}
-                            className="w-full py-3 px-4 border-2 border-dashed border-primary-300 rounded-xl text-primary-700 font-semibold hover:border-primary-500 hover:bg-primary-50 transition-all duration-200 flex items-center justify-center gap-2"
+                            className="w-full py-3 px-4 border-2 border-dashed border-primary-300 dark:border-primary-700 rounded-xl text-primary-700 dark:text-primary-300 font-semibold hover:border-primary-500 dark:hover:border-primary-600 hover:bg-primary-50 dark:hover:bg-primary-950/40 transition-all duration-200 flex items-center justify-center gap-2"
                         >
                             <span className="text-lg leading-none">🐾</span>
                             Add a Pet
@@ -329,7 +329,7 @@ export const Wizard = () => {
                     </div>
 
                     {errors.people && typeof errors.people.message === 'string' && (
-                        <p className="text-danger-500 text-sm mt-2">{errors.people.message}</p>
+                        <p className="text-danger-500 dark:text-danger-400 text-sm mt-2">{errors.people.message}</p>
                     )}
                 </div>
 
@@ -372,7 +372,7 @@ Are you sure you want to continue?"
                             {revealSteps.slice(0, revealedCount).map(step => (
                                 <li
                                     key={step.personId}
-                                    className="reveal-line flex gap-2 text-gray-700 break-words"
+                                    className="reveal-line flex gap-2 text-gray-700 dark:text-gray-300 break-words"
                                 >
                                     <span aria-hidden="true">✨</span>
                                     <span className="flex-1 min-w-0">{step.text}</span>
@@ -385,7 +385,7 @@ Are you sure you want to continue?"
                         <div className="flex justify-center">
                             <button
                                 onClick={handleSkipReveal}
-                                className="text-sm font-semibold text-primary-700 underline hover:text-primary-900"
+                                className="text-sm font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-200"
                             >
                                 Skip ›
                             </button>
@@ -395,12 +395,12 @@ Are you sure you want to continue?"
                     {isRevealComplete && (
                         <>
                             {summary && (
-                                <p className="text-center font-bold text-primary-900 break-words">
+                                <p className="text-center font-bold text-primary-900 dark:text-primary-200 break-words">
                                     {summary.text}
                                 </p>
                             )}
 
-                            <p className="text-gray-700 text-center">
+                            <p className="text-gray-700 dark:text-gray-300 text-center">
                                 Your starter questions are ready! Head to 'My Questions &amp; Items' to add, remove, or tweak them to match how you travel — then create your first list.
                             </p>
 
@@ -414,13 +414,13 @@ Are you sure you want to continue?"
 
                                 <button
                                     onClick={() => handleSuccessAction('/manage-questions')}
-                                    className="w-full text-primary-700 border-2 border-primary-200 hover:border-primary-400 hover:bg-primary-50 px-4 sm:px-6 py-3 rounded-xl font-semibold text-sm sm:text-base break-words transition-all duration-200"
+                                    className="w-full text-primary-700 dark:text-primary-300 border-2 border-primary-200 dark:border-primary-800 hover:border-primary-400 dark:hover:border-primary-600 hover:bg-primary-50 dark:hover:bg-primary-950/40 px-4 sm:px-6 py-3 rounded-xl font-semibold text-sm sm:text-base break-words transition-all duration-200"
                                 >
                                     ✏️ Refine My Packing List Questions
                                 </button>
                             </div>
 
-                            <p className="text-sm text-gray-500 text-center mt-4">
+                            <p className="text-sm text-gray-500 dark:text-gray-400 text-center mt-4">
                                 You can always access these options from the navigation menu above
                             </p>
                         </>

--- a/src/pages/your-data.tsx
+++ b/src/pages/your-data.tsx
@@ -83,10 +83,10 @@ export function YourDataPage() {
     }
 
     return (
-        <div className="max-w-3xl mx-auto bg-white/60 rounded-2xl shadow-soft p-6 md:p-10 space-y-6">
+        <div className="max-w-3xl mx-auto bg-white/60 dark:bg-gray-900/60 rounded-2xl shadow-soft p-6 md:p-10 space-y-6">
             <div>
-                <h1 className="text-3xl font-bold text-primary-900 mb-1">Your data</h1>
-                <p className="text-gray-700">
+                <h1 className="text-3xl font-bold text-primary-900 dark:text-primary-200 mb-1">Your data</h1>
+                <p className="text-gray-700 dark:text-gray-300">
                     Pack Me Up keeps your packing lists on your own device, and — if you choose to sign
                     in — in a Solid Pod that belongs to you. There are no Pack Me Up servers holding your
                     lists. This page is where you delete any of it.
@@ -94,14 +94,14 @@ export function YourDataPage() {
             </div>
 
             <section className="space-y-3">
-                <h2 className="text-xl font-bold text-primary-900">On this device</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">On this device</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     Your packing lists, your questions and items, and your app settings are stored on
                     this device so the app works offline. Deleting them removes them from this device
                     only — other devices you've used keep their own copies.
                 </p>
                 {isLoggedIn && (
-                    <p className="text-gray-700 font-medium">
+                    <p className="text-gray-700 dark:text-gray-300 font-medium">
                         You're signed in, so anything also saved in your pod will sync back to this device
                         next time you sign in. To remove it for good, use "Delete everything" below.
                     </p>
@@ -114,17 +114,17 @@ export function YourDataPage() {
                 >
                     Delete all data on this device
                 </Button>
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                     You can also do this without opening the app: on Android, Settings → Apps → Pack Me Up
                     → Storage → Clear storage. Uninstalling the app removes it as well.
                 </p>
             </section>
 
             <section className="space-y-3">
-                <h2 className="text-xl font-bold text-primary-900">In your Solid Pod</h2>
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">In your Solid Pod</h2>
                 {isLoggedIn ? (
                     <>
-                        <p className="text-gray-700">
+                        <p className="text-gray-700 dark:text-gray-300">
                             Everything the app has saved lives in a single <code>pack-me-up</code> folder
                             in your pod{podUrl ? <> (<span className="break-all">{podUrl}</span>)</> : null},
                             including your backups. Deleting it leaves the rest of your pod untouched.
@@ -137,21 +137,21 @@ export function YourDataPage() {
                         >
                             Delete everything
                         </Button>
-                        <p className="text-sm text-gray-600">
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
                             This removes your pod copy and this device's copy together. There's no
                             pod-only option because it wouldn't hold: signing in again re-uploads whatever
                             is still on this device, rebuilding the folder you just deleted.
                         </p>
                     </>
                 ) : (
-                    <p className="text-gray-700">
+                    <p className="text-gray-700 dark:text-gray-300">
                         If you've signed in with a Solid Pod, everything the app saved is in a single{' '}
                         <code>pack-me-up</code> folder in that pod. Sign in here to delete it with one tap,
                         or delete the folder yourself using your pod provider's file manager — you don't
                         need this app installed to do that.
                     </p>
                 )}
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                     If you've shared a list with someone, deleting your copy doesn't delete theirs. Revoke
                     their access from the list's share dialog before deleting if you want it gone from
                     their view too.
@@ -159,8 +159,8 @@ export function YourDataPage() {
             </section>
 
             <section className="space-y-3">
-                <h2 className="text-xl font-bold text-primary-900">Error reports and analytics</h2>
-                <p className="text-gray-700">
+                <h2 className="text-xl font-bold text-primary-900 dark:text-primary-200">Error reports and analytics</h2>
+                <p className="text-gray-700 dark:text-gray-300">
                     The only things that leave your device to us are crash reports and page-view counts,
                     and neither is linked to you. A crash report carries the error message, a stack trace
                     and your browser or device type — no name, no email, no account, and no IP address.
@@ -169,14 +169,14 @@ export function YourDataPage() {
                     for one person — and equally nothing in them that points back to you. Crash reports
                     are deleted automatically after {ERROR_REPORT_RETENTION} either way.
                 </p>
-                <p className="text-gray-700">
+                <p className="text-gray-700 dark:text-gray-300">
                     The exception is anything you send us on purpose. If you report a bug with the app's
                     feedback button, or email us directly, we have whatever you chose to put in it —
                     including your name and email address if you filled those in. Ask us to delete it and
                     we will:{' '}
                     <a
                         href={`mailto:${SUPPORT_EMAIL}`}
-                        className="font-semibold text-primary-700 underline hover:text-primary-900"
+                        className="font-semibold text-primary-700 dark:text-primary-300 underline hover:text-primary-900 dark:hover:text-primary-200"
                     >
                         {SUPPORT_EMAIL}
                     </a>


### PR DESCRIPTION
Closes #301.

Re-lands the dark mode that was split out of #281, with the correctness and contrast problems the review of that PR found.

📋 **[Manual test report — 2026-08-24, with 30 screenshots](https://github.com/timgent/pack-me-up/blob/agent-testing/2026-08-24-issue-301-dark-mode/README.md)** (on the `agent-testing` branch)

## What

- **`ThemeContext`** resolves the theme from a stored choice first and the OS second, and keeps following the OS until the user picks one.
- **A guarded inline script in `index.html`** puts the class on `<html>` before the first paint, so there is no flash of the wrong theme.
- **`index.css`** switches Tailwind v4's `dark:` variant from the media query to a class selector, and `<html>` gets its own background so the WebView has the right ground before React mounts.
- **A sun/moon toggle** in the desktop nav, the mobile header, and as a labelled row in the mobile menu.
- **`dark:` variants across the app** — ~1000 of them, plus the palettes in `person-colors.ts` and `section-accent.ts`.

## The two bugs from the #281 review

**A user's explicit choice was overridden by the OS.** The fix is structural rather than a patched-up listener: the resolved theme is derived, `preference ?? systemTheme`, so a stored choice wins by construction and no OS event can overwrite it. Writes go to `localStorage` and state together, so the two cannot drift apart. Covered by unit tests, and checked in a real browser with the OS theme changed mid-session.

**The pre-paint script had no `try`/`catch`.** Every storage access is guarded now, in the script and in the context. Three unit tests read the actual `<script>` out of `index.html` and run it — including with `localStorage` throwing — so the test cannot drift from the shipped markup.

## The 15 permanent hover styles

Can't happen here: the sweep was mechanical and carried every variant prefix across, so `hover:bg-primary-50` gains `dark:hover:bg-primary-950/40`, never `dark:bg-primary-950/40`. The grep from the issue comes back with 0.

## The contrast failures

All of the reported ones are fixed and screenshotted in the report: the packing-list card badges, kebab and progress track (and the copy of that code in `foreign-packing-lists.tsx`), the view-list sticky progress strip, `your-data`, `privacy-policy` and the provider selector.

Screenshotting every page found five more that the class map could not reach, all translucent-white washes whose `/opacity` suffix put them outside it — the footer band, the sync prompt, the past-trips toggle, the questions page's per-section delete, and the modal backdrop (that last one a pre-existing light-mode bug too: `bg-opacity-75` is Tailwind v3 and does nothing in v4). react-select paints its menu with inline styles no `dark:` class can reach, so its palette is handed over in JS.

## Test plan

- [x] `npm test` — 1875 passed (99 files), including 15 new `ThemeContext` tests and 4 new `ThemeToggle` tests
- [x] `npm run lint` — 0 errors
- [x] `npx playwright test` — 88 passed
- [x] Every page driven in dark and light, desktop and mobile, signed out, signed in, and viewing a shared pod
- [x] `npx cap sync` — android + ios
- [ ] **Native app builds** — could not be compiled here (no Android SDK, no Xcode), so iOS/Android still want a run on a machine with the toolchains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zCXYbnMi9Yaksf4cireai

---
_Generated by [Claude Code](https://claude.ai/code/session_014zCXYbnMi9Yaksf4cireai)_