### PR TITLE
Gather packing list card actions behind a kebab menu

### DIFF
--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -12,6 +12,12 @@ async function runWizard(page: import('@playwright/test').Page) {
   await page.waitForURL(/#\/create-packing-list/, { timeout: 5_000 })
 }
 
+/** Open a list card's kebab menu and pick one of its actions. */
+async function chooseCardAction(page: import('@playwright/test').Page, listName: string, action: RegExp | string) {
+  await page.getByRole('button', { name: `More actions for ${listName}` }).click()
+  await page.getByRole('menuitem', { name: action }).click()
+}
+
 async function createList(page: import('@playwright/test').Page, name: string) {
   // Wait for the question set to load (questions appear on the page)
   await page.waitForLoadState('networkidle')
@@ -96,7 +102,7 @@ test.describe('C – Packing Lists', () => {
     await runWizard(page)
     await createList(page, 'Old Name')
     await page.goto('/#/view-lists')
-    await page.getByRole('button', { name: /Rename/i }).first().click()
+    await chooseCardAction(page, 'Old Name', /Rename/i)
     // Rename modal input
     const renameInput = page.locator('[role="dialog"] input[type="text"]')
     await renameInput.clear()
@@ -110,7 +116,7 @@ test.describe('C – Packing Lists', () => {
     await runWizard(page)
     await createList(page, 'Original List')
     await page.goto('/#/view-lists')
-    await page.getByRole('button', { name: /Duplicate/i }).first().click()
+    await chooseCardAction(page, 'Original List', /Duplicate/i)
     await expect(page.getByText(/Copy of Original List/i)).toBeVisible({ timeout: 5_000 })
   })
 
@@ -119,7 +125,7 @@ test.describe('C – Packing Lists', () => {
     await createList(page, 'To Delete')
     await page.goto('/#/view-lists')
     await expect(page.getByText('To Delete')).toBeVisible()
-    await page.getByRole('button', { name: /Delete/i }).first().click()
+    await chooseCardAction(page, 'To Delete', /^Delete$/)
     // Confirmation dialog
     await expect(page.getByText(/Are you sure.*delete/i)).toBeVisible()
     await page.getByRole('button', { name: /^Delete$/ }).click()

--- a/e2e/tests/f-sync.spec.ts
+++ b/e2e/tests/f-sync.spec.ts
@@ -114,7 +114,8 @@ test.describe('F – Solid Pod Sync', () => {
     await syncListToPod()
 
     await page.goto('/#/view-lists')
-    await page.locator('.rounded-2xl').filter({ hasText: f3ListName }).getByRole('button', { name: /Delete/i }).click()
+    await page.getByRole('button', { name: `More actions for ${f3ListName}` }).click()
+    await page.getByRole('menuitem', { name: /^Delete$/ }).click()
     await page.getByRole('button', { name: /^Delete$/ }).click()
     // The list card heading disappearing confirms both local removal and pod delete completed.
     // Using getByRole('heading') avoids matching the dialog text which also contains the list name.
@@ -254,7 +255,8 @@ test.describe('F – Solid Pod Sync', () => {
 
     // Device A: delete the list.
     await page.goto('/#/view-lists')
-    await page.locator('.rounded-2xl').filter({ hasText: f7ListName }).getByRole('button', { name: /Delete/i }).click()
+    await page.getByRole('button', { name: `More actions for ${f7ListName}` }).click()
+    await page.getByRole('menuitem', { name: /^Delete$/ }).click()
     await page.getByRole('button', { name: /^Delete$/ }).click()
     await expect(page.getByRole('heading').filter({ hasText: f7ListName })).not.toBeVisible({ timeout: 5_000 })
 

--- a/e2e/tests/g-cross-context.spec.ts
+++ b/e2e/tests/g-cross-context.spec.ts
@@ -86,7 +86,8 @@ test.describe('G – Cross-context Pod Sync', () => {
       r => r.url().includes('/pack-me-up/packing-lists/') && r.request().method() === 'PUT',
       { timeout: 15_000 }
     )
-    await page.locator('.rounded-2xl').filter({ hasText: originalName }).getByRole('button', { name: /Rename/i }).click()
+    await page.getByRole('button', { name: `More actions for ${originalName}` }).click()
+    await page.getByRole('menuitem', { name: /Rename/i }).click()
     const renameInput = page.locator('[role="dialog"] input[type="text"]')
     await renameInput.clear()
     await renameInput.fill(renamedName)

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { PackingLists } from './packing-lists'
@@ -108,6 +108,20 @@ function renderComponent() {
             <PackingLists />
         </MemoryRouter>
     )
+}
+
+/**
+ * Open a card's kebab menu. Radix opens its menu on pointerdown, which
+ * fireEvent.click does not send.
+ */
+function openCardMenu(listName = 'Summer Holiday') {
+    fireEvent.pointerDown(screen.getByRole('button', { name: `More actions for ${listName}` }), { button: 0 })
+    return screen.getByRole('menu')
+}
+
+/** Pick an action out of a card's kebab menu. */
+function chooseCardAction(action: RegExp, listName = 'Summer Holiday') {
+    fireEvent.click(within(openCardMenu(listName)).getByRole('menuitem', { name: action }))
 }
 
 describe('PackingLists', () => {
@@ -255,7 +269,7 @@ describe('PackingLists delete confirmation', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByText('🗑️ Delete'))
+        chooseCardAction(/delete/i)
 
         expect(db.deletePackingList).not.toHaveBeenCalled()
     })
@@ -268,7 +282,7 @@ describe('PackingLists delete confirmation', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByText('🗑️ Delete'))
+        chooseCardAction(/delete/i)
 
         await waitFor(() => {
             expect(screen.getByText(/cannot be undone/i)).toBeTruthy()
@@ -284,7 +298,7 @@ describe('PackingLists delete confirmation', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByText('🗑️ Delete'))
+        chooseCardAction(/delete/i)
 
         await waitFor(() => expect(screen.getByText(/cannot be undone/i)).toBeTruthy())
 
@@ -304,7 +318,7 @@ describe('PackingLists delete confirmation', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByText('🗑️ Delete'))
+        chooseCardAction(/delete/i)
 
         await screen.findByText(/cannot be undone/i)
 
@@ -328,7 +342,7 @@ describe('PackingLists delete confirmation', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByText('🗑️ Delete'))
+        chooseCardAction(/delete/i)
         await screen.findByText(/cannot be undone/i)
         fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
 
@@ -350,7 +364,7 @@ describe('PackingLists rename', () => {
         })
     })
 
-    it('shows a Rename button on each list card', async () => {
+    it("offers Rename in each card's kebab menu", async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
@@ -358,7 +372,7 @@ describe('PackingLists rename', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        expect(screen.getByRole('button', { name: /rename/i })).toBeTruthy()
+        expect(within(openCardMenu()).getByRole('menuitem', { name: /rename/i })).toBeTruthy()
     })
 
     it('opens a rename modal pre-filled with the current list name when Rename is clicked', async () => {
@@ -369,7 +383,7 @@ describe('PackingLists rename', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByRole('button', { name: /rename/i }))
+        chooseCardAction(/rename/i)
 
         await waitFor(() => {
             const input = screen.getByRole('textbox')
@@ -385,7 +399,7 @@ describe('PackingLists rename', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByRole('button', { name: /rename/i }))
+        chooseCardAction(/rename/i)
 
         await waitFor(() => screen.getByRole('textbox'))
 
@@ -407,7 +421,7 @@ describe('PackingLists rename', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByRole('button', { name: /rename/i }))
+        chooseCardAction(/rename/i)
 
         await waitFor(() => screen.getByRole('textbox'))
 
@@ -452,7 +466,7 @@ describe('PackingLists duplicate', () => {
         })
     })
 
-    it('shows a Duplicate button on each list card', async () => {
+    it("offers Duplicate in each card's kebab menu", async () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
@@ -460,7 +474,7 @@ describe('PackingLists duplicate', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        expect(screen.getByRole('button', { name: /duplicate/i })).toBeTruthy()
+        expect(within(openCardMenu()).getByRole('menuitem', { name: /duplicate/i })).toBeTruthy()
     })
 
     it('calls savePackingList with a new list named "Copy of {name}" when Duplicate is clicked', async () => {
@@ -471,7 +485,7 @@ describe('PackingLists duplicate', () => {
 
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByRole('button', { name: /duplicate/i }))
+        chooseCardAction(/duplicate/i)
 
         await waitFor(() => {
             expect(db.savePackingList).toHaveBeenCalledWith(
@@ -549,7 +563,7 @@ describe('PackingLists pod sync on mutation', () => {
         renderComponent()
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByRole('button', { name: /rename/i }))
+        chooseCardAction(/rename/i)
         await waitFor(() => screen.getByRole('textbox'))
         fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Winter Holiday' } })
         fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
@@ -570,7 +584,7 @@ describe('PackingLists pod sync on mutation', () => {
         renderComponent()
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByRole('button', { name: /duplicate/i }))
+        chooseCardAction(/duplicate/i)
 
         await waitFor(() => {
             expect(mockSaveRdfToPod).toHaveBeenCalledWith(
@@ -588,7 +602,7 @@ describe('PackingLists pod sync on mutation', () => {
         renderComponent()
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByText('🗑️ Delete'))
+        chooseCardAction(/delete/i)
         await screen.findByText(/cannot be undone/i)
         fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
 
@@ -614,7 +628,7 @@ describe('PackingLists pod sync on mutation', () => {
         renderComponent()
         await screen.findByText(/Summer Holiday/)
 
-        fireEvent.click(screen.getByRole('button', { name: /duplicate/i }))
+        chooseCardAction(/duplicate/i)
 
         await waitFor(() => {
             expect(makeDb().savePackingList).toBeDefined()
@@ -1002,5 +1016,106 @@ describe('PackingLists past trips', () => {
 
         expect(await screen.findByText(/No upcoming trips/i)).toBeTruthy()
         expect(screen.queryByText(/No packing lists found/i)).toBeNull()
+    })
+})
+
+describe('PackingLists card actions menu', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: makeDb() as unknown as PackingAppDatabase })
+        mockNavigate.mockClear()
+    })
+
+    it('opens the list when the card body is clicked', async () => {
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByTestId('packing-list-card'))
+
+        expect(mockNavigate).toHaveBeenCalledWith('/view-lists/list-1')
+    })
+
+    it('opens the shared list when a cached copy of someone else’s card is clicked', async () => {
+        const db = makeDb()
+        db.getAllPackingLists = vi.fn().mockResolvedValue([
+            { ...testList, sharedFromPodUrl: 'https://someone-else.example/' },
+        ])
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        fireEvent.click(screen.getByTestId('packing-list-card'))
+
+        expect(mockNavigate).toHaveBeenCalledWith('/view-lists/list-1?pod=https://someone-else.example/')
+    })
+
+    it('does not open the list when the kebab is clicked', async () => {
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        const kebab = screen.getByRole('button', { name: 'More actions for Summer Holiday' })
+        fireEvent.pointerDown(kebab, { button: 0 })
+        fireEvent.click(kebab)
+
+        expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('gathers Rename, Duplicate and Delete behind the kebab', async () => {
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        const menu = openCardMenu()
+        expect(within(menu).getAllByRole('menuitem').map(item => item.textContent)).toEqual([
+            'Rename', 'Duplicate', 'Delete',
+        ])
+    })
+
+    it('leaves no action buttons loose on the card', async () => {
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        const card = screen.getByTestId('packing-list-card')
+        expect(within(card).getAllByRole('button').map(b => b.getAttribute('aria-label'))).toEqual([
+            'More actions for Summer Holiday',
+        ])
+    })
+
+    it('closes the menu on Escape without opening the list', async () => {
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        openCardMenu()
+        fireEvent.keyDown(document.activeElement ?? document.body, { key: 'Escape' })
+
+        await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+        expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('does not open the list when an action is chosen from the menu', async () => {
+        const db = { ...makeDb(), savePackingList: vi.fn().mockResolvedValue({ rev: '1' }) }
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday/)
+
+        chooseCardAction(/duplicate/i)
+
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        expect(mockNavigate).not.toHaveBeenCalled()
     })
 })

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useNavigate } from 'react-router-dom'
 import { PackingList } from '../create-packing-list/types'
 import { useDatabase } from '../components/DatabaseContext'
@@ -20,6 +21,70 @@ import { PastTripsSection } from '../components/PastTripsSection'
 
 type SharingStatus = 'public' | 'shared' | 'private'
 
+/**
+ * The card's actions, behind a kebab. Gathering them into one menu replaces the
+ * three sibling buttons that each had to stop its own click from reaching the
+ * card underneath and opening the list. The menu keeps clicks off the card in
+ * two places instead of once per action: the trigger, and the content — the
+ * latter because a React portal still propagates events up the React tree, so
+ * the card's onClick sees an item click even though the menu is rendered
+ * outside the card in the DOM.
+ */
+function ListCardMenu({ listName, onRename, onDuplicate, onDelete }: {
+    listName: string
+    onRename: () => void
+    onDuplicate: () => void
+    onDelete: () => void
+}) {
+    return (
+        <DropdownMenu.Root>
+            <span onClick={e => e.stopPropagation()} className="inline-flex">
+                <DropdownMenu.Trigger asChild>
+                    <button
+                        type="button"
+                        aria-label={`More actions for ${listName}`}
+                        title="More actions"
+                        className="text-gray-700 dark:text-gray-200 hover:text-gray-900 dark:hover:text-white bg-white/60 dark:bg-white/10 hover:bg-white/80 dark:hover:bg-white/20 px-2 py-1 rounded-lg transition-colors duration-200"
+                    >
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <circle cx="12" cy="5" r="1.5" />
+                            <circle cx="12" cy="12" r="1.5" />
+                            <circle cx="12" cy="19" r="1.5" />
+                        </svg>
+                    </button>
+                </DropdownMenu.Trigger>
+            </span>
+            <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                    align="end"
+                    sideOffset={4}
+                    onClick={e => e.stopPropagation()}
+                    className="w-40 bg-white dark:bg-gray-900 rounded-lg shadow-lg border border-gray-100 dark:border-gray-800 py-1 z-50"
+                >
+                    <DropdownMenu.Item
+                        onSelect={onRename}
+                        className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none"
+                    >
+                        Rename
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                        onSelect={onDuplicate}
+                        className="px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none"
+                    >
+                        Duplicate
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                        onSelect={onDelete}
+                        className="px-4 py-2.5 text-sm text-danger-600 dark:text-danger-400 hover:bg-danger-50 dark:hover:bg-danger-950/40 cursor-default outline-none"
+                    >
+                        Delete
+                    </DropdownMenu.Item>
+                </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+    )
+}
+
 export function PackingLists() {
     const [packingLists, setPackingLists] = useState<PackingList[]>([])
     const [isLoading, setIsLoading] = useState(true)
@@ -38,13 +103,11 @@ export function PackingLists() {
     const { db } = useDatabase()
     const handlePodError = usePodErrorHandler()
 
-    const requestDeletePackingList = (id: string, name: string, event: React.MouseEvent) => {
-        event.stopPropagation()
+    const requestDeletePackingList = (id: string, name: string) => {
         setListToDelete({ id, name })
     }
 
-    const requestRenamePackingList = (id: string, name: string, event: React.MouseEvent) => {
-        event.stopPropagation()
+    const requestRenamePackingList = (id: string, name: string) => {
         setListToRename({ id, name })
         setRenameValue(name)
     }
@@ -65,8 +128,7 @@ export function PackingLists() {
         }
     }
 
-    const handleDuplicatePackingList = async (list: PackingList, event: React.MouseEvent) => {
-        event.stopPropagation()
+    const handleDuplicatePackingList = async (list: PackingList) => {
         try {
             const newList: PackingList = {
                 id: generateUUID(),
@@ -247,24 +309,12 @@ export function PackingLists() {
                                 ? `📅 ${tripDates}`
                                 : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
                         </span>
-                        <button
-                            onClick={(e) => requestRenamePackingList(list.id, list.name, e)}
-                            className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg"
-                        >
-                            ✏️ Rename
-                        </button>
-                        <button
-                            onClick={(e) => handleDuplicatePackingList(list, e)}
-                            className="text-secondary-600 dark:text-secondary-400 hover:text-secondary-800 dark:hover:text-secondary-200 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg"
-                        >
-                            📋 Duplicate
-                        </button>
-                        <button
-                            onClick={(e) => requestDeletePackingList(list.id, list.name, e)}
-                            className="text-danger-600 dark:text-danger-400 hover:text-danger-800 dark:hover:text-danger-200 text-sm font-bold hover:scale-110 transition-transform duration-200 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg"
-                        >
-                            🗑️ Delete
-                        </button>
+                        <ListCardMenu
+                            listName={list.name}
+                            onRename={() => requestRenamePackingList(list.id, list.name)}
+                            onDuplicate={() => handleDuplicatePackingList(list)}
+                            onDelete={() => requestDeletePackingList(list.id, list.name)}
+                        />
                     </div>
                 </div>
                 <div className="flex items-center gap-4">


### PR DESCRIPTION
Closes #299

## What

The packing list card's three sibling action buttons — `✏️ Rename`, `📋 Duplicate`, `🗑️ Delete` — each stopped its own click from reaching the card underneath. They now live in one portalled Radix dropdown behind a kebab, so the propagation handling sits in the menu rather than being repeated per action. Clicking anywhere else on the card still opens the list.

Rename joins Duplicate and Delete in the menu: it was added to the card after the issue was written and was doing the same `stopPropagation` dance, so leaving it outside would have defeated the point.

## Notes against the issue as written

- **`lucide-react` was not added.** The issue anticipated it for the kebab icon, but the repo already draws this exact icon as an inline SVG in `questions-page.tsx`, and `@radix-ui/react-dropdown-menu` is already a dependency. The menu follows that existing pattern, so this adds no new packages.
- **The two dark-mode faults called out for the re-land are fixed**: the Delete item uses `dark:hover:bg-danger-950/40` (not `dark:bg-`), so the row is tinted only on hover; and the kebab carries `dark:bg-white/10` with a `dark:text-gray-200` glyph so it is visible on a dark card. Both verified in the report below.
- **`foreign-packing-lists.tsx` is explicitly deferred**: those cards carry no per-card actions at all, so there is nothing to gather behind a kebab. The whole card is already the click target.

One thing worth knowing for review: the menu stops clicks reaching the card in *two* places, not one. A React portal still propagates events up the **React** tree, so without `onClick` on `DropdownMenu.Content` the card's handler fires on every menu item click even though the menu is outside the card in the DOM. A test pins that.

## Tests

Seven new component tests in `src/pages/packing-lists.test.tsx` cover card-body click navigating (own and shared lists), kebab click *not* navigating, the menu's contents and ordering, no loose action buttons left on the card, Escape closing the menu, and choosing an action not opening the list. The existing rename/duplicate/delete tests now drive the menu.

`c-packing-lists.spec.ts` (C4–C6), `f-sync.spec.ts` (F3, F7) and `g-cross-context.spec.ts` were updated to open the kebab, since the buttons they clicked no longer exist.

```
npm test   →  101 files, 1896 tests passed
e2e C4/C5/C6 against the built app → 3 passed
```

📋 **[Manual test report — 2026-08-24, with screenshots](https://github.com/timgent/pack-me-up/blob/agent-testing/2026-08-24-issue-299-card-kebab-menu/README.md)** (on the `agent-testing` branch) — desktop and mobile, light and dark, every acceptance criterion walked through in the real app. No bugs found.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164ySvoWkxCnphySmPq6XgW)_