### PR TITLE
Write question-named section headings without the question mark

### DIFF
--- a/src/components/AddItemComposer.test.tsx
+++ b/src/components/AddItemComposer.test.tsx
@@ -207,6 +207,32 @@ describe('AddItemComposer: suggestions', () => {
         expect(onAdd).not.toHaveBeenCalled()
     })
 
+    it('writes a question-named section the way the card heading does', () => {
+        // The badge names the section the suggestion would land in, and the
+        // card it lands on is headed without the question mark — see
+        // `sectionHeading`. The stored category is untouched, so the item
+        // still joins the section it names.
+        const questionSuggestions = buildSuggestionIndex([
+            mk({ itemText: 'Pyjamas', personName: 'Bob', category: 'Will you be staying overnight?' }),
+        ])
+        const { onAdd, input } = renderComposer({
+            suggestions: questionSuggestions,
+            categoryOptions: ['Will you be staying overnight?', 'Other'],
+        })
+        fireEvent.change(input, { target: { value: 'pyj' } })
+
+        expect(screen.getByRole('option', { name: /Pyjamas/ }).textContent)
+            .toBe('PyjamasWill you be staying overnight')
+
+        fireEvent.click(screen.getByRole('option', { name: /Pyjamas/ }))
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onAdd).toHaveBeenCalledWith(
+            expect.objectContaining({ category: 'Will you be staying overnight?' }),
+            'Pyjamas',
+            undefined,
+        )
+    })
+
     it('closes the suggestions on Escape without closing the composer', () => {
         const onClose = vi.fn()
         const { input } = renderComposer({ suggestions, onClose })

--- a/src/components/ItemNameField.tsx
+++ b/src/components/ItemNameField.tsx
@@ -15,6 +15,7 @@
  */
 import { useMemo, useState } from 'react'
 import { suggestFor, type ItemSuggestion, type SuggestionIndex } from '../utils/itemSuggestions'
+import { sectionHeading } from '../utils/sectionHeading'
 
 /** A composer field, bar the focus ring — each page brings its own accent. */
 export const FIELD_BASE = 'px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-sm text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2'
@@ -160,7 +161,7 @@ export function ItemNameField({
                                 <span className="truncate">{suggestion.text}</span>
                                 {suggestion.category && (
                                     <span className="shrink-0 rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-[11px] text-gray-500 dark:text-gray-400">
-                                        {suggestion.category}
+                                        {sectionHeading(suggestion.category)}
                                     </span>
                                 )}
                             </button>

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -3875,3 +3875,91 @@ describe('ViewPackingList people filter', () => {
         })
     })
 })
+
+describe('a section named after a question', () => {
+    // The section a question's items fall into is named with the question's own
+    // text (see `defaultCategoryFor`), so a heading arrives as "Will you be
+    // staying overnight?" — a question where the card wants a noun phrase.
+    const QUESTION_CATEGORY = 'Will you be staying overnight?'
+    const questionCategoryList = {
+        id: 'test-list-question-heading',
+        name: 'Question Heading Trip',
+        createdAt: '2026-01-01T00:00:00Z',
+        items: [
+            { id: 'qh-1', itemText: 'Pyjamas', personName: 'Alice', personId: 'p1', questionId: 'q1', optionId: 'o1', packed: false, category: QUESTION_CATEGORY, order: 0 },
+        ],
+    }
+
+    let savePackingList: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...questionCategoryList, _rev: '2' }),
+        })
+        savePackingList = vi.fn().mockResolvedValue({ rev: '2' })
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getPackingList: vi.fn().mockResolvedValue(questionCategoryList),
+                savePackingList,
+                getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }),
+            } as unknown as PackingAppDatabase,
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    async function renderList() {
+        render(
+            <MemoryRouter initialEntries={['/view-list/test-list-question-heading']}>
+                <Routes>
+                    <Route path="/view-list/:id" element={<ViewPackingList />} />
+                </Routes>
+            </MemoryRouter>
+        )
+        await waitFor(() => expect(row('Pyjamas')).toBeTruthy())
+    }
+
+    it('drops the question mark from the heading', async () => {
+        await renderList()
+
+        expect(screen.getByText('Will you be staying overnight')).toBeTruthy()
+        expect(screen.queryByText(QUESTION_CATEGORY)).toBeNull()
+    })
+
+    it('drops it from the controls that name the section too', async () => {
+        await renderList()
+
+        expect(screen.getByRole('button', { name: 'Collapse Will you be staying overnight list' })).toBeTruthy()
+        expect(screen.getByRole('button', { name: 'Check all in Will you be staying overnight' })).toBeTruthy()
+    })
+
+    it('files an item typed into the card under the section it was typed into', async () => {
+        // The heading is display only: strip the question mark from the stored
+        // category and a typed item starts a second card beside the first.
+        await renderList()
+
+        const card = screen.getByTestId('list-section')
+        fireEvent.change(within(card).getByPlaceholderText('Add new item...'), { target: { value: 'Eye mask' } })
+        fireEvent.click(within(card).getByRole('button', { name: 'Add' }))
+
+        await waitFor(() => expect(savePackingList).toHaveBeenCalled())
+        const saved = savePackingList.mock.calls[0][0] as { items: PackingListItem[] }
+        expect(saved.items.find(item => item.itemText === 'Eye mask')?.category).toBe(QUESTION_CATEGORY)
+
+        await waitFor(() => expect(screen.getAllByTestId('list-section').length).toBe(1))
+    })
+})

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -29,6 +29,7 @@ import { formatTripDates } from '../create-packing-list/tripDetails'
 import { tapFeedback } from '../utils/haptics'
 import { prefersReducedMotion } from '../utils/prefersReducedMotion'
 import { groupItemsByCategory, sortByOrder, type CategoryAccessors } from '../utils/groupByCategory'
+import { sectionHeading } from '../utils/sectionHeading'
 import { CATEGORY_ORDER } from '../edit-questions/item-sections'
 import { useSectionOrder } from '../hooks/useSectionOrder'
 import { clearPendingSignInAction, getPendingSignInAction, setPendingSignInAction } from '../utils/pendingSignInAction'
@@ -110,7 +111,9 @@ const CONFETTI_PIECES = [
 ]
 
 interface ListSection {
+    /** The section's stored name — what a category is written as on its items. */
     key: string
+    /** What the card is headed with: the name as `sectionHeading` writes it. */
     title: string
     items: PackingListItem[]
     // Name used in aria-labels and guest actions; '' for the shared section
@@ -1437,7 +1440,7 @@ export function ViewPackingList() {
     const allCategorySections: ListSection[] = groupByCategory(packingList.items.filter(i => !i.lastMinute), sectionOrder)
         .map(({ label, items }) => ({
             key: label,
-            title: label,
+            title: sectionHeading(label),
             name: '',
             items,
             isCategory: true,
@@ -2053,7 +2056,7 @@ export function ViewPackingList() {
                                         <AddItemComposer
                                             personName={solePerson?.name ?? ''}
                                             personId={solePerson?.personId ?? ''}
-                                            category={isLastMinute ? undefined : categoryFromLabel(title)}
+                                            category={isLastMinute ? undefined : categoryFromLabel(sectionKey)}
                                             lastMinute={isLastMinute}
                                             peopleOptions={sectionPeopleChoices}
                                             suggestions={suggestionIndex}
@@ -2145,7 +2148,7 @@ export function ViewPackingList() {
                 // card's isn't: its items keep the section they came from, so a
                 // copy made there takes it from the item beside it.
                 category: openRowSection?.isCategory
-                    ? categoryFromLabel(openRowSection.title)
+                    ? categoryFromLabel(openRowSection.key)
                     : row.items[0]?.category,
                 lastMinute: openRowSection?.lastMinute,
             }, row.label, row.quantity)}

--- a/src/utils/sectionHeading.test.ts
+++ b/src/utils/sectionHeading.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { sectionHeading } from './sectionHeading'
+
+describe('sectionHeading', () => {
+    it('strips the trailing question mark a question-text section is named with', () => {
+        expect(sectionHeading('Will you be staying overnight?')).toBe('Will you be staying overnight')
+    })
+
+    it('takes the whitespace around the question mark with it', () => {
+        expect(sectionHeading('Will you be staying overnight ?  ')).toBe('Will you be staying overnight')
+    })
+
+    it('strips a run of question marks', () => {
+        expect(sectionHeading('Camping???')).toBe('Camping')
+    })
+
+    it('leaves an ordinary section name exactly as it is', () => {
+        expect(sectionHeading('Toiletries')).toBe('Toiletries')
+    })
+
+    it('leaves a question mark that is not at the end alone', () => {
+        expect(sectionHeading('What now? Kit')).toBe('What now? Kit')
+    })
+
+    it('keeps a label that is nothing but question marks, rather than losing the heading', () => {
+        expect(sectionHeading('???')).toBe('???')
+    })
+})

--- a/src/utils/sectionHeading.ts
+++ b/src/utils/sectionHeading.ts
@@ -1,0 +1,21 @@
+/**
+ * How a section's name is written when it is used as a heading.
+ *
+ * A section's name is often a question's text — that is what `defaultCategoryFor`
+ * falls back to when a question's items carry no category of their own — so a
+ * card ends up headed "Will you be staying overnight?". Every other heading on
+ * the list is a noun phrase naming a pile of things, and a question mark among
+ * them reads as if the card were asking rather than labelling.
+ *
+ * It is a display transform and nothing else: the stored category keeps its
+ * question mark, so items typed into the card still join the section they were
+ * typed into and nothing has to be migrated. Which also means it applies to
+ * questions the user wrote themselves, and to sections they named, without
+ * anyone having to fill in a second "short name" field.
+ */
+export function sectionHeading(label: string): string {
+    const stripped = label.replace(/\s*\?+\s*$/, '')
+    // A label that was only punctuation would vanish entirely — better an odd
+    // heading than a card with no name on it at all.
+    return stripped === '' ? label : stripped
+}


### PR DESCRIPTION
A section's name falls back to its question's text, so a card came out
headed "Will you be staying overnight?" — a question sitting among
headings that are otherwise noun phrases naming a pile of things.

`sectionHeading` strips the trailing question mark for display only. The
stored category keeps it, so nothing needs migrating and an item typed
into the card still joins the section it was typed into — the two places
that read the heading as data now read the section's key instead. Being a
plain label transform, it covers user-written questions and user-named
sections without anyone filling in a second field.

The suggestion badge in the composer names a section too, so it is
written the same way — otherwise it disagrees with the card the item
would land on.

Closes #206