### PR TITLE
Warm up confirmation copy: toasts, duplicate names and empty states

### DIFF
--- a/e2e/helpers/toasts.ts
+++ b/e2e/helpers/toasts.ts
@@ -1,0 +1,11 @@
+import { SUCCESS_TOAST_VARIANTS, type SuccessToastKey } from '../../src/utils/successToastCopy'
+
+/**
+ * Matcher for a success confirmation that is deliberately worded more than one
+ * way — see `src/utils/successToastCopy.ts`. Pinning one sentence would make
+ * the test fail two runs in three.
+ */
+export function successToastMatching(key: SuccessToastKey): RegExp {
+    const escaped = SUCCESS_TOAST_VARIANTS[key].map(variant => variant.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    return new RegExp(escaped.join('|'))
+}

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -117,7 +117,7 @@ test.describe('C – Packing Lists', () => {
     await createList(page, 'Original List')
     await page.goto('/#/view-lists')
     await chooseCardAction(page, 'Original List', /Duplicate/i)
-    await expect(page.getByText(/Copy of Original List/i)).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText('Original List (again!)')).toBeVisible({ timeout: 5_000 })
   })
 
   test('C6: delete a packing list with confirmation', async ({ freshPage: page }) => {

--- a/e2e/tests/h-backups.spec.ts
+++ b/e2e/tests/h-backups.spec.ts
@@ -3,6 +3,7 @@ import { fillPersonRequiredFields } from '../helpers/wizard'
 import { loginToCss } from '../helpers/login'
 import { CSS_ISSUER, HUSER_EMAIL, HUSER_PASSWORD } from '../../playwright.config'
 import { expandAllSections, firstItemChip } from '../helpers/packing-list'
+import { successToastMatching } from '../helpers/toasts'
 
 // H tests share the same user's backups pod resource; running them in parallel causes
 // concurrent creates/deletes to make counts non-deterministic.
@@ -46,7 +47,7 @@ test.describe('H – Backups', () => {
     await expect(page.getByRole('button', { name: 'Create Backup' })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('button', { name: 'Create Backup' }).click()
     // Toast success
-    await expect(page.getByText(/backup created/i)).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(successToastMatching('backupCreated'))).toBeVisible({ timeout: 10_000 })
     // Backup entry appears
     await expect(page.getByRole('button', { name: 'Restore' }).first()).toBeVisible()
     await expect(page.locator('text=/packing list/').first()).toBeVisible()
@@ -56,11 +57,11 @@ test.describe('H – Backups', () => {
     await page.goto('/#/backups')
     await expect(page.getByRole('button', { name: 'Create Backup' })).toBeVisible({ timeout: 15_000 })
     await page.getByRole('button', { name: 'Create Backup' }).click()
-    await expect(page.getByText(/backup created/i)).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(successToastMatching('backupCreated'))).toBeVisible({ timeout: 10_000 })
     // Handle window.confirm for restore
     page.on('dialog', dialog => dialog.accept())
     await page.getByRole('button', { name: 'Restore' }).first().click()
-    await expect(page.getByText(/backup restored/i)).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(successToastMatching('backupRestored'))).toBeVisible({ timeout: 10_000 })
   })
 
   test('H3: delete a backup removes it from the list', async () => {
@@ -69,7 +70,7 @@ test.describe('H – Backups', () => {
     await expect(page.getByRole('button', { name: 'Create Backup' })).toBeVisible({ timeout: 15_000 })
     // Create a fresh backup to guarantee at least one exists
     await page.getByRole('button', { name: 'Create Backup' }).click()
-    await expect(page.getByText(/backup created/i)).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(successToastMatching('backupCreated'))).toBeVisible({ timeout: 10_000 })
     // Wait for the newly created backup to appear in the list
     await expect(page.getByRole('button', { name: 'Restore' }).first()).toBeVisible({ timeout: 5_000 })
     const initialCount = await page.getByRole('button', { name: 'Restore' }).count()

--- a/src/pages/backups.test.tsx
+++ b/src/pages/backups.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
 import React from 'react'
 import type { AppSession as Session } from '../types/AppSession'
 import type { PackingAppDatabase } from '../services/database'
@@ -12,8 +12,9 @@ vi.mock('../components/DatabaseContext', () => ({
     useDatabase: vi.fn(),
 }))
 
+const mockShowToast = vi.fn()
 vi.mock('../components/ToastContext', () => ({
-    useToast: vi.fn(() => ({ showToast: vi.fn() })),
+    useToast: vi.fn(() => ({ showToast: mockShowToast })),
 }))
 
 vi.mock('../hooks/usePodErrorHandler', () => ({
@@ -35,12 +36,14 @@ import { BackupsPage } from './backups'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useDatabase } from '../components/DatabaseContext'
 import { getPrimaryPodUrl } from '../services/solidPod'
-import { listBackups } from '../services/solidPodBackup'
+import { listBackups, createBackup } from '../services/solidPodBackup'
+import { SUCCESS_TOAST_VARIANTS, resetSuccessToastVariety } from '../utils/successToastCopy'
 
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockUseDatabase = vi.mocked(useDatabase)
 const mockGetPrimaryPodUrl = vi.mocked(getPrimaryPodUrl)
 const mockListBackups = vi.mocked(listBackups)
+const mockCreateBackup = vi.mocked(createBackup)
 
 describe('BackupsPage loading state', () => {
     beforeEach(() => {
@@ -79,5 +82,58 @@ describe('BackupsPage loading state', () => {
 
         await waitFor(() => expect(screen.getByText('No backups yet')).toBeTruthy())
         expect(screen.queryByRole('status')).toBeNull()
+    })
+})
+
+describe('BackupsPage confirmation copy', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        resetSuccessToastVariety()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: true,
+            session: {} as Session,
+            webId: 'https://pod.example/profile/card#me',
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseDatabase.mockReturnValue({ db: {} as PackingAppDatabase })
+        mockGetPrimaryPodUrl.mockResolvedValue('https://pod.example/')
+        mockListBackups.mockResolvedValue([])
+        mockCreateBackup.mockResolvedValue(undefined as never)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    async function createABackup() {
+        render(<BackupsPage />)
+        await screen.findByText('No backups yet')
+        fireEvent.click(screen.getByRole('button', { name: /create backup/i }))
+        await waitFor(() => expect(mockCreateBackup).toHaveBeenCalled())
+    }
+
+    it('confirms a backup with one of the warm success phrasings', async () => {
+        await createABackup()
+
+        await waitFor(() => {
+            const success = mockShowToast.mock.calls.find(call => call[1] === 'success')
+            expect(SUCCESS_TOAST_VARIANTS.backupCreated as readonly string[]).toContain(success?.[0])
+        })
+    })
+
+    // Backing up is the most repeated action on this page; the same sentence
+    // every time is a sentence people stop reading.
+    it('does not repeat the same confirmation on a second backup', async () => {
+        await createABackup()
+        cleanup()
+        await createABackup()
+
+        await waitFor(() => {
+            const messages = mockShowToast.mock.calls.filter(call => call[1] === 'success').map(call => call[0])
+            expect(messages).toHaveLength(2)
+            expect(messages[1]).not.toBe(messages[0])
+        })
     })
 })

--- a/src/pages/backups.tsx
+++ b/src/pages/backups.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useDatabase } from '../components/DatabaseContext'
 import { useToast } from '../components/ToastContext'
+import { successToast } from '../utils/successToastCopy'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { Button } from '../components/Button'
 import { LoadingState } from '../components/LoadingState'
@@ -57,7 +58,7 @@ export function BackupsPage() {
         setIsCreating(true)
         try {
             await createBackup(session, podUrl, db)
-            showToast('Backup created successfully!', 'success')
+            showToast(successToast('backupCreated'), 'success')
             await fetchBackups()
         } catch (error) {
             handlePodError(error, 'Failed to create backup.')
@@ -81,7 +82,7 @@ export function BackupsPage() {
 
         try {
             await restoreBackup(session, podUrl, db, backup.url)
-            showToast('Backup restored successfully!', 'success')
+            showToast(successToast('backupRestored'), 'success')
         } catch (error) {
             handlePodError(error, 'Failed to restore backup.')
         }

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -477,7 +477,9 @@ describe('PackingLists duplicate', () => {
         expect(within(openCardMenu()).getByRole('menuitem', { name: /duplicate/i })).toBeTruthy()
     })
 
-    it('calls savePackingList with a new list named "Copy of {name}" when Duplicate is clicked', async () => {
+    // People duplicate a list because they are going somewhere again, not
+    // because they want a photocopy of it.
+    it('names the duplicate after the trip it repeats when Duplicate is clicked', async () => {
         const db = { ...makeDb(), savePackingList: vi.fn().mockResolvedValue({ rev: '1' }) }
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
 
@@ -489,7 +491,31 @@ describe('PackingLists duplicate', () => {
 
         await waitFor(() => {
             expect(db.savePackingList).toHaveBeenCalledWith(
-                expect.objectContaining({ name: 'Copy of Summer Holiday', id: 'new-uuid' })
+                expect.objectContaining({ name: 'Summer Holiday (again!)', id: 'new-uuid' })
+            )
+        })
+    })
+
+    it('counts up rather than reusing the name of a duplicate already on the page', async () => {
+        const db = {
+            ...makeDb(),
+            getAllPackingLists: vi.fn().mockResolvedValue([
+                testList,
+                { id: 'list-2', name: 'Summer Holiday (again!)', createdAt: '2026-01-02T00:00:00Z', items: [] },
+            ]),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '1' }),
+        }
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        renderComponent()
+
+        await screen.findByText(/Summer Holiday \(again!\)/)
+
+        chooseCardAction(/duplicate/i)
+
+        await waitFor(() => {
+            expect(db.savePackingList).toHaveBeenCalledWith(
+                expect.objectContaining({ name: 'Summer Holiday (again! \u00d72)' })
             )
         })
     })
@@ -590,7 +616,7 @@ describe('PackingLists pod sync on mutation', () => {
             expect(mockSaveRdfToPod).toHaveBeenCalledWith(
                 expect.objectContaining({
                     fileUrl: expect.stringContaining('.ttl'),
-                    data: expect.objectContaining({ name: 'Copy of Summer Holiday' }),
+                    data: expect.objectContaining({ name: 'Summer Holiday (again!)' }),
                 })
             )
         })

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -16,6 +16,7 @@ import { packingListToDataset, deletedPackingListsToDataset } from '../services/
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { useLocalFirstLoad } from '../hooks/useLocalFirstLoad'
 import { generateUUID } from '../utils/uuid'
+import { duplicateListName } from '../utils/duplicateListName'
 import { formatTripCountdown, formatTripDates, splitCurrentAndPastTrips } from '../create-packing-list/tripDetails'
 import { TripCountdownBadge } from '../components/TripCountdownBadge'
 import { PastTripsSection } from '../components/PastTripsSection'
@@ -133,7 +134,7 @@ export function PackingLists() {
         try {
             const newList: PackingList = {
                 id: generateUUID(),
-                name: `Copy of ${list.name}`,
+                name: duplicateListName(list.name, packingLists.map(l => l.name)),
                 createdAt: new Date().toISOString(),
                 lastModified: new Date().toISOString(),
                 items: list.items.map(item => ({ ...item, id: generateUUID(), packed: false })),

--- a/src/pages/questions-page.empty-state.test.tsx
+++ b/src/pages/questions-page.empty-state.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import type { PackingAppDatabase } from '../services/database'
+
+vi.mock('../components/DatabaseContext', () => ({ useDatabase: vi.fn() }))
+vi.mock('../components/SolidPodContext', () => ({ useSolidPod: vi.fn() }))
+vi.mock('../components/ForeignPodContext', () => ({ useForeignPod: vi.fn() }))
+
+vi.mock('../hooks/useSyncCoordinator', () => ({
+    useSyncCoordinator: vi.fn(() => ({
+        saveWithSyncPrevention: vi.fn(),
+        handleSyncSuccess: vi.fn(),
+        handleSyncError: vi.fn(),
+    })),
+}))
+
+vi.mock('../hooks/usePodSync', () => ({
+    usePodSync: vi.fn(() => ({ saveToPod: vi.fn(), syncFromPod: vi.fn() })),
+}))
+
+vi.mock('../services/migration', () => ({
+    DatabaseMigration: {
+        checkMigrationNeeded: vi.fn().mockResolvedValue({ needed: false }),
+        performMigration: vi.fn(),
+    },
+}))
+
+vi.mock('../services/solidPod', () => ({
+    POD_CONTAINERS: { ROOT: 'pack-me-up/' },
+}))
+
+vi.mock('../services/rdfSerialization', () => ({
+    questionSetToDataset: vi.fn(),
+    datasetToQuestionSet: vi.fn(),
+}))
+
+import { QuestionsPage } from './questions-page'
+import { useDatabase } from '../components/DatabaseContext'
+import { useSolidPod } from '../components/SolidPodContext'
+import { useForeignPod } from '../components/ForeignPodContext'
+
+const mockUseDatabase = vi.mocked(useDatabase)
+const mockUseSolidPod = vi.mocked(useSolidPod)
+const mockUseForeignPod = vi.mocked(useForeignPod)
+
+const emptyQuestionSet = { _id: '1', _rev: '1', questions: [], people: [], alwaysNeededItems: [] }
+
+const populatedQuestionSet = {
+    _id: '1',
+    _rev: '1',
+    questions: [],
+    people: [{ id: 'p1', name: 'Alice', personSelections: [] }],
+    alwaysNeededItems: [],
+}
+
+function renderQuestionsPage(questionSet: unknown) {
+    mockUseDatabase.mockReturnValue({
+        db: { getQuestionSet: () => Promise.resolve(questionSet), saveQuestionSet: vi.fn() } as unknown as PackingAppDatabase,
+        loginSyncInProgress: false,
+        loginSyncVersion: 0,
+    })
+    return render(
+        <MemoryRouter>
+            <QuestionsPage />
+        </MemoryRouter>
+    )
+}
+
+describe('QuestionsPage empty state', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUseForeignPod.mockReturnValue(null)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    // A page of empty scaffolding with no suggestion of what to do with it is
+    // where a new user gives up.
+    it('offers a way forward when there is nothing set up yet', async () => {
+        renderQuestionsPage(emptyQuestionSet)
+
+        const emptyState = await screen.findByTestId('questions-empty-state')
+        expect(emptyState.textContent).toMatch(/nothing here yet/i)
+    })
+
+    it('points the empty state at the setup wizard', async () => {
+        renderQuestionsPage(emptyQuestionSet)
+
+        await screen.findByTestId('questions-empty-state')
+        const wizardLink = screen.getByRole('link', { name: /setup wizard/i })
+        expect(wizardLink.getAttribute('href')).toBe('/wizard')
+    })
+
+    // The wizard isn't the only route in — someone who wants to build their own
+    // set from scratch should still find the manual one.
+    it('leaves the manual route in place alongside the empty state', async () => {
+        renderQuestionsPage(emptyQuestionSet)
+
+        await screen.findByTestId('questions-empty-state')
+        expect(screen.getByRole('button', { name: /add question/i })).toBeTruthy()
+    })
+
+    // "Redo the setup wizard" is wrong advice for someone who has never done it.
+    it('does not also offer to redo a wizard that was never done', async () => {
+        renderQuestionsPage(emptyQuestionSet)
+
+        await screen.findByTestId('questions-empty-state')
+        expect(screen.queryByText(/redo the setup wizard/i)).toBeNull()
+    })
+
+    it('drops the empty state once there is something set up', async () => {
+        renderQuestionsPage(populatedQuestionSet)
+
+        await waitFor(() => expect(screen.getByText('My Questions & Items')).toBeTruthy())
+        expect(screen.queryByTestId('questions-empty-state')).toBeNull()
+        expect(screen.getByText(/redo the setup wizard/i)).toBeTruthy()
+    })
+
+    // Someone else's pod is not somewhere you can run your setup wizard.
+    it('keeps the wizard out of an empty pod that belongs to somebody else', async () => {
+        mockUseForeignPod.mockReturnValue({ foreignPodUrl: 'https://friend.example/' } as ReturnType<typeof useForeignPod>)
+        renderQuestionsPage(emptyQuestionSet)
+
+        await waitFor(() => expect(screen.getByText('Questions & Items')).toBeTruthy())
+        expect(screen.queryByTestId('questions-empty-state')).toBeNull()
+        expect(screen.queryByRole('link', { name: /setup wizard/i })).toBeNull()
+    })
+})

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -1982,8 +1982,32 @@ export function QuestionsPage() {
                 <div className="mb-2">
                     <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{isForeign ? 'Questions & Items' : 'My Questions & Items'}</h1>
                     <p className="mt-1 text-gray-600 dark:text-gray-400 text-sm">Customise the questions and packing items that generate your lists. Changes here affect all future packing lists you create.</p>
-                    {!isForeign && <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">Want to start from scratch? <Link to="/wizard" className="text-primary-600 dark:text-primary-400 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</p>}
+                    {/* "Redo the setup wizard" is the wrong advice for someone
+                        who has never done it — the empty state below makes the
+                        first-time offer instead. */}
+                    {!isForeign && !nothingStoredYet && <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">Want to start from scratch? <Link to="/wizard" className="text-primary-600 dark:text-primary-400 hover:underline">Redo the setup wizard</Link> to regenerate your questions.</p>}
                 </div>
+                {/* Empty scaffolding with no suggestion of what to do with it is
+                    where a new user gives up. Someone else's pod gets no offer:
+                    their setup is not ours to run a wizard over. */}
+                {!isForeign && nothingStoredYet && (
+                    <div
+                        data-testid="questions-empty-state"
+                        className="text-center py-10 px-6 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft"
+                    >
+                        <p className="text-lg font-semibold text-gray-800 dark:text-gray-100">Nothing here yet — let's fix that 🧳</p>
+                        <p className="mx-auto mt-2 max-w-md text-sm text-gray-600 dark:text-gray-400">
+                            Answer a few questions about who's travelling and we'll build your questions and packing items for you. Everything stays editable afterwards.
+                        </p>
+                        <Link
+                            to="/wizard"
+                            className="mt-5 inline-block rounded-xl bg-primary-600 px-5 py-2.5 font-semibold text-white transition-colors hover:bg-primary-700"
+                        >
+                            Start the setup wizard
+                        </Link>
+                        <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">Rather build it yourself? Add your first question below.</p>
+                    </div>
+                )}
                 {!isForeign && (
                     <AgePromotionCard
                         questionSet={data}

--- a/src/pages/sharing-settings.test.tsx
+++ b/src/pages/sharing-settings.test.tsx
@@ -34,6 +34,7 @@ import { useDatabase } from '../components/DatabaseContext'
 import { useSolidPod } from '../components/SolidPodContext'
 import { saveRdfToPod, getFullCollaborators, getCollaborators } from '../services/solidPod'
 import { useToast } from '../components/ToastContext'
+import { SUCCESS_TOAST_VARIANTS } from '../utils/successToastCopy'
 import { getPendingSignInAction, setPendingSignInAction } from '../utils/pendingSignInAction'
 
 const mockUseDatabase = vi.mocked(useDatabase)
@@ -218,7 +219,10 @@ describe('SharingSettingsPage — full setup vs individual lists', () => {
         })
         fireEvent.click(screen.getByRole('button', { name: /share my setup/i }))
 
-        await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.stringMatching(/full setup is shared/i), 'success'))
+        await waitFor(() => {
+            const success = showToast.mock.calls.find(call => call[1] === 'success')
+            expect(SUCCESS_TOAST_VARIANTS.setupShared as readonly string[]).toContain(success?.[0])
+        })
     })
 
     it('does not count a full-setup collaborator as an individual list share', async () => {

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useDatabase } from '../components/DatabaseContext'
 import { useToast } from '../components/ToastContext'
+import { successToast } from '../utils/successToastCopy'
 import { reportError } from '../errorReporting'
 import {
     grantFullCollaboratorAccess,
@@ -193,7 +194,7 @@ export function SharingSettingsPage() {
             setSharedWith(collaboratorWebId.trim())
             setCollaboratorWebId('')
             await loadCollaborators()
-            showToast('Your full setup is shared', 'success')
+            showToast(successToast('setupShared'), 'success')
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err)
             const details = reportError(err, 'SharingSettingsPage: failed to grant access')
@@ -207,7 +208,7 @@ export function SharingSettingsPage() {
         if (!inviteLink) return
         try {
             await navigator.clipboard.writeText(inviteLink)
-            showToast('Invite link copied', 'success')
+            showToast(successToast('inviteLinkCopied'), 'success')
         } catch (err) {
             // Clipboard access can be refused (permissions, insecure origin) —
             // the link is on screen and selectable, so say so rather than fail

--- a/src/pages/useWizardGeneration.test.ts
+++ b/src/pages/useWizardGeneration.test.ts
@@ -7,8 +7,9 @@ vi.mock('../components/DatabaseContext', () => ({
     useDatabase: vi.fn(),
 }))
 
+const mockShowToast = vi.fn()
 vi.mock('../components/ToastContext', () => ({
-    useToast: vi.fn(() => ({ showToast: vi.fn() })),
+    useToast: vi.fn(() => ({ showToast: mockShowToast })),
 }))
 
 const mockSaveToPod = vi.fn().mockResolvedValue(true)
@@ -18,6 +19,7 @@ vi.mock('../hooks/usePodSync', () => ({
 
 import { useDatabase } from '../components/DatabaseContext'
 import type { PackingAppDatabase } from '../services/database'
+import { SUCCESS_TOAST_VARIANTS, resetSuccessToastVariety } from '../utils/successToastCopy'
 
 const mockUseDatabase = vi.mocked(useDatabase)
 
@@ -32,6 +34,33 @@ describe('useWizardGeneration', () => {
         const db = makeDb()
         mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
         mockSaveToPod.mockClear()
+        mockShowToast.mockClear()
+        resetSuccessToastVariety()
+    })
+
+    async function generateFor(name: string) {
+        const { result } = renderHook(() => useWizardGeneration())
+        await act(async () => {
+            await result.current.generateAndSave({ people: [{ name, ageRange: 'Adult' }] })
+        })
+    }
+
+    it('confirms with one of the warm success phrasings', async () => {
+        await generateFor('Alice')
+
+        const [message, type] = mockShowToast.mock.calls[0]
+        expect(SUCCESS_TOAST_VARIANTS.questionsGenerated as readonly string[]).toContain(message)
+        expect(type).toBe('success')
+    })
+
+    // Redoing the wizard shouldn't produce the same sentence twice — see
+    // successToastCopy.
+    it('does not repeat the same confirmation on a second run', async () => {
+        await generateFor('Alice')
+        await generateFor('Bob')
+
+        const [first, second] = mockShowToast.mock.calls.map(call => call[0])
+        expect(second).not.toBe(first)
     })
 
     it('passes gender from form data through to the saved question set people', async () => {

--- a/src/pages/useWizardGeneration.ts
+++ b/src/pages/useWizardGeneration.ts
@@ -6,6 +6,7 @@ import { createExampleData, WIZARD_TEMPLATE_VERSION } from '../edit-questions/ex
 import { QUESTION_SET_ID } from '../constants'
 import { WizardFormData } from './wizard-types'
 import { generateUUID } from '../utils/uuid'
+import { successToast } from '../utils/successToastCopy'
 import { Person, PackingListQuestionSet } from '../edit-questions/types'
 import { deriveAgeRange } from '../edit-questions/age-derivation'
 import { usePodSync } from '../hooks/usePodSync'
@@ -65,7 +66,7 @@ export function useWizardGeneration() {
                 saveToPod
             )
 
-            showToast('Packing list questions generated successfully!', 'success')
+            showToast(successToast('questionsGenerated'), 'success')
             setGeneratedSet(questionSet)
             setIsSuccess(true)
         } catch (err) {

--- a/src/utils/duplicateListName.test.ts
+++ b/src/utils/duplicateListName.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { duplicateListName } from './duplicateListName'
+
+describe('duplicateListName', () => {
+    it('names a duplicate after the trip it repeats', () => {
+        expect(duplicateListName('Cornwall', ['Cornwall'])).toBe('Cornwall (again!)')
+    })
+
+    it('does not collide with a duplicate that is already there', () => {
+        expect(duplicateListName('Cornwall', ['Cornwall', 'Cornwall (again!)']))
+            .toBe('Cornwall (again! ×2)')
+    })
+
+    it('keeps counting up rather than reusing a taken name', () => {
+        expect(duplicateListName('Cornwall', ['Cornwall', 'Cornwall (again!)', 'Cornwall (again! ×2)']))
+            .toBe('Cornwall (again! ×3)')
+    })
+
+    // Otherwise the fourth Cornwall trip is "Cornwall (again!) (again!) (again!)".
+    it('counts up from the original trip name when duplicating a duplicate', () => {
+        expect(duplicateListName('Cornwall (again!)', ['Cornwall', 'Cornwall (again!)']))
+            .toBe('Cornwall (again! ×2)')
+    })
+
+    it('counts up from a numbered duplicate too', () => {
+        expect(duplicateListName('Cornwall (again! ×2)', ['Cornwall (again!)', 'Cornwall (again! ×2)']))
+            .toBe('Cornwall (again! ×3)')
+    })
+
+    // "cornwall (again!)" and "Cornwall (again!)" are the same name to a person
+    // scanning their lists, whatever the string comparison says.
+    it('treats names that differ only in case or padding as taken', () => {
+        expect(duplicateListName('Cornwall', ['  cornwall (AGAIN!)  ']))
+            .toBe('Cornwall (again! ×2)')
+    })
+
+    it('trims the name it builds on', () => {
+        expect(duplicateListName('  Cornwall  ', [])).toBe('Cornwall (again!)')
+    })
+
+    it('still produces a usable name when the original has none', () => {
+        expect(duplicateListName('   ', [])).toBe('Packing list (again!)')
+    })
+
+    it('leaves a name that merely mentions again alone', () => {
+        expect(duplicateListName('Never again', [])).toBe('Never again (again!)')
+    })
+})

--- a/src/utils/duplicateListName.ts
+++ b/src/utils/duplicateListName.ts
@@ -1,0 +1,33 @@
+/**
+ * Default name for a duplicated packing list.
+ *
+ * "Copy of Cornwall" is accurate and joyless, and it describes the wrong thing:
+ * people duplicate a list because they are going to Cornwall *again*, not
+ * because they want a photocopy. The name is only a default — it stays
+ * editable from the list's Rename action.
+ */
+
+const FALLBACK_BASE = 'Packing list'
+
+/** "(again!)" or "(again! ×3)" on the end of a name we produced earlier. */
+const AGAIN_SUFFIX = /\s*\(again!(?:\s*×\s*\d+)?\)$/i
+
+const normalise = (name: string) => name.trim().replace(/\s+/g, ' ').toLowerCase()
+
+/**
+ * `originalName` with an "(again!)" suffix, counting up past any name in
+ * `existingNames` — compared the way a person reads their list of trips, so
+ * case and stray padding don't let two identical-looking names through.
+ */
+export function duplicateListName(originalName: string, existingNames: readonly string[]): string {
+    // Duplicating a duplicate counts up from the trip, not from the last copy:
+    // otherwise the fourth Cornwall is "Cornwall (again!) (again!) (again!)".
+    const base = originalName.trim().replace(AGAIN_SUFFIX, '').trim() || FALLBACK_BASE
+
+    const taken = new Set(existingNames.map(normalise))
+    const candidateFor = (repeat: number) => repeat === 1 ? `${base} (again!)` : `${base} (again! ×${repeat})`
+
+    let repeat = 1
+    while (taken.has(normalise(candidateFor(repeat)))) repeat++
+    return candidateFor(repeat)
+}

--- a/src/utils/successToastCopy.test.ts
+++ b/src/utils/successToastCopy.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SUCCESS_TOAST_VARIANTS, successToast, resetSuccessToastVariety, type SuccessToastKey } from './successToastCopy'
+
+const keys = Object.keys(SUCCESS_TOAST_VARIANTS) as SuccessToastKey[]
+
+describe('successToast', () => {
+    beforeEach(() => {
+        resetSuccessToastVariety()
+    })
+
+    it.each(keys)('returns one of the variants for %s', key => {
+        expect(SUCCESS_TOAST_VARIANTS[key]).toContain(successToast(key))
+    })
+
+    // The point of the whole module: doing the same thing twice should not
+    // produce the same sentence twice, or the second one goes unread.
+    it.each(keys)('never repeats itself twice in a row for %s', key => {
+        let previous = successToast(key)
+        for (let i = 0; i < 50; i++) {
+            const next = successToast(key)
+            expect(next).not.toBe(previous)
+            previous = next
+        }
+    })
+
+    it('tracks what was last said per action, so one action does not silence another', () => {
+        const first = successToast('backupCreated')
+        successToast('backupRestored')
+        // The backupRestored call must not have cleared backupCreated's memory.
+        expect(successToast('backupCreated')).not.toBe(first)
+    })
+
+    it.each(keys)('eventually uses every variant of %s, so no copy is dead weight', key => {
+        const seen = new Set<string>()
+        for (let i = 0; i < 500; i++) seen.add(successToast(key))
+        expect(seen.size).toBe(SUCCESS_TOAST_VARIANTS[key].length)
+    })
+
+    // With only one variant there is nothing to vary, and the no-repeat rule
+    // above would be unsatisfiable.
+    it.each(keys)('offers at least two variants for %s', key => {
+        expect(SUCCESS_TOAST_VARIANTS[key].length).toBeGreaterThanOrEqual(2)
+    })
+
+    // Toasts sit in a fixed-width box on a 390px phone; a long sentence wraps
+    // to a paragraph and pushes the dismiss button off the edge.
+    it.each(keys)('keeps every variant of %s short enough for a narrow phone', key => {
+        for (const variant of SUCCESS_TOAST_VARIANTS[key]) {
+            expect(variant.length).toBeLessThanOrEqual(48)
+        }
+    })
+})

--- a/src/utils/successToastCopy.ts
+++ b/src/utils/successToastCopy.ts
@@ -1,0 +1,66 @@
+/**
+ * Confirmation copy for things that went right, in more than one wording each.
+ *
+ * Packing for a family is a chore, and the tool for a chore shouldn't sound
+ * like a receipt printer. More practically: a sentence you have already read
+ * is a sentence you stop reading, so backing up twice in a row saying
+ * "Backup created successfully!" twice trains people to ignore the toast that
+ * eventually tells them something they need.
+ *
+ * Only success copy lives here, deliberately. When something has failed a
+ * person needs plain and precise — a wry line there reads as the app not
+ * taking the problem seriously, and it is the message they may have to quote
+ * to get help. Error toasts stay literal and keep their copyable details.
+ */
+
+export const SUCCESS_TOAST_VARIANTS = {
+    questionsGenerated: [
+        'Your questions and items are ready 🎉',
+        'All set — your questions are ready',
+        'Done! Have a look at what we came up with',
+    ],
+    backupCreated: [
+        'Backed up — safely tucked away',
+        'Backup saved. Nothing to worry about',
+        'All copied. Sleep easy',
+    ],
+    backupRestored: [
+        'Restored — welcome back',
+        'Everything is back where it was',
+        'Backup restored. Carry on where you left off',
+    ],
+    inviteLinkCopied: [
+        'Link copied — go and share it',
+        'Copied! Paste it wherever suits',
+        'Invite link is on your clipboard',
+    ],
+    setupShared: [
+        'Your full setup is shared 🎉',
+        'Shared — they can see your setup now',
+        'Done. Your setup is theirs to see too',
+    ],
+} as const satisfies Record<string, readonly [string, string, ...string[]]>
+
+export type SuccessToastKey = keyof typeof SUCCESS_TOAST_VARIANTS
+
+/** What each action said last, so it can say something else this time. */
+const lastShown = new Map<SuccessToastKey, string>()
+
+/**
+ * A confirmation for `key`, different from the one this action gave last time.
+ * Random rather than round-robin so a run of them doesn't turn into a
+ * recognisable cycle of its own.
+ */
+export function successToast(key: SuccessToastKey): string {
+    const variants: readonly string[] = SUCCESS_TOAST_VARIANTS[key]
+    const previous = lastShown.get(key)
+    const choices = variants.filter(variant => variant !== previous)
+    const chosen = choices[Math.floor(Math.random() * choices.length)] ?? variants[0]
+    lastShown.set(key, chosen)
+    return chosen
+}
+
+/** Test seam: forget what was last said, so cases don't lean on each other. */
+export function resetSuccessToastVariety(): void {
+    lastShown.clear()
+}


### PR DESCRIPTION
Closes #250

Three small copy touches that individually are minor but together set the app's tone.

## Success toasts vary; errors stay plain

New `src/utils/successToastCopy.ts` holds several phrasings per action and hands back one that isn't what that action said last time. Backing up twice in a row no longer prints the same sentence twice — a sentence you have already read is a sentence you stop reading, which trains people to ignore the toast that eventually matters.

Wired into the actions people actually repeat: wizard generation, backup created, backup restored, invite link copied, full setup shared.

Error copy is deliberately absent from the module and untouched at the call sites. A failure is something people may have to quote to get help, so it stays literal and keeps its copyable details.

## Duplicate list names

`Copy of Cornwall` → `Cornwall (again!)`. The common case is the same trip again, not a photocopy.

`duplicateListName` counts up past names already in use (`Cornwall (again! ×2)`), comparing them the way a person reads their list of trips (case- and padding-insensitive), and counts up from the trip rather than from the last copy — so the fourth Cornwall isn't `Cornwall (again!) (again!) (again!)`. The name stays editable from the card's Rename action.

## Questions page empty state

An empty questions page was previously just scaffolding with nothing to do — the only hint was `No people added` in the person legend. It now shows a card pointing at the setup wizard, with the manual `+ Add Question` route left in place beside it.

Two details:
- The header's "Redo the setup wizard" line is hidden while the page is empty — it's the wrong advice for someone who has never done it.
- Somebody else's pod gets no offer at all: their setup isn't ours to run a wizard over.

## Tests

TDD throughout. New: `successToastCopy.test.ts` (no repeats, every variant gets used, all variants short enough for a 390px toast), `duplicateListName.test.ts`, `questions-page.empty-state.test.tsx`, plus cases in `packing-lists.test.tsx`, `backups.test.tsx` and `useWizardGeneration.test.ts`.

Existing e2e assertions that pinned a single sentence now match the variant set through a new `e2e/helpers/toasts.ts`.

Rebased onto `main` at e553d5f (the trip-countdown PR #323). The only conflict was an import line in `packing-lists.tsx`; both sides kept.

`npm test` — 1987 passing. `npx playwright test` — 90 passing (re-run of suites B, C and H after the rebase: 41 passing). Lint clean (only pre-existing warnings).

## Verified

The empty state was checked in a running browser at 1280px and at 390px: the longer copy wraps to three lines inside the card and the "Start the setup wizard" button stays fully on screen, no truncation. The duplicate flow is covered end-to-end by e2e C5, which now asserts the new name.

## Follow-up filed

`handleDuplicatePackingList` builds the new list from an allowlist of five fields, so a duplicate silently loses `nights`, `destination`, the trip dates, `guests`, `deletedItems`, `questionAnswers` and `selectedPeopleIds` — the same allowlist-shaped bug as #260, in a different place. This PR changed the name that handler produces but deliberately left its field handling alone, since fixing it needs a product call on what a repeat trip should inherit. Written up as #325.