### PR TITLE
Detect renames, section moves, sharing and removals when updating from questions

### DIFF
--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -184,6 +184,121 @@ test.describe('C – Packing Lists', () => {
     await expect(page.getByRole('button', { name: /Add \d+ item/i })).not.toBeVisible()
   })
 
+  // Open the always-needed row for `itemName` in its inline editor.
+  async function editAlwaysNeededItem(page: import('@playwright/test').Page, itemName: string) {
+    await page.goto('/#/manage-questions')
+    await expect(page.getByRole('heading', { name: 'My Questions & Items' })).toBeVisible({ timeout: 8_000 })
+    await page.getByRole('button', { name: /Always Needed Items/i }).first().click()
+    await page.getByTestId('item-row').filter({ hasText: itemName }).first().click()
+    const editor = page.getByTestId('item-inline-editor')
+    await expect(editor).toBeVisible({ timeout: 3_000 })
+    return editor
+  }
+
+  /** Put `itemName` on `listUrl` via the update preview, so a later test step can change it. */
+  async function seedListWithQuestionItem(
+    page: import('@playwright/test').Page,
+    listUrl: string,
+    itemName: string,
+  ) {
+    await addAlwaysNeededItem(page, itemName)
+    await page.goto(listUrl)
+    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await page.getByRole('button', { name: /Add 1 item/i }).click()
+    await expandAllSections(page)
+    await expect(page.getByText(itemName)).toBeVisible({ timeout: 5_000 })
+  }
+
+  // The three change kinds beyond "add" — each takes its own path through the
+  // matcher, and none of them existed before #304.
+  test('C10: a renamed question item is offered as a change, not a second item', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'Renaming Trip')
+    const listUrl = page.url()
+    await seedListWithQuestionItem(page, listUrl, 'RenameMeTest')
+
+    // Rename it in the question set
+    const editor = await editAlwaysNeededItem(page, 'RenameMeTest')
+    await editor.getByTestId('item-name-field').locator('.cursor-text').click()
+    const control = page.locator('.react-select__control').last()
+    await control.click()
+    // The name field opens seeded with the current name, so it has to be
+    // cleared before the new one is typed or the two run together.
+    await page.keyboard.press('ControlOrMeta+a')
+    await page.keyboard.type('RenamedTest')
+    await page.locator('.react-select__option').filter({ hasText: /RenamedTest/i }).first().click()
+    await page.getByRole('button', { name: 'Done' }).click()
+    await page.waitForTimeout(800)
+
+    await page.goto(listUrl)
+    await expandAllSections(page)
+    await page.getByRole('button', { name: /Update from questions/i }).click()
+
+    // Grouped as a change, with the old name shown, rather than as a new item
+    await expect(page.getByText('Changed items')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(/Renamed from .RenameMeTest./)).toBeVisible()
+    await page.getByRole('button', { name: /Apply 1 change/i }).click()
+
+    await expect(page.getByText('RenamedTest')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText('RenameMeTest')).not.toBeVisible()
+
+    // And the list now matches, so the rename was applied rather than duplicated
+    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await expect(page.getByText('This list already matches your questions')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('C11: an item deleted from the questions is offered for removal, unticked', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'Shrinking Trip')
+    const listUrl = page.url()
+    await seedListWithQuestionItem(page, listUrl, 'DeleteMeTest')
+
+    const editor = await editAlwaysNeededItem(page, 'DeleteMeTest')
+    await editor.getByRole('button', { name: 'Delete DeleteMeTest' }).click()
+    await expect(editor).not.toBeVisible({ timeout: 3_000 })
+    await page.waitForTimeout(800)
+
+    await page.goto(listUrl)
+    await expandAllSections(page)
+    await page.getByRole('button', { name: /Update from questions/i }).click()
+
+    await expect(page.getByText('No longer in your questions')).toBeVisible({ timeout: 5_000 })
+    // Removals arrive unticked: nothing comes off the list without being asked for
+    const removal = page.getByLabel('Remove DeleteMeTest')
+    await expect(removal).not.toBeChecked()
+    await expect(page.getByRole('button', { name: 'Update list' })).toBeDisabled()
+
+    await removal.check()
+    await page.getByRole('button', { name: /Apply 1 change/i }).click()
+    await expect(page.getByText('DeleteMeTest')).not.toBeVisible({ timeout: 5_000 })
+  })
+
+  test('C12: an item that becomes shared replaces the personal copy', async ({ freshPage: page }) => {
+    await runWizard(page)
+    await createList(page, 'Sharing Trip')
+    const listUrl = page.url()
+    await seedListWithQuestionItem(page, listUrl, 'ShareMeTest')
+
+    const editor = await editAlwaysNeededItem(page, 'ShareMeTest')
+    await editor.getByRole('button', { name: 'Toggle shared for ShareMeTest' }).click()
+    await page.getByRole('button', { name: 'Done' }).click()
+    await page.waitForTimeout(800)
+
+    await page.goto(listUrl)
+    await expandAllSections(page)
+    await page.getByRole('button', { name: /Update from questions/i }).click()
+
+    await expect(page.getByText('Changed items')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(/Now shared for everyone/)).toBeVisible()
+    await page.getByRole('button', { name: /Apply 1 change/i }).click()
+
+    // Still one item, not two: the personal copy went as the shared one arrived
+    await expandAllSections(page)
+    await expect(page.getByText('ShareMeTest')).toHaveCount(1, { timeout: 5_000 })
+    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await expect(page.getByText('This list already matches your questions')).toBeVisible({ timeout: 5_000 })
+  })
+
   test('C9: a person’s chosen colour follows them onto a packing list', async ({ freshPage: page }) => {
     await runWizard(page)
 

--- a/src/components/UpdateFromQuestionsModal.tsx
+++ b/src/components/UpdateFromQuestionsModal.tsx
@@ -1,85 +1,121 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Modal } from './Modal'
 import { Button } from './Button'
-import { PackingListItem } from '../create-packing-list/types'
+import { QuestionSetChange, QuestionSetChangeType } from '../create-packing-list/updateFromQuestions'
 
 interface UpdateFromQuestionsModalProps {
     isOpen: boolean
     onClose: () => void
-    additions: PackingListItem[]
-    onConfirm: (selected: PackingListItem[]) => void
+    changes: QuestionSetChange[]
+    onConfirm: (selected: QuestionSetChange[]) => void
 }
 
-// Groups additions by traveller for the preview, communal ("Shared items")
-// first, then people alphabetically.
-function groupAdditions(additions: PackingListItem[]): Array<{ label: string; items: PackingListItem[] }> {
-    const shared: PackingListItem[] = []
-    const byPerson = new Map<string, PackingListItem[]>()
-    for (const item of additions) {
-        if (item.communal || item.personId === '') {
-            shared.push(item)
-        } else {
-            const key = item.personName || 'Unassigned'
-            if (!byPerson.has(key)) byPerson.set(key, [])
-            byPerson.get(key)!.push(item)
-        }
-    }
-    const groups: Array<{ label: string; items: PackingListItem[] }> = []
-    if (shared.length > 0) groups.push({ label: 'Shared items', items: shared })
-    for (const label of [...byPerson.keys()].sort((a, b) => a.localeCompare(b))) {
-        groups.push({ label, items: byPerson.get(label)! })
-    }
-    return groups
+interface Section {
+    type: QuestionSetChangeType | 'changed'
+    title: string
+    hint?: string
+    changes: QuestionSetChange[]
+}
+
+/**
+ * Adding and correcting are what the user came for, so they arrive ticked.
+ * Removing is the one kind that takes something away, and an item leaving your
+ * questions is not the same as you being finished with it on this trip — a
+ * one-off you added an option for, a thing you pack anyway. So those arrive
+ * unticked and are opted into one at a time.
+ */
+function startsSelected(change: QuestionSetChange): boolean {
+    return change.type !== 'remove'
+}
+
+/** Shared items first, then people alphabetically, so the list reads the same way twice. */
+function byOwner(a: QuestionSetChange, b: QuestionSetChange): number {
+    if (!a.personName !== !b.personName) return a.personName ? 1 : -1
+    return a.personName.localeCompare(b.personName) || a.itemText.localeCompare(b.itemText)
+}
+
+function verbFor(type: QuestionSetChangeType | 'changed'): string {
+    if (type === 'add') return 'Add'
+    if (type === 'remove') return 'Remove'
+    return 'Update'
 }
 
 export function UpdateFromQuestionsModal({
     isOpen,
     onClose,
-    additions,
+    changes,
     onConfirm,
 }: UpdateFromQuestionsModalProps) {
-    // All additions start selected; the user unchecks any they don't want.
-    const [excludedIds, setExcludedIds] = useState<Set<string>>(new Set())
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
 
-    const groups = useMemo(() => groupAdditions(additions), [additions])
-    const selectedCount = additions.length - excludedIds.size
+    // A fresh diff is a fresh set of choices; the previous run's ticks belong to
+    // items that may not even be in this one.
+    useEffect(() => {
+        setSelectedIds(new Set(changes.filter(startsSelected).map(change => change.id)))
+    }, [changes])
+
+    const sections = useMemo<Section[]>(() => {
+        const of = (...types: QuestionSetChangeType[]) =>
+            changes.filter(change => types.includes(change.type)).sort(byOwner)
+        return ([
+            { type: 'add', title: 'New items', changes: of('add') },
+            { type: 'changed', title: 'Changed items', changes: of('update', 'sharing') },
+            {
+                type: 'remove',
+                title: 'No longer in your questions',
+                hint: 'These came from your questions and no longer do. Nothing is removed unless you tick it.',
+                changes: of('remove'),
+            },
+        ] satisfies Section[]).filter(section => section.changes.length > 0)
+    }, [changes])
+
+    const selected = changes.filter(change => selectedIds.has(change.id))
+    const onlyAdding = selected.length > 0 && selected.every(change => change.type === 'add')
 
     const toggle = (id: string) => {
-        setExcludedIds(prev => {
-            const next = new Set(prev)
+        setSelectedIds(previous => {
+            const next = new Set(previous)
             if (next.has(id)) next.delete(id)
             else next.add(id)
             return next
         })
     }
 
-    const handleConfirm = () => {
-        onConfirm(additions.filter(item => !excludedIds.has(item.id)))
-    }
-
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Update from questions">
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                Your questions have new items that match this trip. Choose which to add.
+                Your questions have changed since this list was made. Choose what to bring across.
             </p>
-            <div className="max-h-96 overflow-y-auto space-y-4">
-                {groups.map(group => (
-                    <div key={group.label}>
-                        <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{group.label}</p>
-                        <div className="space-y-1">
-                            {group.items.map(item => (
-                                <label key={item.id} className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer">
+            <div className="max-h-96 overflow-y-auto space-y-5">
+                {sections.map(section => (
+                    <div key={section.title}>
+                        <p className="text-sm font-semibold text-gray-700 dark:text-gray-300">{section.title}</p>
+                        {section.hint && (
+                            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 mb-2">{section.hint}</p>
+                        )}
+                        <div className={`space-y-1 ${section.hint ? '' : 'mt-2'}`}>
+                            {section.changes.map(change => (
+                                <label
+                                    key={change.id}
+                                    className="flex items-start gap-3 px-2 py-1.5 rounded hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer"
+                                >
                                     <input
                                         type="checkbox"
-                                        aria-label={`Add ${item.itemText}${item.personName ? ` for ${item.personName}` : ''}`}
-                                        checked={!excludedIds.has(item.id)}
-                                        onChange={() => toggle(item.id)}
-                                        className="h-4 w-4 text-blue-600 dark:text-blue-400 rounded focus:ring-2 focus:ring-blue-500"
+                                        aria-label={`${verbFor(change.type)} ${change.itemText}${change.personName ? ` for ${change.personName}` : ''}`}
+                                        checked={selectedIds.has(change.id)}
+                                        onChange={() => toggle(change.id)}
+                                        className="mt-1 h-4 w-4 text-blue-600 dark:text-blue-400 rounded focus:ring-2 focus:ring-blue-500"
                                     />
-                                    <span className="text-gray-900 dark:text-gray-100">
-                                        {item.itemText}
-                                        {item.quantity !== undefined && (
-                                            <span className="ml-1.5 text-sm text-gray-500 dark:text-gray-400">×{item.quantity}</span>
+                                    <span className="min-w-0">
+                                        <span className="text-gray-900 dark:text-gray-100">{change.itemText}</span>
+                                        {change.additions[0]?.quantity !== undefined && change.type === 'add' && (
+                                            <span className="ml-1.5 text-sm text-gray-500 dark:text-gray-400">×{change.additions[0].quantity}</span>
+                                        )}
+                                        {change.personName && (
+                                            <span className="ml-1.5 text-sm text-gray-500 dark:text-gray-400">for {change.personName}</span>
+                                        )}
+                                        {change.detail && (
+                                            <span className="block text-xs text-gray-500 dark:text-gray-400">{change.detail}</span>
                                         )}
                                     </span>
                                 </label>
@@ -95,10 +131,14 @@ export function UpdateFromQuestionsModal({
                 <Button
                     type="button"
                     variant="primary"
-                    onClick={handleConfirm}
-                    disabled={selectedCount === 0}
+                    onClick={() => onConfirm(selected)}
+                    disabled={selected.length === 0}
                 >
-                    {selectedCount > 0 ? `Add ${selectedCount} item${selectedCount === 1 ? '' : 's'}` : 'Add items'}
+                    {selected.length === 0
+                        ? 'Update list'
+                        : onlyAdding
+                            ? `Add ${selected.length} item${selected.length === 1 ? '' : 's'}`
+                            : `Apply ${selected.length} change${selected.length === 1 ? '' : 's'}`}
                 </Button>
             </div>
         </Modal>

--- a/src/create-packing-list/generatePackingListItems.ts
+++ b/src/create-packing-list/generatePackingListItems.ts
@@ -1,6 +1,9 @@
 import { Question, Person, Item } from '../edit-questions/types'
 import { ALWAYS_NEEDED_CATEGORY, defaultCategoryFor } from '../edit-questions/item-sections'
 import { PackingListItem } from './types'
+// Not crypto.randomUUID directly: it is missing from older WebViews, which is
+// exactly where the Capacitor builds run.
+import { generateUUID } from '../utils/uuid'
 
 interface ItemContext {
     questionId: string
@@ -46,7 +49,7 @@ function generateItemInstances(
             || item.personSelections.some(ps => ps.selected && selectedPeopleIds.includes(ps.personId))
         if (!triggered) return []
         return [{
-            id: crypto.randomUUID(),
+            id: generateUUID(),
             itemText: item.text,
             personId: '',
             personName: '',
@@ -65,7 +68,7 @@ function generateItemInstances(
     return selectedPeople.flatMap(ps => {
         const person = people.find(p => p.id === ps.personId)!
         return {
-            id: crypto.randomUUID(),
+            id: generateUUID(),
             itemText: item.text,
             personId: ps.personId,
             personName: person.name,

--- a/src/create-packing-list/types.ts
+++ b/src/create-packing-list/types.ts
@@ -43,6 +43,18 @@ export interface PackingListItem {
     // toothbrush, passport in a pocket. Shown in a section of its own at the
     // end of the list rather than among the items that can be packed now.
     lastMinute?: boolean
+    // The user has renamed / re-quantified this generated item by hand, so it
+    // is theirs rather than the question set's. Both optional and additive:
+    // absent means "still whatever my questions say", which is what every item
+    // was before "Update from questions" could do anything but add.
+    //
+    // They exist because the two sides are otherwise indistinguishable. A
+    // question-set rename and a list rename both end as "these two strings
+    // differ", so without a record of which side moved, updating a list would
+    // offer to undo the user's own edits every time. See `buildUpdate` in
+    // updateFromQuestions.ts.
+    textEdited?: boolean
+    quantityEdited?: boolean
     lastModified?: string // ISO timestamp; absent on legacy items
 }
 

--- a/src/create-packing-list/updateFromQuestions.test.ts
+++ b/src/create-packing-list/updateFromQuestions.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import PouchDB from 'pouchdb'
 import PouchDBMemoryAdapter from 'pouchdb-adapter-memory'
 import { PackingAppDatabase } from '../services/database'
-import { computeQuestionSetAdditions, reconstructGenerationInputs } from './updateFromQuestions'
+import {
+    applyQuestionSetChanges,
+    computeQuestionSetChanges,
+    reconstructGenerationInputs,
+    type QuestionSetChange,
+} from './updateFromQuestions'
 import { PackingList, PackingListItem } from './types'
 import { PackingListQuestionSet, Question, Person, Item } from '../edit-questions/types'
 
@@ -47,7 +52,9 @@ function makeList(overrides: Partial<PackingList> = {}): PackingList {
     }
 }
 
-// A packing-list item generated from a question option
+// A packing-list item generated from a question option. `category` matches what
+// `defaultCategoryFor` gives a multiple-choice question — the option's text —
+// so a fixture that hasn't moved sections doesn't look like it has.
 function listItem(overrides: Partial<PackingListItem> = {}): PackingListItem {
     return {
         id: crypto.randomUUID(),
@@ -56,30 +63,40 @@ function listItem(overrides: Partial<PackingListItem> = {}): PackingListItem {
         personName: 'Alice',
         questionId: 'q-activities',
         optionId: 'opt-swimming',
+        category: 'Swimming',
         packed: false,
         ...overrides,
     }
 }
 
-describe('computeQuestionSetAdditions', () => {
+/** The one option most tests hang their items off. */
+function swimming(items: Item[]) {
+    return makeQuestionSet({
+        questions: [makeQuestion({
+            options: [{ id: 'opt-swimming', text: 'Swimming', order: 0, items }],
+        })],
+    })
+}
+
+const answeredSwimming = [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }]
+
+const only = (changes: QuestionSetChange[], type: QuestionSetChange['type']) =>
+    changes.filter(change => change.type === type)
+
+/** The items a run of changes would append, which is what the old API returned. */
+const additions = (changes: QuestionSetChange[]) =>
+    only(changes, 'add').flatMap(change => change.additions)
+
+describe('additions', () => {
     it('adds a new item in a selected option for each selected traveller', () => {
-        const questionSet = makeQuestionSet({
-            questions: [makeQuestion({
-                options: [{
-                    id: 'opt-swimming', text: 'Swimming', order: 0,
-                    items: [makeItem('Goggles', ['p1', 'p2'])],
-                }],
-            })],
-        })
-        const list = makeList({
-            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
-        })
+        const questionSet = swimming([makeItem('Goggles', ['p1', 'p2'])])
+        const list = makeList({ questionAnswers: answeredSwimming })
 
-        const additions = computeQuestionSetAdditions(list, questionSet)
+        const added = additions(computeQuestionSetChanges(list, questionSet))
 
-        expect(additions.map(a => `${a.itemText}:${a.personName}`).sort())
+        expect(added.map(a => `${a.itemText}:${a.personName}`).sort())
             .toEqual(['Goggles:Alice', 'Goggles:Bob'])
-        additions.forEach(a => {
+        added.forEach(a => {
             expect(a.packed).toBe(false)
             expect(a.id).toBeTruthy()
             expect(a.lastModified).toBeTruthy()
@@ -95,77 +112,48 @@ describe('computeQuestionSetAdditions', () => {
                 ],
             })],
         })
-        const list = makeList({
-            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
-        })
+        const list = makeList({ questionAnswers: answeredSwimming })
 
-        const additions = computeQuestionSetAdditions(list, questionSet)
-
-        expect(additions.map(a => a.itemText)).toEqual(['Goggles'])
+        expect(additions(computeQuestionSetChanges(list, questionSet)).map(a => a.itemText)).toEqual(['Goggles'])
     })
 
-    it('skips items already on the list, including hand-added custom items with the same text', () => {
-        const questionSet = makeQuestionSet({
-            questions: [makeQuestion({
-                options: [{
-                    id: 'opt-swimming', text: 'Swimming', order: 0,
-                    items: [makeItem('Goggles', ['p1'])],
-                }],
-            })],
-        })
+    it('leaves alone an item already on the list, including a hand-added one with the same text', () => {
+        const questionSet = swimming([makeItem('Goggles', ['p1'])])
         const list = makeList({
-            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+            questionAnswers: answeredSwimming,
             // custom item added by hand with no questionId but same text/person
-            items: [listItem({ itemText: 'goggles', personId: 'p1', personName: 'Alice', questionId: '', optionId: '' })],
+            items: [listItem({ itemText: 'goggles', questionId: '', optionId: '', category: undefined })],
         })
 
-        const additions = computeQuestionSetAdditions(list, questionSet)
-
-        expect(additions).toEqual([])
+        expect(computeQuestionSetChanges(list, questionSet)).toEqual([])
     })
 
     it('never resurrects an item the user previously deleted', () => {
-        const questionSet = makeQuestionSet({
-            questions: [makeQuestion({
-                options: [{
-                    id: 'opt-swimming', text: 'Swimming', order: 0,
-                    items: [makeItem('Goggles', ['p1'])],
-                }],
-            })],
-        })
+        const questionSet = swimming([makeItem('Goggles', ['p1'])])
         const list = makeList({
-            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
-            deletedItems: [listItem({ itemText: 'Goggles', personId: 'p1', personName: 'Alice' })],
+            questionAnswers: answeredSwimming,
+            deletedItems: [listItem({ itemText: 'Goggles' })],
         })
 
-        const additions = computeQuestionSetAdditions(list, questionSet)
-
-        expect(additions).toEqual([])
+        expect(computeQuestionSetChanges(list, questionSet)).toEqual([])
     })
 
     it('respects communal trigger semantics and skips deleted communal items', () => {
-        const questionSet = makeQuestionSet({
-            questions: [makeQuestion({
-                options: [{
-                    id: 'opt-swimming', text: 'Swimming', order: 0,
-                    items: [
-                        makeItem('Beach umbrella', ['p1'], { communal: true }),
-                        makeItem('Cooler', ['p1'], { communal: true }),
-                    ],
-                }],
-            })],
-        })
+        const questionSet = swimming([
+            makeItem('Beach umbrella', ['p1'], { communal: true }),
+            makeItem('Cooler', ['p1'], { communal: true }),
+        ])
         const list = makeList({
-            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+            questionAnswers: answeredSwimming,
             // Cooler was already deleted as a communal item (personId '')
             deletedItems: [listItem({ itemText: 'Cooler', personId: '', personName: '', communal: true })],
         })
 
-        const additions = computeQuestionSetAdditions(list, questionSet)
+        const added = additions(computeQuestionSetChanges(list, questionSet))
 
-        expect(additions.map(a => a.itemText)).toEqual(['Beach umbrella'])
-        expect(additions[0].communal).toBe(true)
-        expect(additions[0].personId).toBe('')
+        expect(added.map(a => a.itemText)).toEqual(['Beach umbrella'])
+        expect(added[0].communal).toBe(true)
+        expect(added[0].personId).toBe('')
     })
 
     it('does not generate items for a person removed from the question set', () => {
@@ -178,14 +166,9 @@ describe('computeQuestionSetAdditions', () => {
                 }],
             })],
         })
-        const list = makeList({
-            selectedPeopleIds: ['p1', 'p2'],
-            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
-        })
+        const list = makeList({ selectedPeopleIds: ['p1', 'p2'], questionAnswers: answeredSwimming })
 
-        const additions = computeQuestionSetAdditions(list, questionSet)
-
-        expect(additions.map(a => a.personName)).toEqual(['Alice'])
+        expect(additions(computeQuestionSetChanges(list, questionSet)).map(a => a.personName)).toEqual(['Alice'])
     })
 
     it('silently ignores answers pointing at deleted questions/options', () => {
@@ -194,7 +177,7 @@ describe('computeQuestionSetAdditions', () => {
             questionAnswers: [{ questionId: 'q-gone', selectedOptionIds: ['opt-gone'] }],
         })
 
-        expect(computeQuestionSetAdditions(list, questionSet)).toEqual([])
+        expect(computeQuestionSetChanges(list, questionSet)).toEqual([])
     })
 
     it('applies suggested quantities when nights is set', () => {
@@ -207,74 +190,377 @@ describe('computeQuestionSetAdditions', () => {
                 }],
             })],
         })
-        const list = makeList({
-            selectedPeopleIds: ['p1'],
-            nights: 3,
-            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
-        })
+        const list = makeList({ selectedPeopleIds: ['p1'], nights: 3, questionAnswers: answeredSwimming })
 
-        const additions = computeQuestionSetAdditions(list, questionSet)
+        const added = additions(computeQuestionSetChanges(list, questionSet))
 
-        expect(additions).toHaveLength(1)
-        expect(additions[0].quantity).toBe(3)
+        expect(added).toHaveLength(1)
+        expect(added[0].quantity).toBe(3)
     })
 
     it('adds new always-needed items', () => {
-        const questionSet = makeQuestionSet({
-            people: [alice],
-            alwaysNeededItems: [makeItem('Passport', ['p1'])],
-        })
+        const questionSet = makeQuestionSet({ people: [alice], alwaysNeededItems: [makeItem('Passport', ['p1'])] })
         const list = makeList({ selectedPeopleIds: ['p1'] })
 
-        const additions = computeQuestionSetAdditions(list, questionSet)
-
-        expect(additions.map(a => a.itemText)).toEqual(['Passport'])
+        expect(additions(computeQuestionSetChanges(list, questionSet)).map(a => a.itemText)).toEqual(['Passport'])
     })
 
     describe('legacy lists without stored generation inputs', () => {
         it('reconstructs answers and travellers from existing items', () => {
-            const questionSet = makeQuestionSet({
-                questions: [makeQuestion({
-                    options: [{
-                        id: 'opt-swimming', text: 'Swimming', order: 0,
-                        items: [
-                            makeItem('Swimsuit', ['p1']),
-                            makeItem('Goggles', ['p1']), // the new item
-                        ],
-                    }],
-                })],
-            })
+            const questionSet = swimming([
+                makeItem('Swimsuit', ['p1']),
+                makeItem('Goggles', ['p1']), // the new item
+            ])
             // Legacy: no questionAnswers / selectedPeopleIds fields at all
             const list: PackingList = {
                 id: 'list-1', name: 'Trip', createdAt: '2024-01-01T00:00:00.000Z',
-                items: [listItem({ itemText: 'Swimsuit', personId: 'p1', personName: 'Alice', optionId: 'opt-swimming' })],
+                items: [listItem({ itemText: 'Swimsuit' })],
             }
 
-            const additions = computeQuestionSetAdditions(list, questionSet)
-
-            expect(additions.map(a => a.itemText)).toEqual(['Goggles'])
+            expect(additions(computeQuestionSetChanges(list, questionSet)).map(a => a.itemText)).toEqual(['Goggles'])
         })
 
         it('reconstructs travellers from deleted items too', () => {
-            const questionSet = makeQuestionSet({
-                questions: [makeQuestion({
-                    options: [{
-                        id: 'opt-swimming', text: 'Swimming', order: 0,
-                        items: [makeItem('Goggles', ['p1'])],
-                    }],
-                })],
-            })
+            const questionSet = swimming([makeItem('Goggles', ['p1'])])
             const list: PackingList = {
                 id: 'list-1', name: 'Trip', createdAt: '2024-01-01T00:00:00.000Z',
                 items: [],
-                deletedItems: [listItem({ itemText: 'Swimsuit', personId: 'p1', personName: 'Alice', optionId: 'opt-swimming' })],
+                deletedItems: [listItem({ itemText: 'Swimsuit' })],
             }
 
-            const additions = computeQuestionSetAdditions(list, questionSet)
+            const changes = computeQuestionSetChanges(list, questionSet)
 
             // Swimsuit was deleted so it's skipped; Goggles is new for reconstructed traveller p1
-            expect(additions.map(a => a.itemText)).toEqual(['Goggles'])
+            expect(additions(changes).map(a => a.itemText)).toEqual(['Goggles'])
         })
+    })
+})
+
+describe('removals', () => {
+    it('offers an item the questions no longer produce', () => {
+        const questionSet = swimming([makeItem('Goggles', ['p1'])])
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            questionAnswers: answeredSwimming,
+            items: [listItem({ itemText: 'Goggles' }), listItem({ id: 'snorkel', itemText: 'Snorkel' })],
+        })
+
+        const removals = only(computeQuestionSetChanges(list, questionSet), 'remove')
+
+        expect(removals.map(change => change.itemText)).toEqual(['Snorkel'])
+        expect(removals[0].removedIds).toEqual(['snorkel'])
+        expect(removals[0].additions).toEqual([])
+    })
+
+    it('never offers to remove an item the user added by hand', () => {
+        const questionSet = swimming([makeItem('Goggles', ['p1'])])
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            questionAnswers: answeredSwimming,
+            items: [
+                listItem({ itemText: 'Goggles' }),
+                listItem({ itemText: 'Book', questionId: '', optionId: '', category: undefined }),
+            ],
+        })
+
+        expect(only(computeQuestionSetChanges(list, questionSet), 'remove')).toEqual([])
+    })
+
+    // The #260 shape: a list whose generation inputs went missing regenerates
+    // nothing, and must not read that as "everything has gone".
+    it('offers nothing when the list no longer remembers answering the question', () => {
+        const questionSet = swimming([makeItem('Goggles', ['p1'])])
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            questionAnswers: [],
+            items: [listItem({ itemText: 'Goggles' })],
+        })
+
+        expect(only(computeQuestionSetChanges(list, questionSet), 'remove')).toEqual([])
+    })
+
+    it('leaves always-needed items alone when there is nobody left to generate them for', () => {
+        const questionSet = makeQuestionSet({ people: [], alwaysNeededItems: [] })
+        const list = makeList({
+            selectedPeopleIds: [],
+            items: [listItem({
+                itemText: 'Passport', questionId: 'always-needed', optionId: 'always-needed', category: 'Essentials',
+            })],
+        })
+
+        expect(computeQuestionSetChanges(list, questionSet)).toEqual([])
+    })
+
+    it('offers an always-needed item that has left the question set', () => {
+        const questionSet = makeQuestionSet({ people: [alice], alwaysNeededItems: [makeItem('Passport', ['p1'])] })
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            items: [
+                listItem({ itemText: 'Passport', questionId: 'always-needed', optionId: 'always-needed', category: 'Essentials' }),
+                listItem({ itemText: 'Sun cream', questionId: 'always-needed', optionId: 'always-needed', category: 'Essentials' }),
+            ],
+        })
+
+        expect(only(computeQuestionSetChanges(list, questionSet), 'remove').map(c => c.itemText)).toEqual(['Sun cream'])
+    })
+})
+
+describe('updates', () => {
+    it('pairs a renamed item with the one already on the list, keeping its id and packed state', () => {
+        const questionSet = swimming([makeItem('Swimming goggles', ['p1'])])
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            questionAnswers: answeredSwimming,
+            items: [listItem({ id: 'goggles', itemText: 'Goggles', packed: true })],
+        })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes).toHaveLength(1)
+        expect(changes[0].type).toBe('update')
+        expect(changes[0].itemText).toBe('Swimming goggles')
+        expect(changes[0].detail).toContain('Renamed from “Goggles”')
+        const [replacement] = changes[0].replacements
+        expect(replacement.id).toBe('goggles')
+        expect(replacement.packed).toBe(true)
+        expect(replacement.itemText).toBe('Swimming goggles')
+    })
+
+    it('offers a section move', () => {
+        const questionSet = swimming([makeItem('Goggles', ['p1'], { category: 'Beach kit' })])
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            questionAnswers: answeredSwimming,
+            items: [listItem({ itemText: 'Goggles' })],
+        })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes).toHaveLength(1)
+        expect(changes[0].detail).toBe('Moved to Beach kit')
+        expect(changes[0].replacements[0].category).toBe('Beach kit')
+    })
+
+    it('offers a changed suggested quantity', () => {
+        const questionSet = swimming([makeItem('Socks', ['p1'], { perNight: 2 })])
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            nights: 3,
+            questionAnswers: answeredSwimming,
+            items: [listItem({ itemText: 'Socks', quantity: 3 })],
+        })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes[0].detail).toBe('Now ×6 (was ×3)')
+        expect(changes[0].replacements[0].quantity).toBe(6)
+    })
+
+    it('says nothing when the item is unchanged', () => {
+        const questionSet = swimming([makeItem('Goggles', ['p1'])])
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            questionAnswers: answeredSwimming,
+            items: [listItem({ itemText: 'Goggles' })],
+        })
+
+        expect(computeQuestionSetChanges(list, questionSet)).toEqual([])
+    })
+
+    it('will not guess which of two renamed items is which', () => {
+        const questionSet = swimming([makeItem('Swim goggles', ['p1']), makeItem('Swim cap', ['p1'])])
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            questionAnswers: answeredSwimming,
+            items: [listItem({ itemText: 'Goggles' }), listItem({ itemText: 'Cap' })],
+        })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(only(changes, 'update')).toEqual([])
+        expect(only(changes, 'add').map(c => c.itemText).sort()).toEqual(['Swim cap', 'Swim goggles'])
+        expect(only(changes, 'remove').map(c => c.itemText).sort()).toEqual(['Cap', 'Goggles'])
+    })
+
+    // Deliberate, and the reason rename pairing only ever looks at items still
+    // on the list: a tombstone says "not this, on this trip", and it is matched
+    // by name. Deciding that a differently-named item is *really* the one that
+    // was thrown away would mean silently withholding a genuine addition —
+    // invisible to the user, where an addition they don't want is one untick
+    // away.
+    it('offers an item the user deleted and then renamed in their questions as a new item', () => {
+        const questionSet = swimming([makeItem('Swimming goggles', ['p1'])])
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            questionAnswers: answeredSwimming,
+            deletedItems: [listItem({ itemText: 'Goggles' })],
+        })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes.map(c => `${c.type}:${c.itemText}`)).toEqual(['add:Swimming goggles'])
+    })
+
+    // The product decision this flow turns on: a generated item the user has
+    // renamed on the list is theirs. The question set is no longer allowed to
+    // rename it back — and it must not turn up as a duplicate addition either.
+    describe('an item the user renamed by hand', () => {
+        const questionSet = swimming([makeItem('Goggles', ['p1'])])
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            questionAnswers: answeredSwimming,
+            items: [listItem({ itemText: 'Kids’ goggles', textEdited: true })],
+        })
+
+        it('is never renamed back, nor offered again as an addition', () => {
+            expect(computeQuestionSetChanges(list, questionSet)).toEqual([])
+        })
+
+        it('still follows the question set into another section', () => {
+            const moved = swimming([makeItem('Goggles', ['p1'], { category: 'Beach kit' })])
+
+            const changes = computeQuestionSetChanges(list, moved)
+
+            expect(changes).toHaveLength(1)
+            expect(changes[0].detail).toBe('Moved to Beach kit')
+            // Their name survives the section move
+            expect(changes[0].replacements[0].itemText).toBe('Kids’ goggles')
+        })
+
+        it('is still offered for removal once it leaves the questions', () => {
+            const gone = swimming([])
+
+            const changes = computeQuestionSetChanges(list, gone)
+
+            expect(changes.map(c => c.type)).toEqual(['remove'])
+        })
+    })
+
+    it('leaves a hand-set quantity alone', () => {
+        const questionSet = swimming([makeItem('Socks', ['p1'], { perNight: 2 })])
+        const list = makeList({
+            selectedPeopleIds: ['p1'],
+            nights: 3,
+            questionAnswers: answeredSwimming,
+            items: [listItem({ itemText: 'Socks', quantity: 2, quantityEdited: true })],
+        })
+
+        expect(computeQuestionSetChanges(list, questionSet)).toEqual([])
+    })
+})
+
+describe('items crossing the communal boundary', () => {
+    it('replaces everybody’s own copy with one for the group', () => {
+        const questionSet = swimming([makeItem('Cooler', ['p1', 'p2'], { communal: true })])
+        const list = makeList({
+            questionAnswers: answeredSwimming,
+            items: [
+                listItem({ id: 'cooler-a', itemText: 'Cooler', packed: true }),
+                listItem({ id: 'cooler-b', itemText: 'Cooler', personId: 'p2', personName: 'Bob', packed: true }),
+            ],
+        })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes.map(c => c.type)).toEqual(['sharing'])
+        expect(changes[0].removedIds.sort()).toEqual(['cooler-a', 'cooler-b'])
+        expect(changes[0].additions).toHaveLength(1)
+        expect(changes[0].additions[0].personId).toBe('')
+        expect(changes[0].additions[0].communal).toBe(true)
+        // Packed for everyone was packed, so the shared copy arrives packed
+        expect(changes[0].additions[0].packed).toBe(true)
+        expect(changes[0].detail).toContain('Now shared for everyone')
+    })
+
+    it('does not call it packed when only one person had packed theirs', () => {
+        const questionSet = swimming([makeItem('Cooler', ['p1', 'p2'], { communal: true })])
+        const list = makeList({
+            questionAnswers: answeredSwimming,
+            items: [
+                listItem({ itemText: 'Cooler', packed: true }),
+                listItem({ itemText: 'Cooler', personId: 'p2', personName: 'Bob', packed: false }),
+            ],
+        })
+
+        expect(computeQuestionSetChanges(list, questionSet)[0].additions[0].packed).toBe(false)
+    })
+
+    it('replaces the group’s copy with one each', () => {
+        const questionSet = swimming([makeItem('Towel', ['p1', 'p2'])])
+        const list = makeList({
+            questionAnswers: answeredSwimming,
+            items: [listItem({ id: 'towel', itemText: 'Towel', personId: '', personName: '', communal: true, packed: true })],
+        })
+
+        const changes = computeQuestionSetChanges(list, questionSet)
+
+        expect(changes.map(c => c.type)).toEqual(['sharing'])
+        expect(changes[0].removedIds).toEqual(['towel'])
+        expect(changes[0].additions.map(i => i.personName).sort()).toEqual(['Alice', 'Bob'])
+        expect(changes[0].additions.every(i => i.packed)).toBe(true)
+        expect(changes[0].detail).toContain('Now one each')
+    })
+
+    it('honours a deleted shared copy rather than reinstating it', () => {
+        const questionSet = swimming([makeItem('Cooler', ['p1', 'p2'], { communal: true })])
+        const list = makeList({
+            questionAnswers: answeredSwimming,
+            items: [listItem({ itemText: 'Cooler' }), listItem({ itemText: 'Cooler', personId: 'p2', personName: 'Bob' })],
+            deletedItems: [listItem({ itemText: 'Cooler', personId: '', personName: '', communal: true })],
+        })
+
+        // Nothing at all: the shared copy stays deleted, and the personal copies
+        // it would have replaced are not left looking like strays either.
+        expect(computeQuestionSetChanges(list, questionSet)).toEqual([])
+    })
+})
+
+describe('applyQuestionSetChanges', () => {
+    it('adds, replaces and removes in a single pass', () => {
+        const list = makeList({
+            items: [
+                listItem({ id: 'keep', itemText: 'Keep' }),
+                listItem({ id: 'rename', itemText: 'Old', packed: true }),
+                listItem({ id: 'drop', itemText: 'Drop' }),
+            ],
+        })
+        const changes: QuestionSetChange[] = [
+            {
+                id: 'a', type: 'add', itemText: 'New', personName: 'Alice',
+                additions: [listItem({ id: 'new', itemText: 'New' })], removedIds: [], replacements: [],
+            },
+            {
+                id: 'u', type: 'update', itemText: 'New name', personName: 'Alice',
+                additions: [], removedIds: [],
+                replacements: [listItem({ id: 'rename', itemText: 'New name', packed: true })],
+            },
+            {
+                id: 'r', type: 'remove', itemText: 'Drop', personName: 'Alice',
+                additions: [], removedIds: ['drop'], replacements: [],
+            },
+        ]
+
+        const updated = applyQuestionSetChanges(list, changes)
+
+        expect(updated.items.map(i => `${i.id}:${i.itemText}`))
+            .toEqual(['keep:Keep', 'rename:New name', 'new:New'])
+        expect(updated.items.find(i => i.id === 'rename')!.packed).toBe(true)
+        // A removal from this flow is not a deletion the user made, so it leaves
+        // no tombstone to block the item coming back with its option.
+        expect(updated.deletedItems).toBeUndefined()
+    })
+
+    it('leaves the list untouched when nothing is selected', () => {
+        const list = makeList({ items: [listItem({ id: 'keep' })] })
+        expect(applyQuestionSetChanges(list, []).items).toEqual(list.items)
+    })
+})
+
+describe('with no question set on the device', () => {
+    it('reports no changes rather than throwing', () => {
+        const list = makeList({ items: [listItem({ itemText: 'Goggles' })] })
+        expect(computeQuestionSetChanges(list, null)).toEqual([])
+        expect(computeQuestionSetChanges(list, undefined)).toEqual([])
     })
 })
 
@@ -355,22 +641,22 @@ describe('after a save/load round-trip through the local database', () => {
         nights: 3,
         selectedPeopleIds: ['p1'],
         questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming', 'opt-rainy'] }],
-        items: [listItem({ itemText: 'Goggles', personId: 'p1', optionId: 'opt-swimming' })],
+        items: [listItem({ itemText: 'Goggles' })],
     })
 
     it('uses the stored generation inputs and nights, not the reconstruction fallback', async () => {
         await db.savePackingList(savedList)
         const reloaded = await db.getPackingList(savedList.id)
 
-        const additions = computeQuestionSetAdditions(reloaded, questionSet)
+        const added = additions(computeQuestionSetChanges(reloaded, questionSet))
 
         // Reconstruction cannot see 'opt-rainy' — no item on the list points at it.
-        expect(additions.map(a => a.itemText)).toEqual(['Socks'])
+        expect(added.map(a => a.itemText)).toEqual(['Socks'])
         // 1 per night × 3 nights, from the stored `nights`.
-        expect(additions[0].quantity).toBe(3)
+        expect(added[0].quantity).toBe(3)
     })
 
-    it('finds nothing when the generation inputs are missing (the pre-fix behaviour)', () => {
+    it('adds nothing when the generation inputs are missing (the pre-fix behaviour)', () => {
         const withoutStoredInputs: PackingList = {
             ...savedList,
             nights: undefined,
@@ -378,7 +664,22 @@ describe('after a save/load round-trip through the local database', () => {
             selectedPeopleIds: undefined,
         }
 
-        expect(computeQuestionSetAdditions(withoutStoredInputs, questionSet)).toEqual([])
+        expect(additions(computeQuestionSetChanges(withoutStoredInputs, questionSet))).toEqual([])
+    })
+
+    it('keeps a hand-edited name and amount through the local database', async () => {
+        const edited = makeList({
+            id: 'list-edited',
+            selectedPeopleIds: ['p1'],
+            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
+            items: [listItem({ itemText: 'Kids’ goggles', textEdited: true, quantity: 2, quantityEdited: true })],
+        })
+        await db.savePackingList(edited)
+        const reloaded = await db.getPackingList(edited.id)
+
+        expect(reloaded.items[0].textEdited).toBe(true)
+        expect(reloaded.items[0].quantityEdited).toBe(true)
+        expect(computeQuestionSetChanges(reloaded, questionSet)).toEqual([])
     })
 })
 
@@ -399,12 +700,11 @@ describe('an item reaching one person from two answers', () => {
     })
 
     it('offers it once, not once per answer', () => {
-        const additions = computeQuestionSetAdditions(list, questionSet)
-        expect(additions.filter(i => i.itemText === 'Towels')).toHaveLength(1)
+        expect(additions(computeQuestionSetChanges(list, questionSet)).filter(i => i.itemText === 'Towels')).toHaveLength(1)
     })
 
     it('offers the larger of the two suggested quantities', () => {
-        const [towels] = computeQuestionSetAdditions(list, questionSet)
+        const [towels] = additions(computeQuestionSetChanges(list, questionSet))
         expect(towels.quantity).toBe(3)
     })
 })
@@ -422,28 +722,17 @@ describe('entities the user has deleted from the question set', () => {
                 }],
             })],
         })
-        const list = makeList({
-            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
-        })
-        expect(computeQuestionSetAdditions(list, questionSet)).toHaveLength(0)
+        const list = makeList({ questionAnswers: answeredSwimming })
+        expect(additions(computeQuestionSetChanges(list, questionSet))).toHaveLength(0)
     })
 
     it('skips a deleted item inside a live option', () => {
-        const questionSet = makeQuestionSet({
-            questions: [makeQuestion({
-                options: [{
-                    id: 'opt-swimming', text: 'Swimming', order: 0,
-                    items: [
-                        makeItem('Goggles', ['p1']),
-                        makeItem('Wetsuit', ['p1'], { deletedAt: DELETED }),
-                    ],
-                }],
-            })],
-        })
-        const list = makeList({
-            questionAnswers: [{ questionId: 'q-activities', selectedOptionIds: ['opt-swimming'] }],
-        })
-        expect(computeQuestionSetAdditions(list, questionSet).map(i => i.itemText)).toEqual(['Goggles'])
+        const questionSet = swimming([
+            makeItem('Goggles', ['p1']),
+            makeItem('Wetsuit', ['p1'], { deletedAt: DELETED }),
+        ])
+        const list = makeList({ questionAnswers: answeredSwimming })
+        expect(additions(computeQuestionSetChanges(list, questionSet)).map(i => i.itemText)).toEqual(['Goggles'])
     })
 
     it('skips a deleted always-needed item', () => {
@@ -453,7 +742,7 @@ describe('entities the user has deleted from the question set', () => {
                 makeItem('Sun cream', ['p1'], { deletedAt: DELETED }),
             ],
         })
-        expect(computeQuestionSetAdditions(makeList(), questionSet).map(i => i.itemText)).toEqual(['Passport'])
+        expect(additions(computeQuestionSetChanges(makeList(), questionSet)).map(i => i.itemText)).toEqual(['Passport'])
     })
 
     it('packs nothing for a traveller who has been deleted', () => {
@@ -461,7 +750,6 @@ describe('entities the user has deleted from the question set', () => {
             people: [alice, { ...bob, deletedAt: DELETED }],
             alwaysNeededItems: [makeItem('Passport', ['p1', 'p2'])],
         })
-        const additions = computeQuestionSetAdditions(makeList(), questionSet)
-        expect(additions.map(i => i.personId)).toEqual(['p1'])
+        expect(additions(computeQuestionSetChanges(makeList(), questionSet)).map(i => i.personId)).toEqual(['p1'])
     })
 })

--- a/src/create-packing-list/updateFromQuestions.ts
+++ b/src/create-packing-list/updateFromQuestions.ts
@@ -6,6 +6,7 @@ import { generateQuestionBasedItems, generateAlwaysNeededItems } from './generat
 // from two answers behaves the same whether the list is being created or
 // updated — including taking the larger of the two suggested quantities.
 import { deduplicateItems, itemIdentityKey as itemKey } from './deduplicate'
+import { generateUUID } from '../utils/uuid'
 
 // The sentinel questionId used for always-needed items; such items carry no real
 // question/option ids to reconstruct answers from.
@@ -16,14 +17,51 @@ interface GenerationInputs {
     selectedPeopleIds: string[]
 }
 
+/**
+ * One thing the user can accept or decline in the "Update from questions"
+ * preview. Every kind is described the same way — items to append, ids to drop,
+ * replacements for items already on the list — so applying a selection is one
+ * pass over the list whatever mix of kinds it contains (`applyQuestionSetChanges`).
+ *
+ * - `add`      an item your questions now produce that the list hasn't got
+ * - `remove`   an item on the list your questions no longer produce
+ * - `update`   the same item, renamed / moved to another section / re-quantified,
+ *              keeping its id and whether it is packed
+ * - `sharing`  an item that crossed the communal boundary: one shared copy in
+ *              place of everybody's own, or the other way round
+ */
+export type QuestionSetChangeType = 'add' | 'remove' | 'update' | 'sharing'
+
+export interface QuestionSetChange {
+    /** Stable key for the checkbox, and for identifying a selection. */
+    id: string
+    type: QuestionSetChangeType
+    /** What to call it in the preview — the *new* name where the name changed. */
+    itemText: string
+    /** Who it is for. '' for shared items. */
+    personName: string
+    /** One line saying what actually changes. Absent for a plain add/remove. */
+    detail?: string
+    /** Items to append to the list. */
+    additions: PackingListItem[]
+    /**
+     * Ids of items to drop. Deliberately *not* tombstoned into `deletedItems`:
+     * a tombstone means "I don't want this on this trip" and blocks the item
+     * for good, whereas these come off because the questions changed. Put the
+     * option back in your questions and the item comes back with it.
+     */
+    removedIds: string[]
+    /** Replacements for items already on the list, matched by id. */
+    replacements: PackingListItem[]
+}
 
 // Legacy lists (created before generation inputs were persisted) have neither
 // `questionAnswers` nor `selectedPeopleIds`. Rebuild what we can from the items
 // that were generated: the distinct (questionId → optionId) pairs become the
 // answers, and the distinct non-empty personIds become the travellers. This is
 // lossy — an option that generated no instances, or whose items were all
-// deleted-and-purged, is invisible — but safe for additions: at worst it misses
-// some additions, it never invents wrong ones.
+// deleted-and-purged, is invisible — but safe: at worst it misses some changes,
+// it never invents wrong ones.
 export function reconstructGenerationInputs(list: PackingList): GenerationInputs {
     const optionIdsByQuestion = new Map<string, Set<string>>()
     const peopleIds = new Set<string>()
@@ -56,14 +94,131 @@ function resolveGenerationInputs(list: PackingList): GenerationInputs {
     return reconstructGenerationInputs(list)
 }
 
-// Re-runs the generator for the list's stored (or reconstructed) inputs against
-// the current question set, and returns only the items that are genuinely new:
-// not already on the list, and not previously deleted from it. Additions carry
-// a fresh id and lastModified so the item-level merge can track them.
-export function computeQuestionSetAdditions(
+/**
+ * Which answer an item came from, ignoring its name. Two items in the same
+ * group are the same slot in the question set for the same person, which is
+ * what makes a rename recognisable: the name changed, everything else didn't.
+ */
+function groupKey(item: Pick<PackingListItem, 'questionId' | 'optionId' | 'personId'>): string {
+    return `${item.questionId}|${item.optionId}|${item.personId}`
+}
+
+function normalise(text: string): string {
+    return text.trim().toLowerCase()
+}
+
+/** A generated item is shared when it belongs to nobody in particular. */
+function isShared(item: PackingListItem): boolean {
+    return item.personId === ''
+}
+
+/** Items the user typed themselves are theirs alone; this flow never touches them. */
+function isCustom(item: PackingListItem): boolean {
+    return item.questionId === ''
+}
+
+function pushTo<T>(map: Map<string, T[]>, key: string, value: T): void {
+    const existing = map.get(key)
+    if (existing) existing.push(value)
+    else map.set(key, [value])
+}
+
+function quantityLabel(quantity: number | undefined): string {
+    return quantity === undefined ? 'no set amount' : `×${quantity}`
+}
+
+/**
+ * The replacement for `existing` if the question set now describes it
+ * differently, or `null` if it doesn't — including when the only differences
+ * are ones the user has since made their own.
+ *
+ * **Hand edits win.** A generated item the user has renamed or re-quantified on
+ * the list carries `textEdited` / `quantityEdited`, and this leaves that field
+ * exactly as they left it. Without that flag the two cases are indistinguishable
+ * — "the question set was renamed" and "the list item was renamed" both end as
+ * "these two strings differ" — and the update would offer to undo the user's
+ * own edit every time they opened it. The rest of the item still updates: a
+ * renamed item can still follow its section, an item with a hand-set amount can
+ * still be renamed.
+ */
+function buildUpdate(existing: PackingListItem, regenerated: PackingListItem): QuestionSetChange | null {
+    if (isCustom(existing)) return null
+
+    const reasons: string[] = []
+    const replacement: PackingListItem = { ...existing }
+
+    if (!existing.textEdited && normalise(existing.itemText) !== normalise(regenerated.itemText)) {
+        reasons.push(`Renamed from “${existing.itemText}”`)
+        replacement.itemText = regenerated.itemText
+    }
+    // An item with no section of its own has never had an opinion about where it
+    // lives — every item on a list made before sections existed is like this —
+    // and filling one in is not a move the user needs to approve. Only an item
+    // that names a section can be moved out of it.
+    if (existing.category !== undefined && regenerated.category !== undefined
+        && existing.category !== regenerated.category) {
+        reasons.push(`Moved to ${regenerated.category}`)
+        replacement.category = regenerated.category
+    }
+    if (!existing.quantityEdited && existing.quantity !== regenerated.quantity) {
+        reasons.push(`Now ${quantityLabel(regenerated.quantity)} (was ${quantityLabel(existing.quantity)})`)
+        if (regenerated.quantity === undefined) delete replacement.quantity
+        else replacement.quantity = regenerated.quantity
+    }
+
+    if (reasons.length === 0) return null
+
+    // Keep the item pointing at wherever it now comes from, and wearing the
+    // traveller's current name. Neither is worth a line in the preview on its
+    // own, but both would otherwise go stale on an item that is being rewritten
+    // anyway.
+    replacement.questionId = regenerated.questionId
+    replacement.optionId = regenerated.optionId
+    replacement.personName = regenerated.personName
+    replacement.lastModified = new Date().toISOString()
+
+    return {
+        id: `update:${existing.id}`,
+        type: 'update',
+        itemText: replacement.itemText,
+        personName: replacement.personName,
+        detail: reasons.join(' · '),
+        additions: [],
+        removedIds: [],
+        replacements: [replacement],
+    }
+}
+
+function asAddition(item: PackingListItem, now: string): PackingListItem {
+    return { ...item, id: generateUUID(), packed: false, lastModified: now }
+}
+
+/**
+ * What the current question set would change about `list`, as a list of choices
+ * to put to the user.
+ *
+ * Matching runs in four passes, most certain first, so that the cheap and
+ * unambiguous answers are settled before anything is guessed:
+ *
+ * 1. **Same name, same person** — the item is already there. Nothing to do
+ *    unless its section or suggested amount moved.
+ * 2. **Same name, different owner** — the item crossed the communal boundary.
+ * 3. **Same slot, different name** — one item left in an answer on each side is
+ *    a rename, not a coincidence.
+ * 4. **Leftovers** — a regenerated item nobody claimed is new; a list item
+ *    nobody claimed is gone from the questions.
+ *
+ * Nothing here mutates `list`; see `applyQuestionSetChanges`.
+ */
+export function computeQuestionSetChanges(
     list: PackingList,
-    storedQuestionSet: PackingListQuestionSet,
-): PackingListItem[] {
+    storedQuestionSet: PackingListQuestionSet | null | undefined,
+): QuestionSetChange[] {
+    // No question set at all (a list restored on a device that has never run
+    // the wizard) means nothing to compare against — not a crash inside the
+    // generator on `questionSet.people`.
+    if (!storedQuestionSet) return []
+
     // Deletions in the question set are tombstones, so read past them: a
     // question, item or person the user has deleted must never come back as an
     // addition. See `activeQuestionSet`.
@@ -75,7 +230,7 @@ export function computeQuestionSetAdditions(
     const currentPeopleIds = new Set(questionSet.people.map(p => p.id))
     const validPeopleIds = selectedPeopleIds.filter(id => currentPeopleIds.has(id))
 
-    const regenerated = [
+    const regenerated = deduplicateItems([
         ...generateQuestionBasedItems(
             questionSet.questions,
             questionAnswers,
@@ -89,19 +244,205 @@ export function computeQuestionSetAdditions(
             validPeopleIds,
             list.nights,
         ),
-    ]
+    ])
 
-    // Anything already present (incl. custom items the user added by hand with
-    // the same text) or previously deleted is not an addition.
-    const existingKeys = new Set<string>()
-    for (const item of list.items) existingKeys.add(itemKey(item.personId, item.itemText))
-    for (const item of (list.deletedItems ?? [])) existingKeys.add(itemKey(item.personId, item.itemText))
+    // What the user has thrown off this list. Recognised by name and owner and
+    // by nothing else: guessing that a differently-named item is "really" one
+    // they deleted would silently withhold a genuine addition, and a withheld
+    // addition is invisible, where an unwanted one is one untick away.
+    const deletedKeys = new Set(
+        (list.deletedItems ?? []).map(item => itemKey(item.personId, item.itemText)),
+    )
 
-    const additions: PackingListItem[] = []
+    const changes: QuestionSetChange[] = []
     const now = new Date().toISOString()
-    for (const item of deduplicateItems(regenerated)) {
-        if (existingKeys.has(itemKey(item.personId, item.itemText))) continue
-        additions.push({ ...item, id: crypto.randomUUID(), packed: false, lastModified: now })
+    const claimedListIds = new Set<string>()
+
+    // ── Pass 1: the same item, still called the same thing ──────────────────
+    const liveByIdentity = new Map<string, PackingListItem[]>()
+    for (const item of list.items) pushTo(liveByIdentity, itemKey(item.personId, item.itemText), item)
+
+    let unclaimed: PackingListItem[] = []
+    for (const item of regenerated) {
+        const match = (liveByIdentity.get(itemKey(item.personId, item.itemText)) ?? [])
+            .find(candidate => !claimedListIds.has(candidate.id))
+        if (!match) {
+            unclaimed.push(item)
+            continue
+        }
+        claimedListIds.add(match.id)
+        const update = buildUpdate(match, item)
+        if (update) changes.push(update)
     }
-    return additions
+
+    const stillOnList = () => list.items.filter(item => !claimedListIds.has(item.id))
+
+    // ── Pass 2: an item that crossed the communal boundary ──────────────────
+    const liveByText = new Map<string, PackingListItem[]>()
+    for (const item of stillOnList()) {
+        if (isCustom(item)) continue
+        pushTo(liveByText, normalise(item.itemText), item)
+    }
+    const regeneratedByText = new Map<string, PackingListItem[]>()
+    for (const item of unclaimed) pushTo(regeneratedByText, normalise(item.itemText), item)
+
+    const sharingClaimed = new Set<PackingListItem>()
+    for (const [text, incoming] of regeneratedByText) {
+        const existing = liveByText.get(text) ?? []
+        if (existing.length === 0) continue
+
+        const incomingShared = incoming.filter(isShared)
+        const incomingPersonal = incoming.filter(item => !isShared(item))
+        const existingShared = existing.filter(isShared)
+        const existingPersonal = existing.filter(item => !isShared(item))
+
+        // Everybody's own copies replaced by one for the group.
+        if (incomingShared.length === 1 && incomingPersonal.length === 0
+            && existingPersonal.length > 0 && existingShared.length === 0) {
+            const [shared] = incomingShared
+            for (const item of existingPersonal) claimedListIds.add(item.id)
+            sharingClaimed.add(shared)
+            // The user deleted the shared copy already; honour that rather than
+            // bringing it back through the side door.
+            if (deletedKeys.has(itemKey(shared.personId, shared.itemText))) continue
+            changes.push({
+                id: `sharing:${shared.questionId}:${shared.optionId}:${text}`,
+                type: 'sharing',
+                itemText: shared.itemText,
+                personName: '',
+                detail: `Now shared for everyone, instead of one each for ${existingPersonal.map(item => item.personName || 'Unassigned').join(', ')}`,
+                additions: [{
+                    ...asAddition(shared, now),
+                    // Already in the bag for everyone is already in the bag.
+                    packed: existingPersonal.every(item => item.packed),
+                    ...(existingPersonal.some(item => item.lastMinute) ? { lastMinute: true } : {}),
+                }],
+                removedIds: existingPersonal.map(item => item.id),
+                replacements: [],
+            })
+            continue
+        }
+
+        // One for the group replaced by everybody's own copy.
+        if (incomingPersonal.length > 0 && incomingShared.length === 0
+            && existingShared.length === 1 && existingPersonal.length === 0) {
+            const [shared] = existingShared
+            claimedListIds.add(shared.id)
+            for (const item of incomingPersonal) sharingClaimed.add(item)
+            const wanted = incomingPersonal.filter(
+                item => !deletedKeys.has(itemKey(item.personId, item.itemText)),
+            )
+            if (wanted.length === 0) continue
+            changes.push({
+                id: `sharing:${shared.id}`,
+                type: 'sharing',
+                itemText: shared.itemText,
+                personName: '',
+                detail: `Now one each for ${wanted.map(item => item.personName || 'Unassigned').join(', ')}, instead of one shared`,
+                additions: wanted.map(item => ({
+                    ...asAddition(item, now),
+                    packed: shared.packed,
+                    ...(shared.lastMinute ? { lastMinute: true } : {}),
+                })),
+                removedIds: [shared.id],
+                replacements: [],
+            })
+        }
+    }
+    unclaimed = unclaimed.filter(item => !sharingClaimed.has(item))
+
+    // ── Pass 3: the same slot in the questions, under a new name ────────────
+    const liveByGroup = new Map<string, PackingListItem[]>()
+    for (const item of stillOnList()) {
+        if (isCustom(item)) continue
+        pushTo(liveByGroup, groupKey(item), item)
+    }
+    const regeneratedByGroup = new Map<string, PackingListItem[]>()
+    for (const item of unclaimed) pushTo(regeneratedByGroup, groupKey(item), item)
+
+    const renameClaimed = new Set<PackingListItem>()
+    for (const [key, incoming] of regeneratedByGroup) {
+        // More than one candidate on either side and there is no telling which
+        // renamed which, so leave them to be an add and a removal.
+        if (incoming.length !== 1) continue
+        const existing = liveByGroup.get(key) ?? []
+        if (existing.length > 1) continue
+
+        if (existing.length === 0) continue
+
+        claimedListIds.add(existing[0].id)
+        renameClaimed.add(incoming[0])
+        const update = buildUpdate(existing[0], incoming[0])
+        if (update) changes.push(update)
+    }
+    unclaimed = unclaimed.filter(item => !renameClaimed.has(item))
+
+    // ── Pass 4: whatever nobody claimed ─────────────────────────────────────
+    for (const item of unclaimed) {
+        if (deletedKeys.has(itemKey(item.personId, item.itemText))) continue
+        const addition = asAddition(item, now)
+        changes.push({
+            id: `add:${addition.id}`,
+            type: 'add',
+            itemText: addition.itemText,
+            personName: addition.personName,
+            additions: [addition],
+            removedIds: [],
+            replacements: [],
+        })
+    }
+
+    // Whether an item's absence from the regenerated set actually means
+    // anything. It doesn't if the generator was never in a position to produce
+    // it: an answer the list no longer remembers giving, or an always-needed
+    // item with nobody left to need it. Without this a list whose generation
+    // inputs went missing (#260) would offer to strip itself bare.
+    const answeredQuestionIds = new Set(
+        questionAnswers.filter(a => a.selectedOptionIds.length > 0).map(a => a.questionId),
+    )
+    const couldHaveBeenGenerated = (item: PackingListItem) =>
+        item.questionId === ALWAYS_NEEDED_QUESTION_ID
+            ? validPeopleIds.length > 0
+            : answeredQuestionIds.has(item.questionId)
+
+    for (const item of stillOnList()) {
+        if (isCustom(item)) continue
+        if (!couldHaveBeenGenerated(item)) continue
+        changes.push({
+            id: `remove:${item.id}`,
+            type: 'remove',
+            itemText: item.itemText,
+            personName: item.personName,
+            additions: [],
+            removedIds: [item.id],
+            replacements: [],
+        })
+    }
+
+    return changes
+}
+
+/**
+ * The list with `changes` applied, in one pass so a mixed selection lands
+ * atomically rather than each handler starting from its own snapshot.
+ */
+export function applyQuestionSetChanges(
+    list: PackingList,
+    changes: readonly QuestionSetChange[],
+): PackingList {
+    const removedIds = new Set(changes.flatMap(change => change.removedIds))
+    const replacements = new Map(
+        changes.flatMap(change => change.replacements.map(item => [item.id, item] as const)),
+    )
+    const additions = changes.flatMap(change => change.additions)
+
+    return {
+        ...list,
+        items: [
+            ...list.items
+                .filter(item => !removedIds.has(item.id))
+                .map(item => replacements.get(item.id) ?? item),
+            ...additions,
+        ],
+    }
 }

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -23,7 +23,7 @@ import { UpdateFromQuestionsModal } from '../components/UpdateFromQuestionsModal
 import { useForeignPod } from '../components/ForeignPodContext'
 import { useSharedListsSync } from '../hooks/useSharedListsSync'
 import { mergePackingLists } from '../utils/mergePackingLists'
-import { computeQuestionSetAdditions } from '../create-packing-list/updateFromQuestions'
+import { applyQuestionSetChanges, computeQuestionSetChanges, type QuestionSetChange } from '../create-packing-list/updateFromQuestions'
 import { MILESTONE_MESSAGES, resolveMilestone } from './packing-milestones'
 import { formatTripCountdown, formatTripDates } from '../create-packing-list/tripDetails'
 import { TripCountdownBadge } from '../components/TripCountdownBadge'
@@ -68,6 +68,27 @@ const LAST_MINUTE_SECTION_KEY = '__last_minute__'
 // items that can be packed now, whichever way the list is grouped.
 const LAST_MINUTE_TITLE = 'Last Minute'
 const LAST_MINUTE_HINT = 'Pack these just before you go.'
+
+// Stable empty diff for the closed preview, so the modal isn't handed a new
+// array — and told its choices have changed — on every render of this page.
+const NO_QUESTION_UPDATES: QuestionSetChange[] = []
+
+/** What actually happened, in the order the preview listed it. */
+function questionUpdateSummary(applied: readonly QuestionSetChange[]): string {
+    const added = applied.reduce((total, change) => total + change.additions.length, 0)
+    const removed = applied.reduce((total, change) => total + change.removedIds.length, 0)
+    const changed = applied.filter(change => change.type === 'update').length
+
+    if (removed === 0 && changed === 0) {
+        return `Added ${added} item${added === 1 ? '' : 's'} from your questions`
+    }
+    const parts = [
+        added > 0 ? `${added} added` : null,
+        changed > 0 ? `${changed} updated` : null,
+        removed > 0 ? `${removed} removed` : null,
+    ].filter(Boolean)
+    return `Updated from your questions: ${parts.join(', ')}`
+}
 
 // Long enough for the last (delayed) confetti piece to finish falling
 const CONFETTI_DURATION_MS = 4000
@@ -238,8 +259,11 @@ export function ViewPackingList() {
     // Sharing needs a pod, so a logged-out sharer gets the ask framed around
     // sharing rather than a generic "set up a pod" pitch.
     const [signInToSharePromptOpen, setSignInToSharePromptOpen] = useState(false)
-    // Additions computed from the question set; non-null opens the preview modal.
-    const [questionUpdateAdditions, setQuestionUpdateAdditions] = useState<PackingListItem[] | null>(null)
+    // Changes computed from the question set; non-null opens the preview modal.
+    // Computed on demand rather than watched: the diff regenerates the whole
+    // list from the question set, which is not something to re-run every time a
+    // checkbox is ticked.
+    const [questionUpdateChanges, setQuestionUpdateChanges] = useState<QuestionSetChange[] | null>(null)
     // Whether the question set exists locally (gates the "Update from questions" button).
     const [hasQuestionSet, setHasQuestionSet] = useState(false)
     const [ownPodUrl, setOwnPodUrl] = useState<string | null>(null)
@@ -880,38 +904,53 @@ export function ViewPackingList() {
     const handleOpenQuestionUpdate = async () => {
         if (!packingList) return
         try {
-            const questionSet = await db.getQuestionSet()
-            const additions = computeQuestionSetAdditions(packingList, questionSet)
-            if (additions.length === 0) {
+            // No question set on this device is a state, not a failure: say so
+            // and take the button away, rather than letting the generator throw
+            // on `questionSet.people` and reporting it as an error.
+            const questionSet = await db.getQuestionSet().catch(() => null)
+            if (!questionSet) {
+                setHasQuestionSet(false)
+                showToast('There are no questions saved on this device to update from', 'error')
+                return
+            }
+            const changes = computeQuestionSetChanges(packingList, questionSet)
+            if (changes.length === 0) {
                 showToast('This list already matches your questions', 'success')
                 return
             }
-            setQuestionUpdateAdditions(additions)
+            setQuestionUpdateChanges(changes)
         } catch (err) {
             const details = reportError(err, 'Error computing question updates')
             showToast('Failed to check for question updates', 'error', details)
         }
     }
 
-    const handleConfirmQuestionUpdate = async (selected: PackingListItem[]) => {
+    const handleConfirmQuestionUpdate = async (selected: QuestionSetChange[]) => {
         if (!packingList || selected.length === 0) {
-            setQuestionUpdateAdditions(null)
+            setQuestionUpdateChanges(null)
             return
         }
-        // Close the preview first. The items appear on the list as soon as they
-        // are added now, and leaving the preview up over a list that already has
-        // them reads as the click not having worked.
-        setQuestionUpdateAdditions(null)
+        // Close the preview first. The items change on the list as soon as they
+        // are applied now, and leaving the preview up over a list that already
+        // shows them reads as the click not having worked.
+        setQuestionUpdateChanges(null)
         try {
-            const updatedList: PackingList = {
-                ...packingList,
-                items: [...packingList.items, ...selected],
+            const updatedList = applyQuestionSetChanges(packingList, selected)
+            // Items the questions no longer produce come off without a tombstone
+            // (see QuestionSetChange), so drop any stale form entries by hand.
+            const formValues = getValues('items')
+            for (const change of selected) {
+                for (const removedId of change.removedIds) delete formValues[removedId]
             }
+            for (const change of selected) {
+                for (const addition of change.additions) formValues[addition.id] = addition.packed
+            }
+            setValue('items', formValues)
             await persistPackingList(updatedList)
-            showToast(`Added ${selected.length} item${selected.length === 1 ? '' : 's'} from your questions`, 'success')
+            showToast(questionUpdateSummary(selected), 'success')
         } catch (err) {
-            const details = reportError(err, 'Error adding question updates')
-            showToast('Failed to add items', 'error', details)
+            const details = reportError(err, 'Error applying question updates')
+            showToast('Failed to update the list', 'error', details)
         }
     }
 
@@ -1040,7 +1079,13 @@ export function ViewPackingList() {
         return persistItemChanges(
             list => ({
                 ...list,
-                items: list.items.map(item => ids.has(item.id) ? { ...item, itemText: trimmed, lastModified: now } : item),
+                items: list.items.map(item => ids.has(item.id)
+                    // The name is now the user's, not the question set's. Without
+                    // this, updating from questions could not tell a rename the
+                    // user made here from one they made in their questions, and
+                    // would offer to undo this one. See `buildUpdate`.
+                    ? { ...item, itemText: trimmed, ...(item.questionId !== '' ? { textEdited: true } : {}), lastModified: now }
+                    : item),
             }),
             'Error renaming item',
         )
@@ -1056,7 +1101,14 @@ export function ViewPackingList() {
                     // Absent rather than 1: an explicit 1 says nothing the default
                     // doesn't, and it would travel to the pod saying it.
                     const { quantity: _previous, ...rest } = item
-                    return { ...rest, ...(quantity !== undefined && quantity > 1 ? { quantity } : {}), lastModified: now }
+                    // Hand-set amounts belong to the trip, not to the questions;
+                    // the same reasoning as `textEdited` above.
+                    return {
+                        ...rest,
+                        ...(quantity !== undefined && quantity > 1 ? { quantity } : {}),
+                        ...(item.questionId !== '' ? { quantityEdited: true } : {}),
+                        lastModified: now,
+                    }
                 }),
             }),
             'Error saving quantity',
@@ -2226,9 +2278,9 @@ export function ViewPackingList() {
             />
         )}
         <UpdateFromQuestionsModal
-            isOpen={questionUpdateAdditions !== null}
-            onClose={() => setQuestionUpdateAdditions(null)}
-            additions={questionUpdateAdditions ?? []}
+            isOpen={questionUpdateChanges !== null}
+            onClose={() => setQuestionUpdateChanges(null)}
+            changes={questionUpdateChanges ?? NO_QUESTION_UPDATES}
             onConfirm={handleConfirmQuestionUpdate}
         />
         </>

--- a/src/services/rdfSerialization.ts
+++ b/src/services/rdfSerialization.ts
@@ -170,6 +170,8 @@ function packingListItemToThing(item: PackingListItem, itemUrl: string): Thing {
     if (item.category !== undefined) t = t.addStringNoLocale(PMU.category, item.category)
     if (item.reviewed !== undefined) t = t.addBoolean(PMU.reviewed, item.reviewed)
     if (item.lastMinute !== undefined) t = t.addBoolean(PMU.lastMinute, item.lastMinute)
+    if (item.textEdited !== undefined) t = t.addBoolean(PMU.textEdited, item.textEdited)
+    if (item.quantityEdited !== undefined) t = t.addBoolean(PMU.quantityEdited, item.quantityEdited)
     if (item.order !== undefined) t = t.addInteger(PMU.order, item.order)
     if (item.lastModified !== undefined) t = t.addDatetime(PMU.itemLastModified, new Date(item.lastModified))
 
@@ -192,6 +194,8 @@ function thingToPackingListItem(thing: Thing | null, url: string): PackingListIt
     const category = getStringNoLocale(thing, PMU.category) ?? undefined
     const reviewed = getBoolean(thing, PMU.reviewed)
     const lastMinute = getBoolean(thing, PMU.lastMinute)
+    const textEdited = getBoolean(thing, PMU.textEdited)
+    const quantityEdited = getBoolean(thing, PMU.quantityEdited)
     const order = getInteger(thing, PMU.order)
     const itemLastModified = getDatetime(thing, PMU.itemLastModified)?.toISOString()
 
@@ -208,6 +212,8 @@ function thingToPackingListItem(thing: Thing | null, url: string): PackingListIt
         ...(category !== undefined ? { category } : {}),
         ...(reviewed !== null ? { reviewed } : {}),
         ...(lastMinute !== null ? { lastMinute } : {}),
+        ...(textEdited !== null ? { textEdited } : {}),
+        ...(quantityEdited !== null ? { quantityEdited } : {}),
         ...(order !== null ? { order } : {}),
         ...(itemLastModified !== undefined ? { lastModified: itemLastModified } : {}),
     }

--- a/src/services/rdfVocab.ts
+++ b/src/services/rdfVocab.ts
@@ -44,6 +44,10 @@ export const PMU = {
     // Item that can only be packed on the way out of the door, kept in a
     // section of its own at the end of the list
     lastMinute: `${PMU_NS}lastMinute`,
+    // The user has made this generated item's name / amount their own, so an
+    // update from the question set leaves that field alone
+    textEdited: `${PMU_NS}textEdited`,
+    quantityEdited: `${PMU_NS}quantityEdited`,
     itemLastModified: `${PMU_NS}itemLastModified`,
     // Shared by PackingListItem and QuestionItem: item is packed once for the
     // whole group rather than per person

--- a/src/test-utils/fullyPopulatedFixtures.ts
+++ b/src/test-utils/fullyPopulatedFixtures.ts
@@ -42,6 +42,8 @@ const fullyPopulatedItem: Required<PackingListItem> = {
     order: 2,
     reviewed: true,
     lastMinute: true,
+    textEdited: true,
+    quantityEdited: true,
     lastModified: '2025-01-02T00:00:00.000Z',
 }
 


### PR DESCRIPTION
Closes #304

Updating a list from your questions could only ever *add* to it. Renaming an item in your questions left the old one behind; removing an option left its items stranded on every list that used it.

`computeQuestionSetAdditions` is gone, replaced by `computeQuestionSetChanges` — a four-pass matcher returning `add` / `update` / `sharing` / `remove` choices — plus `applyQuestionSetChanges`, which applies a selection in one pass so a mixed selection lands atomically rather than each kind starting from its own snapshot.

The passes run most-certain-first, so the unambiguous answers are settled before anything is guessed:

1. **Same name, same person** — already there; nothing to do unless its section or suggested amount moved.
2. **Same name, different owner** — the item crossed the communal boundary.
3. **Same slot in the questions, different name** — one item left in an answer on each side is a rename, not a coincidence.
4. **Leftovers** — a regenerated item nobody claimed is new; a list item nobody claimed has gone from the questions.

## The two product decisions

**A hand edit wins.** This is the one the issue flagged as needing a deliberate answer. A generated item the user renames or re-quantifies on the list now carries `textEdited` / `quantityEdited`, and the question set is no longer allowed to change that field back.

It needs a stored flag because the two cases are otherwise indistinguishable: "I renamed it in my questions" and "I renamed it on the list" both end as *these two strings differ*. Without a record of which side moved, pass 3 would pair them and offer to undo the user's own edit — every time they opened the dialog. Quantities are worse: anyone who had ever nudged an amount by hand would be nagged to revert it on every run.

The item is protected per-field, not wholesale — a renamed item still follows its section into a new one, and an item with a hand-set amount can still be renamed. It is still offered for removal once it leaves the questions: it's the user's *name*, not their exemption from the list changing. (Items edited before this PR carry no flag, so a first run may offer to revert them; it's opt-in per checkbox.)

**The button stays visible.** #281 hid it when there was nothing to do; this keeps it and keeps the reassuring "This list already matches your questions". An affordance that vanishes is one the user can't ask a question of, and "did my questions reach this list?" is exactly the question they have. (A count badge would be nicer still, but it means computing the diff eagerly on every list open — deliberately not done here, see below.)

Two smaller calls that follow from the same instinct:

- **Removals arrive unticked.** Everything else is pre-selected. An item leaving your questions isn't the same as you being finished with it on this trip.
- **Removals leave no tombstone.** A tombstone means "not this, on this trip" and blocks the item for good; these come off because the questions changed, so putting the option back brings the item back with it.

## The concerns from the review

- **`computeQuestionSetAdditions`** — deleted, tests ported. Its old assertions now read through an `additions(changes)` helper, so the add path is still pinned by exactly the cases it was.
- **`crypto.randomUUID()`** — replaced with `generateUUID()` here and in `generatePackingListItems`, which is the generator this path calls. That wrapper exists for the older WebViews the Capacitor builds run in.
- **Recomputing on every mutation** — not introduced. The diff is computed on demand when the button is pressed, so ticking a checkbox never re-reads the question set or re-runs the matcher.
- **Absent question set** — `computeQuestionSetChanges` takes `null | undefined` and returns `[]`; the page catches a missing set explicitly, says so and takes the button away, instead of letting `questionSet.people.map` throw into a `.catch`.

One thing the four-pass design could have done and deliberately doesn't: guess that a *differently-named* regenerated item is really one the user deleted. Deletion is matched by name and owner and nothing else. A wrongly withheld addition is invisible to the user; an addition they didn't want is one untick away.

Sections get the same treatment in reverse: an item with no `category` of its own is never reported as "moved". Every item on a list made before sections existed is like that, and filling one in isn't a move worth approving — it would have turned the dialog into a wall of no-op checkboxes for exactly the oldest lists.

## New persisted fields

`textEdited` and `quantityEdited` on `PackingListItem`, both optional and additive. Wired through PouchDB (omit-list, so automatic), the pod's RDF serialisation, and `fullyPopulatedFixtures` — the round-trip guards from #260 cover them, and a test asserts a hand-edited name and amount survive the local database and still suppress the revert.

## Testing

- 44 unit tests in `updateFromQuestions.test.ts`: all four change kinds, the hand-edit decision from both directions, ambiguous groups (two renames in one answer → add + remove, never a guess), and the existing guards — custom items, unanswered questions, deleted items, deleted people, deleted questions.
- **E2E C10 / C11 / C12** drive `update`, `remove` and `sharing` through a real browser. Those are the three paths #281 changed ~200 lines of and never once ran by hand; C11 also asserts removals arrive unticked with the confirm button disabled, and C10/C12 assert the list matches afterwards, so a rename is proven to have replaced rather than duplicated.
- Full suite: 2037 unit tests and 41 E2E (suites B and C) green; no new lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6NK4soPoQHS2EfvchAf3W

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6NK4soPoQHS2EfvchAf3W)_