### PR TITLE
Move occasional actions to header menu, add guest to people strip

### DIFF
--- a/e2e/helpers/packing-list.ts
+++ b/e2e/helpers/packing-list.ts
@@ -65,3 +65,23 @@ export async function expandAllSections(page: Page): Promise<void> {
     const expandAll = page.getByRole('button', { name: /^Expand all$/ }).first()
     if (await expandAll.count() > 0) await expandAll.click()
 }
+
+/**
+ * A list's occasional actions — Share, Update from questions — live behind the
+ * kebab in the page header, so reaching either starts by opening it.
+ *
+ * Returns the open menu, so callers can scope a `menuitem` query to it and not
+ * to whatever else on the page happens to carry the same word.
+ */
+export async function openListActions(page: Page): Promise<Locator> {
+    await page.getByRole('button', { name: 'List actions' }).click()
+    const menu = page.getByRole('menu')
+    await expect(menu).toBeVisible({ timeout: 5_000 })
+    return menu
+}
+
+/** Open the header's actions menu and pick one of its entries. */
+export async function chooseListAction(page: Page, action: RegExp | string): Promise<void> {
+    const menu = await openListActions(page)
+    await menu.getByRole('menuitem', { name: action }).click()
+}

--- a/e2e/tests/c-packing-lists.spec.ts
+++ b/e2e/tests/c-packing-lists.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../fixtures'
 import { fillPersonRequiredFields } from '../helpers/wizard'
-import { chipInput, chipsForPerson, expandAllSections, firstItemChip } from '../helpers/packing-list'
+import { chipInput, chipsForPerson, chooseListAction, expandAllSections, firstItemChip, openListActions } from '../helpers/packing-list'
 import { personEmojiAt } from '../../src/edit-questions/person-emoji'
 
 async function runWizard(page: import('@playwright/test').Page) {
@@ -163,7 +163,7 @@ test.describe('C – Packing Lists', () => {
     await expect(page.getByRole('heading', { name: 'Evolving Trip' })).toBeVisible({ timeout: 8_000 })
 
     // Update from questions surfaces the new item in a preview
-    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await chooseListAction(page, /Update from questions/i)
     await expect(page.getByRole('button', { name: /Add 1 item/i })).toBeVisible({ timeout: 5_000 })
     await expect(page.getByLabel(/Add GadgetTest/i)).toBeVisible()
     await page.getByRole('button', { name: /Add 1 item/i }).click()
@@ -178,7 +178,7 @@ test.describe('C – Packing Lists', () => {
     await page.getByRole('button', { name: /^Remove$/ }).click()
     await expect(page.getByText('GadgetTest')).not.toBeVisible({ timeout: 5_000 })
 
-    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await chooseListAction(page, /Update from questions/i)
     // No preview — the list already matches (the deleted item is not resurrected)
     await expect(page.getByText('This list already matches your questions')).toBeVisible({ timeout: 5_000 })
     await expect(page.getByRole('button', { name: /Add \d+ item/i })).not.toBeVisible()
@@ -203,7 +203,7 @@ test.describe('C – Packing Lists', () => {
   ) {
     await addAlwaysNeededItem(page, itemName)
     await page.goto(listUrl)
-    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await chooseListAction(page, /Update from questions/i)
     await page.getByRole('button', { name: /Add 1 item/i }).click()
     await expandAllSections(page)
     await expect(page.getByText(itemName)).toBeVisible({ timeout: 5_000 })
@@ -232,7 +232,7 @@ test.describe('C – Packing Lists', () => {
 
     await page.goto(listUrl)
     await expandAllSections(page)
-    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await chooseListAction(page, /Update from questions/i)
 
     // Grouped as a change, with the old name shown, rather than as a new item
     await expect(page.getByText('Changed items')).toBeVisible({ timeout: 5_000 })
@@ -243,7 +243,7 @@ test.describe('C – Packing Lists', () => {
     await expect(page.getByText('RenameMeTest')).not.toBeVisible()
 
     // And the list now matches, so the rename was applied rather than duplicated
-    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await chooseListAction(page, /Update from questions/i)
     await expect(page.getByText('This list already matches your questions')).toBeVisible({ timeout: 5_000 })
   })
 
@@ -260,7 +260,7 @@ test.describe('C – Packing Lists', () => {
 
     await page.goto(listUrl)
     await expandAllSections(page)
-    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await chooseListAction(page, /Update from questions/i)
 
     await expect(page.getByText('No longer in your questions')).toBeVisible({ timeout: 5_000 })
     // Removals arrive unticked: nothing comes off the list without being asked for
@@ -286,7 +286,7 @@ test.describe('C – Packing Lists', () => {
 
     await page.goto(listUrl)
     await expandAllSections(page)
-    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await chooseListAction(page, /Update from questions/i)
 
     await expect(page.getByText('Changed items')).toBeVisible({ timeout: 5_000 })
     await expect(page.getByText(/Now shared for everyone/)).toBeVisible()
@@ -295,7 +295,7 @@ test.describe('C – Packing Lists', () => {
     // Still one item, not two: the personal copy went as the shared one arrived
     await expandAllSections(page)
     await expect(page.getByText('ShareMeTest')).toHaveCount(1, { timeout: 5_000 })
-    await page.getByRole('button', { name: /Update from questions/i }).click()
+    await chooseListAction(page, /Update from questions/i)
     await expect(page.getByText('This list already matches your questions')).toBeVisible({ timeout: 5_000 })
   })
 
@@ -521,14 +521,15 @@ test.describe('C – Contextual sign-in prompts (logged out)', () => {
     await runWizard(page)
     await createList(page, 'Share Prompt Trip')
 
-    await page.getByRole('button', { name: 'Share', exact: true }).click()
+    await chooseListAction(page, 'Share')
     await expect(page.getByRole('heading', { name: /Sign in to share this list/i })).toBeVisible({ timeout: 5_000 })
     await expect(page.getByText(/Send a friend a link/i)).toBeVisible()
 
     // Backing out leaves the list exactly as it was
     await page.getByRole('button', { name: 'Not now' }).click()
     await expect(page.getByRole('heading', { name: /Sign in to share this list/i })).toHaveCount(0)
-    await expect(page.getByRole('button', { name: 'Share', exact: true })).toBeVisible()
+    await expect((await openListActions(page)).getByRole('menuitem', { name: 'Share' })).toBeVisible()
+    await page.keyboard.press('Escape')
   })
 
   test('C13: both contextual prompts work on a phone-sized screen', async ({ freshPage: page }) => {
@@ -537,7 +538,7 @@ test.describe('C – Contextual sign-in prompts (logged out)', () => {
     await createList(page, 'Mobile Prompt Trip')
 
     // Share prompt: the modal and both of its buttons fit the viewport
-    await page.getByRole('button', { name: 'Share', exact: true }).click()
+    await chooseListAction(page, 'Share')
     const signInButton = page.getByRole('button', { name: /Sign in to share/i })
     await expect(signInButton).toBeVisible({ timeout: 5_000 })
     const signInBox = await signInButton.boundingBox()

--- a/e2e/tests/f-sync.spec.ts
+++ b/e2e/tests/f-sync.spec.ts
@@ -184,7 +184,8 @@ test.describe('F – Solid Pod Sync', () => {
     const customItemName = 'super special sunscreen'
     const addItemInput = page.getByPlaceholder('Add new item...').first()
     await addItemInput.fill(customItemName)
-    // Use Enter to submit — avoids ambiguity with the "+ Add Guest" button which also matches 'Add'
+    // Use Enter to submit — the composer's own Add is not the only thing on the
+    // page matching 'Add' once the people strip's guest field is open
     await addItemInput.press('Enter')
     await expect(page.locator('span.text-green-600').first()).toBeVisible({ timeout: 8_000 })
     await expect(page.locator('span.text-green-600').first()).not.toBeVisible({ timeout: 8_000 })

--- a/e2e/tests/l-sharing.spec.ts
+++ b/e2e/tests/l-sharing.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '../fixtures'
 import { fillPersonRequiredFields } from '../helpers/wizard'
 import { loginToCss } from '../helpers/login'
 import { CSS_ISSUER, CSS_PORT, LUSER_EMAIL, LUSER_PASSWORD, LUSER_POD_NAME, COLLAB_EMAIL, COLLAB_PASSWORD, COLLAB_POD_NAME } from '../../playwright.config'
-import { expandAllSections, firstItemChip } from '../helpers/packing-list'
+import { chooseListAction, expandAllSections, firstItemChip, openListActions } from '../helpers/packing-list'
 
 // L tests use two pod users. Serial mode gives exclusive pod access.
 test.describe.configure({ mode: 'serial' })
@@ -56,12 +56,15 @@ test.describe('L – Sharing a packing list', () => {
     })
 
     test('L1: User A shares a list; shareable link contains expected params', async () => {
-        // Share button renders immediately, enabled once pod URL resolves (~1 network round-trip)
-        // exact: true — the packing list's "Collapse the shared items list" section header also matches a bare 'Share' substring
-        await expect(pageA.getByRole('button', { name: 'Share', exact: true })).toBeEnabled({ timeout: 10_000 })
+        // Share renders immediately, enabled once the pod URL resolves (~1 network
+        // round-trip). It lives in the header's actions menu; a `menuitem` query
+        // scoped to that menu also keeps the packing list's own "Collapse the
+        // shared items list" section header out of the way.
+        const actions = await openListActions(pageA)
+        await expect(actions.getByRole('menuitem', { name: 'Share' })).toBeEnabled({ timeout: 10_000 })
 
         // Open share modal
-        await pageA.getByRole('button', { name: 'Share', exact: true }).click()
+        await actions.getByRole('menuitem', { name: 'Share' }).click()
         await expect(pageA.getByText('Manage sharing')).toBeVisible({ timeout: 5_000 })
 
         // Enter User B's WebID then submit via the dialog's Share button (not the toolbar one)
@@ -101,8 +104,10 @@ test.describe('L – Sharing a packing list', () => {
             // List name must match what User A created
             await expect(pageB.getByText(listName)).toBeVisible({ timeout: 15_000 })
 
-            // Share button must NOT be visible on a shared list
-            await expect(pageB.getByRole('button', { name: 'Share', exact: true })).not.toBeVisible()
+            // Someone else's list carries none of the owner's actions, so the
+            // menu that would hold Share is not there either.
+            await expect(pageB.getByRole('button', { name: 'List actions' })).not.toBeVisible()
+            await expect(pageB.getByRole('menuitem', { name: 'Share' })).not.toBeVisible()
         } finally {
             await ctxB.close()
         }
@@ -149,8 +154,8 @@ test.describe('L – Sharing a packing list', () => {
             await residualDialog.getByRole('button', { name: 'Close' }).click()
             await expect(residualDialog).toHaveCount(0)
         }
-        // Now the toolbar Share button is the only one visible
-        await pageA.getByRole('button', { name: 'Share', exact: true }).click()
+        // With the dialog gone, the header's own Share is reachable again
+        await chooseListAction(pageA, 'Share')
         await expect(pageA.getByText('Manage sharing')).toBeVisible({ timeout: 5_000 })
         await pageA.getByRole('button', { name: 'Anyone with the link' }).click()
         await pageA.getByRole('dialog').getByRole('button', { name: /^Share publicly/i }).click()

--- a/e2e/tests/z-verify-offline-share.spec.ts
+++ b/e2e/tests/z-verify-offline-share.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures'
 import { accountMenu, loginToCss } from '../helpers/login'
 import { fillPersonRequiredFields } from '../helpers/wizard'
+import { chooseListAction, openListActions } from '../helpers/packing-list'
 import { CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD } from '../../playwright.config'
 
 // Verify fix: offline-created list can be shared without 404
@@ -40,8 +41,10 @@ test.describe('Z – Offline list → login → share (regression for 404 fix)',
 
         // ── 3. Navigate to the list ──────────────────────────────────────────
         await page.goto(`/#/view-lists/${listId}`)
-        const shareBtn = page.getByRole('button', { name: /^share$/i })
-        await expect(shareBtn).toBeVisible({ timeout: 10_000 })
+        // Share lives in the header's actions menu, and stays disabled until the
+        // pod URL resolves (~1 network round-trip after login).
+        const shareBtn = (await openListActions(page)).getByRole('menuitem', { name: /^share$/i })
+        await expect(shareBtn).toBeEnabled({ timeout: 10_000 })
         await shareBtn.click()
 
         // ── 4. Check current access loaded cleanly (not frozen on "Loading…") ─
@@ -74,7 +77,7 @@ test.describe('Z – Offline list → login → share (regression for 404 fix)',
         await closeBtn.click({ timeout: 3_000 }).catch(() => page.keyboard.press('Escape'))
         // Wait for modal to be fully gone before clicking Share again
         await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5_000 })
-        await shareBtn.click()
+        await chooseListAction(page, /^share$/i)
         await expect(page.getByText('🌐 Anyone with the link')).toBeVisible({ timeout: 8_000 })
         console.log('"Anyone with the link" row visible ✓')
 

--- a/src/components/ActionMenu.tsx
+++ b/src/components/ActionMenu.tsx
@@ -1,0 +1,72 @@
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import type { ReactNode } from 'react'
+
+/**
+ * The actions a page has but rarely needs, behind one control.
+ *
+ * A page's header is read on the way to its content, so what sits there is
+ * charged against the content. Actions taken once a trip — share it, pull in
+ * the latest questions — do not earn a filled button each; they earn a place
+ * that is quiet until asked, which is this.
+ *
+ * The same kebab, and the same Radix menu, that the list cards already use for
+ * their own actions (`ListCardMenu` in `packing-lists.tsx`): a menu of list
+ * actions should be the same object wherever a list is looked at. Radix is
+ * what makes it a real `role="menu"` — roving arrow-key focus, typeahead,
+ * Escape, outside-click, focus returned to the trigger — none of which a
+ * hand-rolled panel of buttons gets for free.
+ */
+export function ActionMenu({ label, children }: {
+    /** What the trigger is, for the people who cannot see three dots. */
+    label: string
+    /** `ActionMenuItem`s. */
+    children: ReactNode
+}) {
+    return (
+        <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
+                <button
+                    type="button"
+                    aria-label={label}
+                    title={label}
+                    className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-600 dark:text-gray-300 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400"
+                >
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                        <circle cx="12" cy="5" r="1.5" />
+                        <circle cx="12" cy="12" r="1.5" />
+                        <circle cx="12" cy="19" r="1.5" />
+                    </svg>
+                </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                    align="end"
+                    sideOffset={4}
+                    className="w-64 bg-white dark:bg-gray-900 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 py-1 z-50"
+                >
+                    {children}
+                </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+    )
+}
+
+/** One row of an `ActionMenu`, so the items in a panel agree with each other. */
+export function ActionMenuItem({ onSelect, disabled, icon, children }: {
+    onSelect: () => void
+    disabled?: boolean
+    /** Decorative — the label is what names the action. */
+    icon?: ReactNode
+    children: ReactNode
+}) {
+    return (
+        <DropdownMenu.Item
+            onSelect={onSelect}
+            disabled={disabled}
+            className="flex min-h-[44px] items-center gap-2.5 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-default outline-none data-[disabled]:opacity-50 data-[disabled]:hover:bg-transparent"
+        >
+            {icon && <span aria-hidden="true" className="shrink-0 text-base leading-none">{icon}</span>}
+            <span className="min-w-0">{children}</span>
+        </DropdownMenu.Item>
+    )
+}

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * A button's variant is a claim about how important it is, and the styles are
+ * where that claim either holds or quietly stops holding. These pin the three
+ * things that went wrong once: a filled variant with unreadable text on it, a
+ * tap target smaller than a fingertip, and a bounce that plays for people who
+ * asked the OS for no bouncing.
+ */
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Button } from './Button'
+
+const classesOf = (name: string) => screen.getByRole('button', { name }).className
+
+describe('emphasis', () => {
+    it('gives the occasional action a neutral box rather than a filled one', () => {
+        render(<Button variant="subtle">Share</Button>)
+
+        const classes = classesOf('Share')
+        expect(classes).toContain('bg-gray-100')
+        // The whole point of the variant: it must not reach for either brand
+        // gradient, because those are how a page says "this one".
+        expect(classes).not.toContain('bg-gradient-secondary')
+        expect(classes).not.toContain('bg-gradient-primary')
+    })
+
+    it('keeps the filled variants on the gradients built for white text', () => {
+        render(
+            <>
+                <Button variant="primary">Go</Button>
+                <Button variant="secondary">Also go</Button>
+            </>
+        )
+
+        // `-button` and not the bare `gradient-primary`: the decorative
+        // gradient is two shades too light to carry a word.
+        expect(classesOf('Go')).toContain('bg-gradient-primary-button')
+        expect(classesOf('Also go')).toContain('bg-gradient-secondary-button')
+    })
+})
+
+describe('reachable by hand and by eye', () => {
+    it('is at least as tall as a fingertip', () => {
+        render(<Button>Tap</Button>)
+
+        // 44px, the same floor the people chips hold themselves to.
+        expect(classesOf('Tap')).toContain('min-h-[44px]')
+    })
+
+    it('holds its label centred once a minimum height stretches the box', () => {
+        render(<Button>Tap</Button>)
+
+        expect(classesOf('Tap')).toContain('items-center')
+        expect(classesOf('Tap')).toContain('justify-center')
+    })
+
+    it('does not bounce at somebody who asked for no motion', () => {
+        render(<Button>Tap</Button>)
+
+        const classes = classesOf('Tap')
+        expect(classes).toContain('motion-safe:hover:scale-105')
+        expect(classes).toContain('motion-safe:active:scale-95')
+        // The unguarded forms are the bug, not merely the old spelling.
+        expect(classes).not.toMatch(/(^|\s)hover:scale-105/)
+        expect(classes).not.toMatch(/(^|\s)active:scale-95/)
+    })
+})

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,16 +1,49 @@
 import React from 'react'
 
+/**
+ * A variant is a claim about importance, so a screen showing four filled
+ * buttons is claiming four things are the most important thing on it — which
+ * is how the packing list came to open with a row of orange pills above the
+ * list they were less important than. The tiers, loudest first:
+ *
+ * - `primary`   — the one action the screen exists for
+ * - `secondary` — the one that is nearly it
+ * - `danger`    — the one that cannot be undone
+ * - `subtle`    — everything occasional: a neutral box, still plainly a button
+ * - `ghost`     — the same quiet tier, with no box at all
+ *
+ * `subtle` exists because `ghost` is primary-tinted: a row of ghost buttons
+ * still reads teal, and a row of *occasional* actions should read as nothing
+ * in particular.
+ */
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-    variant?: 'primary' | 'secondary' | 'danger' | 'ghost'
+    variant?: 'primary' | 'secondary' | 'danger' | 'subtle' | 'ghost'
 }
 
 export function Button({ variant = 'primary', ...props }: ButtonProps) {
-    const baseStyles = 'px-4 py-2 rounded-xl font-semibold transition-all duration-200 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transform hover:scale-105 active:scale-95'
+    /*
+     * `min-h-[44px]` is the same floor PeopleFilterBar's chips hold, and the
+     * reason is the same: a 36px control is smaller than the finger going to
+     * it. It needs the flex centring beside it, or the label sits at the top
+     * of a box the minimum has stretched.
+     *
+     * The scale bounce is behind `motion-safe:` because "reduce motion" is an
+     * accessibility setting people turn on for vestibular reasons, not a
+     * preference about polish.
+     */
+    const baseStyles = 'inline-flex items-center justify-center gap-1.5 min-h-[44px] px-4 py-2 rounded-xl font-semibold transition-all duration-200 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed motion-safe:transform motion-safe:hover:scale-105 motion-safe:active:scale-95'
 
+    /*
+     * The filled variants use the `-button` gradients, not the decorative ones.
+     * White on `secondary-500` is 2.8:1 and on `primary-500` 2.5:1 — both far
+     * under the 4.5:1 that 14px semibold text needs. The darker ends clear it.
+     * See the note beside the tokens in `index.css`.
+     */
     const variantStyles = {
-        primary: 'bg-gradient-primary text-white shadow-soft hover:shadow-glow-primary focus:ring-primary-500',
-        secondary: 'bg-gradient-secondary text-white shadow-soft hover:shadow-glow-secondary focus:ring-secondary-500',
-        danger: 'bg-gradient-to-r from-danger-500 to-danger-600 text-white shadow-soft hover:shadow-lg focus:ring-danger-500',
+        primary: 'bg-gradient-primary-button text-white shadow-soft hover:shadow-glow-primary focus:ring-primary-500',
+        secondary: 'bg-gradient-secondary-button text-white shadow-soft hover:shadow-glow-secondary focus:ring-secondary-500',
+        danger: 'bg-gradient-to-r from-danger-600 to-danger-700 text-white shadow-soft hover:shadow-lg focus:ring-danger-500',
+        subtle: 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 border border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700 hover:border-gray-400 dark:hover:border-gray-500 focus:ring-gray-400',
         ghost: 'text-primary-700 dark:text-primary-300 hover:bg-primary-50 dark:hover:bg-primary-950/40 border-2 border-primary-200 dark:border-primary-800 hover:border-primary-400 dark:hover:border-primary-600 focus:ring-primary-500'
     }[variant]
 
@@ -22,4 +55,4 @@ export function Button({ variant = 'primary', ...props }: ButtonProps) {
             {props.children}
         </button>
     )
-} 
+}

--- a/src/components/PeopleFilterBar.test.tsx
+++ b/src/components/PeopleFilterBar.test.tsx
@@ -124,3 +124,120 @@ describe('what a chip says without being asked', () => {
         expect(screen.getByRole('button', { name: /^Shared/ }).getAttribute('aria-pressed')).toBe('true')
     })
 })
+
+describe('adding somebody to the strip', () => {
+    function renderWithAdd(
+        onAddGuest = vi.fn(),
+        people: { name: string; id: string }[] = [{ name: 'Alice', id: 'p1' }, { name: 'Amy', id: 'p2' }],
+    ) {
+        render(
+            <PeopleFilterBar
+                columns={buildGridColumns(people, [])}
+                selected={new Set()}
+                totals={totals}
+                personIdentity={() => ({ color: PERSON_COLORS[0] })}
+                onToggle={vi.fn()}
+                onAddGuest={onAddGuest}
+                controlsId="sections"
+            />
+        )
+        return onAddGuest
+    }
+
+    const addChip = () => screen.getByRole('button', { name: /add guest/i })
+
+    it('offers the plus where the people already are, not in the page header', () => {
+        renderWithAdd()
+
+        // Inside the group the chips live in: "add another one of these" is a
+        // sentence about the strip, and it should be read off the strip.
+        const group = screen.getByRole('group', { name: 'Filter by person' })
+        expect(group.contains(addChip())).toBe(true)
+    })
+
+    it('leaves the strip alone on a list nobody can be added to', () => {
+        render(
+            <PeopleFilterBar
+                columns={columns}
+                selected={new Set()}
+                totals={totals}
+                personIdentity={() => ({ color: PERSON_COLORS[0] })}
+                onToggle={vi.fn()}
+                controlsId="sections"
+            />
+        )
+
+        expect(screen.queryByRole('button', { name: /add guest/i })).toBeNull()
+    })
+
+    it('opens the name field next to the plus that opened it', () => {
+        renderWithAdd()
+        fireEvent.click(addChip())
+
+        const field = screen.getByPlaceholderText(/guest name/i)
+        expect(field).toBeTruthy()
+        expect(document.activeElement).toBe(field)
+    })
+
+    it('hands the trimmed name back and closes', async () => {
+        const onAddGuest = renderWithAdd()
+        fireEvent.click(addChip())
+
+        fireEvent.change(screen.getByPlaceholderText(/guest name/i), { target: { value: '  Dan  ' } })
+        fireEvent.click(screen.getByRole('button', { name: /^Add guest$/i }))
+
+        expect(onAddGuest).toHaveBeenCalledWith('Dan')
+        expect(screen.queryByPlaceholderText(/guest name/i)).toBeNull()
+    })
+
+    it('takes Enter as the submit, because a name is one field', () => {
+        const onAddGuest = renderWithAdd()
+        fireEvent.click(addChip())
+
+        const field = screen.getByPlaceholderText(/guest name/i)
+        fireEvent.change(field, { target: { value: 'Dan' } })
+        fireEvent.keyDown(field, { key: 'Enter' })
+
+        expect(onAddGuest).toHaveBeenCalledWith('Dan')
+    })
+
+    it('asks for nobody when the name is blank', () => {
+        const onAddGuest = renderWithAdd()
+        fireEvent.click(addChip())
+
+        fireEvent.change(screen.getByPlaceholderText(/guest name/i), { target: { value: '   ' } })
+        fireEvent.click(screen.getByRole('button', { name: /^Add guest$/i }))
+
+        expect(onAddGuest).not.toHaveBeenCalled()
+    })
+
+    it('backs out on Escape without adding anybody', () => {
+        const onAddGuest = renderWithAdd()
+        fireEvent.click(addChip())
+
+        const field = screen.getByPlaceholderText(/guest name/i)
+        fireEvent.change(field, { target: { value: 'Dan' } })
+        fireEvent.keyDown(field, { key: 'Escape' })
+
+        expect(onAddGuest).not.toHaveBeenCalled()
+        expect(screen.queryByPlaceholderText(/guest name/i)).toBeNull()
+    })
+
+    /*
+     * The strip used to hide itself when there was nobody to choose between,
+     * which is right for a filter and wrong for the only way of adding the
+     * second person. It stays, minus the choice.
+     */
+    it('still shows the plus on a list with only one person', () => {
+        renderWithAdd(vi.fn(), [{ name: 'Alice', id: 'p1' }])
+
+        expect(addChip()).toBeTruthy()
+    })
+
+    it('names that one person without offering a filter that filters nothing', () => {
+        renderWithAdd(vi.fn(), [{ name: 'Alice', id: 'p1' }])
+
+        expect(screen.getByTestId('sole-person').textContent).toContain('Alice')
+        expect(screen.queryByRole('button', { name: /^Alice/ })).toBeNull()
+    })
+})

--- a/src/components/PeopleFilterBar.tsx
+++ b/src/components/PeopleFilterBar.tsx
@@ -50,6 +50,12 @@ export interface PeopleFilterBarProps {
     sharedStat?: PersonStat
     /** Names the region the strip filters, for assistive tech. */
     controlsId: string
+    /**
+     * Adding another person, on a list the viewer is allowed to change. Given,
+     * the strip grows a plus on the end; omitted, it is a filter and nothing
+     * more. The name arrives trimmed and non-empty.
+     */
+    onAddGuest?: (name: string) => void
 }
 
 /** Finished packing — said on the face, so the chip's fill can stay the answer
@@ -78,6 +84,7 @@ export function PeopleFilterBar({
     onToggle,
     sharedStat,
     controlsId,
+    onAddGuest,
 }: PeopleFilterBarProps) {
     /**
      * Who a chip belongs to, on a screen with no room to write it beside them.
@@ -93,6 +100,28 @@ export function PeopleFilterBar({
     const [revealed, setRevealed] = useState<{ name: string; left: number; top: number } | null>(null)
     const pressTimer = useRef<number | null>(null)
     const wasLongPress = useRef(false)
+
+    /**
+     * Adding a guest is a name and nothing else, so it is a field on the strip
+     * rather than a dialog over it. It used to be a button in the page header
+     * that opened this field several hundred pixels below, past the sticky bar
+     * — on a phone the field could open off-screen, and the only feedback for
+     * pressing the button was the page not appearing to change.
+     */
+    const [addingGuest, setAddingGuest] = useState(false)
+    const [guestName, setGuestName] = useState('')
+
+    const closeGuestForm = useCallback(() => {
+        setAddingGuest(false)
+        setGuestName('')
+    }, [])
+
+    const submitGuest = useCallback(() => {
+        const trimmed = guestName.trim()
+        if (!trimmed) return
+        onAddGuest?.(trimmed)
+        closeGuestForm()
+    }, [guestName, onAddGuest, closeGuestForm])
 
     const cancelPress = useCallback(() => {
         if (pressTimer.current !== null) {
@@ -139,7 +168,11 @@ export function PeopleFilterBar({
 
     // One person is not a choice, and neither is nobody — unless the group's
     // own items are also on offer, which makes it a choice again.
-    if (columns.length <= 1 && sharedStat === undefined) return null
+    const offersFilters = columns.length > 1 || sharedStat !== undefined
+    // With no choice to offer, the strip used to disappear entirely. That is
+    // right for a filter and wrong for the plus on the end of it: a list with
+    // one person on it is exactly the list a second person gets added to.
+    if (!offersFilters && !onAddGuest) return null
 
     return (
         <div className="mt-1.5 flex items-center gap-2 border-t border-gray-100 dark:border-gray-800 pt-1.5">
@@ -160,7 +193,20 @@ export function PeopleFilterBar({
                 aria-controls={controlsId}
                 className="flex flex-wrap items-center gap-1.5"
             >
-                {columns.map(column => {
+                {/* A lone person gets named but not offered as a filter: one
+                    chip that selects everything and deselects everything is a
+                    control with one state wearing two. */}
+                {!offersFilters && columns.map(column => (
+                    <span
+                        key={column.key}
+                        data-testid="sole-person"
+                        className="flex min-h-[44px] shrink-0 items-center gap-1.5 text-xs font-medium text-gray-700 dark:text-gray-300"
+                    >
+                        <PersonAvatar name={column.name} identity={personIdentity({ id: column.personId, name: column.name })} initial={column.initial} />
+                        <span className="whitespace-nowrap">{column.name}</span>
+                    </span>
+                ))}
+                {offersFilters && columns.map(column => {
                     const isSelected = selected.has(column.key)
                     // Somebody with nothing of their own still has a total, and
                     // it is worth saying: a bare chip where every other selected
@@ -232,6 +278,59 @@ export function PeopleFilterBar({
                         </button>
                     )
                 })()}
+                {/* Last of all, and the only chip that is not a person: the way
+                    the strip gets another one. Dashed, so it never reads as
+                    somebody who failed to load a face. */}
+                {onAddGuest && !addingGuest && (
+                    <button
+                        type="button"
+                        onClick={() => setAddingGuest(true)}
+                        aria-label="Add guest"
+                        title="Add guest"
+                        className="flex min-h-[44px] min-w-[44px] shrink-0 items-center justify-center gap-1.5 rounded-full border border-dashed border-gray-300 dark:border-gray-600 bg-transparent p-2 text-gray-500 dark:text-gray-400 transition-colors hover:border-gray-400 dark:hover:border-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-200 sm:py-1.5 sm:pl-2 sm:pr-3"
+                    >
+                        <span aria-hidden="true" className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-dashed border-current text-base leading-none">+</span>
+                        <span aria-hidden="true" className="hidden whitespace-nowrap text-xs font-medium sm:inline">Guest</span>
+                    </button>
+                )}
+                {/* Opening on a line of its own, directly under the chips: a
+                    name needs the width, and sharing the chips' row left the
+                    field about four characters wide on a phone. */}
+                {onAddGuest && addingGuest && (
+                    <span className="flex min-h-[44px] w-full basis-full items-center gap-1.5">
+                        <input
+                            type="text"
+                            value={guestName}
+                            onChange={e => setGuestName(e.target.value)}
+                            onKeyDown={e => {
+                                if (e.key === 'Enter') { e.preventDefault(); submitGuest() }
+                                if (e.key === 'Escape') { e.preventDefault(); closeGuestForm() }
+                            }}
+                            placeholder="Guest name…"
+                            aria-label="Guest name"
+                            autoFocus
+                            className="min-w-0 flex-1 rounded-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        />
+                        {/* Named in full for anything reading the page rather
+                            than looking at it: every category composer on the
+                            list below also has a button that says "Add". */}
+                        <button
+                            type="button"
+                            onClick={submitGuest}
+                            aria-label="Add guest"
+                            className="min-h-[44px] shrink-0 rounded-full bg-blue-600 px-3 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+                        >
+                            Add
+                        </button>
+                        <button
+                            type="button"
+                            onClick={closeGuestForm}
+                            className="min-h-[44px] min-w-[44px] shrink-0 rounded-full px-2 text-sm font-medium text-gray-500 dark:text-gray-400 transition-colors hover:text-gray-900 dark:hover:text-gray-100"
+                        >
+                            Cancel
+                        </button>
+                    </span>
+                )}
             </div>
             {revealed && (
                 <span

--- a/src/index.css
+++ b/src/index.css
@@ -91,6 +91,15 @@
   --background-image-gradient-secondary: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
   --background-image-gradient-accent: linear-gradient(135deg, #a855f7 0%, #9333ea 100%);
 
+  /* The same two ramps, dropped to the shades that can carry white text.
+     White on `#f97316` is 2.80:1 and on `#14b8a6` 2.49:1 — a filled button's
+     label is 14px semibold, which WCAG counts as small text and holds to
+     4.5:1. These start at 5.15:1 and 5.46:1 and darken from there. The
+     decorative gradients above stay bright on purpose: a progress bar is a
+     fill nobody reads words off, and it answers to the 3:1 non-text rule. */
+  --background-image-gradient-primary-button: linear-gradient(135deg, #0f766e 0%, #115e59 100%);
+  --background-image-gradient-secondary-button: linear-gradient(135deg, #c2410c 0%, #9a3412 100%);
+
   /* Custom Box Shadows — the `--shadow-*` namespace is what Tailwind v4 turns
      into `shadow-soft`, `shadow-glow-primary`, … utilities. */
   --shadow-soft: 0 2px 15px -3px rgba(0, 0, 0, 0.07), 0 10px 20px -2px rgba(0, 0, 0, 0.04);

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -13,14 +13,14 @@ export const LandingPage = () => {
     const primaryCta = hasQuestions ? (
         <Link
             to="/view-lists"
-            className="inline-block bg-gradient-primary text-white px-8 py-4 rounded-2xl text-lg font-bold hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
+            className="inline-block bg-gradient-primary-button text-white px-8 py-4 rounded-2xl text-lg font-bold motion-safe:hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
         >
             📋 View Packing Lists
         </Link>
     ) : (
         <Link
             to="/wizard"
-            className="inline-block bg-gradient-primary text-white px-8 py-4 rounded-2xl text-lg font-bold hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
+            className="inline-block bg-gradient-primary-button text-white px-8 py-4 rounded-2xl text-lg font-bold motion-safe:hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
         >
             ✨ Get Started with the Wizard
         </Link>

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -117,6 +117,15 @@ function renderComponent() {
 }
 
 /**
+ * Share and "Update from questions" live in the header's actions menu now, so
+ * reaching either of them starts by opening it. See ActionMenu.
+ */
+async function openListActions() {
+    // pointerDown, not click: Radix's dropdown opens on the pointer going down.
+    fireEvent.pointerDown(await screen.findByRole('button', { name: /list actions/i }), { button: 0 })
+}
+
+/**
  * A row of the category grid, by the button carrying its name.
  *
  * Not `getByText`: a row's name is split so that its last word can hold on to
@@ -1417,7 +1426,10 @@ describe('ViewPackingList foreign pod (?pod= param)', () => {
 
         await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
 
-        expect(screen.queryByRole('button', { name: /^share$/i })).toBeNull()
+        // Someone else's list has none of these actions, so the menu holding
+        // them is not there either — and Share with it.
+        expect(screen.queryByRole('button', { name: /list actions/i })).toBeNull()
+        expect(screen.queryByRole('menuitem', { name: /^share$/i })).toBeNull()
     })
 
     it('shows Share button when logged in and no ?pod= param', async () => {
@@ -1425,7 +1437,8 @@ describe('ViewPackingList foreign pod (?pod= param)', () => {
 
         await waitFor(() => expect(screen.getByText('Test Trip')).toBeTruthy())
 
-        await waitFor(() => expect(screen.getByRole('button', { name: /^share$/i })).toBeTruthy())
+        await openListActions()
+        await waitFor(() => expect(screen.getByRole('menuitem', { name: /^share$/i })).toBeTruthy())
     })
 
     it('keeps loading state when getPackingList throws not_found on a foreign pod', async () => {
@@ -2044,14 +2057,19 @@ describe('ViewPackingList update from questions', () => {
     it('hides the button when no question set exists', async () => {
         renderUpdatable({ getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }) })
         await waitFor(() => expect(screen.getByText('Swimsuit')).toBeTruthy())
-        expect(screen.queryByRole('button', { name: /update from questions/i })).toBeNull()
+        await openListActions()
+        // The menu is open and still has Share in it — it is this one entry
+        // that is missing, not the whole menu.
+        expect(screen.getByRole('menuitem', { name: /^share$/i })).toBeTruthy()
+        expect(screen.queryByRole('menuitem', { name: /update from questions/i })).toBeNull()
     })
 
     it('shows new items in a preview when the question set has additions', async () => {
         renderUpdatable()
         await waitFor(() => expect(screen.getByText('Swimsuit')).toBeTruthy())
 
-        fireEvent.click(await screen.findByRole('button', { name: /update from questions/i }))
+        await openListActions()
+        fireEvent.click(await screen.findByRole('menuitem', { name: /update from questions/i }))
 
         // Preview modal lists the new item, not the one already on the list
         await waitFor(() => expect(screen.getByRole('button', { name: /add 1 item/i })).toBeTruthy())
@@ -2073,7 +2091,8 @@ describe('ViewPackingList update from questions', () => {
         renderUpdatable({ getQuestionSet: vi.fn().mockResolvedValue(matchingQs) })
         await waitFor(() => expect(screen.getByText('Swimsuit')).toBeTruthy())
 
-        fireEvent.click(await screen.findByRole('button', { name: /update from questions/i }))
+        await openListActions()
+        fireEvent.click(await screen.findByRole('menuitem', { name: /update from questions/i }))
 
         await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith('This list already matches your questions', 'success'))
         expect(screen.queryByRole('button', { name: /add 1 item/i })).toBeNull()
@@ -2089,7 +2108,8 @@ describe('ViewPackingList update from questions', () => {
         })
         await waitFor(() => expect(screen.getByRole('heading', { name: 'Updatable Trip' })).toBeTruthy())
 
-        fireEvent.click(await screen.findByRole('button', { name: /update from questions/i }))
+        await openListActions()
+        fireEvent.click(await screen.findByRole('menuitem', { name: /update from questions/i }))
         await screen.findByRole('button', { name: /add 2 items/i })
 
         // Uncheck Swimsuit, leaving only Goggles
@@ -2118,7 +2138,8 @@ describe('ViewPackingList update from questions', () => {
             </MemoryRouter>
         )
         await waitFor(() => expect(screen.getByText('Swimsuit')).toBeTruthy())
-        expect(screen.queryByRole('button', { name: /update from questions/i })).toBeNull()
+        expect(screen.queryByRole('button', { name: /list actions/i })).toBeNull()
+        expect(screen.queryByRole('menuitem', { name: /update from questions/i })).toBeNull()
     })
 })
 
@@ -3359,15 +3380,17 @@ describe('ViewPackingList contextual sign-in to share', () => {
         mockLoggedOut()
         renderComponent()
 
-        const shareButton = await screen.findByRole('button', { name: 'Share' })
-        expect((shareButton as HTMLButtonElement).disabled).toBe(false)
+        await openListActions()
+        const shareButton = await screen.findByRole('menuitem', { name: 'Share' })
+        expect(shareButton.getAttribute('aria-disabled')).not.toBe('true')
     })
 
     it('frames the sign-in ask around sharing when a logged-out user shares', async () => {
         mockLoggedOut()
         renderComponent()
 
-        fireEvent.click(await screen.findByRole('button', { name: 'Share' }))
+        await openListActions()
+        fireEvent.click(await screen.findByRole('menuitem', { name: 'Share' }))
 
         expect(screen.getByText(/sign in to share this list/i)).toBeTruthy()
         expect(screen.getByRole('button', { name: /sign in to share/i })).toBeTruthy()
@@ -3377,7 +3400,8 @@ describe('ViewPackingList contextual sign-in to share', () => {
         mockLoggedOut()
         renderComponent()
 
-        fireEvent.click(await screen.findByRole('button', { name: 'Share' }))
+        await openListActions()
+        fireEvent.click(await screen.findByRole('menuitem', { name: 'Share' }))
         fireEvent.click(screen.getByRole('button', { name: /sign in to share/i }))
         fireEvent.click(screen.getByLabelText('Inrupt PodSpaces'))
 
@@ -3389,7 +3413,8 @@ describe('ViewPackingList contextual sign-in to share', () => {
         mockLoggedOut()
         renderComponent()
 
-        fireEvent.click(await screen.findByRole('button', { name: 'Share' }))
+        await openListActions()
+        fireEvent.click(await screen.findByRole('menuitem', { name: 'Share' }))
         fireEvent.click(screen.getByRole('button', { name: /not now/i }))
 
         await waitFor(() => expect(screen.queryByText(/sign in to share this list/i)).toBeNull())
@@ -4139,5 +4164,104 @@ describe('ViewPackingList save-to-Pod failures', () => {
         act(() => onSaveError(cause.message, cause))
 
         expect(mockCaptureException).toHaveBeenCalledWith(cause)
+    })
+})
+
+/**
+ * The header used to open with four filled orange buttons — Add Guest, Update
+ * from questions, Share, Back to Lists — stacked two rows deep above the list
+ * they were all less important than. Each of these pins one part of the way
+ * back out of that.
+ */
+describe('ViewPackingList header emphasis', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            isLoggedIn: false,
+            session: null,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+        mockUsePodSync.mockReturnValue({ saveToPod: vi.fn() })
+        mockUseSyncCoordinator.mockReturnValue({
+            syncingFromPod: false,
+            handleSyncSuccess: vi.fn(),
+            handleSyncError: vi.fn(),
+            saveWithSyncPrevention: vi.fn().mockResolvedValue({ ...testPackingList, _rev: '2' }),
+        })
+        mockUseDatabase.mockReturnValue({
+            db: { ...makeDb(), getQuestionSet: vi.fn().mockResolvedValue({ people: [] }) } as unknown as PackingAppDatabase,
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    /** Every button in the non-sticky header above the list. */
+    function headerButtons() {
+        const heading = screen.getByRole('heading', { name: 'Test Trip' })
+        const header = heading.closest('div')?.parentElement as HTMLElement
+        return Array.from(header.querySelectorAll('button'))
+    }
+
+    it('spends no filled button on an action the page is not for', async () => {
+        renderComponent()
+        await screen.findByRole('heading', { name: 'Test Trip' })
+
+        for (const button of headerButtons()) {
+            expect(button.className).not.toContain('bg-gradient-secondary')
+            expect(button.className).not.toContain('bg-gradient-primary')
+        }
+    })
+
+    it('leaves the header two controls, not four', async () => {
+        renderComponent()
+        await screen.findByRole('heading', { name: 'Test Trip' })
+
+        expect(headerButtons().map(b => b.getAttribute('aria-label')))
+            .toEqual(['Back to lists', 'List actions'])
+    })
+
+    it('goes up a level from a chevron rather than a button the size of the title', async () => {
+        renderComponent()
+
+        const back = await screen.findByRole('button', { name: /back to lists/i })
+        fireEvent.click(back)
+
+        // A breadcrumb carries no words of its own; the label is for the
+        // people who cannot see the chevron.
+        expect(back.textContent).toBe('')
+    })
+
+    it('keeps both occasional actions one press away', async () => {
+        renderComponent()
+        await screen.findByRole('heading', { name: 'Test Trip' })
+
+        expect(screen.queryByRole('menuitem', { name: /^share$/i })).toBeNull()
+        await openListActions()
+
+        expect(screen.getByRole('menuitem', { name: /^share$/i })).toBeTruthy()
+        await waitFor(() => expect(screen.getByRole('menuitem', { name: /update from questions/i })).toBeTruthy())
+    })
+
+    it('gathers them into a real menu, the same one the list cards use', async () => {
+        renderComponent()
+        await openListActions()
+
+        // role="menu" is the promise of arrow-key focus and Escape, which is
+        // Radix's to keep — and only if the menu is actually one.
+        const menu = screen.getByRole('menu')
+        await waitFor(() => expect(within(menu).getAllByRole('menuitem').map(i => i.textContent))
+            .toEqual(['🔗Share', '🔄Update from questions']))
+    })
+
+    it('adds a guest from the strip the guests are on, not from the header', async () => {
+        renderComponent()
+        await screen.findByRole('heading', { name: 'Test Trip' })
+
+        expect(headerButtons().some(b => /guest/i.test(b.getAttribute('aria-label') ?? ''))).toBe(false)
+        expect(screen.getByRole('button', { name: /add guest/i })).toBeTruthy()
     })
 })

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -40,6 +40,7 @@ import { CategoryItemGrid } from '../components/CategoryItemGrid'
 import { ItemRowPanel } from '../components/ItemRowPanel'
 import { buildCategoryRows, buildGridColumns, UNASSIGNED_COLUMN_KEY, type GridRow } from '../utils/categoryItemGrid'
 import { PeopleFilterBar } from '../components/PeopleFilterBar'
+import { ActionMenu, ActionMenuItem } from '../components/ActionMenu'
 import { togglePerson, isFiltered, personTotals, filterSummary, sharedTotal, sharedSelected, filterLabel, filterNames } from '../utils/peopleFilter'
 import { buildSuggestionIndex } from '../utils/itemSuggestions'
 import { useIsDesktop } from '../hooks/useIsDesktop'
@@ -312,10 +313,8 @@ export function ViewPackingList() {
     const hasFoldedOnOpenRef = useRef(false)
     // The first-open fold happens once per mount at most, whatever else changes.
     const hasSeededFoldRef = useRef(false)
-    const [showAddGuest, setShowAddGuest] = useState(false)
     // Reveals an empty Shared Items section on lists that have no communal
     // items yet; once an item is added the section persists from the data.
-    const [newGuestName, setNewGuestName] = useState('')
     const [renamingGuestId, setRenamingGuestId] = useState<string | null>(null)
     const [renamingGuestName, setRenamingGuestName] = useState('')
     const [guestToRemove, setGuestToRemove] = useState<string | null>(null)
@@ -1228,15 +1227,15 @@ export function ViewPackingList() {
         (target: AddItemTarget, itemText: string, quantity?: number) => {
             addItemRef.current(target, itemText, quantity)
         }, [])
-    const handleAddGuest = async () => {
-        if (!packingList || !newGuestName.trim()) return
-        const guest = { id: crypto.randomUUID(), name: newGuestName.trim() }
+    // The name arrives trimmed and non-empty from the strip's own field; this
+    // end only has to put the guest on the list.
+    const handleAddGuest = async (name: string) => {
+        if (!packingList) return
+        const guest = { id: crypto.randomUUID(), name }
         await persistPackingList({
             ...packingList,
             guests: [...(packingList.guests ?? []), guest],
         })
-        setNewGuestName('')
-        setShowAddGuest(false)
     }
 
     const handleRenameGuest = async (guestId: string, newName: string) => {
@@ -1658,8 +1657,23 @@ export function ViewPackingList() {
         <div className="w-full flex flex-col items-center py-8 px-0 sm:px-4">
             {/* Non-sticky header: name, actions */}
             <div className="w-full max-w-screen-2xl mb-3">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div className="flex items-center gap-3 min-w-0">
+                <div className="flex items-center justify-between gap-3">
+                    <div className="flex min-w-0 flex-1 items-center gap-2">
+                        {/* Going up a level is navigation, not an action: a
+                            breadcrumb's weight, in the place a breadcrumb sits.
+                            The nav bar already carries "Lists" — this said it a
+                            second time in a filled button three times the size. */}
+                        <button
+                            type="button"
+                            onClick={() => navigate(backPath)}
+                            aria-label="Back to lists"
+                            title="Back to lists"
+                            className="-ml-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-gray-500 dark:text-gray-400 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400"
+                        >
+                            <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" className="h-5 w-5">
+                                <path fillRule="evenodd" d="M12.79 5.23a.75.75 0 0 1 .02 1.06L9.06 10l3.75 3.71a.75.75 0 1 1-1.06 1.06l-4.25-4.24a.75.75 0 0 1 0-1.06l4.25-4.24a.75.75 0 0 1 1.04 0Z" clipRule="evenodd" />
+                            </svg>
+                        </button>
                         <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 truncate">{packingList.name}</h1>
                         {foreignPodUrl && (
                             <span className="text-xs font-medium text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/40 border border-blue-200 dark:border-blue-800 rounded-full px-2 py-0.5 shrink-0">
@@ -1675,43 +1689,34 @@ export function ViewPackingList() {
                             {autoSaveStatus === 'error' && <span className="text-xs text-red-600 dark:text-red-400">Error saving</span>}
                         </div>
                     </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                        {!foreignPodUrl && (
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                onClick={() => { setShowAddGuest(v => !v); setNewGuestName('') }}
-                            >
-                                + Add Guest
-                            </Button>
-                        )}
-                        {!foreignPodUrl && hasQuestionSet && (
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                onClick={handleOpenQuestionUpdate}
-                            >
-                                Update from questions
-                            </Button>
-                        )}
-                        {!foreignPodUrl && (
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                onClick={() => isLoggedIn ? setShareModalOpen(true) : setSignInToSharePromptOpen(true)}
+                    {/* What is left of a row of four filled buttons. None of
+                        these is what the page is for — the page is for ticking
+                        items off — and rendering them at full weight above the
+                        list put the loudest thing on the screen on the least
+                        frequent action. "Add guest" went to the people strip,
+                        where the people are; "back" is the chevron above. */}
+                    {!foreignPodUrl && (
+                        <ActionMenu label="List actions">
+                            <ActionMenuItem
+                                icon="🔗"
                                 disabled={isLoggedIn && !ownPodUrl}
+                                onSelect={() => {
+                                    if (isLoggedIn) setShareModalOpen(true)
+                                    else setSignInToSharePromptOpen(true)
+                                }}
                             >
                                 Share
-                            </Button>
-                        )}
-                        <Button
-                            type="button"
-                            variant="secondary"
-                            onClick={() => navigate(backPath)}
-                        >
-                            Back to Lists
-                        </Button>
-                    </div>
+                            </ActionMenuItem>
+                            {hasQuestionSet && (
+                                <ActionMenuItem
+                                    icon="🔄"
+                                    onSelect={handleOpenQuestionUpdate}
+                                >
+                                    Update from questions
+                                </ActionMenuItem>
+                            )}
+                        </ActionMenu>
+                    )}
                 </div>
                 {(packingList.destination || tripDates) && (
                     <div
@@ -1797,9 +1802,13 @@ export function ViewPackingList() {
                                         {everySectionFolded ? (isDesktop ? 'Expand all' : 'Expand') : (isDesktop ? 'Collapse all' : 'Collapse')}
                                     </button>
                                 )}
+                                {/* Loud only while there is something behind it:
+                                    with nothing packed yet this button reveals
+                                    an empty set, and it was the brightest thing
+                                    on the screen for it. */}
                                 <Button
                                     type="button"
-                                    variant={hiddenPackedCount > 0 ? 'primary' : 'secondary'}
+                                    variant={hiddenPackedCount > 0 ? 'primary' : 'subtle'}
                                     onClick={() => setShowPacked(!showPacked)}
                                 >
                                     {showPacked ? 'Hide Packed' : 'Show Packed'}
@@ -1818,6 +1827,7 @@ export function ViewPackingList() {
                                 personIdentity={personIdentity}
                                 onToggle={handleTogglePerson}
                                 controlsId={LIST_SECTIONS_ID}
+                                onAddGuest={foreignPodUrl ? undefined : handleAddGuest}
                             />
                         </div>
                         {/* Only while a filter is on: unfiltered it held a line
@@ -1986,37 +1996,6 @@ export function ViewPackingList() {
 
             {/* Main content */}
             <div className="w-full">
-                {/* Add Guest inline form — appears just above the grid */}
-                {showAddGuest && (
-                    <div className="mb-4 flex gap-2 max-w-sm">
-                        <input
-                            type="text"
-                            value={newGuestName}
-                            onChange={(e) => setNewGuestName(e.target.value)}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter') { e.preventDefault(); handleAddGuest() }
-                                if (e.key === 'Escape') { setShowAddGuest(false); setNewGuestName('') }
-                            }}
-                            placeholder="Guest name..."
-                            autoFocus
-                            className="flex-1 min-w-0 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
-                        />
-                        <button
-                            type="button"
-                            onClick={handleAddGuest}
-                            className="shrink-0 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
-                        >
-                            Add
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => { setShowAddGuest(false); setNewGuestName('') }}
-                            className="shrink-0 px-3 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 border border-gray-300 dark:border-gray-600 rounded-md text-sm"
-                        >
-                            Cancel
-                        </button>
-                    </div>
-                )}
                 <div>
                     {/* Once everything is packed the cards hold nothing but empty
                         celebrations, so they fold away and leave the banner as the

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -407,7 +407,7 @@ Are you sure you want to continue?"
                             <div className="space-y-3">
                                 <button
                                     onClick={() => handleSuccessAction('/create-packing-list')}
-                                    className="w-full bg-gradient-primary text-white px-4 sm:px-6 py-4 rounded-xl font-bold text-base sm:text-lg break-words hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
+                                    className="w-full bg-gradient-primary-button text-white px-4 sm:px-6 py-4 rounded-xl font-bold text-base sm:text-lg break-words motion-safe:hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
                                 >
                                     🚀 Create My First Packing List
                                 </button>


### PR DESCRIPTION
## Summary

Reorganizes the packing list header to reduce visual weight on less-frequent actions. Moves "Share" and "Update from questions" behind a kebab menu, replaces the "Back to Lists" button with a subtle chevron, and relocates "Add Guest" from the header to the people filter strip where it's contextually relevant.

## Key Changes

- **Header redesign**: Replaced four filled buttons (Add Guest, Update from questions, Share, Back to Lists) with two controls:
  - A subtle chevron button for navigation back to lists
  - A kebab menu (`ActionMenu`) containing Share and Update from questions
  
- **New `ActionMenu` component**: Created `src/components/ActionMenu.tsx` using Radix UI dropdown menu for consistent, accessible menu behavior with proper focus management and keyboard navigation

- **Guest addition moved to people strip**: Integrated guest-adding UI into `PeopleFilterBar` via new `onAddGuest` callback, with inline name input that appears on demand rather than a header button

- **Button variant refinement**: Added `subtle` variant to `Button` component for occasional actions (neutral box, no gradient), with comprehensive test coverage ensuring proper emphasis hierarchy

- **Accessibility improvements**:
  - Back button uses `aria-label` only (no text content) to avoid redundancy with nav bar
  - Menu items use proper `role="menuitem"` with Radix's roving focus and typeahead
  - Minimum 44px touch targets maintained throughout
  - Motion-safe guards on scale animations for users with reduced motion preferences

- **Test updates**: Updated 30+ test cases across `view-packing-list.test.tsx`, `PeopleFilterBar.test.tsx`, and e2e tests to reflect new menu structure and guest-adding location

## Implementation Details

- The people strip now shows a dashed "+" button when `onAddGuest` is provided, opening an inline text field on the next line for full-width input
- Guest name is trimmed and validated before submission; empty names are rejected
- The strip remains visible even with a single person (to enable adding a second), but shows that person as a label rather than a filter chip
- All occasional actions now live behind the menu, keeping the header focused on the list itself
- Button emphasis hierarchy is now enforced: primary/secondary for main actions, subtle for occasional ones, ghost for minimal UI

https://claude.ai/code/session_01Heb85VVme2oQbrv8UVifjZ