### PR TITLE
Carry the whole trip over when a list is duplicated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,10 @@ Two guards catch a repeat, and `npm test` runs both (CI included):
    (`database.test.ts` → "Field fidelity") and through the pod's RDF serialisation
    (`rdfSerialization.test.ts` → "Field fidelity").
 
+The same fixture guards **duplication** (`src/utils/duplicatePackingList.ts`, #325): a
+duplicate is built with an omit-list too, and `duplicatePackingList.test.ts` fails until a
+new field is listed as carried, regenerated or deliberately dropped.
+
 So when the type check sends you to the fixtures, add the field with a distinctive value
 and run the tests — don't reach for `as` or a partial fixture. A field that genuinely must
 not leave the device belongs in `packingListLocalOnlyFields` with a comment saying why.

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -496,6 +496,72 @@ describe('PackingLists duplicate', () => {
         })
     })
 
+    it('carries the trip context and generation inputs onto the copy', async () => {
+        const richList = {
+            ...testList,
+            nights: 5,
+            destination: 'Lisbon',
+            startDate: daysFromToday(10),
+            endDate: daysFromToday(15),
+            guests: [{ id: 'g1', name: 'Zoe' }],
+            deletedItems: [{ id: 'd1', itemText: 'Umbrella', personId: '', personName: '', questionId: 'q1', optionId: 'o1', packed: false }],
+            questionAnswers: [{ questionId: 'q1', selectedOptionIds: ['o1'] }],
+            selectedPeopleIds: ['p1'],
+        }
+        const db = {
+            ...makeDb(),
+            getAllPackingLists: vi.fn().mockResolvedValue([richList]),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '1' }),
+        }
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+
+        chooseCardAction(/duplicate/i)
+
+        await waitFor(() => {
+            expect(db.savePackingList).toHaveBeenCalledWith(expect.objectContaining({
+                nights: 5,
+                destination: 'Lisbon',
+                guests: richList.guests,
+                deletedItems: richList.deletedItems,
+                questionAnswers: richList.questionAnswers,
+                selectedPeopleIds: richList.selectedPeopleIds,
+            }))
+        })
+        // A repeat trip has new dates, so the copy claims none.
+        const saved = db.savePackingList.mock.calls[0][0]
+        expect(saved.startDate).toBeUndefined()
+        expect(saved.endDate).toBeUndefined()
+    })
+
+    it('turns a cached copy of a shared list into a list of your own', async () => {
+        const foreignList = {
+            ...testList,
+            sharedFromPodUrl: 'https://alice.example/pod/',
+            ownerWebId: 'https://alice.example/profile/card#me',
+            _rev: '3-abcdef',
+        }
+        const db = {
+            ...makeDb(),
+            getAllPackingLists: vi.fn().mockResolvedValue([foreignList]),
+            savePackingList: vi.fn().mockResolvedValue({ rev: '1' }),
+        }
+        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+
+        renderComponent()
+        await screen.findByText(/Summer Holiday/)
+
+        chooseCardAction(/duplicate/i)
+
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        const saved = db.savePackingList.mock.calls[0][0]
+        expect(saved.sharedFromPodUrl).toBeUndefined()
+        expect(saved.ownerWebId).toBeUndefined()
+        expect(saved._rev).toBeUndefined()
+    })
+
     it('counts up rather than reusing the name of a duplicate already on the page', async () => {
         const db = {
             ...makeDb(),

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -15,8 +15,7 @@ import { useOwnerDisplayNames } from '../hooks/useOwnerDisplayName'
 import { packingListToDataset, deletedPackingListsToDataset } from '../services/rdfSerialization'
 import { usePodErrorHandler } from '../hooks/usePodErrorHandler'
 import { useLocalFirstLoad } from '../hooks/useLocalFirstLoad'
-import { generateUUID } from '../utils/uuid'
-import { duplicateListName } from '../utils/duplicateListName'
+import { duplicatePackingList } from '../utils/duplicatePackingList'
 import { formatTripCountdown, formatTripDates, splitCurrentAndPastTrips } from '../create-packing-list/tripDetails'
 import { TripCountdownBadge } from '../components/TripCountdownBadge'
 import { PastTripsSection } from '../components/PastTripsSection'
@@ -132,13 +131,10 @@ export function PackingLists() {
 
     const handleDuplicatePackingList = async (list: PackingList) => {
         try {
-            const newList: PackingList = {
-                id: generateUUID(),
-                name: duplicateListName(list.name, packingLists.map(l => l.name)),
-                createdAt: new Date().toISOString(),
-                lastModified: new Date().toISOString(),
-                items: list.items.map(item => ({ ...item, id: generateUUID(), packed: false })),
-            }
+            // Which fields a copy inherits — and the few it must not — live
+            // with the helper, so a field added to `PackingList` is carried
+            // without anyone having to remember this page.
+            const newList: PackingList = duplicatePackingList(list, packingLists.map(l => l.name))
             await db.savePackingList(newList)
             setPackingLists([newList, ...packingLists])
             syncListToPod(newList)

--- a/src/test-utils/fullyPopulatedFixtures.ts
+++ b/src/test-utils/fullyPopulatedFixtures.ts
@@ -20,6 +20,10 @@ import type { PackingListQuestionSet, Person, Item, SavedQuestion, Option } from
  * `savePackingList` built its document from a hand-maintained field allowlist
  * and silently dropped `nights`, `questionAnswers` and `selectedPeopleIds`.
  *
+ * `duplicatePackingList.test.ts` leans on `fullyPopulatedPackingList` for the
+ * same reason (#325): duplicating a list is another place that used to name the
+ * fields to keep, so a new field has to be accounted for there too.
+ *
  * So: when the type check points you here, add the new field with a
  * distinctive value. Don't reach for `as` or a partial fixture.
  */

--- a/src/utils/duplicatePackingList.test.ts
+++ b/src/utils/duplicatePackingList.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { duplicatePackingList, duplicateDroppedFields } from './duplicatePackingList'
+import { fullyPopulatedPackingList } from '../test-utils/fullyPopulatedFixtures'
+import type { PackingList } from '../create-packing-list/types'
+
+vi.mock('./uuid', () => {
+    let n = 0
+    return { generateUUID: vi.fn(() => `uuid-${++n}`) }
+})
+
+const original: PackingList = { ...fullyPopulatedPackingList, _rev: '3-abcdef' }
+
+/**
+ * Every field of `PackingList`, split by what a duplicate does with it. The
+ * three lists below have to add up to the whole type — the last test in this
+ * file asserts exactly that against the fully populated fixture, so adding a
+ * field to `PackingList` fails here until someone has decided what duplicating
+ * should do with it.
+ */
+const regeneratedFields = ['id', 'name', 'createdAt', 'lastModified', 'items'] as const
+const carriedFields = [
+    'nights', 'destination', 'deletedItems', 'guests', 'questionAnswers', 'selectedPeopleIds',
+] as const
+
+describe('duplicatePackingList', () => {
+    beforeEach(() => vi.clearAllMocks())
+
+    it('carries the trip context over instead of listing fields to keep', () => {
+        const copy = duplicatePackingList(original, [original.name])
+
+        for (const field of carriedFields) {
+            expect({ [field]: copy[field] }).toEqual({ [field]: original[field] })
+        }
+    })
+
+    it('gives the copy its own identity, a fresh name and fresh timestamps', () => {
+        const before = Date.now()
+        const copy = duplicatePackingList(original, [original.name])
+
+        expect(copy.id).not.toBe(original.id)
+        expect(copy.name).toBe('Fully populated trip (again!)')
+        expect(new Date(copy.createdAt).getTime()).toBeGreaterThanOrEqual(before)
+        expect(copy.lastModified).toBe(copy.createdAt)
+    })
+
+    it('starts every item unpacked and under a new id', () => {
+        const copy = duplicatePackingList(original, [])
+
+        expect(copy.items).toHaveLength(original.items.length)
+        copy.items.forEach((item, i) => {
+            expect(item.id).not.toBe(original.items[i].id)
+            expect(item.packed).toBe(false)
+            expect(item.itemText).toBe(original.items[i].itemText)
+        })
+    })
+
+    // A repeat trip is next year's, not last year's: keeping the dates would
+    // date-stamp the copy with a trip that has already happened.
+    it('clears the trip dates', () => {
+        const copy = duplicatePackingList(original, [])
+
+        expect(copy.startDate).toBeUndefined()
+        expect(copy.endDate).toBeUndefined()
+    })
+
+    // Duplicate is offered on cached copies of other people's shared lists too.
+    it('produces a list of your own from a cached copy of a shared list', () => {
+        const copy = duplicatePackingList(original, [])
+
+        expect(copy.sharedFromPodUrl).toBeUndefined()
+        expect(copy.ownerWebId).toBeUndefined()
+        expect('sharedFromPodUrl' in copy).toBe(false)
+        expect('ownerWebId' in copy).toBe(false)
+    })
+
+    it('does not carry the original document revision', () => {
+        const copy = duplicatePackingList(original, [])
+
+        expect('_rev' in copy).toBe(false)
+    })
+
+    it('leaves the original untouched', () => {
+        const snapshot = structuredClone(original)
+        duplicatePackingList(original, [])
+
+        expect(original).toEqual(snapshot)
+    })
+
+    it('carries a field the caller knows nothing about', () => {
+        const withFutureField = { ...original, someFutureField: 'keep me' } as PackingList
+
+        const copy = duplicatePackingList(withFutureField, []) as PackingList & { someFutureField?: string }
+
+        expect(copy.someFutureField).toBe('keep me')
+    })
+
+    // The guard: `fullyPopulatedPackingList` is `Required<...>`, so a new field
+    // on the type has to appear there, and then here.
+    it('accounts for every field of PackingList', () => {
+        const accountedFor = new Set<string>([
+            ...regeneratedFields,
+            ...carriedFields,
+            ...duplicateDroppedFields,
+        ])
+
+        const unaccounted = Object.keys(original).filter(field => !accountedFor.has(field))
+
+        expect(unaccounted).toEqual([])
+    })
+})

--- a/src/utils/duplicatePackingList.ts
+++ b/src/utils/duplicatePackingList.ts
@@ -1,0 +1,67 @@
+import type { PackingList } from '../create-packing-list/types'
+import { generateUUID } from './uuid'
+import { duplicateListName } from './duplicateListName'
+
+/**
+ * Fields a duplicate deliberately does **not** inherit, and why.
+ *
+ * This is an omit-list on purpose, the same way `database.ts` builds its
+ * documents with `toDocumentData(entity, [...])`. A list of fields to *keep*
+ * silently drops every field added to `PackingList` later — that is exactly how
+ * `nights`, `questionAnswers` and `selectedPeopleIds` went missing from a
+ * duplicate (#325), with no type error and no failing test. Everything not
+ * named here is carried over by default.
+ */
+export const duplicateDroppedFields = [
+    // Belongs to the original's PouchDB document; a new list has no revision.
+    '_rev',
+    // Duplicate is offered on cached copies of other people's shared lists too.
+    // Carrying these would make your own new list look like a cached copy of
+    // somebody else's — among other things, deleting it would then skip the
+    // tombstone that stops it coming back from the pod.
+    'sharedFromPodUrl',
+    'ownerWebId',
+    // A repeat trip is the next one, not last year's. Keeping the dates would
+    // stamp the copy with a trip that has already happened, and sort it in
+    // among the past trips; the user sets the new dates when they know them.
+    'startDate',
+    'endDate',
+] as const satisfies readonly (keyof PackingList)[]
+
+/** Fields regenerated below rather than copied, so a duplicate is its own list. */
+const regeneratedFields = ['id', 'name', 'createdAt', 'lastModified', 'items'] as const
+
+type DroppedField = typeof duplicateDroppedFields[number]
+
+/**
+ * A fresh list repeating `list`: same trip, same generation inputs, nothing
+ * packed yet.
+ *
+ * `existingNames` are the names already on the user's list page, so the default
+ * name can count past a duplicate made earlier.
+ */
+export function duplicatePackingList(
+    list: PackingList,
+    existingNames: readonly string[]
+): Omit<PackingList, DroppedField> {
+    const skipped: readonly string[] = [...duplicateDroppedFields, ...regeneratedFields]
+
+    const carried: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(list)) {
+        if (skipped.includes(key)) continue
+        if (value === undefined) continue
+        carried[key] = value
+    }
+
+    const now = new Date().toISOString()
+    return {
+        ...(carried as Omit<PackingList, DroppedField | typeof regeneratedFields[number]>),
+        id: generateUUID(),
+        name: duplicateListName(list.name, existingNames),
+        createdAt: now,
+        lastModified: now,
+        // Fresh ids so the two lists' items are independent, and nothing is
+        // packed for a trip that hasn't been packed for yet.
+        items: list.items.map(item => ({ ...item, id: generateUUID(), packed: false })),
+    }
+}


### PR DESCRIPTION
Closes #325

## What was wrong

`handleDuplicatePackingList` rebuilt the copy from an allowlist of five fields, so `nights`, `destination`, `startDate`/`endDate`, `guests`, `deletedItems`, `questionAnswers` and `selectedPeopleIds` were all silently dropped — and every field added to `PackingList` in future would have been dropped the same way, with no type error and no failing test.

## The fix

New `src/utils/duplicatePackingList.ts` builds the copy with an **omit-list**, the way `database.ts` builds its documents with `toDocumentData`: everything is carried unless it is named. What's named, and why (the reasons live next to the list in the code):

- `_rev` — belongs to the original's PouchDB document.
- `sharedFromPodUrl` / `ownerWebId` — Duplicate is offered on cached copies of other people's shared lists too; carrying these would make your own new list look like a cached copy of somebody else's, and `confirmDeletePackingList` would then skip its tombstone.
- `startDate` / `endDate` — a repeat trip is the next one, not last year's. Clearing them means the copy honestly reads "Created today" instead of claiming a date that has passed, and it doesn't sort in among the past trips.

`id`, `name`, `createdAt`, `lastModified` and per-item `id`/`packed` are regenerated exactly as before. Destination, nights, guests, deleted-item tombstones and the generation inputs now come across, so "Update from questions" on a duplicate uses the real answers rather than the lossy `reconstructGenerationInputs` fallback.

## The guard against a repeat

`duplicatePackingList.test.ts` partitions **every** field of `fullyPopulatedPackingList` (the `Required<...>` fixture that already guards persistence) into carried / regenerated / dropped and asserts nothing is left over. So a new field on `PackingList`:

1. fails the type check at the fixture (as today), and then
2. fails this test until someone has decided what duplicating should do with it —

while the omit-list means the safe default (carry it) is what happens even before anyone looks. Verified by temporarily adding a field to the type: both steps fail as intended.

## Tests

- New unit tests for the helper (carrying, fresh identity, unpacked items, cleared dates, no `_rev`/`sharedFromPodUrl`/`ownerWebId`, original untouched, unknown field carried, exhaustiveness).
- Two new page-level tests in `packing-lists.test.tsx`: trip context and generation inputs reach `savePackingList`, and duplicating a cached shared list produces a list of your own.
- `npm test` passes (typecheck + 1998 tests); eslint clean on the changed files.

## Mobile & Desktop

Ran the app and duplicated a Cornwall trip (destination, 5 nights, 10–15 Sep 2026):

- Desktop (1280px): the copy "Cornwall (again!)" shows 📍 Cornwall, UK, all 29 items unpacked, and "📅 Created 8/24/2026" — no inherited dates.
- Mobile (390px): same, laid out correctly with no overflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTwrEQAksnr5yt1xg282Su)_