### PR TITLE
Keep deleted questions, people and items out of a new packing list

### DIFF
--- a/src/create-packing-list/updateFromQuestions.test.ts
+++ b/src/create-packing-list/updateFromQuestions.test.ts
@@ -408,3 +408,60 @@ describe('an item reaching one person from two answers', () => {
         expect(towels.quantity).toBe(3)
     })
 })
+
+describe('entities the user has deleted from the question set', () => {
+    const DELETED = '2026-01-01T00:00:00.000Z'
+
+    it('adds nothing for a question that has been deleted', () => {
+        const questionSet = makeQuestionSet({
+            questions: [makeQuestion({
+                deletedAt: DELETED,
+                options: [{
+                    id: 'opt-swimming', text: 'Swimming', order: 0,
+                    items: [makeItem('Goggles', ['p1'])],
+                }],
+            })],
+        })
+        const list = makeList({
+            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+        })
+        expect(computeQuestionSetAdditions(list, questionSet)).toHaveLength(0)
+    })
+
+    it('skips a deleted item inside a live option', () => {
+        const questionSet = makeQuestionSet({
+            questions: [makeQuestion({
+                options: [{
+                    id: 'opt-swimming', text: 'Swimming', order: 0,
+                    items: [
+                        makeItem('Goggles', ['p1']),
+                        makeItem('Wetsuit', ['p1'], { deletedAt: DELETED }),
+                    ],
+                }],
+            })],
+        })
+        const list = makeList({
+            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+        })
+        expect(computeQuestionSetAdditions(list, questionSet).map(i => i.itemText)).toEqual(['Goggles'])
+    })
+
+    it('skips a deleted always-needed item', () => {
+        const questionSet = makeQuestionSet({
+            alwaysNeededItems: [
+                makeItem('Passport', ['p1']),
+                makeItem('Sun cream', ['p1'], { deletedAt: DELETED }),
+            ],
+        })
+        expect(computeQuestionSetAdditions(makeList(), questionSet).map(i => i.itemText)).toEqual(['Passport'])
+    })
+
+    it('packs nothing for a traveller who has been deleted', () => {
+        const questionSet = makeQuestionSet({
+            people: [alice, { ...bob, deletedAt: DELETED }],
+            alwaysNeededItems: [makeItem('Passport', ['p1', 'p2'])],
+        })
+        const additions = computeQuestionSetAdditions(makeList(), questionSet)
+        expect(additions.map(i => i.personId)).toEqual(['p1'])
+    })
+})

--- a/src/create-packing-list/updateFromQuestions.ts
+++ b/src/create-packing-list/updateFromQuestions.ts
@@ -1,4 +1,5 @@
 import { PackingListQuestionSet } from '../edit-questions/types'
+import { activeQuestionSet } from '../edit-questions/tombstones'
 import { PackingList, PackingListItem } from './types'
 import { generateQuestionBasedItems, generateAlwaysNeededItems } from './generatePackingListItems'
 // Identity and collapsing are shared with the creation flow, so an item arriving
@@ -61,8 +62,12 @@ function resolveGenerationInputs(list: PackingList): GenerationInputs {
 // a fresh id and lastModified so the item-level merge can track them.
 export function computeQuestionSetAdditions(
     list: PackingList,
-    questionSet: PackingListQuestionSet,
+    storedQuestionSet: PackingListQuestionSet,
 ): PackingListItem[] {
+    // Deletions in the question set are tombstones, so read past them: a
+    // question, item or person the user has deleted must never come back as an
+    // addition. See `activeQuestionSet`.
+    const questionSet = activeQuestionSet(storedQuestionSet)
     const { questionAnswers, selectedPeopleIds } = resolveGenerationInputs(list)
 
     // A person removed from the question set must not be regenerated; this also

--- a/src/edit-questions/tombstones.test.ts
+++ b/src/edit-questions/tombstones.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { activeQuestionSet } from './tombstones'
+import { PackingListQuestionSet } from './types'
+
+const DELETED = '2026-01-01T00:00:00.000Z'
+
+function makeSet(overrides: Partial<PackingListQuestionSet> = {}): PackingListQuestionSet {
+    return { people: [], alwaysNeededItems: [], questions: [], ...overrides }
+}
+
+describe('activeQuestionSet', () => {
+    it('drops deleted questions, keeping the live ones in order', () => {
+        const set = makeSet({
+            questions: [
+                { id: 'q1', type: 'saved', text: 'Where to?', order: 0, options: [] },
+                { id: 'q2', type: 'saved', text: 'Gone?', order: 1, options: [], deletedAt: DELETED },
+            ],
+        })
+        expect(activeQuestionSet(set).questions.map(q => q.id)).toEqual(['q1'])
+    })
+
+    it('drops deleted items nested inside a live question option', () => {
+        const set = makeSet({
+            questions: [{
+                id: 'q1', type: 'saved', text: 'Where to?', order: 0,
+                options: [{
+                    id: 'o1', text: 'Beach', order: 0,
+                    items: [
+                        { text: 'Towel', personSelections: [] },
+                        { text: 'Wetsuit', personSelections: [], deletedAt: DELETED },
+                    ],
+                }],
+            }],
+        })
+        expect(activeQuestionSet(set).questions[0].options[0].items.map(i => i.text)).toEqual(['Towel'])
+    })
+
+    it('drops deleted always-needed items', () => {
+        const set = makeSet({
+            alwaysNeededItems: [
+                { text: 'Passport', personSelections: [] },
+                { text: 'Sun cream', personSelections: [], deletedAt: DELETED },
+            ],
+        })
+        expect(activeQuestionSet(set).alwaysNeededItems.map(i => i.text)).toEqual(['Passport'])
+    })
+
+    it('drops deleted people', () => {
+        const set = makeSet({
+            people: [{ id: 'p1', name: 'Alice' }, { id: 'p2', name: 'Ghost', deletedAt: DELETED }],
+        })
+        expect(activeQuestionSet(set).people.map(p => p.name)).toEqual(['Alice'])
+    })
+
+    it('leaves the stored set untouched, so writers still carry the tombstones', () => {
+        const set = makeSet({
+            people: [{ id: 'p2', name: 'Ghost', deletedAt: DELETED }],
+            alwaysNeededItems: [{ text: 'Sun cream', personSelections: [], deletedAt: DELETED }],
+            questions: [{ id: 'q2', type: 'saved', text: 'Gone?', order: 0, options: [], deletedAt: DELETED }],
+        })
+        activeQuestionSet(set)
+        expect(set.people).toHaveLength(1)
+        expect(set.alwaysNeededItems).toHaveLength(1)
+        expect(set.questions).toHaveLength(1)
+    })
+
+    it('keeps everything else on the set, so it is a drop-in for reading', () => {
+        const set = makeSet({ sectionOrder: ['Essentials'], templateVersion: 3, lastModified: DELETED })
+        expect(activeQuestionSet(set)).toMatchObject({
+            sectionOrder: ['Essentials'],
+            templateVersion: 3,
+            lastModified: DELETED,
+        })
+    })
+})

--- a/src/edit-questions/tombstones.ts
+++ b/src/edit-questions/tombstones.ts
@@ -1,0 +1,40 @@
+import { Item, PackingListQuestionSet } from './types'
+
+/**
+ * People, questions and question-set items are deleted by tombstone: they stay
+ * in the document carrying a `deletedAt`, so the deletion can reach the pod and
+ * win the per-entity merge instead of being re-added by a device that still has
+ * the entity (see `mergeQuestionSets`).
+ *
+ * That makes the stored set the wrong thing to read from. A tombstoned question
+ * is a deletion, not a question — showing it on the create-a-list page put back
+ * every question the user had deleted, with none of its options under it (an
+ * option is removed outright, so a deleted question that was emptied first has
+ * nothing left to show). The same goes for generating: a deleted item must not
+ * land on a new list.
+ *
+ * `activeQuestionSet` is the view every reader wants — the same set with every
+ * tombstone dropped, including the items nested inside each option. Writers
+ * must keep using the stored set: saving this one back would purge the
+ * tombstones, and every deletion with them.
+ */
+export function activeQuestionSet(questionSet: PackingListQuestionSet): PackingListQuestionSet {
+    return {
+        ...questionSet,
+        people: questionSet.people.filter(person => !person.deletedAt),
+        alwaysNeededItems: activeItems(questionSet.alwaysNeededItems),
+        questions: questionSet.questions
+            .filter(question => !question.deletedAt)
+            .map(question => ({
+                ...question,
+                options: question.options.map(option => ({
+                    ...option,
+                    items: activeItems(option.items),
+                })),
+            })),
+    }
+}
+
+export function activeItems(items: Item[]): Item[] {
+    return items.filter(item => !item.deletedAt)
+}

--- a/src/pages/create-packing-list.test.tsx
+++ b/src/pages/create-packing-list.test.tsx
@@ -1612,3 +1612,125 @@ describe('CreatePackingList – landing on the new list', () => {
         expect(showToast).not.toHaveBeenCalledWith(expect.stringMatching(/created successfully/i), 'success')
     })
 })
+
+// ─── CreatePackingList – deleted questions, people and items ──────────────────
+
+describe('CreatePackingList – tombstoned questions, people and items', () => {
+    const DELETED = '2026-01-01T00:00:00.000Z'
+
+    // A set as it looks after the user has deleted a question, a traveller and
+    // a couple of items: the tombstones are still in the document, because
+    // that's how the deletions reach the pod.
+    const tombstonedQuestionSet: PackingListQuestionSet = {
+        people: [
+            { id: 'p1', name: 'Alice' },
+            { id: 'p2', name: 'Ghost', deletedAt: DELETED },
+        ],
+        alwaysNeededItems: [
+            { text: 'Passport', personSelections: [{ personId: 'p1', selected: true }] },
+            { text: 'Sun cream', personSelections: [{ personId: 'p1', selected: true }], deletedAt: DELETED },
+        ],
+        questions: [
+            {
+                id: 'q1', type: 'saved', text: 'Where are you going?', order: 0,
+                options: [{
+                    id: 'o1', text: 'Beach', order: 0,
+                    items: [
+                        { text: 'Towel', personSelections: [{ personId: 'p1', selected: true }] },
+                        { text: 'Wetsuit', personSelections: [{ personId: 'p1', selected: true }], deletedAt: DELETED },
+                    ],
+                }],
+            },
+            // Deleted, and emptied of its options before it was deleted — the
+            // shape that showed up on this page as a question with nothing
+            // under it.
+            { id: 'q2', type: 'saved', text: 'Which activities?', order: 1, options: [], deletedAt: DELETED },
+        ],
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSolidPod.mockReturnValue({ isLoggedIn: false } as ReturnType<typeof useSolidPod>)
+        mockUseToast.mockReturnValue({ showToast: vi.fn() } as ReturnType<typeof useToast>)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    function makeTombstonedDb() {
+        return makeDb({
+            getQuestionSet: vi.fn().mockResolvedValue(tombstonedQuestionSet),
+            getAllPackingLists: vi.fn().mockResolvedValue([]),
+        })
+    }
+
+    async function renderWithTombstones() {
+        const db = makeTombstonedDb()
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/Answer the questions below/i))
+        return db
+    }
+
+    it('does not show a question the user has deleted', async () => {
+        await renderWithTombstones()
+        expect(screen.queryByText('Which activities?')).toBeNull()
+    })
+
+    it('still shows the questions that are left, with their options', async () => {
+        await renderWithTombstones()
+        expect(screen.getByText('Where are you going?')).toBeTruthy()
+        expect(screen.getByText('Beach')).toBeTruthy()
+    })
+
+    it('does not offer a deleted traveller', async () => {
+        await renderWithTombstones()
+        expect(screen.getByText('Alice')).toBeTruthy()
+        expect(screen.queryByText('Ghost')).toBeNull()
+    })
+
+    it('leaves deleted items off the list it creates', async () => {
+        const db = await renderWithTombstones()
+
+        fireEvent.change(screen.getByLabelText('Packing List Name'), { target: { value: 'Cornwall' } })
+        fireEvent.click(screen.getByRole('radio', { name: /beach/i }))
+        fireEvent.click(screen.getByRole('button', { name: /create packing list/i }))
+
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        const savedList = db.savePackingList.mock.calls[0][0] as PackingList
+        const texts = savedList.items.map(i => i.itemText)
+        expect(texts).toContain('Passport')
+        expect(texts).toContain('Towel')
+        expect(texts).not.toContain('Sun cream')
+        expect(texts).not.toContain('Wetsuit')
+    })
+
+    it('does not select a deleted traveller, so nothing is packed for them', async () => {
+        const db = await renderWithTombstones()
+
+        fireEvent.change(screen.getByLabelText('Packing List Name'), { target: { value: 'Cornwall' } })
+        fireEvent.click(screen.getByRole('button', { name: /create packing list/i }))
+
+        await waitFor(() => expect(db.savePackingList).toHaveBeenCalled())
+        const savedList = db.savePackingList.mock.calls[0][0] as PackingList
+        expect(savedList.selectedPeopleIds).toEqual(['p1'])
+        expect(savedList.items.every(i => i.personId !== 'p2')).toBe(true)
+    })
+
+    it('does not offer a deleted question as a home for a suggested item', async () => {
+        const db = makeDb({
+            getQuestionSet: vi.fn().mockResolvedValue(tombstonedQuestionSet),
+            getAllPackingLists: vi.fn().mockResolvedValue([pastList]),
+        })
+        mockUseDatabase.mockReturnValue({ db } as ReturnType<typeof useDatabase>)
+        renderCreatePackingList()
+        await waitFor(() => screen.getByText(/past trips you added items/i))
+        fireEvent.click(screen.getByRole('button', { name: /review/i }))
+
+        const select = screen.getByRole('combobox', { name: /destination for sunscreen spf50/i }) as HTMLSelectElement
+        const optionLabels = Array.from(select.options).map(o => o.text)
+        expect(optionLabels).toContain('Where are you going?: Beach')
+        expect(optionLabels.some(label => label?.includes('Which activities?'))).toBe(false)
+    })
+})

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useCallback, useRef } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { Link, useNavigate } from 'react-router-dom'
 import { PackingListQuestionSet } from '../edit-questions/types'
+import { activeQuestionSet } from '../edit-questions/tombstones'
 import { PackingList, PackingListFormData, PackingListItem } from '../create-packing-list/types'
 import { useDatabase } from '../components/DatabaseContext'
 import { Input } from '../components/Input'
@@ -346,7 +347,7 @@ export function CreatePackingList() {
         if (foreignPodUrl) {
             // Foreign pod: just set state, don't write to local DB
             setQuestionSet(podData)
-            setSelectedPeopleIds(podData.people.map(p => p.id))
+            setSelectedPeopleIds(podData.people.filter(p => !p.deletedAt).map(p => p.id))
             setIsLoading(false)
             return
         }
@@ -404,7 +405,7 @@ export function CreatePackingList() {
                 setQuestionSet(doc)
                 setAllPackingLists(lists)
                 setNoQuestionsFound(false)
-                setSelectedPeopleIds(doc.people.map(p => p.id))
+                setSelectedPeopleIds(doc.people.filter(p => !p.deletedAt).map(p => p.id))
             } catch (err: unknown) {
                 const hasName = typeof err === 'object' && err !== null && 'name' in err
                 if (hasName && (err as { name: string }).name === 'not_found') {
@@ -421,14 +422,23 @@ export function CreatePackingList() {
         return fetchQuestionSet()
     }, [db, foreignPodUrl, session])
 
+    // What the page shows and generates from. `questionSet` is the stored
+    // document, tombstones and all — those have to survive every write, or the
+    // deletions would be undone on the next sync — so everything read here goes
+    // through the active view instead. See `activeQuestionSet`.
+    const activeSet = useMemo(
+        () => questionSet ? activeQuestionSet(questionSet) : null,
+        [questionSet]
+    )
+
     const suggestions = useMemo(
-        () => questionSet ? getUnreviewedCustomItems(allPackingLists, questionSet) : [],
-        [allPackingLists, questionSet]
+        () => activeSet ? getUnreviewedCustomItems(allPackingLists, activeSet) : [],
+        [allPackingLists, activeSet]
     )
 
     const deletionSuggestions = useMemo(
-        () => questionSet ? getUnreviewedDeletedItems(allPackingLists, questionSet) : [],
-        [allPackingLists, questionSet]
+        () => activeSet ? getUnreviewedDeletedItems(allPackingLists, activeSet) : [],
+        [allPackingLists, activeSet]
     )
 
     const handleSaveToQuestionSet = async (listId: string, item: PackingListItem, destination: SaveDestination, communal: boolean) => {
@@ -583,7 +593,7 @@ export function CreatePackingList() {
     }
 
     const onSubmit: SubmitHandler<PackingListFormData> = async (data) => {
-        if (!questionSet) return
+        if (!questionSet || !activeSet) return
 
         if (selectedPeopleIds.length === 0) {
             showToast('Please select at least one traveller.', 'error')
@@ -602,17 +612,17 @@ export function CreatePackingList() {
 
         // Get items from question answers
         const questionBasedItems = generateQuestionBasedItems(
-            questionSet.questions,
+            activeSet.questions,
             data.questionAnswers,
-            questionSet.people,
+            activeSet.people,
             selectedPeopleIds,
             nights
         )
 
         // Get always needed items
         const alwaysNeededItems = generateAlwaysNeededItems(
-            questionSet.alwaysNeededItems,
-            questionSet.people,
+            activeSet.alwaysNeededItems,
+            activeSet.people,
             selectedPeopleIds,
             nights
         )
@@ -756,7 +766,7 @@ export function CreatePackingList() {
         )
     }
 
-    if (!questionSet) {
+    if (!questionSet || !activeSet) {
         return null
     }
 
@@ -781,7 +791,7 @@ export function CreatePackingList() {
                 <div className="mb-6">
                     <SuggestionCard
                         suggestions={suggestions}
-                        questionSet={questionSet}
+                        questionSet={activeSet}
                         onSaveToQuestionSet={handleSaveToQuestionSet}
                         onSkip={handleSkip}
                         onDismiss={() => setIsSuggestionDismissed(true)}
@@ -846,7 +856,7 @@ export function CreatePackingList() {
                 </div>
 
                 {/* Person Selection */}
-                {questionSet.people.length > 0 && (
+                {activeSet.people.length > 0 && (
                     <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
                         <div className="flex items-center justify-between mb-4">
                             <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
@@ -855,17 +865,17 @@ export function CreatePackingList() {
                             <button
                                 type="button"
                                 onClick={() =>
-                                    selectedPeopleIds.length === questionSet.people.length
+                                    selectedPeopleIds.length === activeSet.people.length
                                         ? setSelectedPeopleIds([])
-                                        : setSelectedPeopleIds(questionSet.people.map(p => p.id))
+                                        : setSelectedPeopleIds(activeSet.people.map(p => p.id))
                                 }
                                 className="text-sm text-blue-600 dark:text-blue-400 underline hover:text-blue-800 dark:hover:text-blue-200"
                             >
-                                {selectedPeopleIds.length === questionSet.people.length ? 'Select none' : 'Select all'}
+                                {selectedPeopleIds.length === activeSet.people.length ? 'Select none' : 'Select all'}
                             </button>
                         </div>
                         <div className="space-y-2">
-                            {questionSet.people.map((person, personIndex) => (
+                            {activeSet.people.map((person, personIndex) => (
                                 <label key={person.id} className="flex items-center space-x-3">
                                     <input
                                         type="checkbox"
@@ -897,7 +907,7 @@ export function CreatePackingList() {
                     </div>
                 )}
 
-                {questionSet.questions.map((question, index) => {
+                {activeSet.questions.map((question, index) => {
                     // Default to single-choice for backward compatibility
                     const questionType = question.questionType || "single-choice"
 


### PR DESCRIPTION
Deleting a question, a traveller or a question-set item leaves a tombstone
in the question set — the entity stays in the document carrying a
`deletedAt` so the deletion reaches the pod and wins the per-entity merge.
The create-a-list page read the stored document straight, so every deleted
question came back on it, with nothing under it whenever its options had
been removed first (an option is deleted outright, so an emptied-then-
deleted question has none left to show). Deleted travellers were offered
and pre-selected too, and deleted items were generated onto the new list.

Add `activeQuestionSet`, the tombstone-free view of a set, and read through
it wherever the create flow shows or generates from the question set —
including "update from questions", which was re-adding deleted items as
additions. Writes still use the stored set: saving the filtered one back
would purge the tombstones and undo every deletion on the next sync.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015sWWKuzqv6fjBejJNniGCk