### PR TITLE
Stop signing people out over a network blip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,25 @@ Each serial suite that writes to a Solid pod **must use its own dedicated pod us
 
 When raising a PR that addresses a GitHub issue, always reference the issue in the PR description using `Closes #<issue-number>` or `Fixes #<issue-number>` so GitHub automatically links and closes the issue on merge.
 
+## Solid session
+
+Never end a session because a request failed. `@uvdsl/solid-oidc-client-browser`'s
+`SessionCore` ships no refresh lifecycle — that is this app's job, and it lives in
+`ResilientSession` (`src/services/ResilientSession.ts`). Two rules it exists to keep:
+
+- **Only the provider may end a session.** `invalid_grant`/`invalid_client`, or a DPoP
+  key that no longer matches, are terminal. Network errors, 5xx, 429, JWKS fetch
+  failures and clock skew are retried. Never call the library's `logout()` in response
+  to a 401 — it calls `database.clear()`, which deletes the refresh token and makes a
+  recoverable session unrecoverable.
+- **Bank a rotated refresh token before doing anything that can throw.** Providers
+  treat a re-presented refresh token as a replay and revoke the whole grant, so a
+  replacement that is received but not stored is a dead session.
+
+`docs/staying-signed-in.md` has the full trace of the logout bugs these rules came
+from. `SolidPodContext.resilience.test.tsx`, `ResilientSession.test.ts` and e2e suite J
+pin the behaviour; suite J in particular asserts that a 401 does *not* sign the user out.
+
 ## Data Access
 
 Never call `db.*` (local PouchDB) and pod storage functions directly in the same place. Use the established intermediate layers:

--- a/docs/staying-signed-in.md
+++ b/docs/staying-signed-in.md
@@ -1,0 +1,164 @@
+# Staying signed in to a Solid Pod
+
+Why the app used to sign people out at seemingly random intervals, and what now
+stops it. Written up because the symptom ("it logged me out again") is one of the
+hardest to report — by the time you notice, the page has reloaded and the console
+is empty.
+
+## The short version
+
+The app was treating *"I couldn't reach the token endpoint just now"* and *"your
+session is over"* as the same event. They are not. A refresh token stays valid for
+hours or days; a Wi-Fi handover lasts two seconds. Every one of the bugs below is
+a variation on that single confusion, and in every case the refresh token sitting
+in IndexedDB was still perfectly good at the moment the user was signed out.
+
+## What was actually happening
+
+`@uvdsl/solid-oidc-client-browser` ships two session classes. `WebWorkerSession`
+runs a SharedWorker that owns the refresh lifecycle; `SessionCore`, which this app
+uses, deliberately ships **no** refresh lifecycle at all — its own documentation
+hands that job to the surrounding app:
+
+> The SessionCore class manages session state and core logic but does not handle
+> the refresh lifecycle. […] That database can be re-used by (your!) surrounding
+> implementation to handle the refresh lifecycle.
+
+The app never built that half. What it had instead was a ten-minute
+`setInterval` firing a `HEAD` at the user's WebID. Seven distinct ways to lose a
+live session followed.
+
+### 1. A failed restore on startup was swallowed
+
+`initializeSession` ran `restore()` inside `try { … } catch {}` with an empty
+handler. A cold start that beat the network — routine on a phone — left the user
+signed out with a valid refresh token still on disk, and nothing ever tried
+again. Reloading the page fixed it, which is exactly why this looked so random.
+
+### 2. One failed refresh ended the session
+
+`SessionCore.restore()` is a single unguarded attempt. On failure it checks
+whether the current token has already lapsed and, if so, fires
+`onSessionExpiration`. The app turned that straight into "Your session has
+expired". No retry, at any level. One dropped connection at the wrong moment —
+waking from sleep, a tunnel, a captive portal — was a logout.
+
+### 3. There was no way back without a reload
+
+Both the keepalive interval and the tab-focus check were gated on `isLoggedIn`.
+Once that flipped false, every mechanism that might have recovered the session
+had already unmounted.
+
+### 4. A 401 destroyed the refresh token
+
+This was the damaging one. On tab focus the app probed the WebID and, on a 401 or
+403, called the library's `logout()` — which calls `database.clear()`, erasing
+IndexedDB and the refresh token with it. A 401 from an access token that had
+merely aged out is the *recoverable* case; answering it by deleting the means of
+recovery converted a refreshable session into a mandatory re-login, and no reload
+could undo it.
+
+### 5. Tokens were used right up to the expiry instant
+
+`SessionCore` renews only once `exp` has already passed — `_isTokenExpired` takes
+a buffer parameter and is always called with `0`. So a request issued a second
+before expiry arrives after it, and any client clock running behind the server
+means the app believes a token is live that the server has already retired. Both
+produce a 401, which fed straight into bug 4. The period of that loop is the
+access-token lifetime — one hour on CSS. "Periodically logged out", precisely.
+
+### 6. A rotated refresh token could be lost for good
+
+`renewTokens` does this, in this order:
+
+1. POST the refresh token. The provider consumes it and issues a replacement.
+2. Fetch the JWKS **over the network** and verify the new access token.
+3. *Only then* write the replacement to IndexedDB.
+
+Step 2 can fail on its own: `createRemoteJWKSet` is constructed fresh per refresh,
+so every refresh depends on a live JWKS fetch, and `jose` verifies with
+`clockTolerance` defaulting to zero, so a phone a few seconds out of sync fails
+here too. When it does, the replacement is discarded while the provider has
+already retired the original. IndexedDB is left holding a spent token.
+
+Presenting a spent refresh token is how OAuth clients signal a stolen-token
+replay, so providers do not merely refuse it. From `oidc-provider`, which backs
+both CSS and Inrupt's ESS:
+
+```js
+if (refreshToken.consumed) {
+  await Promise.all([
+    refreshToken.destroy(),
+    revoke(ctx, refreshToken.grantId),   // the entire grant
+  ]);
+  throw new InvalidGrant('refresh token already used');
+}
+```
+
+The whole grant is revoked. Nothing recovers that but a full re-login.
+
+### 7. Two tabs could revoke each other
+
+`restore()` de-duplicates concurrent refreshes with an in-memory promise — per
+instance, so per tab. Two tabs share one IndexedDB but not that promise. Two tabs
+waking together read the same refresh token and both spend it; the loser trips
+the replay detection above and takes the grant down for both.
+
+How often that bites depends on the provider's rotation policy, which is why this
+was worse on Inrupt than on a local CSS. `oidc-provider`'s default rotates a
+DPoP-bound token only once it is 70% through its lifetime — about 17 hours of a
+CSS refresh token's 24 — but rotates a public client's token on **every** refresh
+when it is not sender-constrained, and deployments tune this freely.
+
+## What changed
+
+A `ResilientSession` subclass (`src/services/ResilientSession.ts`) keeps
+`SessionCore`'s login, DPoP and fetch handling and replaces the refresh:
+
+- **The rotated refresh token is banked before anything that can throw.** This is
+  the fix for bug 6, and the one that turns an unrecoverable failure into a
+  retryable one.
+- **Refreshes are serialised across tabs** with the Web Locks API, so two tabs
+  cannot spend the same token (bug 7).
+- **Failures are classified.** Only `invalid_grant` / `invalid_client` from the
+  provider, or a DPoP key that no longer matches, end a session. A network error,
+  a 5xx, a 429, a failed JWKS fetch and a clock-skew verification failure are all
+  retried (bugs 1, 2).
+- **Verification tolerates 5 minutes of clock skew**, and the JWKS is cached per
+  issuer instead of refetched every refresh (bug 6).
+- **Renewal happens 2 minutes before expiry**, on a timer pegged to the token's
+  own lifetime, and again on tab focus and on coming back online (bug 5).
+
+`SolidPodContext` then stops throwing away what it has:
+
+- It **never** calls the library's `logout()` on a 401 — the only thing that
+  clears IndexedDB is a deliberate sign-out (bug 4).
+- A restore that fails transiently is retried on a backoff out to 90 seconds, and
+  immediately on `online` or tab focus (bugs 1, 3).
+- Startup waits at most 4 seconds for a restore before rendering; the retry
+  continues in the background and signs the user in when it lands.
+- A failed OAuth callback no longer prevents restoring the session already on the
+  device.
+
+## If it ever happens again
+
+**Your data → Sign-in history** keeps the last 300 auth events on the device,
+across reloads and restarts: every renewal, every retry, every failure, and the
+reason the provider gave. "Copy for a bug report" is the whole sequence. Nothing
+in it is sent anywhere on its own.
+
+The event to look for is `refresh.session-ended`. Its `reason` says whether the
+provider rejected the grant (`invalid_grant` — the session genuinely ended) or
+something else. Repeated `refresh.failed-transiently` or `restore.will-retry`
+without a matching `refresh.succeeded` means the app is trying and failing to
+reach the token endpoint, which is a network or provider-availability story
+rather than an auth one.
+
+## What this does not cover
+
+Browser storage eviction is outside the app's reach. Safari's ITP clears
+script-writable storage — IndexedDB included — after 7 days without a visit to
+the site, and any browser may evict under storage pressure. When that happens the
+refresh token is gone before the app runs, and re-authenticating is the only
+option. A user signed out roughly weekly on Safari, having not opened the app in
+between, is seeing this rather than anything above.

--- a/e2e/tests/j-session-expiry.spec.ts
+++ b/e2e/tests/j-session-expiry.spec.ts
@@ -1,32 +1,79 @@
 import { test, expect } from '../fixtures'
+import { accountMenu } from '../helpers/login'
 
 const CSS_ISSUER = process.env.CSS_ISSUER ?? 'http://localhost:4001'
 const TEST_POD_NAME = 'testuser'
 
-test.describe('J – Session Expiry', () => {
-  test('J1: session expired banner shows when pod returns 401', async ({ authedPage: page }) => {
-    // Intercept the webId HEAD request to simulate a 401 (session expired).
-    // SolidPodContext's validateSession makes a HEAD request to the webId when
-    // the tab becomes visible; a 401 triggers setSessionExpired(true).
-    const webIdUrl = `${CSS_ISSUER}/${TEST_POD_NAME}/profile/card`
-    await page.route(webIdUrl, route => {
-      if (route.request().method() === 'HEAD') {
-        return route.fulfill({ status: 401 })
-      }
-      return route.continue()
-    })
+const isTokenRequest = (url: URL) =>
+  url.port === new URL(CSS_ISSUER).port && url.pathname.endsWith('/token')
 
-    // Simulate the user leaving and returning to the tab (triggers validateSession)
+const expiredBanner = (page: import('@playwright/test').Page) =>
+  page.getByText(/session has expired/i).first()
+
+test.describe('J – Session Expiry', () => {
+  /**
+   * The app used to answer a 401 by calling the auth library's logout(), which
+   * clears IndexedDB — and the refresh token with it. That turned an access token
+   * that had merely aged out into a mandatory re-login. A 401 is the *recoverable*
+   * case, so it must never end the session.
+   */
+  test('J1: a 401 from the pod does not sign the user out', async ({ authedPage: page }) => {
+    const webIdUrl = `${CSS_ISSUER}/${TEST_POD_NAME}/profile/card`
+    await page.route(webIdUrl, route => route.fulfill({ status: 401 }))
+
     await page.evaluate(() => {
       Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
       document.dispatchEvent(new Event('visibilitychange'))
-    })
-    await page.evaluate(() => {
       Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
       document.dispatchEvent(new Event('visibilitychange'))
     })
 
-    // The SessionExpiredBanner shows "Your session has expired." and a "Log in again" button
-    await expect(page.getByText(/session has expired/i).first()).toBeVisible({ timeout: 15_000 })
+    await expect(expiredBanner(page)).not.toBeVisible({ timeout: 5_000 })
+    await expect(accountMenu(page).first()).toBeVisible()
+  })
+
+  /**
+   * The one failure that genuinely ends a session: the provider itself refusing
+   * the refresh token. Only this may show the user the expired banner.
+   */
+  test('J2: the provider rejecting the refresh token does sign the user out', async ({ authedPage: page }) => {
+    await page.route(
+      url => isTokenRequest(url),
+      route => route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'invalid_grant', error_description: 'grant request is invalid' }),
+      }),
+    )
+
+    // A reload makes the app restore from its stored refresh token.
+    await page.reload()
+
+    await expect(expiredBanner(page)).toBeVisible({ timeout: 30_000 })
+  })
+
+  /**
+   * A struggling token endpoint is not a logged-out user. The app must keep
+   * trying, and pick the session back up once the endpoint recovers.
+   */
+  test('J3: a failing token endpoint is retried, not treated as a logout', async ({ authedPage: page }) => {
+    let failures = 0
+    await page.route(
+      url => isTokenRequest(url),
+      async route => {
+        if (failures < 3) {
+          failures++
+          return route.fulfill({ status: 503, body: 'upstream unavailable' })
+        }
+        return route.continue()
+      },
+    )
+
+    await page.reload()
+
+    // The session comes back on its own, without the user touching anything.
+    await expect(accountMenu(page).first()).toBeVisible({ timeout: 60_000 })
+    expect(failures).toBe(3)
+    await expect(expiredBanner(page)).not.toBeVisible()
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@uvdsl/solid-oidc-client-browser": "^0.2.2",
         "@vercel/analytics": "^1.5.0",
         "events": "^3.3.0",
+        "jose": "^5.10.0",
         "pouchdb": "^9.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -6331,6 +6332,60 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.7",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.17",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@uvdsl/solid-oidc-client-browser": "^0.2.2",
     "@vercel/analytics": "^1.5.0",
     "events": "^3.3.0",
+    "jose": "^5.10.0",
     "pouchdb": "^9.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/components/SignInHistory.tsx
+++ b/src/components/SignInHistory.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import { Button } from './Button'
+import { getAuthLog, formatAuthLog, clearAuthLog, type AuthEvent } from '../services/authLog'
+
+/**
+ * Shows what has happened to the sign-in on this device.
+ *
+ * Being signed out unexpectedly is close to impossible to report usefully — by
+ * the time you notice, the page has reloaded and the console is empty. This
+ * keeps the record on the device, so "it signed me out again" can come with the
+ * sequence that led to it, including what the pod provider actually said.
+ */
+
+const LEVEL_STYLES: Record<AuthEvent['level'], string> = {
+    info: 'text-gray-600',
+    warn: 'text-amber-700',
+    error: 'text-danger-600 font-semibold',
+}
+
+function describe(entry: AuthEvent): string {
+    const detail = entry.detail
+        ? Object.entries(entry.detail)
+              .map(([key, value]) => `${key}=${String(value)}`)
+              .join(' ')
+        : ''
+    return detail ? `${entry.event} — ${detail}` : entry.event
+}
+
+export function SignInHistory() {
+    const [expanded, setExpanded] = useState(false)
+    const [copied, setCopied] = useState(false)
+    const [version, setVersion] = useState(0)
+
+    // Re-read on each render pass we ask for; the log is written outside React.
+    const entries = [...getAuthLog()].reverse()
+    void version
+
+    const copy = async () => {
+        try {
+            await navigator.clipboard.writeText(formatAuthLog())
+            setCopied(true)
+            setTimeout(() => setCopied(false), 2000)
+        } catch {
+            setCopied(false)
+        }
+    }
+
+    return (
+        <section className="space-y-3">
+            <h2 className="text-xl font-bold text-primary-900">Sign-in history</h2>
+            <p className="text-gray-700">
+                A record, kept on this device only, of every time the app signed in, renewed its
+                access, or lost it. Nothing here is sent anywhere. If the app ever signs you out
+                when it shouldn't, copying this and sending it to us shows exactly what happened.
+            </p>
+
+            <div className="flex flex-wrap gap-3">
+                <Button variant="ghost" onClick={() => setExpanded(v => !v)}>
+                    {expanded ? 'Hide history' : `Show history (${entries.length})`}
+                </Button>
+                <Button variant="ghost" onClick={copy} disabled={entries.length === 0}>
+                    {copied ? 'Copied' : 'Copy for a bug report'}
+                </Button>
+                <Button
+                    variant="ghost"
+                    onClick={() => { clearAuthLog(); setVersion(v => v + 1) }}
+                    disabled={entries.length === 0}
+                >
+                    Clear
+                </Button>
+            </div>
+
+            {expanded && (
+                entries.length === 0 ? (
+                    <p className="text-sm text-gray-600">Nothing recorded yet.</p>
+                ) : (
+                    <ol className="max-h-80 overflow-y-auto rounded-xl bg-white/70 p-3 text-xs font-mono space-y-1">
+                        {entries.map((entry, index) => (
+                            <li key={`${entry.at}-${index}`} className={LEVEL_STYLES[entry.level]}>
+                                <span className="text-gray-400">
+                                    {new Date(entry.at).toLocaleString()}
+                                </span>{' '}
+                                <span className="break-all">{describe(entry)}</span>
+                            </li>
+                        ))}
+                    </ol>
+                )
+            )}
+        </section>
+    )
+}

--- a/src/components/SolidPodContext.resilience.test.tsx
+++ b/src/components/SolidPodContext.resilience.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import React from 'react'
+import { SolidPodProvider, useSolidPod } from './SolidPodContext'
+import { ToastProvider } from './ToastContext'
+
+/**
+ * Regression suite for the "logged out for no reason" bug.
+ *
+ * Every case here is a moment where the *refresh token is still valid* but the app
+ * used to drop the session anyway. The rule these tests encode: only the identity
+ * provider saying "this refresh token is dead" may end a session. Nothing else —
+ * not a flaky network, not a cold start, not one 401 — may log the user out, and
+ * nothing but a deliberate logout may erase the stored refresh token.
+ */
+
+let capturedCallbacks: {
+    onSessionStateChange?: (event?: Event) => void
+    onSessionExpiration?: (event?: Event) => void
+} = {}
+
+let mockIsActive = false
+let mockWebId: string | undefined
+let mockAuthFetch = vi.fn()
+let mockRestore = vi.fn()
+let mockLogout = vi.fn()
+
+let mockHasStoredSession = vi.fn()
+let mockNeedsRenewal = vi.fn()
+
+vi.mock('../services/ResilientSession', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../services/ResilientSession')>()
+    return {
+        ...actual,
+        ResilientSession: vi.fn().mockImplementation(function (
+            _clientDetails: unknown,
+            _database: unknown,
+            options: typeof capturedCallbacks,
+        ) {
+            capturedCallbacks = options ?? {}
+            return {
+                get isActive() { return mockIsActive },
+                get webId() { return mockWebId },
+                handleRedirectFromLogin: vi.fn().mockResolvedValue(undefined),
+                restore: (...args: unknown[]) => mockRestore(...args),
+                login: vi.fn().mockResolvedValue(undefined),
+                logout: (...args: unknown[]) => mockLogout(...args),
+                authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+                hasStoredSession: (...args: unknown[]) => mockHasStoredSession(...args),
+                needsRenewal: (...args: unknown[]) => mockNeedsRenewal(...args),
+                scheduleRenewal: vi.fn(),
+                cancelRenewal: vi.fn(),
+                getExpiresIn: () => 3600,
+                isExpired: () => false,
+            }
+        }),
+    }
+})
+
+vi.mock('@uvdsl/solid-oidc-client-browser', () => ({
+    SessionIDB: vi.fn().mockImplementation(function () { return {} }),
+}))
+
+const WEB_ID = 'https://user.example.org/profile/card#me'
+
+function Consumer() {
+    const { isLoggedIn, sessionExpired } = useSolidPod()
+    return (
+        <div>
+            <span data-testid="isLoggedIn">{String(isLoggedIn)}</span>
+            <span data-testid="sessionExpired">{String(sessionExpired)}</span>
+        </div>
+    )
+}
+
+function renderApp() {
+    return render(
+        <ToastProvider>
+            <SolidPodProvider><Consumer /></SolidPodProvider>
+        </ToastProvider>
+    )
+}
+
+/** Drives the library's own "session became active" callback, as a real restore would. */
+function activateSession() {
+    mockIsActive = true
+    mockWebId = WEB_ID
+    capturedCallbacks.onSessionStateChange?.(
+        new CustomEvent('sessionStateChange', { detail: { isActive: true, webId: WEB_ID } })
+    )
+}
+
+async function becomeVisible() {
+    await act(async () => {
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+    })
+}
+
+describe('SolidPodContext — staying logged in', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        vi.spyOn(console, 'warn').mockImplementation(() => {})
+        capturedCallbacks = {}
+        mockIsActive = false
+        mockWebId = undefined
+        mockAuthFetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+        mockRestore = vi.fn().mockResolvedValue(undefined)
+        mockLogout = vi.fn().mockResolvedValue(undefined)
+        // A stored refresh token exists unless a test says otherwise.
+        mockHasStoredSession = vi.fn().mockResolvedValue(true)
+        mockNeedsRenewal = vi.fn().mockReturnValue(false)
+        sessionStorage.clear()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        sessionStorage.clear()
+    })
+
+    it('retries a restore that failed on startup, rather than starting up logged out', async () => {
+        // A cold start on mobile routinely beats the network to the punch: the refresh
+        // POST fails, but the refresh token in IndexedDB is untouched and still good.
+        mockRestore = vi.fn()
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockImplementation(async () => { activateSession() })
+
+        renderApp()
+
+        await waitFor(
+            () => expect(screen.getByTestId('isLoggedIn').textContent).toBe('true'),
+            { timeout: 10_000 }
+        )
+    }, 15_000)
+
+    it('does not tell the user their session expired when a refresh merely failed', async () => {
+        // ResilientSession reserves the expiration callback for a provider that has
+        // actually rejected the grant. Anything it hands back as a plain rejection is
+        // still recoverable, and must not surface as "your session has expired".
+        mockRestore = vi.fn().mockRejectedValue(new Error('Could not reach the token endpoint'))
+
+        renderApp()
+
+        await waitFor(() => expect(mockRestore).toHaveBeenCalled(), { timeout: 10_000 })
+        expect(screen.getByTestId('sessionExpired').textContent).toBe('false')
+    }, 15_000)
+
+    it('reports an expired session only when the provider rejects the grant', async () => {
+        renderApp()
+        await act(async () => { activateSession() })
+        await waitFor(() => expect(screen.getByTestId('isLoggedIn').textContent).toBe('true'))
+
+        await act(async () => {
+            mockIsActive = false
+            mockWebId = undefined
+            capturedCallbacks.onSessionExpiration?.()
+        })
+
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('false')
+            expect(screen.getByTestId('sessionExpired').textContent).toBe('true')
+        })
+    }, 15_000)
+
+    it('never erases the stored refresh token when the pod answers 401', async () => {
+        renderApp()
+        await act(async () => { activateSession() })
+        await waitFor(() => expect(screen.getByTestId('isLoggedIn').textContent).toBe('true'))
+
+        // The app used to probe the WebID on tab focus and, on a 401, call the
+        // library's logout() — which clears IndexedDB and takes the refresh token
+        // with it, turning an ageing access token into a mandatory re-login.
+        mockAuthFetch = vi.fn().mockResolvedValue(new Response(null, { status: 401 }))
+
+        await becomeVisible()
+        await new Promise(r => setTimeout(r, 50))
+
+        expect(mockLogout).not.toHaveBeenCalled()
+        expect(screen.getByTestId('sessionExpired').textContent).toBe('false')
+    }, 15_000)
+
+    it('renews on tab focus while the token is still valid, not after it has lapsed', async () => {
+        // Waiting for `exp` to pass means every request in the final moments races
+        // the expiry boundary, and any clock skew loses that race.
+        renderApp()
+        await act(async () => { activateSession() })
+        await waitFor(() => expect(screen.getByTestId('isLoggedIn').textContent).toBe('true'))
+
+        mockRestore = vi.fn().mockResolvedValue(undefined)
+        mockNeedsRenewal = vi.fn().mockReturnValue(true)
+
+        await becomeVisible()
+
+        await waitFor(() => expect(mockRestore).toHaveBeenCalled(), { timeout: 10_000 })
+    }, 15_000)
+
+    it('still reports a later genuine expiry after a deliberate logout', async () => {
+        // The "this logout was intentional" flag used to stay set, so the first
+        // real expiry after a manual sign-out passed silently.
+        function Actions() {
+            const { logout } = useSolidPod()
+            return <button onClick={() => { void logout() }}>logout</button>
+        }
+
+        render(
+            <ToastProvider>
+                <SolidPodProvider><Consumer /><Actions /></SolidPodProvider>
+            </ToastProvider>
+        )
+
+        await act(async () => { activateSession() })
+        await waitFor(() => expect(screen.getByTestId('isLoggedIn').textContent).toBe('true'))
+
+        await act(async () => { screen.getByRole('button', { name: 'logout' }).click() })
+        await waitFor(() => expect(screen.getByTestId('sessionExpired').textContent).toBe('false'))
+
+        await act(async () => { activateSession() })
+        await waitFor(() => expect(screen.getByTestId('isLoggedIn').textContent).toBe('true'))
+
+        await act(async () => {
+            mockIsActive = false
+            mockWebId = undefined
+            capturedCallbacks.onSessionExpiration?.()
+        })
+
+        await waitFor(() => expect(screen.getByTestId('sessionExpired').textContent).toBe('true'))
+    }, 15_000)
+})

--- a/src/components/SolidPodContext.test.tsx
+++ b/src/components/SolidPodContext.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { render, screen, act, waitFor } from '@testing-library/react'
 import React from 'react'
 import { SolidPodProvider, useSolidPod } from './SolidPodContext'
+import { ResilientSession } from '../services/ResilientSession'
 import { ToastProvider } from './ToastContext'
 
 function Wrapper({ children }: { children: React.ReactNode }) {
@@ -22,25 +23,46 @@ let mockAuthFetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }
 let mockIsActive = false
 let mockWebId: string | undefined
 
-vi.mock('@uvdsl/solid-oidc-client-browser/core', () => ({
-    // Must use a regular function (not arrow) so vitest can call it as a constructor
-    SessionCore: vi.fn().mockImplementation(function(_clientDetails: unknown, options: typeof capturedCallbacks) {
-        capturedCallbacks = options ?? {}
-        return {
-            get isActive() { return mockIsActive },
-            get webId() { return mockWebId },
-            handleRedirectFromLogin: vi.fn().mockResolvedValue(undefined),
-            restore: vi.fn().mockResolvedValue(undefined),
-            login: vi.fn().mockResolvedValue(undefined),
-            logout: vi.fn().mockResolvedValue(undefined),
-            authFetch: mockAuthFetch,
-        }
-    }),
-}))
+vi.mock('../services/ResilientSession', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../services/ResilientSession')>()
+    return {
+        ...actual,
+        // Must use a regular function (not arrow) so vitest can call it as a constructor
+        ResilientSession: vi.fn().mockImplementation(function(
+            _clientDetails: unknown,
+            _database: unknown,
+            options: typeof capturedCallbacks,
+        ) {
+            capturedCallbacks = options ?? {}
+            return {
+                get isActive() { return mockIsActive },
+                get webId() { return mockWebId },
+                handleRedirectFromLogin: vi.fn().mockResolvedValue(undefined),
+                restore: vi.fn().mockResolvedValue(undefined),
+                login: vi.fn().mockResolvedValue(undefined),
+                logout: vi.fn().mockResolvedValue(undefined),
+                authFetch: mockAuthFetch,
+                hasStoredSession: vi.fn().mockResolvedValue(false),
+                needsRenewal: vi.fn().mockReturnValue(false),
+                scheduleRenewal: vi.fn(),
+                cancelRenewal: vi.fn(),
+            }
+        }),
+    }
+})
 
 vi.mock('@uvdsl/solid-oidc-client-browser', () => ({
     SessionIDB: vi.fn().mockImplementation(function() { return {} }),
 }))
+
+/** The ResilientSession instance the provider constructed. */
+function constructedSession() {
+    const ctor = vi.mocked(ResilientSession)
+    return ctor.mock.results[ctor.mock.results.length - 1].value as {
+        scheduleRenewal: ReturnType<typeof vi.fn>
+        cancelRenewal: ReturnType<typeof vi.fn>
+    }
+}
 
 function fireStateChange(isActive: boolean, webId?: string) {
     capturedCallbacks.onSessionStateChange?.(
@@ -272,10 +294,11 @@ describe('SolidPodContext', () => {
         })
     })
 
-    it('periodically calls authFetch to keep the session alive', async () => {
-        const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
-
-        render(<Wrapper><Consumer /></Wrapper>)
+    it('arms a renewal timer for the life of the session, and disarms it on logout', async () => {
+        // Keeping the session alive is the session object's job now: it renews on a
+        // timer pegged to the token's own expiry, rather than a fixed poll that
+        // could only ever notice a token already dead.
+        render(<Wrapper><ConsumerWithActions /></Wrapper>)
 
         await act(async () => {
             mockIsActive = true
@@ -287,18 +310,17 @@ describe('SolidPodContext', () => {
             expect(screen.getByTestId('isLoggedIn').textContent).toBe('true')
         })
 
-        const keepaliveCall = setIntervalSpy.mock.calls.find(([, delay]) => delay === 10 * 60 * 1000)
-        expect(keepaliveCall).toBeDefined()
+        const session = constructedSession()
+        expect(session.scheduleRenewal).toHaveBeenCalled()
 
-        mockAuthFetch.mockClear()
         await act(async () => {
-            await (keepaliveCall![0] as () => Promise<void>)()
+            screen.getByRole('button', { name: 'logout' }).click()
         })
 
-        expect(mockAuthFetch).toHaveBeenCalledWith(
-            'https://user.example.org/profile/card#me',
-            { method: 'HEAD' }
-        )
+        await waitFor(() => {
+            expect(screen.getByTestId('isLoggedIn').textContent).toBe('false')
+            expect(session.cancelRenewal).toHaveBeenCalled()
+        })
     })
 
     it('clearSessionExpired sets sessionExpired to false', async () => {

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -1,7 +1,9 @@
-import { createContext, ReactNode, useContext, useState, useEffect, useRef } from "react";
-import { SessionCore, type SessionStateChangeDetail } from "@uvdsl/solid-oidc-client-browser/core";
+import { createContext, ReactNode, useContext, useState, useEffect, useRef, useCallback } from "react";
+import { type SessionStateChangeDetail } from "@uvdsl/solid-oidc-client-browser/core";
 import { SessionIDB } from "@uvdsl/solid-oidc-client-browser";
-import { isAuthenticationError, resetPodSessionCaches } from "../services/solidPod";
+import { ResilientSession, SessionEndedError } from "../services/ResilientSession";
+import { logAuthEvent } from "../services/authLog";
+import { resetPodSessionCaches } from "../services/solidPod";
 import { AUTH_RETURN_TO_KEY } from "../pages/solid-pod-handle-redirect-page";
 import { AppSession } from "../types/AppSession";
 
@@ -18,6 +20,16 @@ interface SolidPodContextValue {
 
 const SolidPodContext = createContext<SolidPodContextValue | undefined>(undefined);
 
+/** Backoff schedule for retrying a session we believe is still restorable. */
+const RECOVERY_DELAYS_MS = [1_000, 3_000, 8_000, 20_000, 45_000, 90_000];
+
+/**
+ * How long startup waits for a session to come back before rendering anyway.
+ * The restore keeps going in the background; this only decides whether the user
+ * stares at a spinner while it does.
+ */
+const STARTUP_RESTORE_BUDGET_MS = 4_000;
+
 export function SolidPodProvider({ children }: { children: ReactNode }) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [webId, setWebId] = useState<string | undefined>(undefined);
@@ -25,14 +37,21 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const intentionalLogoutRef = useRef(false);
 
-  const uvdslSessionRef = useRef<SessionCore>(null!);
+  // A session we could not restore yet but have no reason to believe is dead.
+  // While this is set, the app keeps quietly trying rather than showing the user
+  // a login prompt for what is usually a few seconds of bad network.
+  const recoveringRef = useRef(false);
+  const recoveryAttemptRef = useRef(0);
+  const recoveryTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const uvdslSessionRef = useRef<ResilientSession>(null!);
   if (!uvdslSessionRef.current) {
     const origin = window.location.origin || "http://localhost";
     // On production, VITE_CLIENT_ID_URL is set so the provider fetches the hosted Client ID
     // Document (static registration). On preview deploys and localhost it is unset, so we fall
     // back to dynamic client registration using the current origin's redirect URI.
     const clientIdUrl = import.meta.env.VITE_CLIENT_ID_URL as string | undefined;
-    uvdslSessionRef.current = new SessionCore(
+    uvdslSessionRef.current = new ResilientSession(
       clientIdUrl
         ? { client_id: clientIdUrl }
         : {
@@ -42,16 +61,23 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
             redirect_uris: [origin + "/"],
             client_name: "Pack Me Up",
           },
+      new SessionIDB(),
       {
-        database: new SessionIDB(),
         onSessionStateChange: (e) => {
           const { isActive, webId: newWebId } = (e as CustomEvent<SessionStateChangeDetail>).detail;
           setIsLoggedIn(isActive);
           setWebId(isActive ? newWebId : undefined);
-          if (isActive) setSessionExpired(false);
+          if (isActive) {
+            setSessionExpired(false);
+            recoveringRef.current = false;
+            recoveryAttemptRef.current = 0;
+          }
         },
+        // ResilientSession fires this only when the provider has rejected the
+        // grant — not for network trouble, which it retries on its own.
         onSessionExpiration: () => {
           if (!intentionalLogoutRef.current) setSessionExpired(true);
+          recoveringRef.current = false;
           setIsLoggedIn(false);
           setWebId(undefined);
           intentionalLogoutRef.current = false;
@@ -66,10 +92,49 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
     ? { fetch: uvdslSession.authFetch.bind(uvdslSession), info: { isLoggedIn, webId } }
     : null;
 
+  /**
+   * Tries to restore, and keeps trying on a backoff while the failure looks
+   * temporary. Only the provider rejecting the grant stops the attempts — a
+   * refresh token that is merely unreachable is not a logged-out user.
+   */
+  const attemptRestore = useCallback(async (trigger: string): Promise<boolean> => {
+    if (uvdslSession.isActive) return true;
+    if (!(await uvdslSession.hasStoredSession())) {
+      logAuthEvent("restore.no-stored-session", { trigger });
+      recoveringRef.current = false;
+      return false;
+    }
+
+    try {
+      logAuthEvent("restore.attempt", { trigger, attempt: recoveryAttemptRef.current + 1 });
+      await uvdslSession.restore();
+      recoveringRef.current = false;
+      recoveryAttemptRef.current = 0;
+      logAuthEvent("restore.succeeded", { trigger });
+      return true;
+    } catch (error) {
+      if (error instanceof SessionEndedError) {
+        logAuthEvent("restore.session-ended", { trigger, reason: error.reason }, "error");
+        recoveringRef.current = false;
+        return false;
+      }
+      // Still recoverable. Schedule another go.
+      recoveringRef.current = true;
+      const attempt = recoveryAttemptRef.current;
+      recoveryAttemptRef.current = attempt + 1;
+      const delay = RECOVERY_DELAYS_MS[Math.min(attempt, RECOVERY_DELAYS_MS.length - 1)];
+      logAuthEvent("restore.will-retry", { trigger, attempt: attempt + 1, delay }, "warn");
+
+      clearTimeout(recoveryTimerRef.current);
+      recoveryTimerRef.current = setTimeout(() => { void attemptRestore("backoff"); }, delay);
+      return false;
+    }
+  }, [uvdslSession]);
+
   useEffect(() => {
     const initializeSession = async () => {
       try {
-        console.log("Initializing Solid session...");
+        logAuthEvent("init.start");
 
         const searchParams = new URLSearchParams(window.location.search);
         const isOAuthCallback = searchParams.has("code") || searchParams.has("state");
@@ -78,98 +143,114 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
           sessionStorage.setItem(AUTH_RETURN_TO_KEY, window.location.hash.substring(1) || "/");
         }
 
-        await uvdslSession.handleRedirectFromLogin();
+        try {
+          await uvdslSession.handleRedirectFromLogin();
+        } catch (error) {
+          // A malformed or stale callback must not cost us the session already
+          // stored on this device — fall through and restore it below.
+          logAuthEvent("login.redirect-failed", { reason: String(error) }, "warn");
+        }
 
         if (isOAuthCallback && uvdslSession.isActive) {
           // Redirect completed — navigate to the stored return route.
           // We handle this here instead of via pod-auth-callback.html so the
           // redirect_uri registered with the IdP can be the plain SPA root ("/").
+          logAuthEvent("login.completed", { webId: uvdslSession.webId });
+          uvdslSession.scheduleRenewal();
           const returnTo = sessionStorage.getItem(AUTH_RETURN_TO_KEY) || "/solid-pod-handle-redirect";
           window.location.replace("/#" + returnTo);
           return;
         }
 
         if (!uvdslSession.isActive) {
-          try {
-            await uvdslSession.restore();
-          } catch {
-            // No saved session — user starts logged out
-          }
+          // Don't hold the first paint hostage to a slow network — the retry
+          // continues in the background and signs the user in when it lands.
+          await Promise.race([
+            attemptRestore("startup"),
+            new Promise(resolve => setTimeout(resolve, STARTUP_RESTORE_BUDGET_MS)),
+          ]);
         }
-
-        console.log("Session initialized:", { isActive: uvdslSession.isActive, webId: uvdslSession.webId });
       } catch (error) {
-        console.error("Error initializing session:", error);
+        logAuthEvent("init.failed", { reason: String(error) }, "error");
       } finally {
         setIsLoading(false);
       }
     };
 
-    initializeSession();
+    void initializeSession();
+    return () => clearTimeout(recoveryTimerRef.current);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Validate session when user returns to the tab
+  // Take every chance to get a stalled session back: coming online, or the user
+  // returning to the tab, are both good moments to retry ahead of the backoff.
   useEffect(() => {
-    if (!isLoggedIn || !webId) return;
-
-    const handleSessionExpired = async () => {
-      console.log("Session validation failed - session has expired");
-      await uvdslSession.logout();
-      setIsLoggedIn(false);
-      setWebId(undefined);
-      setSessionExpired(true);
+    const retryIfRecovering = (trigger: string) => {
+      if (!recoveringRef.current || uvdslSession.isActive) return;
+      clearTimeout(recoveryTimerRef.current);
+      void attemptRestore(trigger);
     };
 
-    const validateSession = async () => {
-      try {
-        const response = await uvdslSession.authFetch(webId, { method: "HEAD" });
-        if (response.status === 401 || response.status === 403) {
-          await handleSessionExpired();
-        }
-      } catch (error: unknown) {
-        if (isAuthenticationError(error)) {
-          await handleSessionExpired();
-        } else {
-          console.error("Session validation failed with non-auth error:", error);
-        }
-      }
+    const onOnline = () => retryIfRecovering("online");
+    const onVisible = () => {
+      if (document.visibilityState === "visible") retryIfRecovering("visible");
     };
 
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        console.log("Tab became visible - validating session");
-        validateSession();
-      }
+    window.addEventListener("online", onOnline);
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      window.removeEventListener("online", onOnline);
+      document.removeEventListener("visibilitychange", onVisible);
     };
+  }, [attemptRestore, uvdslSession]);
 
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
-  }, [isLoggedIn, webId]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Proactively refresh the access token so it doesn't silently expire between user actions.
-  // (SessionCore has no background worker, so we poll manually.)
+  // Returning to the tab is when a token is most likely to have lapsed while the
+  // device slept. Renew it before the user's first action needs it.
   useEffect(() => {
-    if (!isLoggedIn || !webId) return;
-    const intervalId = setInterval(async () => {
-      try {
-        await uvdslSession.authFetch(webId, { method: "HEAD" });
-      } catch {
-        // Best-effort; event listeners handle real auth failures
-      }
-    }, 10 * 60 * 1000);
-    return () => clearInterval(intervalId);
-  }, [isLoggedIn, webId]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (!isLoggedIn) return;
+
+    const renewIfNeeded = () => {
+      if (document.visibilityState !== "visible") return;
+      if (!uvdslSession.needsRenewal()) return;
+      logAuthEvent("refresh.on-visible");
+      void uvdslSession.restore().catch(() => { /* restore() reports and retries */ });
+    };
+
+    document.addEventListener("visibilitychange", renewIfNeeded);
+    window.addEventListener("online", renewIfNeeded);
+    return () => {
+      document.removeEventListener("visibilitychange", renewIfNeeded);
+      window.removeEventListener("online", renewIfNeeded);
+    };
+  }, [isLoggedIn, uvdslSession]);
+
+  // Keep the renewal timer armed for the life of the session.
+  useEffect(() => {
+    if (!isLoggedIn) {
+      uvdslSession.cancelRenewal();
+      return;
+    }
+    uvdslSession.scheduleRenewal();
+    return () => uvdslSession.cancelRenewal();
+  }, [isLoggedIn, uvdslSession]);
 
   const login = async (oidcIssuer: string, returnTo?: string) => {
     const currentLocation = returnTo || window.location.hash.substring(1) || "/";
     sessionStorage.setItem(AUTH_RETURN_TO_KEY, currentLocation);
     const redirectUri = (window.location.origin || "http://localhost") + "/";
+    logAuthEvent("login.redirecting", { oidcIssuer });
     await uvdslSession.login(oidcIssuer, redirectUri);
   };
 
   const logout = async () => {
     intentionalLogoutRef.current = true;
-    await uvdslSession.logout();
+    recoveringRef.current = false;
+    clearTimeout(recoveryTimerRef.current);
+    try {
+      await uvdslSession.logout();
+    } finally {
+      // Leaving this set would swallow the banner for the next genuine expiry.
+      intentionalLogoutRef.current = false;
+    }
     // Which pod a WebID lives in, and which of its containers exist, are facts
     // about the identity that just went away.
     resetPodSessionCaches();

--- a/src/pages/your-data.tsx
+++ b/src/pages/your-data.tsx
@@ -6,6 +6,7 @@ import { Button } from '../components/Button'
 import { ConfirmationDialog } from '../components/ConfirmationDialog'
 import { getPrimaryPodUrl } from '../services/solidPod'
 import { deleteAllLocalData, deleteAllPodData } from '../services/dataDeletion'
+import { SignInHistory } from '../components/SignInHistory'
 
 const SUPPORT_EMAIL = 'tim.packmeup@gmail.com'
 
@@ -183,6 +184,8 @@ export function YourDataPage() {
                     .
                 </p>
             </section>
+
+            <SignInHistory />
 
             {pendingScope && (
                 <ConfirmationDialog

--- a/src/services/ResilientSession.test.ts
+++ b/src/services/ResilientSession.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { generateKeyPair, exportJWK, SignJWT, calculateJwkThumbprint, createLocalJWKSet } from 'jose'
+import { ResilientSession, SessionEndedError } from './ResilientSession'
+
+/**
+ * These cover the exchange that decides whether a user stays logged in.
+ *
+ * The case that matters most is the one the underlying library gets wrong: a
+ * refresh that succeeds at the token endpoint but fails afterwards. The provider
+ * has already retired the old refresh token by then, so if the replacement is not
+ * banked immediately the session is unrecoverable — and presenting the spent one
+ * next time gets the entire grant revoked as a suspected replay.
+ */
+
+const TOKEN_ENDPOINT = 'https://idp.example.org/token'
+const JWKS_URI = 'https://idp.example.org/jwks'
+const IDP = 'https://idp.example.org'
+const CLIENT_ID = 'https://app.example.org/client-id.json'
+const WEB_ID = 'https://user.example.org/profile/card#me'
+
+/** An in-memory stand-in for SessionIDB. */
+class FakeDb {
+    items = new Map<string, unknown>()
+    closed = 0
+    async init() { return this }
+    async setItem(id: string, value: unknown) { this.items.set(id, value) }
+    async getItem(id: string) { return this.items.has(id) ? this.items.get(id) : null }
+    async deleteItem(id: string) { this.items.delete(id) }
+    async clear() { this.items.clear() }
+    close() { this.closed++ }
+}
+
+let signingKeys: Awaited<ReturnType<typeof generateKeyPair>>
+let dpopKeys: Awaited<ReturnType<typeof generateKeyPair>>
+let localJwks: ReturnType<typeof createLocalJWKSet>
+
+async function makeAccessToken(
+    opts: { expiresIn?: string | number; signWith?: CryptoKey } = {},
+): Promise<string> {
+    const jkt = await calculateJwkThumbprint(await exportJWK(dpopKeys.publicKey))
+    return new SignJWT({ webid: WEB_ID, client_id: CLIENT_ID, cnf: { jkt } })
+        .setProtectedHeader({ alg: 'ES256', kid: 'test-key' })
+        .setIssuer(IDP)
+        .setAudience('solid')
+        .setIssuedAt()
+        .setExpirationTime(opts.expiresIn ?? '1h')
+        .sign(opts.signWith ?? signingKeys.privateKey)
+}
+
+function makeSession(db: FakeDb, onExpiration?: () => void) {
+    return new ResilientSession(
+        { client_id: CLIENT_ID },
+        db as unknown as ConstructorParameters<typeof ResilientSession>[1],
+        {
+            onSessionExpiration: onExpiration,
+            // Verify against the local test key set rather than a remote JWKS.
+            resolveJwks: () => localJwks,
+        },
+    )
+}
+
+function seed(db: FakeDb, refreshToken = 'refresh-token-v1') {
+    db.items.set('client_id', CLIENT_ID)
+    db.items.set('token_endpoint', TOKEN_ENDPOINT)
+    db.items.set('dpop_keypair', dpopKeys)
+    db.items.set('refresh_token', refreshToken)
+    db.items.set('idp', IDP)
+    db.items.set('jwks_uri', JWKS_URI)
+}
+
+describe('ResilientSession', () => {
+    let db: FakeDb
+
+    beforeEach(async () => {
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+        vi.spyOn(console, 'warn').mockImplementation(() => {})
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        signingKeys = await generateKeyPair('ES256')
+        dpopKeys = await generateKeyPair('ES256')
+        const jwk = await exportJWK(signingKeys.publicKey)
+        localJwks = createLocalJWKSet({ keys: [{ ...jwk, alg: 'ES256', kid: 'test-key', use: 'sig' }] })
+        db = new FakeDb()
+        seed(db)
+        localStorage.clear()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        vi.unstubAllGlobals()
+    })
+
+    it('banks the rotated refresh token even when the refresh fails afterwards', async () => {
+        // The provider rotates and answers 200, then verification fails — exactly
+        // the window where the old token is already spent. Whatever goes wrong
+        // after the exchange, the replacement must not be lost with it.
+        const strangerKeys = await generateKeyPair('ES256')
+        vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+            const url = String(input instanceof Request ? input.url : input)
+            if (url.startsWith(TOKEN_ENDPOINT)) {
+                return new Response(JSON.stringify({
+                    access_token: await makeAccessToken({ signWith: strangerKeys.privateKey }),
+                    refresh_token: 'refresh-token-v2',
+                    expires_in: 3600,
+                    token_type: 'DPoP',
+                }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+            }
+            throw new TypeError('Network request failed')
+        }))
+
+        const session = makeSession(db)
+        await expect(session.restore()).rejects.toThrow()
+
+        // The replacement must have survived the failure. Keeping the old value
+        // here is what strands a session for good.
+        expect(db.items.get('refresh_token')).toBe('refresh-token-v2')
+    }, 30_000)
+
+    it('restores the session and stores the rotated token on success', async () => {
+        vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+            const url = String(input instanceof Request ? input.url : input)
+            if (url.startsWith(TOKEN_ENDPOINT)) {
+                return new Response(JSON.stringify({
+                    access_token: await makeAccessToken(),
+                    refresh_token: 'refresh-token-v2',
+                    expires_in: 3600,
+                    token_type: 'DPoP',
+                }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+            }
+            throw new Error(`unexpected request to ${url}`)
+        }))
+
+        const session = makeSession(db)
+        await session.restore()
+
+        expect(session.isActive).toBe(true)
+        expect(session.webId).toBe(WEB_ID)
+        expect(db.items.get('refresh_token')).toBe('refresh-token-v2')
+        session.cancelRenewal()
+    }, 30_000)
+
+    it('ends the session only when the provider rejects the grant', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => new Response(
+            JSON.stringify({ error: 'invalid_grant', error_description: 'grant request is invalid' }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } },
+        )))
+
+        const onExpiration = vi.fn()
+        const session = makeSession(db, onExpiration)
+
+        await expect(session.restore()).rejects.toBeInstanceOf(SessionEndedError)
+        expect(onExpiration).toHaveBeenCalledTimes(1)
+    }, 30_000)
+
+    it('retries a 503 rather than treating it as the end of the session', async () => {
+        const fetchMock = vi.fn(async () => new Response('upstream unavailable', { status: 503 }))
+        vi.stubGlobal('fetch', fetchMock)
+
+        const onExpiration = vi.fn()
+        const session = makeSession(db, onExpiration)
+
+        await expect(session.restore()).rejects.not.toBeInstanceOf(SessionEndedError)
+        expect(fetchMock.mock.calls.length).toBeGreaterThan(1)
+        // A struggling server is not a logged-out user.
+        expect(onExpiration).not.toHaveBeenCalled()
+        expect(db.items.get('refresh_token')).toBe('refresh-token-v1')
+    }, 30_000)
+
+    it('retries an unreachable token endpoint and keeps the refresh token', async () => {
+        const fetchMock = vi.fn(async () => { throw new TypeError('Failed to fetch') })
+        vi.stubGlobal('fetch', fetchMock)
+
+        const onExpiration = vi.fn()
+        const session = makeSession(db, onExpiration)
+
+        await expect(session.restore()).rejects.not.toBeInstanceOf(SessionEndedError)
+        expect(onExpiration).not.toHaveBeenCalled()
+        expect(db.items.get('refresh_token')).toBe('refresh-token-v1')
+    }, 30_000)
+
+    it('recovers on a later attempt once the network comes back', async () => {
+        // One blip, then the network is there. The retry inside a single restore()
+        // should ride straight over it. Longer outages are the caller's backoff.
+        let failuresLeft = 1
+        vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+            const url = String(input instanceof Request ? input.url : input)
+            if (url.startsWith(TOKEN_ENDPOINT)) {
+                if (failuresLeft-- > 0) throw new TypeError('Failed to fetch')
+                return new Response(JSON.stringify({
+                    access_token: await makeAccessToken(),
+                    refresh_token: 'refresh-token-v2',
+                    expires_in: 3600,
+                    token_type: 'DPoP',
+                }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+            }
+            throw new Error(`unexpected request to ${url}`)
+        }))
+
+        const session = makeSession(db)
+        await session.restore()
+
+        expect(session.isActive).toBe(true)
+        session.cancelRenewal()
+    }, 30_000)
+
+    it('reports no stored session when there is nothing to restore', async () => {
+        const empty = new FakeDb()
+        const session = makeSession(empty)
+        expect(await session.hasStoredSession()).toBe(false)
+        expect(await makeSession(db).hasStoredSession()).toBe(true)
+    })
+
+    it('wants renewal before the token has actually lapsed', async () => {
+        vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+            const url = String(input instanceof Request ? input.url : input)
+            if (url.startsWith(TOKEN_ENDPOINT)) {
+                return new Response(JSON.stringify({
+                    // 90s of life left: still valid, but inside the renewal buffer.
+                    access_token: await makeAccessToken({ expiresIn: '90s' }),
+                    refresh_token: 'refresh-token-v2',
+                    expires_in: 90,
+                    token_type: 'DPoP',
+                }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+            }
+            throw new Error(`unexpected request to ${url}`)
+        }))
+
+        const session = makeSession(db)
+        await session.restore()
+
+        expect(session.isActive).toBe(true)
+        expect(session.getExpiresIn()).toBeGreaterThan(0)
+        expect(session.needsRenewal()).toBe(true)
+        session.cancelRenewal()
+    }, 30_000)
+})

--- a/src/services/ResilientSession.ts
+++ b/src/services/ResilientSession.ts
@@ -1,0 +1,408 @@
+import { SessionCore, type SessionOptions } from '@uvdsl/solid-oidc-client-browser/core'
+import type { SessionIDB } from '@uvdsl/solid-oidc-client-browser'
+import {
+    SignJWT,
+    exportJWK,
+    jwtVerify,
+    createRemoteJWKSet,
+    calculateJwkThumbprint,
+    type JWTVerifyGetKey,
+} from 'jose'
+import { logAuthEvent } from './authLog'
+
+/**
+ * A SessionCore that treats "I could not reach the token endpoint" and
+ * "your session is over" as the different things they are.
+ *
+ * SessionCore deliberately ships no refresh lifecycle — its docs hand that job to
+ * the surrounding app. Its own `restore()` is a single unguarded attempt, and the
+ * refresh it performs has an ordering bug that can strand a session permanently:
+ *
+ *   1. POST the refresh token. The provider consumes it and issues a replacement.
+ *   2. Fetch the JWKS over the network and verify the new access token.
+ *   3. *Only then* write the replacement refresh token to IndexedDB.
+ *
+ * If step 2 fails — a dropped connection, a slow JWKS endpoint, a phone whose
+ * clock is a few seconds off (jose verifies with zero clock tolerance) — the
+ * replacement is thrown away while the provider has already retired the old one.
+ * IndexedDB is left holding a spent token. Presenting a spent refresh token is
+ * how OAuth clients signal a stolen-token replay, so the provider does not merely
+ * refuse it: `oidc-provider`, which backs both CSS and Inrupt's ESS, destroys the
+ * whole grant. The next refresh cannot fail any harder, and the only way back is
+ * a full re-login.
+ *
+ * This subclass keeps SessionCore's login, DPoP and fetch handling and replaces
+ * only the refresh:
+ *
+ *   - the replacement refresh token is written **before** anything that can throw;
+ *   - refreshes are serialised across tabs with the Web Locks API, so two tabs
+ *     waking together cannot both spend the same token and trip replay detection;
+ *   - transient failures are retried with backoff instead of ending the session;
+ *   - the session ends only when the provider itself rejects the grant;
+ *   - tokens are renewed *before* they lapse, so no request races the expiry.
+ */
+
+/** Renew this many seconds before the access token actually expires. */
+const EXPIRY_BUFFER_SECONDS = 120
+
+/** Tolerated clock difference between this device and the provider. */
+const CLOCK_TOLERANCE_SECONDS = 300
+
+/**
+ * Attempts within a single restore() before handing back to the caller. Kept
+ * small on purpose: SolidPodContext retries on a much longer backoff, and on
+ * anything it hears about coming back (network, tab focus). Grinding through a
+ * long backoff here would only stall the app's first paint.
+ */
+const MAX_ATTEMPTS = 2
+
+const RETRY_BASE_MS = 800
+
+const REFRESH_LOCK = 'pmu-solid-token-refresh'
+
+/**
+ * Thrown when the provider has rejected the grant itself. This is the only
+ * failure that genuinely ends a session — everything else is worth retrying.
+ */
+export class SessionEndedError extends Error {
+    readonly reason: string
+    constructor(reason: string, message?: string) {
+        super(message ?? `Solid session ended: ${reason}`)
+        this.name = 'SessionEndedError'
+        this.reason = reason
+    }
+}
+
+/** A failure we expect to recover from — network, server, or verification hiccup. */
+class TransientRefreshError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'TransientRefreshError'
+    }
+}
+
+interface StoredKeyPair {
+    publicKey: CryptoKey
+    privateKey: CryptoKey
+}
+
+interface TokenResponse {
+    access_token: string
+    refresh_token?: string
+    expires_in: number
+    token_type: string
+    id_token?: string
+    scope?: string
+}
+
+/**
+ * One JWKS per issuer, reused across refreshes. `createRemoteJWKSet` caches
+ * internally, so holding the instance keeps the refresh path off the network in
+ * the common case — one fewer thing that can fail mid-refresh.
+ */
+const jwksCache = new Map<string, JWTVerifyGetKey>()
+
+function jwksFor(jwksUri: string): JWTVerifyGetKey {
+    let jwks = jwksCache.get(jwksUri)
+    if (!jwks) {
+        jwks = createRemoteJWKSet(new URL(jwksUri))
+        jwksCache.set(jwksUri, jwks)
+    }
+    return jwks
+}
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * Runs `fn` while holding a browser-wide lock, so only one tab refreshes at a
+ * time. Falls back to running unguarded where Web Locks is unavailable.
+ */
+async function withRefreshLock<T>(fn: () => Promise<T>): Promise<T> {
+    const locks = typeof navigator !== 'undefined' ? navigator.locks : undefined
+    if (!locks?.request) return fn()
+    return locks.request(REFRESH_LOCK, fn) as Promise<T>
+}
+
+/** Builds the DPoP proof for the token request. */
+async function createTokenEndpointDPoP(tokenEndpoint: string, keyPair: StoredKeyPair): Promise<string> {
+    const publicJwk = await exportJWK(keyPair.publicKey)
+    publicJwk.alg = 'ES256'
+    return new SignJWT({ htu: tokenEndpoint, htm: 'POST' })
+        .setIssuedAt()
+        .setJti(crypto.randomUUID())
+        .setProtectedHeader({ alg: 'ES256', typ: 'dpop+jwt', jwk: publicJwk })
+        .sign(keyPair.privateKey)
+}
+
+/**
+ * The provider's answer to a refused grant tells us whether to give up. Only
+ * `invalid_grant` means the refresh token itself is finished; `invalid_client`
+ * means our registration is gone. Everything else — 429, 5xx, a gateway's HTML
+ * error page — is worth another try.
+ */
+function classifyTokenError(status: number, body: string): TransientRefreshError | SessionEndedError {
+    let oauthError = ''
+    try {
+        oauthError = (JSON.parse(body) as { error?: string }).error ?? ''
+    } catch {
+        // Not JSON — a proxy or gateway error page. Treat as transient.
+    }
+
+    if (oauthError === 'invalid_grant') {
+        return new SessionEndedError('invalid_grant', 'The identity provider rejected the refresh token.')
+    }
+    if (oauthError === 'invalid_client' || oauthError === 'unauthorized_client') {
+        return new SessionEndedError(oauthError, 'The identity provider no longer recognises this app registration.')
+    }
+    return new TransientRefreshError(`Token endpoint returned ${status}${oauthError ? ` (${oauthError})` : ''}`)
+}
+
+export interface ResilientSessionOptions extends Omit<SessionOptions, 'database'> {
+    /**
+     * How to obtain the provider's signing keys. Injectable so tests can verify
+     * against a local key set instead of reaching the network.
+     */
+    resolveJwks?: (jwksUri: string) => JWTVerifyGetKey
+}
+
+export class ResilientSession extends SessionCore {
+    /** SessionCore keeps its database private, so we hold our own handle. */
+    private readonly db: SessionIDB
+    private readonly resolveJwks: (jwksUri: string) => JWTVerifyGetKey
+    private renewalTimer: ReturnType<typeof setTimeout> | undefined
+
+    constructor(
+        clientDetails: ConstructorParameters<typeof SessionCore>[0],
+        database: SessionIDB,
+        sessionOptions: ResilientSessionOptions,
+    ) {
+        const { resolveJwks, ...coreOptions } = sessionOptions
+        super(clientDetails, { ...coreOptions, database })
+        this.db = database
+        this.resolveJwks = resolveJwks ?? jwksFor
+    }
+
+    /**
+     * Replaces SessionCore's single-shot restore with a locked, retrying refresh
+     * that only gives up when the provider rejects the grant.
+     */
+    async restore(): Promise<void> {
+        if (this.refreshPromise) return this.refreshPromise
+
+        this.refreshPromise = new Promise<void>((resolve, reject) => {
+            this.resolveRefresh = resolve
+            this.rejectRefresh = reject
+        })
+        // Nothing must reject this promise before a caller attaches a handler.
+        const pending = this.refreshPromise
+        pending.catch(() => { /* observed below by callers of restore() */ })
+
+        const wasActive = this.isActive
+
+        void (async () => {
+            try {
+                const tokens = await withRefreshLock(() => this.refreshWithRetries())
+                await this.setTokenDetails(tokens)
+                this.scheduleRenewal()
+                logAuthEvent('refresh.succeeded', { expiresIn: this.getExpiresIn() })
+                this.resolveRefresh?.()
+            } catch (error) {
+                const ended = error instanceof SessionEndedError
+                logAuthEvent(
+                    ended ? 'refresh.session-ended' : 'refresh.failed-transiently',
+                    { reason: ended ? error.reason : String(error) },
+                    ended ? 'error' : 'warn',
+                )
+                this.rejectRefresh?.(error instanceof Error ? error : new Error(String(error)))
+                // Only the provider disowning the grant ends the session. A transient
+                // failure leaves the stored refresh token intact for the next attempt.
+                if (ended) this.dispatchExpirationEvent()
+            } finally {
+                this.clearRefreshPromise()
+                if (wasActive !== this.isActive) this.dispatchStateChangeEvent()
+            }
+        })()
+
+        return this.refreshPromise
+    }
+
+    /** Renews slightly early, so no request is ever issued against a lapsed token. */
+    async authFetch(
+        input: string | URL | globalThis.Request,
+        init?: RequestInit,
+        dpopPayload?: unknown,
+    ): Promise<Response> {
+        if (this.isActive && this.needsRenewal()) {
+            try {
+                await this.restore()
+            } catch {
+                // Fall through: the existing token may still be good enough, and
+                // restore() has already reported the failure.
+            }
+        }
+        return super.authFetch(input, init, dpopPayload)
+    }
+
+    async logout(): Promise<void> {
+        this.cancelRenewal()
+        logAuthEvent('logout.requested')
+        await super.logout()
+    }
+
+    /** True once the access token is inside the pre-expiry buffer. */
+    needsRenewal(): boolean {
+        const expiresIn = this.getExpiresIn()
+        if (expiresIn < 0) return true
+        return expiresIn <= EXPIRY_BUFFER_SECONDS
+    }
+
+    /** Whether a session is stored and worth trying to restore. */
+    async hasStoredSession(): Promise<boolean> {
+        try {
+            await this.db.init()
+            const refreshToken = await this.db.getItem('refresh_token')
+            return Boolean(refreshToken)
+        } catch {
+            return false
+        } finally {
+            try { this.db.close() } catch { /* already closed */ }
+        }
+    }
+
+    /** Renews shortly before expiry rather than waiting for a request to fail. */
+    scheduleRenewal(): void {
+        this.cancelRenewal()
+        if (!this.isActive) return
+
+        const expiresIn = this.getExpiresIn()
+        const delaySeconds = Math.max(expiresIn - EXPIRY_BUFFER_SECONDS, 30)
+        // setTimeout clamps above ~24.8 days; sessions never live that long, but
+        // guard anyway so a bogus `exp` cannot schedule an immediate loop.
+        const delayMs = Math.min(delaySeconds, 60 * 60 * 24) * 1000
+
+        this.renewalTimer = setTimeout(() => {
+            logAuthEvent('refresh.scheduled-renewal')
+            void this.restore().catch(() => { /* reported by restore() */ })
+        }, delayMs)
+    }
+
+    cancelRenewal(): void {
+        if (this.renewalTimer !== undefined) {
+            clearTimeout(this.renewalTimer)
+            this.renewalTimer = undefined
+        }
+    }
+
+    private async refreshWithRetries() {
+        let lastError: unknown
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                return await this.performRefresh()
+            } catch (error) {
+                lastError = error
+                if (error instanceof SessionEndedError) throw error
+                if (attempt === MAX_ATTEMPTS) break
+                const backoff = RETRY_BASE_MS * 2 ** (attempt - 1)
+                logAuthEvent('refresh.retrying', { attempt, backoff, reason: String(error) }, 'warn')
+                await sleep(backoff)
+            }
+        }
+        throw lastError instanceof Error ? lastError : new Error(String(lastError))
+    }
+
+    /**
+     * One refresh-token exchange.
+     *
+     * The ordering here is the whole point: the replacement refresh token is
+     * persisted the moment it arrives, before verification, before anything else
+     * that can throw. A rotated token that is received but not stored is a dead
+     * session; a stored token that later fails verification just gets retried.
+     */
+    private async performRefresh() {
+        await this.db.init()
+        try {
+            const [clientId, tokenEndpoint, keyPair, refreshToken, idp, jwksUri] = await Promise.all([
+                this.db.getItem('client_id') as Promise<string | null>,
+                this.db.getItem('token_endpoint') as Promise<string | null>,
+                this.db.getItem('dpop_keypair') as Promise<StoredKeyPair | null>,
+                this.db.getItem('refresh_token') as Promise<string | null>,
+                this.db.getItem('idp') as Promise<string | null>,
+                this.db.getItem('jwks_uri') as Promise<string | null>,
+            ])
+
+            if (!clientId || !tokenEndpoint || !keyPair || !refreshToken || !idp || !jwksUri) {
+                throw new SessionEndedError('no-stored-session', 'No stored Solid session to restore.')
+            }
+
+            const dpop = await createTokenEndpointDPoP(tokenEndpoint, keyPair)
+
+            let response: Response
+            try {
+                response = await fetch(tokenEndpoint, {
+                    method: 'POST',
+                    headers: { dpop, 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: new URLSearchParams({
+                        grant_type: 'refresh_token',
+                        refresh_token: refreshToken,
+                        client_id: clientId,
+                    }),
+                })
+            } catch (error) {
+                // Offline, DNS failure, connection reset. The refresh token was
+                // never presented, so it is certainly still good.
+                throw new TransientRefreshError(`Could not reach the token endpoint: ${String(error)}`)
+            }
+
+            if (!response.ok) {
+                throw classifyTokenError(response.status, await response.text().catch(() => ''))
+            }
+
+            const tokens = (await response.json()) as TokenResponse
+
+            // ── The fix. Persist the rotated token before doing anything fallible. ──
+            if (tokens.refresh_token && tokens.refresh_token !== refreshToken) {
+                await this.db.setItem('refresh_token', tokens.refresh_token)
+                logAuthEvent('refresh.token-rotated')
+            }
+
+            await this.verifyAccessToken(tokens.access_token, { idp, jwksUri, clientId, keyPair })
+
+            return { ...tokens, dpop_key_pair: keyPair } as Parameters<SessionCore['setTokenDetails']>[0]
+        } finally {
+            try { this.db.close() } catch { /* already closed */ }
+        }
+    }
+
+    /**
+     * Verifies the new access token. Failures here are transient by design: the
+     * rotated refresh token is already stored, so retrying is safe, and a phone
+     * with a skewed clock should not be logged out over it.
+     */
+    private async verifyAccessToken(
+        accessToken: string,
+        ctx: { idp: string; jwksUri: string; clientId: string; keyPair: StoredKeyPair },
+    ): Promise<void> {
+        let payload
+        try {
+            ;({ payload } = await jwtVerify(accessToken, this.resolveJwks(ctx.jwksUri), {
+                issuer: ctx.idp,
+                audience: 'solid',
+                clockTolerance: CLOCK_TOLERANCE_SECONDS,
+            }))
+        } catch (error) {
+            // Signature, JWKS fetch or clock problems. Retrying is safe and often works.
+            throw new TransientRefreshError(`Could not verify the new access token: ${String(error)}`)
+        }
+
+        // These two cannot come right on a retry: the stored key or registration
+        // no longer matches what the provider is issuing, so the session is over.
+        const cnf = payload.cnf as { jkt?: string } | undefined
+        const thumbprint = await calculateJwkThumbprint(await exportJWK(ctx.keyPair.publicKey))
+        if (cnf?.jkt !== thumbprint) {
+            throw new SessionEndedError('dpop-key-mismatch', 'The access token is bound to a different key.')
+        }
+        if (payload.client_id !== ctx.clientId) {
+            throw new SessionEndedError('client-id-mismatch', 'The access token was issued to a different client.')
+        }
+    }
+}

--- a/src/services/authLog.ts
+++ b/src/services/authLog.ts
@@ -1,0 +1,110 @@
+import { addBreadcrumb } from '@sentry/react'
+
+/**
+ * A durable record of everything that happens to the Solid session.
+ *
+ * Logouts are the hardest kind of bug to report: by the time the user notices,
+ * the console is gone and the tab has reloaded. This keeps the last few hundred
+ * auth events in localStorage — surviving reloads, restarts and crashes — so
+ * "it logged me out again" can be answered with the actual sequence of events,
+ * including what the identity provider said.
+ */
+
+const STORAGE_KEY = 'pmu-auth-log'
+const MAX_ENTRIES = 300
+
+export type AuthEventLevel = 'info' | 'warn' | 'error'
+
+export interface AuthEvent {
+    /** Epoch millis. */
+    at: number
+    event: string
+    level: AuthEventLevel
+    detail?: Record<string, unknown>
+}
+
+let memoryLog: AuthEvent[] = []
+let loaded = false
+
+function load(): AuthEvent[] {
+    if (loaded) return memoryLog
+    loaded = true
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY)
+        memoryLog = raw ? (JSON.parse(raw) as AuthEvent[]) : []
+    } catch {
+        memoryLog = []
+    }
+    return memoryLog
+}
+
+function persist(): void {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(memoryLog))
+    } catch {
+        // Storage full or blocked (private mode). The in-memory log still works.
+    }
+}
+
+/**
+ * Records an auth event. Also drops a Sentry breadcrumb, so any error report
+ * raised later carries the auth history that led up to it.
+ */
+export function logAuthEvent(
+    event: string,
+    detail?: Record<string, unknown>,
+    level: AuthEventLevel = 'info',
+): void {
+    const entry: AuthEvent = { at: Date.now(), event, level, ...(detail ? { detail } : {}) }
+
+    const log = load()
+    log.push(entry)
+    if (log.length > MAX_ENTRIES) log.splice(0, log.length - MAX_ENTRIES)
+    persist()
+
+    try {
+        // Sentry spells the middle level 'warning'.
+        const sentryLevel = level === 'warn' ? 'warning' : level
+        addBreadcrumb({ category: 'auth', message: event, level: sentryLevel, data: detail })
+    } catch {
+        // Sentry not initialised (tests, local dev) — the local log is what matters.
+    }
+
+    if (import.meta.env.DEV) {
+        const line = `[auth] ${event}`
+        if (level === 'error') console.error(line, detail ?? '')
+        else if (level === 'warn') console.warn(line, detail ?? '')
+        else console.log(line, detail ?? '')
+    }
+}
+
+/** The recorded events, oldest first. */
+export function getAuthLog(): readonly AuthEvent[] {
+    return load()
+}
+
+/** The log as pasteable text, for a bug report. */
+export function formatAuthLog(): string {
+    return load()
+        .map(e => {
+            const detail = e.detail ? ` ${JSON.stringify(e.detail)}` : ''
+            return `${new Date(e.at).toISOString()} [${e.level}] ${e.event}${detail}`
+        })
+        .join('\n')
+}
+
+export function clearAuthLog(): void {
+    memoryLog = []
+    loaded = true
+    try {
+        localStorage.removeItem(STORAGE_KEY)
+    } catch {
+        // Nothing we can do; the in-memory log is already cleared.
+    }
+}
+
+/** Test seam — drops the cached copy so the next read comes from storage. */
+export function resetAuthLogCacheForTests(): void {
+    memoryLog = []
+    loaded = false
+}


### PR DESCRIPTION
The app treated "I could not reach the token endpoint" and "your session is
over" as the same event. They are not: a refresh token stays good for hours,
a Wi-Fi handover for two seconds. Every logout traced back to that confusion,
and in each case the refresh token on disk was still valid when the user was
signed out.

Seven ways a live session was lost:

- A restore that failed on startup was swallowed by an empty catch, so a cold
  start that beat the network left the user signed out with a good token on
  disk and nothing ever trying again.
- SessionCore ends the session on the first failed refresh. There was no retry
  at any level, so one dropped connection was a logout.
- Both recovery paths were gated on isLoggedIn, so once it flipped there was
  no way back short of a reload.
- On a 401 the app called the library's logout(), which clears IndexedDB and
  the refresh token with it — answering the recoverable case by deleting the
  means of recovery.
- Tokens were used to the expiry instant, so requests raced the boundary and
  any clock skew lost, producing the 401 above on a one-hour cycle.
- renewTokens banks a rotated refresh token only after a network JWKS fetch
  and a zero-tolerance clock check. Either failing discards the replacement
  the provider has already swapped in, and re-presenting the spent one reads
  as a replay: oidc-provider revokes the whole grant.
- restore() de-duplicates per instance, so two tabs waking together spend the
  same token and the loser trips that same replay detection.

ResilientSession keeps SessionCore's login, DPoP and fetch handling and
replaces the refresh: the rotated token is banked before anything that can
throw, refreshes are serialised across tabs with Web Locks, failures are
classified so only the provider disowning the grant ends a session, and
renewal happens two minutes before expiry rather than after it.

SolidPodContext then stops discarding what it has: no logout() on a 401,
transient failures retried on a backoff and on online/tab-focus, and startup
capped at four seconds so a slow restore does not hold the first paint.

Your data → Sign-in history keeps the last 300 auth events on the device so
the next one of these can be read rather than guessed at.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DP33yJo9bgyvcQSCNs6vJz