### PR TITLE
Show a trip countdown once a list has trip dates

### DIFF
--- a/src/components/TripCountdownBadge.test.tsx
+++ b/src/components/TripCountdownBadge.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { TripCountdownBadge } from './TripCountdownBadge'
+import { formatTripCountdown } from '../create-packing-list/tripDetails'
+import type { TripCountdownInput } from '../create-packing-list/tripDetails'
+
+/** Renders the badge the way a page does: countdown built from the list. */
+const renderFor = (trip: TripCountdownInput, remainingItems?: number) =>
+    render(<TripCountdownBadge countdown={formatTripCountdown(trip, remainingItems)} />)
+
+/** Freezes the clock mid-afternoon on 15 June 2026, local time. */
+const freezeClock = () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 15, 14, 30))
+}
+
+const badge = () => screen.queryByTestId('trip-countdown')
+
+describe('the trip countdown badge', () => {
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('counts the sleeps until the trip, naming where it is going', () => {
+        freezeClock()
+        renderFor({ startDate: '2026-06-18', destination: 'Cornwall' })
+        expect(badge()!.textContent).toContain('3 sleeps until Cornwall')
+        expect(badge()!.getAttribute('data-countdown-status')).toBe('upcoming')
+    })
+
+    it('renders nothing at all for a list with no dates — not an empty badge', () => {
+        freezeClock()
+        const { container } = renderFor({ destination: 'Cornwall' })
+        expect(badge()).toBeNull()
+        expect(container.innerHTML).toBe('')
+    })
+
+    it('marks the day of the trip differently from the days before it', () => {
+        freezeClock()
+        const { unmount } = renderFor({ startDate: '2026-06-15', destination: 'Cornwall' })
+        expect(badge()!.textContent).toContain('Off to Cornwall today!')
+        expect(badge()!.getAttribute('data-countdown-status')).toBe('today')
+        const dayOfClassName = badge()!.className
+        unmount()
+
+        renderFor({ startDate: '2026-06-25', destination: 'Cornwall' })
+        expect(badge()!.className).not.toBe(dayOfClassName)
+    })
+
+    it('says the trip is under way rather than counting past zero', () => {
+        freezeClock()
+        renderFor({ startDate: '2026-06-10', endDate: '2026-06-20', destination: 'Cornwall' })
+        expect(badge()!.textContent).toContain('In Cornwall now')
+        expect(badge()!.getAttribute('data-countdown-status')).toBe('in-progress')
+    })
+
+    it('looks back on a trip that is over', () => {
+        freezeClock()
+        renderFor({ startDate: '2026-06-01', endDate: '2026-06-08', destination: 'Cornwall' })
+        expect(badge()!.textContent).toContain('Back from Cornwall')
+        expect(badge()!.getAttribute('data-countdown-status')).toBe('past')
+    })
+
+    it('carries the items still to pack when the trip is close', () => {
+        freezeClock()
+        renderFor({ startDate: '2026-06-17', destination: 'Cornwall' }, 18)
+        expect(badge()!.textContent).toContain('2 sleeps until Cornwall · 18 items left')
+    })
+
+    it('leaves the emoji out of the accessible name so it is not read aloud', () => {
+        freezeClock()
+        renderFor({ startDate: '2026-06-18', destination: 'Cornwall' })
+        expect(badge()!.querySelector('[aria-hidden="true"]')).not.toBeNull()
+    })
+})

--- a/src/components/TripCountdownBadge.tsx
+++ b/src/components/TripCountdownBadge.tsx
@@ -1,0 +1,51 @@
+import { URGENT_SLEEPS } from '../create-packing-list/tripDetails'
+import type { TripCountdown, TripCountdownStatus } from '../create-packing-list/tripDetails'
+
+interface TripCountdownBadgeProps {
+    /** Built by `formatTripCountdown`; null when there is nothing to count down to. */
+    countdown: TripCountdown | null
+    className?: string
+}
+
+/**
+ * How each state looks. Anticipation warms as the trip approaches — a distant
+ * trip is calm primary, the last few days are accent, the day itself is loud —
+ * then cools once there is nothing left to pack for.
+ */
+const TONES: Record<TripCountdownStatus | 'urgent', string> = {
+    upcoming: 'bg-primary-100 dark:bg-primary-900/40 text-primary-800 dark:text-primary-200 border-primary-200 dark:border-primary-800',
+    urgent: 'bg-accent-100 dark:bg-accent-900/40 text-accent-800 dark:text-accent-200 border-accent-200 dark:border-accent-800',
+    today: 'bg-accent-500 dark:bg-accent-600 text-white border-accent-600 dark:border-accent-500',
+    'in-progress': 'bg-success-100 dark:bg-success-900/40 text-success-800 dark:text-success-200 border-success-200 dark:border-success-800',
+    past: 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-700',
+}
+
+const ICONS: Record<TripCountdownStatus, string> = {
+    upcoming: '🌙',
+    today: '🎉',
+    'in-progress': '🧳',
+    past: '🏡',
+}
+
+/**
+ * The "3 sleeps until Cornwall" badge. Renders nothing at all — not an empty
+ * pill, not a gap — for a list with no dates to count towards, so undated lists
+ * look exactly as they did before.
+ */
+export function TripCountdownBadge({ countdown, className = '' }: TripCountdownBadgeProps) {
+    if (!countdown) return null
+
+    const urgent = countdown.status === 'upcoming' && (countdown.sleeps ?? Infinity) <= URGENT_SLEEPS
+    const tone = TONES[urgent ? 'urgent' : countdown.status]
+
+    return (
+        <span
+            data-testid="trip-countdown"
+            data-countdown-status={countdown.status}
+            className={`inline-flex items-center gap-1 text-sm font-semibold border px-2.5 py-1 rounded-full max-w-full ${tone} ${className}`}
+        >
+            <span aria-hidden="true">{ICONS[countdown.status]}</span>
+            {countdown.label}
+        </span>
+    )
+}

--- a/src/create-packing-list/tripDetails.test.ts
+++ b/src/create-packing-list/tripDetails.test.ts
@@ -6,6 +6,7 @@ import {
     tripIsPast,
     splitCurrentAndPastTrips,
     MAX_UNDATED_CURRENT_TRIPS,
+    formatTripCountdown,
 } from './tripDetails'
 
 describe('formatTripDate', () => {
@@ -243,5 +244,125 @@ describe('splitCurrentAndPastTrips', () => {
 
     it('handles an empty list', () => {
         expect(splitCurrentAndPastTrips([])).toEqual({ current: [], past: [], allPastFinished: true })
+    })
+})
+
+describe('formatTripCountdown', () => {
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    /** Freezes the clock mid-afternoon on 15 June 2026, local time. */
+    const freezeClock = () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date(2026, 5, 15, 14, 30))
+    }
+
+    it('returns null when the list has no dates at all', () => {
+        freezeClock()
+        expect(formatTripCountdown({ destination: 'Cornwall' })).toBeNull()
+    })
+
+    it('returns null when the only date present is unparseable', () => {
+        freezeClock()
+        expect(formatTripCountdown({ startDate: 'not-a-date' })).toBeNull()
+    })
+
+    it('counts the sleeps until a trip still to come, naming the destination', () => {
+        freezeClock()
+        expect(formatTripCountdown({ startDate: '2026-06-18', destination: 'Cornwall' })).toEqual({
+            status: 'upcoming',
+            sleeps: 3,
+            label: '3 sleeps until Cornwall',
+        })
+    })
+
+    it('counts sleeps without a destination when the list has none', () => {
+        freezeClock()
+        expect(formatTripCountdown({ startDate: '2026-06-25' })).toEqual({
+            status: 'upcoming',
+            sleeps: 10,
+            label: '10 sleeps to go',
+        })
+    })
+
+    it('says one sleep rather than 1 sleeps the night before', () => {
+        freezeClock()
+        expect(formatTripCountdown({ startDate: '2026-06-16', destination: 'Cornwall' })?.label)
+            .toBe('1 sleep until Cornwall')
+    })
+
+    it('counts calendar days, not 24-hour blocks, late in the evening', () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date(2026, 5, 15, 23, 59))
+        expect(formatTripCountdown({ startDate: '2026-06-16' })?.sleeps).toBe(1)
+    })
+
+    it('celebrates the day the trip starts instead of counting zero sleeps', () => {
+        freezeClock()
+        expect(formatTripCountdown({ startDate: '2026-06-15', endDate: '2026-06-20', destination: 'Cornwall' })).toEqual({
+            status: 'today',
+            sleeps: 0,
+            label: 'Off to Cornwall today!',
+        })
+        expect(formatTripCountdown({ startDate: '2026-06-15' })?.label).toBe("Today's the day!")
+    })
+
+    it('says the trip is under way once it has started', () => {
+        freezeClock()
+        expect(formatTripCountdown({ startDate: '2026-06-10', endDate: '2026-06-20', destination: 'Cornwall' })).toEqual({
+            status: 'in-progress',
+            label: 'In Cornwall now',
+        })
+        expect(formatTripCountdown({ startDate: '2026-06-10', endDate: '2026-06-15' })?.label)
+            .toBe('Trip in progress')
+    })
+
+    it('never counts backwards for a trip that is over', () => {
+        freezeClock()
+        expect(formatTripCountdown({ startDate: '2026-06-01', endDate: '2026-06-08', destination: 'Cornwall' })).toEqual({
+            status: 'past',
+            label: 'Back from Cornwall',
+        })
+        expect(formatTripCountdown({ startDate: '2026-06-01', endDate: '2026-06-08' })?.label)
+            .toBe('Trip finished')
+    })
+
+    it('treats an end-date-only trip as past once that date has gone', () => {
+        freezeClock()
+        expect(formatTripCountdown({ endDate: '2026-06-08' })?.status).toBe('past')
+    })
+
+    it('has nothing to count down to when only a future end date is known', () => {
+        freezeClock()
+        expect(formatTripCountdown({ endDate: '2026-06-20' })).toBeNull()
+    })
+
+    it('adds the items still to pack once the trip is close enough to matter', () => {
+        freezeClock()
+        expect(formatTripCountdown({ startDate: '2026-06-17', destination: 'Cornwall' }, 18)?.label)
+            .toBe('2 sleeps until Cornwall · 18 items left')
+        expect(formatTripCountdown({ startDate: '2026-06-15' }, 1)?.label)
+            .toBe("Today's the day! 1 item left")
+    })
+
+    it('leaves a distant trip uncluttered by the items count', () => {
+        freezeClock()
+        expect(formatTripCountdown({ startDate: '2026-07-12', destination: 'Cornwall' }, 18)?.label)
+            .toBe('27 sleeps until Cornwall')
+    })
+
+    it('says nothing about items when there are none left to pack', () => {
+        freezeClock()
+        expect(formatTripCountdown({ startDate: '2026-06-16', destination: 'Cornwall' }, 0)?.label)
+            .toBe('1 sleep until Cornwall')
+    })
+
+    it('does not nag about items on a trip already under way or over', () => {
+        freezeClock()
+        expect(formatTripCountdown({ startDate: '2026-06-10', endDate: '2026-06-20' }, 5)?.label)
+            .toBe('Trip in progress')
+        expect(formatTripCountdown({ startDate: '2026-06-01', endDate: '2026-06-08' }, 5)?.label)
+            .toBe('Trip finished')
     })
 })

--- a/src/create-packing-list/tripDetails.ts
+++ b/src/create-packing-list/tripDetails.ts
@@ -140,3 +140,107 @@ export function tripDatesOutOfOrder(startDate: string | undefined, endDate: stri
     if (!start || !end) return false
     return end.getTime() < start.getTime()
 }
+
+/**
+ * Where a trip sits relative to today. Each state gets copy of its own so a
+ * trip that has started or finished never renders as a zero or negative
+ * countdown.
+ */
+export type TripCountdownStatus = 'upcoming' | 'today' | 'in-progress' | 'past'
+
+export interface TripCountdown {
+    status: TripCountdownStatus
+    /** Ready-to-render copy, e.g. "3 sleeps until Cornwall". */
+    label: string
+    /** Nights left before the trip starts; 0 on the day, absent once it has begun. */
+    sleeps?: number
+}
+
+/** The fields of a packing list a countdown is built from. */
+export interface TripCountdownInput {
+    startDate?: string
+    endDate?: string
+    destination?: string
+}
+
+/**
+ * How close a trip has to be before the countdown starts naming the items still
+ * to pack. Further out than this it is anticipation, not a to-do list, and the
+ * card already carries a packed count.
+ */
+export const URGENT_SLEEPS = 3
+
+/** Local midnight today — the day boundary every comparison here is made against. */
+function startOfToday(): Date {
+    const now = new Date()
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate())
+}
+
+/**
+ * Whole calendar days from one local midnight to another. Rounding absorbs the
+ * hour a daylight-saving change adds to or takes off the span.
+ */
+function calendarDaysBetween(from: Date, to: Date): number {
+    return Math.round((to.getTime() - from.getTime()) / 86_400_000)
+}
+
+function pluralise(count: number, noun: string): string {
+    return `${count} ${noun}${count === 1 ? '' : 's'}`
+}
+
+/**
+ * The trip's countdown as copy the traveller can read, or null when there is
+ * nothing to count down to — no dates at all, unreadable dates, or an
+ * open-ended trip that only says when it ends.
+ *
+ * `remainingItems` is folded in only for a trip within `URGENT_SLEEPS`, where
+ * "2 sleeps until Cornwall, 18 items left" is the nudge a parent actually
+ * needs; a trip under way or over is never nagged about packing.
+ */
+export function formatTripCountdown(
+    { startDate, endDate, destination }: TripCountdownInput,
+    remainingItems?: number
+): TripCountdown | null {
+    const start = parseTripDate(startDate)
+    const end = parseTripDate(endDate)
+    if (!start && !end) return null
+
+    if (tripIsPast(startDate, endDate)) {
+        return { status: 'past', label: destination ? `Back from ${destination}` : 'Trip finished' }
+    }
+
+    // Without a start date there is no moment to count towards. The trip is
+    // still ahead of its end date, but saying so would be a guess.
+    if (!start) return null
+
+    const sleeps = calendarDaysBetween(startOfToday(), start)
+
+    if (sleeps > 0) {
+        const label = destination
+            ? `${pluralise(sleeps, 'sleep')} until ${destination}`
+            : `${pluralise(sleeps, 'sleep')} to go`
+        return withRemaining({ status: 'upcoming', sleeps, label }, remainingItems)
+    }
+
+    if (sleeps === 0) {
+        const label = destination ? `Off to ${destination} today!` : "Today's the day!"
+        return withRemaining({ status: 'today', sleeps, label }, remainingItems)
+    }
+
+    return { status: 'in-progress', label: destination ? `In ${destination} now` : 'Trip in progress' }
+}
+
+/**
+ * Appends the items still to pack to a countdown that is close enough to earn
+ * it. Separated by a middot rather than a comma, which a destination can carry
+ * one of already ("Lisbon, Portugal, 2 items left" reads as three things); an
+ * exclamation closes the sentence, so there the count simply follows.
+ */
+function withRemaining(countdown: TripCountdown, remainingItems?: number): TripCountdown {
+    if (!remainingItems || remainingItems <= 0) return countdown
+    if (countdown.sleeps === undefined || countdown.sleeps > URGENT_SLEEPS) return countdown
+
+    const left = `${pluralise(remainingItems, 'item')} left`
+    const separator = countdown.label.endsWith('!') ? ' ' : ' · '
+    return { ...countdown, label: `${countdown.label}${separator}${left}` }
+}

--- a/src/pages/foreign-packing-lists.tsx
+++ b/src/pages/foreign-packing-lists.tsx
@@ -7,7 +7,8 @@ import { datasetToPackingList } from '../services/rdfSerialization'
 import { LoadingState } from '../components/LoadingState'
 import { Button } from '../components/Button'
 import type { PackingList } from '../create-packing-list/types'
-import { formatTripDates, splitCurrentAndPastTrips } from '../create-packing-list/tripDetails'
+import { formatTripCountdown, formatTripDates, splitCurrentAndPastTrips } from '../create-packing-list/tripDetails'
+import { TripCountdownBadge } from '../components/TripCountdownBadge'
 import { PastTripsSection } from '../components/PastTripsSection'
 
 export function ForeignPackingListsPage() {
@@ -77,6 +78,7 @@ export function ForeignPackingListsPage() {
         const displayWidth = packed === 0 ? 0 : Math.max(percent, 4)
         const gradient = gradients[index % gradients.length]
         const tripDates = formatTripDates(list.startDate, list.endDate)
+        const countdown = formatTripCountdown(list, total - packed)
         return (
             <div
                 key={list.id}
@@ -87,11 +89,12 @@ export function ForeignPackingListsPage() {
                 <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
                     <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2 flex-wrap">
                         ✈️ {list.name}
-                        {list.destination && (
+                        {list.destination && !countdown && (
                             <span className="text-xs font-medium bg-white/60 dark:bg-white/10 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700 px-2 py-0.5 rounded-full">
                                 📍 {list.destination}
                             </span>
                         )}
+                        <TripCountdownBadge countdown={countdown} />
                     </h3>
                     <span className="text-sm font-medium text-gray-600 dark:text-gray-400 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg self-start sm:self-auto">
                         {tripDates

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -681,8 +681,16 @@ describe('PackingLists trip destination and dates', () => {
     }
 
     it('shows the destination on the list card', async () => {
+        renderWithList({ ...tripList, startDate: undefined, endDate: undefined })
+        expect(await screen.findByText(/📍 Lisbon, Portugal/)).toBeTruthy()
+    })
+
+    // Two lines both saying Lisbon is one line too many: once the trip has
+    // dates the countdown names the destination, so the badge stands down.
+    it('folds the destination into the countdown once the trip has dates', async () => {
         renderWithList(tripList)
-        expect(await screen.findByText(/Lisbon, Portugal/)).toBeTruthy()
+        expect((await screen.findByTestId('trip-countdown')).textContent).toContain('Lisbon, Portugal')
+        expect(screen.queryByText(/📍 Lisbon, Portugal/)).toBeNull()
     })
 
     it('shows the trip dates rather than the creation date', async () => {
@@ -706,6 +714,89 @@ describe('PackingLists trip destination and dates', () => {
         await screen.findByText(/Summer Holiday/)
 
         expect(screen.queryByText(/📍/)).toBeNull()
+    })
+})
+
+describe('PackingLists trip countdown', () => {
+    const item = (id: string, packed: boolean) => ({
+        id, itemText: id, personName: 'Me', personId: 'p1', questionId: 'q1', optionId: 'o1', packed,
+    })
+
+    const countdownList = (extra: Record<string, unknown>) => ({
+        id: 'list-1',
+        name: 'Summer Holiday',
+        createdAt: '2026-01-01T00:00:00Z',
+        destination: 'Cornwall',
+        items: [item('a', false), item('b', false), item('c', true)],
+        ...extra,
+    })
+
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        localStorage.clear()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function renderWithList(list: Record<string, unknown>) {
+        mockUseDatabase.mockReturnValue({
+            db: {
+                getAllPackingLists: vi.fn().mockResolvedValue([list]),
+                deletePackingList: vi.fn(),
+                savePackingList: vi.fn(),
+                getSharedListsWithMe: vi.fn().mockResolvedValue({ lists: [], lastModified: '' }),
+            } as unknown as PackingAppDatabase,
+        })
+        return renderComponent()
+    }
+
+    it('counts the sleeps until a trip that is still to come', async () => {
+        renderWithList(countdownList({ startDate: daysFromToday(30), endDate: daysFromToday(37) }))
+        expect((await screen.findByTestId('trip-countdown')).textContent).toContain('30 sleeps until Cornwall')
+    })
+
+    it('carries the items still to pack once the trip is days away', async () => {
+        renderWithList(countdownList({ startDate: daysFromToday(2), endDate: daysFromToday(9) }))
+        expect((await screen.findByTestId('trip-countdown')).textContent)
+            .toContain('2 sleeps until Cornwall · 2 items left')
+    })
+
+    it('celebrates the day of the trip rather than showing zero sleeps', async () => {
+        renderWithList(countdownList({ startDate: daysFromToday(0), endDate: daysFromToday(7) }))
+        const countdown = await screen.findByTestId('trip-countdown')
+        expect(countdown.textContent).toContain('Off to Cornwall today!')
+        expect(countdown.textContent).not.toContain('0 sleeps')
+    })
+
+    it('says the trip is under way once it has started', async () => {
+        renderWithList(countdownList({ startDate: daysFromToday(-2), endDate: daysFromToday(5) }))
+        const countdown = await screen.findByTestId('trip-countdown')
+        expect(countdown.textContent).toContain('In Cornwall now')
+        expect(countdown.textContent).not.toContain('-')
+    })
+
+    it('never counts backwards for a trip that is over', async () => {
+        renderWithList(countdownList({ startDate: daysFromToday(-9), endDate: daysFromToday(-2) }))
+        // Finished trips are folded away, so open the section they fold into.
+        fireEvent.click(await screen.findByRole('button', { name: /Past trips/i }))
+        const countdown = await screen.findByTestId('trip-countdown')
+        expect(countdown.textContent).toContain('Back from Cornwall')
+        expect(countdown.textContent).not.toContain('-')
+    })
+
+    it('leaves a list with no dates without a countdown or a gap where one would be', async () => {
+        renderWithList(countdownList({}))
+        await screen.findByText(/Summer Holiday/)
+        expect(screen.queryByTestId('trip-countdown')).toBeNull()
     })
 })
 

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -16,7 +16,8 @@ import { packingListToDataset, deletedPackingListsToDataset } from '../services/
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { useLocalFirstLoad } from '../hooks/useLocalFirstLoad'
 import { generateUUID } from '../utils/uuid'
-import { formatTripDates, splitCurrentAndPastTrips } from '../create-packing-list/tripDetails'
+import { formatTripCountdown, formatTripDates, splitCurrentAndPastTrips } from '../create-packing-list/tripDetails'
+import { TripCountdownBadge } from '../components/TripCountdownBadge'
 import { PastTripsSection } from '../components/PastTripsSection'
 
 type SharingStatus = 'public' | 'shared' | 'private'
@@ -265,6 +266,11 @@ export function PackingLists() {
         // creation date is only worth showing when there are none.
         const tripDates = formatTripDates(list.startDate, list.endDate)
 
+        // How soon the trip is is the reason to open this card, so it gets a
+        // badge of its own under the name. It names the destination itself,
+        // which is why the destination line below stands down when it is here.
+        const countdown = formatTripCountdown(list, totalCount - packedCount)
+
         return (
             <div
                 key={list.id}
@@ -299,9 +305,10 @@ export function PackingLists() {
                     </h3>
                     {/* On its own line so a long destination never
                         pushes the actions onto a second row */}
-                    {list.destination && (
+                    {list.destination && !countdown && (
                         <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 truncate">📍 {list.destination}</p>
                     )}
+                    <TripCountdownBadge countdown={countdown} className="mt-1" />
                     </div>
                     <div data-testid="list-actions" className="flex items-center gap-2 flex-wrap">
                         <span className="text-sm font-medium text-gray-600 dark:text-gray-400 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg">

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -2466,6 +2466,96 @@ describe('ViewPackingList trip destination and dates', () => {
     })
 })
 
+describe('ViewPackingList trip countdown', () => {
+    /**
+     * A YYYY-MM-DD date the given number of days either side of today. Hard-coded
+     * dates would drift into the past and change which state the countdown is in.
+     */
+    const daysFromToday = (days: number) => {
+        const date = new Date()
+        date.setDate(date.getDate() + days)
+        const pad = (n: number) => String(n).padStart(2, '0')
+        return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+    }
+
+    function makeTripDb(overrides: Record<string, unknown>) {
+        return {
+            getPackingList: vi.fn().mockResolvedValue({ ...testPackingList, ...overrides }),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '2' }),
+            getSharedListsWithMe: vi.fn().mockResolvedValue({ lists: [], lastModified: '' }),
+            saveSharedListsWithMe: vi.fn().mockResolvedValue({ rev: '1' }),
+        }
+    }
+
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    function renderTrip(overrides: Record<string, unknown>) {
+        mockUseDatabase.mockReturnValue({ db: makeTripDb(overrides) as unknown as PackingAppDatabase })
+        renderComponent()
+    }
+
+    it('counts the sleeps until a trip still to come', async () => {
+        renderTrip({ destination: 'Cornwall', startDate: daysFromToday(12), endDate: daysFromToday(19) })
+        expect((await screen.findByTestId('trip-countdown')).textContent).toContain('12 sleeps until Cornwall')
+    })
+
+    it('celebrates the day of the trip rather than showing zero sleeps', async () => {
+        renderTrip({ destination: 'Cornwall', startDate: daysFromToday(0), endDate: daysFromToday(7) })
+        const countdown = await screen.findByTestId('trip-countdown')
+        expect(countdown.textContent).toContain('Off to Cornwall today!')
+        expect(countdown.textContent).not.toContain('0 sleeps')
+    })
+
+    it('says the trip is under way once it has started', async () => {
+        renderTrip({ destination: 'Cornwall', startDate: daysFromToday(-3), endDate: daysFromToday(4) })
+        const countdown = await screen.findByTestId('trip-countdown')
+        expect(countdown.textContent).toContain('In Cornwall now')
+        expect(countdown.textContent).not.toContain('-')
+    })
+
+    it('never counts backwards for a trip that is over', async () => {
+        renderTrip({ destination: 'Cornwall', startDate: daysFromToday(-10), endDate: daysFromToday(-3) })
+        const countdown = await screen.findByTestId('trip-countdown')
+        expect(countdown.textContent).toContain('Back from Cornwall')
+        expect(countdown.textContent).not.toContain('-')
+    })
+
+    it('shows no countdown at all for a list with no dates', async () => {
+        renderTrip({ destination: 'Cornwall' })
+        await screen.findByTestId('trip-details')
+        expect(screen.queryByTestId('trip-countdown')).toBeNull()
+    })
+
+    it('still shows the trip dates alongside the countdown', async () => {
+        const start = daysFromToday(12)
+        renderTrip({ destination: 'Cornwall', startDate: start, endDate: daysFromToday(19) })
+
+        const details = await screen.findByTestId('trip-details')
+        const [year, month, day] = start.split('-').map(Number)
+        expect(details.textContent).toContain(new Date(year, month - 1, day).toLocaleDateString())
+    })
+})
+
 describe('ViewPackingList check-off feedback', () => {
     // Two people so the list is never finished by a single tick — the completion
     // celebration has its own tests and would otherwise mask the per-item one.

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -25,7 +25,8 @@ import { useSharedListsSync } from '../hooks/useSharedListsSync'
 import { mergePackingLists } from '../utils/mergePackingLists'
 import { computeQuestionSetAdditions } from '../create-packing-list/updateFromQuestions'
 import { MILESTONE_MESSAGES, resolveMilestone } from './packing-milestones'
-import { formatTripDates } from '../create-packing-list/tripDetails'
+import { formatTripCountdown, formatTripDates } from '../create-packing-list/tripDetails'
+import { TripCountdownBadge } from '../components/TripCountdownBadge'
 import { tapFeedback } from '../utils/haptics'
 import { prefersReducedMotion } from '../utils/prefersReducedMotion'
 import { groupItemsByCategory, sortByOrder, type CategoryAccessors } from '../utils/groupByCategory'
@@ -1560,6 +1561,10 @@ export function ViewPackingList() {
 
     const tripDates = formatTripDates(packingList.startDate, packingList.endDate)
 
+    // The countdown names the destination itself, so the details row shows the
+    // destination separately only when there is no countdown to carry it.
+    const tripCountdown = formatTripCountdown(packingList, totalCount - packedCount)
+
     // One tap between "show me only what I'm packing right now" and the whole
     // list laid out. Worth a control of its own only once there is more than one
     // card to fold.
@@ -1651,7 +1656,10 @@ export function ViewPackingList() {
                         data-testid="trip-details"
                         className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600 dark:text-gray-400"
                     >
-                        {packingList.destination && <span>📍 {packingList.destination}</span>}
+                        {/* Countdown first: how soon the trip is is what the
+                            traveller came to know; the dates back it up. */}
+                        <TripCountdownBadge countdown={tripCountdown} />
+                        {packingList.destination && !tripCountdown && <span>📍 {packingList.destination}</span>}
                         {tripDates && <span>📅 {tripDates}</span>}
                     </div>
                 )}


### PR DESCRIPTION
Closes #251

Nothing in the app conveyed that a trip was *coming* — the lists index showed a creation date, which is admin metadata, not anticipation. Now that #209 has landed trip dates, every surface a list appears on counts the sleeps down to it.

## What it looks like

`formatTripCountdown` (in `src/create-packing-list/tripDetails.ts`) builds the copy from the list's dates and destination, with a state of its own for each side of the trip so a started or finished trip never renders as a zero or negative countdown:

| State | Copy |
|---|---|
| upcoming | 🌙 `3 sleeps until Cornwall` (`3 sleeps to go` with no destination) |
| today | 🎉 `Off to Cornwall today!` |
| in progress | 🧳 `In Cornwall now` |
| past | 🏡 `Back from Cornwall` |

Within the last three sleeps the countdown also carries the items still to pack — `2 sleeps until Cornwall · 18 items left` — which is where the urgency lives. Further out it stays uncluttered, and a trip under way or over is never nagged about packing. The separator is a middot rather than a comma because a destination can carry one of its own ("Lisbon, Portugal, 2 items left" reads as three things).

The badge warms as the trip approaches — calm primary far out, accent in the last few days, loud on the day itself — then cools to grey once there is nothing left to pack for.

## Where it shows

- The lists index card (`packing-lists.tsx`), under the list name
- The list view header (`view-packing-list.tsx`), leading the trip-details row
- Shared lists from another pod (`foreign-packing-lists.tsx`), for consistency

The badge names the destination itself, so the separate `📍` line stands down wherever a countdown is showing rather than saying Cornwall twice on one card. It still shows for undated lists, which is the only case where it carries information the countdown doesn't.

A list with no dates renders no badge at all — not an empty pill, not a gap — so undated lists look exactly as they did.

## Correctness

Dates go through the existing `parseTripDate`, so everything is compared as **local calendar days**: "tomorrow" is tomorrow whatever the time of day, and the day count is rounded so a daylight-saving change cannot shift it by one. A trip with only a future end date has no start to count towards, so it renders nothing rather than guessing.

## Testing

TDD per CLAUDE.md — tests written first, watched fail, then implemented.

- `tripDetails.test.ts` — 15 new cases over every state, plural forms, the calendar-day boundary late in the evening, and when the items count is and isn't folded in
- `TripCountdownBadge.test.tsx` — new file; renders nothing for an undated list, and the day-of styling differs from the days before it
- `packing-lists.test.tsx` / `view-packing-list.test.tsx` — each state on both surfaces, asserting no `-` or `0 sleeps` ever reaches the screen

`npm test` passes (1941 tests, type check included); `npm run lint` reports 0 errors.

## Mobile & Desktop

Verified in the running app on desktop (1280px), mobile (390px) and dark mode, with lists seeded across all four states plus an undated one. At 390px the badge wraps within the card rather than overflowing, and the undated card is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xgzo81DYp1KSmN3yckRJ9S)_