### PR TITLE
Stop the phone being a throwaway OIDC client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ When raising a PR that addresses a GitHub issue, always reference the issue in t
 
 Never end a session because a request failed. `@uvdsl/solid-oidc-client-browser`'s
 `SessionCore` ships no refresh lifecycle — that is this app's job, and it lives in
-`ResilientSession` (`src/services/ResilientSession.ts`). Two rules it exists to keep:
+`ResilientSession` (`src/services/ResilientSession.ts`). Three rules it exists to keep:
 
 - **Only the provider may end a session.** `invalid_grant`/`invalid_client`, or a DPoP
   key that no longer matches, are terminal. Network errors, 5xx, 429, JWKS fetch
@@ -40,6 +40,12 @@ Never end a session because a request failed. `@uvdsl/solid-oidc-client-browser`
 - **Bank a rotated refresh token before doing anything that can throw.** Providers
   treat a re-presented refresh token as a replay and revoke the whole grant, so a
   replacement that is received but not stored is a dead session.
+- **Never let the app be a dynamic client in production.** The native shell is
+  served from `https://localhost`, so it fell through to dynamic client
+  registration — and a registration the provider reclaims answers the next refresh
+  with `invalid_client`, which is terminal. `solidClientIdentity.ts` decides this,
+  and `public/client-id.json` must keep listing the native redirect URI or the
+  mobile app cannot log in at all.
 
 `docs/staying-signed-in.md` has the full trace of the logout bugs these rules came
 from. `SolidPodContext.resilience.test.tsx`, `ResilientSession.test.ts` and e2e suite J

--- a/docs/staying-signed-in.md
+++ b/docs/staying-signed-in.md
@@ -110,6 +110,84 @@ DPoP-bound token only once it is 70% through its lifetime — about 17 hours of 
 CSS refresh token's 24 — but rotates a public client's token on **every** refresh
 when it is not sender-constrained, and deployments tune this freely.
 
+## The phone kept being signed out anyway
+
+Everything above was fixed on the web *and* in the native app — and the Android
+app went on losing its session. What was left was not in the refresh path at all.
+It was who the app said it was.
+
+### 8. The phone was a throwaway client
+
+Solid-OIDC offers two ways to be a client:
+
+- a **Client ID Document** hosted at an https URL, which the provider re-reads on
+  every grant. Nothing about it can lapse.
+- a **dynamic registration**, created at login, which the provider owns and may
+  reclaim. Inrupt's ESS expires them; a Community Solid Server loses them
+  whenever its registration storage is cleared or reset.
+
+The app has a hosted document at `/client-id.json`, and `VITE_CLIENT_ID_URL`
+points the deployed site at it. Everywhere else fell back to dynamic
+registration, and "everywhere else" quietly included both native apps: Capacitor
+serves the shell from `https://localhost`, and the document listed only
+`https://packmeup.tim-gent.com/` as a redirect URI, so the phone could not have
+used it even if the build had been configured to.
+
+When such a registration is reclaimed, the next refresh comes back
+`invalid_client`. That is terminal by definition — the app is no longer a client
+the provider has heard of — so no amount of retrying helps, and the refresh token
+in IndexedDB is still perfectly good when the user is signed out. It looks
+exactly like every bug above, and none of the fixes above touch it. It is also
+why the web app was fine while the phone was not: the web app has never been a
+dynamic client in production.
+
+`public/client-id.json` now lists `https://localhost/` too — Capacitor uses its
+https scheme on both platforms, so one entry covers Android and iOS — and
+`solidClientIdentity.ts` gives the native shell the hosted document. Only an
+origin with no document of its own (localhost, a preview deploy) still registers
+dynamically, where a lost session costs nothing.
+
+Because the client id is stored per session, existing installs keep the dynamic
+client they logged in with. The change takes effect at the next login.
+
+### 9. A transient failure could be nobody's job
+
+`ResilientSession` retries within one `restore()`, and `SolidPodContext` retries
+on a backoff — but only for a session that is *not* active. A phone that wakes
+with the radio still down is the other case: the renewal timer that came due
+while the device slept fires, the refresh fails transiently, and the app is still
+"logged in", so neither backoff engages. Nothing was booked. The token then
+lapsed in silence, and the grant was left to age until the provider gave up on
+it.
+
+`ResilientSession` now books its own retry after a transient failure, backing off
+to five minutes and re-arming the normal schedule as soon as one succeeds.
+
+### 10. Waking up was not always noticed
+
+Coming back to the app is the one moment a stale session must be looked at, and
+`visibilitychange` was the only signal for it. An Android WebView whose activity
+is paused and resumed does not reliably report a visibility change — the timers
+were frozen with the process, so if nothing notices the resume, nothing renews.
+`onAppResumed` (`src/services/appResume.ts`) listens for the App plugin's
+`appStateChange` as well, which is the event that always arrives on a phone.
+
+### 11. Two ways to lose the whole session anyway
+
+`SessionCore._updateSessionDetailsFromToken` answers an access token it cannot
+read — no `webid` claim, no `exp`, not a JWT — by calling its own `logout()`,
+which clears IndexedDB and the refresh token with it. That is bug 4 by another
+route, reachable from a provider having a bad minute rather than from a 401.
+`ResilientSession` now rejects such a token as transient *before* handing it to
+`setTokenDetails`, so nothing but a deliberate sign-out ever clears the database.
+
+Finally, a session ending is not an error anything throws, so nothing reached
+Sentry: on a phone, where the sign-in history cannot be read over someone's
+shoulder, expiries were invisible. `reportSessionEnded` now reports the reason —
+and only the reason, nothing identifying — so `invalid_grant` (a dead grant) can
+be told apart from `invalid_client` (a stale registration) without the device in
+hand.
+
 ## What changed
 
 A `ResilientSession` subclass (`src/services/ResilientSession.ts`) keeps
@@ -139,6 +217,12 @@ A `ResilientSession` subclass (`src/services/ResilientSession.ts`) keeps
   continues in the background and signs the user in when it lands.
 - A failed OAuth callback no longer prevents restoring the session already on the
   device.
+- The native app identifies itself with the hosted Client ID Document, so its
+  client registration cannot be reclaimed underneath it (bug 8).
+- A transient failure always books its own next attempt (bug 9), and a resume is
+  noticed through the App plugin as well as `visibilitychange` (bug 10).
+- An access token the library cannot read is refused before it can trigger the
+  library's `logout()` (bug 11).
 
 ## If it ever happens again
 
@@ -148,8 +232,11 @@ reason the provider gave. "Copy for a bug report" is the whole sequence. Nothing
 in it is sent anywhere on its own.
 
 The event to look for is `refresh.session-ended`. Its `reason` says whether the
-provider rejected the grant (`invalid_grant` — the session genuinely ended) or
-something else. Repeated `refresh.failed-transiently` or `restore.will-retry`
+provider rejected the grant (`invalid_grant` — the session genuinely ended), the
+registration went stale (`invalid_client` — see bug 8) or something else. That
+reason also goes to Sentry as `Solid session ended: <reason>`, tagged
+`auth_session_ended`, which is how a phone's expiry can be read without the
+phone. Repeated `refresh.failed-transiently` or `restore.will-retry`
 without a matching `refresh.succeeded` means the app is trying and failing to
 reach the token endpoint, which is a network or provider-availability story
 rather than an auth one.

--- a/public/client-id.json
+++ b/public/client-id.json
@@ -1,9 +1,15 @@
 {
   "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
   "client_id": "https://packmeup.tim-gent.com/client-id.json",
-  "redirect_uris": ["https://packmeup.tim-gent.com/"],
+  "redirect_uris": [
+    "https://packmeup.tim-gent.com/",
+    "https://localhost/"
+  ],
   "client_name": "Pack Me Up",
   "client_uri": "https://packmeup.tim-gent.com/",
   "scope": "openid offline_access webid",
-  "grant_types": ["refresh_token", "authorization_code"]
+  "grant_types": [
+    "refresh_token",
+    "authorization_code"
+  ]
 }

--- a/src/components/SolidPodContext.test.tsx
+++ b/src/components/SolidPodContext.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, act, waitFor } from '@testing-library/react'
 import React from 'react'
 import { SolidPodProvider, useSolidPod } from './SolidPodContext'
 import { ResilientSession } from '../services/ResilientSession'
+import { HOSTED_CLIENT_ID_URL } from '../services/solidClientIdentity'
 import { ToastProvider } from './ToastContext'
 
 function Wrapper({ children }: { children: React.ReactNode }) {
@@ -53,6 +54,16 @@ vi.mock('../services/ResilientSession', async (importOriginal) => {
 
 vi.mock('@uvdsl/solid-oidc-client-browser', () => ({
     SessionIDB: vi.fn().mockImplementation(function() { return {} }),
+}))
+
+const mockIsNativePlatform = vi.fn(() => false)
+
+vi.mock('@capacitor/core', () => ({
+    Capacitor: { isNativePlatform: () => mockIsNativePlatform() },
+}))
+
+vi.mock('@capacitor/app', () => ({
+    App: { addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }) },
 }))
 
 /** The ResilientSession instance the provider constructed. */
@@ -358,6 +369,30 @@ describe('SolidPodContext', () => {
 
         await waitFor(() => {
             expect(screen.getByTestId('sessionExpired').textContent).toBe('false')
+        })
+    })
+})
+
+describe('SolidPodContext — the client it presents itself as', () => {
+    beforeEach(() => {
+        vi.mocked(ResilientSession).mockClear()
+    })
+
+    afterEach(() => {
+        mockIsNativePlatform.mockReturnValue(false)
+    })
+
+    it('gives the native app the hosted Client ID Document, not a throwaway registration', () => {
+        // The shell is served from https://localhost, which never matched the
+        // hosted document, so it used to register dynamically on every install —
+        // and a dynamic registration the provider reclaims answers the next
+        // refresh with `invalid_client`, which ends the session for good.
+        mockIsNativePlatform.mockReturnValue(true)
+
+        render(<Wrapper><Consumer /></Wrapper>)
+
+        expect(vi.mocked(ResilientSession).mock.calls[0][0]).toEqual({
+            client_id: HOSTED_CLIENT_ID_URL,
         })
     })
 })

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -1,7 +1,10 @@
 import { createContext, ReactNode, useContext, useState, useEffect, useRef, useCallback } from "react";
 import { type SessionStateChangeDetail } from "@uvdsl/solid-oidc-client-browser/core";
 import { SessionIDB } from "@uvdsl/solid-oidc-client-browser";
+import { Capacitor } from "@capacitor/core";
 import { ResilientSession, SessionEndedError } from "../services/ResilientSession";
+import { solidClientDetails } from "../services/solidClientIdentity";
+import { onAppResumed } from "../services/appResume";
 import { logAuthEvent } from "../services/authLog";
 import { resetPodSessionCaches } from "../services/solidPod";
 import { AUTH_RETURN_TO_KEY } from "../pages/solid-pod-handle-redirect-page";
@@ -46,21 +49,15 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
 
   const uvdslSessionRef = useRef<ResilientSession>(null!);
   if (!uvdslSessionRef.current) {
-    const origin = window.location.origin || "http://localhost";
-    // On production, VITE_CLIENT_ID_URL is set so the provider fetches the hosted Client ID
-    // Document (static registration). On preview deploys and localhost it is unset, so we fall
-    // back to dynamic client registration using the current origin's redirect URI.
-    const clientIdUrl = import.meta.env.VITE_CLIENT_ID_URL as string | undefined;
+    // The deployed site and the native app both identify themselves with a hosted
+    // Client ID Document, which cannot lapse. Only an origin with no document of
+    // its own — localhost, a preview deploy — registers dynamically.
     uvdslSessionRef.current = new ResilientSession(
-      clientIdUrl
-        ? { client_id: clientIdUrl }
-        : {
-            // Use SPA root so the redirect_uri in the token exchange matches what's registered.
-            // If we go through pod-auth-callback.html, the library strips params from that URL
-            // and sends the wrong redirect_uri to the token endpoint.
-            redirect_uris: [origin + "/"],
-            client_name: "Pack Me Up",
-          },
+      solidClientDetails({
+        clientIdUrl: import.meta.env.VITE_CLIENT_ID_URL as string | undefined,
+        isNativePlatform: Capacitor.isNativePlatform(),
+        origin: window.location.origin || "http://localhost",
+      }),
       new SessionIDB(),
       {
         onSessionStateChange: (e) => {
@@ -181,8 +178,8 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
     return () => clearTimeout(recoveryTimerRef.current);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Take every chance to get a stalled session back: coming online, or the user
-  // returning to the tab, are both good moments to retry ahead of the backoff.
+  // Take every chance to get a stalled session back: coming online, or the app
+  // returning to the foreground, are both good moments to retry ahead of the backoff.
   useEffect(() => {
     const retryIfRecovering = (trigger: string) => {
       if (!recoveringRef.current || uvdslSession.isActive) return;
@@ -191,34 +188,32 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
     };
 
     const onOnline = () => retryIfRecovering("online");
-    const onVisible = () => {
-      if (document.visibilityState === "visible") retryIfRecovering("visible");
-    };
+    const stopWatchingResume = onAppResumed(() => retryIfRecovering("resumed"));
 
     window.addEventListener("online", onOnline);
-    document.addEventListener("visibilitychange", onVisible);
     return () => {
       window.removeEventListener("online", onOnline);
-      document.removeEventListener("visibilitychange", onVisible);
+      stopWatchingResume();
     };
   }, [attemptRestore, uvdslSession]);
 
-  // Returning to the tab is when a token is most likely to have lapsed while the
-  // device slept. Renew it before the user's first action needs it.
+  // Coming back to the app is when a token is most likely to have lapsed while
+  // the device slept — and on a phone the renewal timer was frozen along with
+  // the process, so this is the only thing that notices. Renew before the user's
+  // first action needs it.
   useEffect(() => {
     if (!isLoggedIn) return;
 
     const renewIfNeeded = () => {
-      if (document.visibilityState !== "visible") return;
       if (!uvdslSession.needsRenewal()) return;
-      logAuthEvent("refresh.on-visible");
+      logAuthEvent("refresh.on-resume");
       void uvdslSession.restore().catch(() => { /* restore() reports and retries */ });
     };
 
-    document.addEventListener("visibilitychange", renewIfNeeded);
+    const stopWatchingResume = onAppResumed(renewIfNeeded);
     window.addEventListener("online", renewIfNeeded);
     return () => {
-      document.removeEventListener("visibilitychange", renewIfNeeded);
+      stopWatchingResume();
       window.removeEventListener("online", renewIfNeeded);
     };
   }, [isLoggedIn, uvdslSession]);

--- a/src/services/ResilientSession.test.ts
+++ b/src/services/ResilientSession.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { generateKeyPair, exportJWK, SignJWT, calculateJwkThumbprint, createLocalJWKSet } from 'jose'
-import { ResilientSession, SessionEndedError } from './ResilientSession'
+import { ResilientSession, SessionEndedError, type ResilientSessionOptions } from './ResilientSession'
 
 /**
  * These cover the exchange that decides whether a user stays logged in.
@@ -35,10 +35,14 @@ let dpopKeys: Awaited<ReturnType<typeof generateKeyPair>>
 let localJwks: ReturnType<typeof createLocalJWKSet>
 
 async function makeAccessToken(
-    opts: { expiresIn?: string | number; signWith?: CryptoKey } = {},
+    opts: { expiresIn?: string | number; signWith?: CryptoKey; omitWebId?: boolean } = {},
 ): Promise<string> {
     const jkt = await calculateJwkThumbprint(await exportJWK(dpopKeys.publicKey))
-    return new SignJWT({ webid: WEB_ID, client_id: CLIENT_ID, cnf: { jkt } })
+    return new SignJWT({
+        ...(opts.omitWebId ? {} : { webid: WEB_ID }),
+        client_id: CLIENT_ID,
+        cnf: { jkt },
+    })
         .setProtectedHeader({ alg: 'ES256', kid: 'test-key' })
         .setIssuer(IDP)
         .setAudience('solid')
@@ -47,7 +51,11 @@ async function makeAccessToken(
         .sign(opts.signWith ?? signingKeys.privateKey)
 }
 
-function makeSession(db: FakeDb, onExpiration?: () => void) {
+function makeSession(
+    db: FakeDb,
+    onExpiration?: () => void,
+    overrides: Partial<ResilientSessionOptions> = {},
+) {
     return new ResilientSession(
         { client_id: CLIENT_ID },
         db as unknown as ConstructorParameters<typeof ResilientSession>[1],
@@ -55,6 +63,7 @@ function makeSession(db: FakeDb, onExpiration?: () => void) {
             onSessionExpiration: onExpiration,
             // Verify against the local test key set rather than a remote JWKS.
             resolveJwks: () => localJwks,
+            ...overrides,
         },
     )
 }
@@ -113,6 +122,7 @@ describe('ResilientSession', () => {
         // The replacement must have survived the failure. Keeping the old value
         // here is what strands a session for good.
         expect(db.items.get('refresh_token')).toBe('refresh-token-v2')
+        session.cancelRenewal()
     }, 30_000)
 
     it('restores the session and stores the rotated token on success', async () => {
@@ -163,6 +173,7 @@ describe('ResilientSession', () => {
         // A struggling server is not a logged-out user.
         expect(onExpiration).not.toHaveBeenCalled()
         expect(db.items.get('refresh_token')).toBe('refresh-token-v1')
+        session.cancelRenewal()
     }, 30_000)
 
     it('retries an unreachable token endpoint and keeps the refresh token', async () => {
@@ -175,6 +186,7 @@ describe('ResilientSession', () => {
         await expect(session.restore()).rejects.not.toBeInstanceOf(SessionEndedError)
         expect(onExpiration).not.toHaveBeenCalled()
         expect(db.items.get('refresh_token')).toBe('refresh-token-v1')
+        session.cancelRenewal()
     }, 30_000)
 
     it('recovers on a later attempt once the network comes back', async () => {
@@ -230,6 +242,69 @@ describe('ResilientSession', () => {
         expect(session.isActive).toBe(true)
         expect(session.getExpiresIn()).toBeGreaterThan(0)
         expect(session.needsRenewal()).toBe(true)
+        session.cancelRenewal()
+    }, 30_000)
+
+    it('comes back on its own after a refresh that failed transiently', async () => {
+        // A phone waking with the radio still down is the common case: the timer
+        // that was due while it slept fires, the refresh fails, and nothing has
+        // asked for a retry. Without one the token quietly lapses and the grant
+        // is left to rot until the provider gives up on it.
+        const fetchMock = vi.fn(async () => { throw new TypeError('Failed to fetch') })
+        vi.stubGlobal('fetch', fetchMock)
+
+        const session = makeSession(db, undefined, { transientRetryDelaysMs: [10] })
+        await expect(session.restore()).rejects.not.toBeInstanceOf(SessionEndedError)
+
+        const callsSoFar = fetchMock.mock.calls.length
+        expect(callsSoFar).toBeGreaterThan(0)
+
+        // Nothing else is watching. The session must come back by itself.
+        await vi.waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThan(callsSoFar))
+        session.cancelRenewal()
+    }, 30_000)
+
+    it('stops trying once the provider has rejected the grant', async () => {
+        const fetchMock = vi.fn(async () => new Response(
+            JSON.stringify({ error: 'invalid_grant' }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } },
+        ))
+        vi.stubGlobal('fetch', fetchMock)
+
+        const session = makeSession(db, undefined, { transientRetryDelaysMs: [10] })
+        await expect(session.restore()).rejects.toBeInstanceOf(SessionEndedError)
+
+        const callsSoFar = fetchMock.mock.calls.length
+        // A dead grant is not worth hammering the token endpoint over.
+        await new Promise(resolve => setTimeout(resolve, 200))
+        expect(fetchMock.mock.calls.length).toBe(callsSoFar)
+    }, 30_000)
+
+    it('never erases the stored session over a token it cannot make sense of', async () => {
+        // SessionCore answers an access token with no `webid` claim by calling its
+        // own logout(), which clears IndexedDB — the refresh token with it. The
+        // provider is having a bad minute; that must not cost the session.
+        vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+            const url = String(input instanceof Request ? input.url : input)
+            if (url.startsWith(TOKEN_ENDPOINT)) {
+                return new Response(JSON.stringify({
+                    access_token: await makeAccessToken({ omitWebId: true }),
+                    refresh_token: 'refresh-token-v2',
+                    expires_in: 3600,
+                    token_type: 'DPoP',
+                }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+            }
+            throw new Error(`unexpected request to ${url}`)
+        }))
+
+        const onExpiration = vi.fn()
+        const session = makeSession(db, onExpiration)
+
+        await expect(session.restore()).rejects.not.toBeInstanceOf(SessionEndedError)
+
+        expect(db.items.get('refresh_token')).toBe('refresh-token-v2')
+        expect(db.items.size).toBeGreaterThan(1)
+        expect(onExpiration).not.toHaveBeenCalled()
         session.cancelRenewal()
     }, 30_000)
 })

--- a/src/services/ResilientSession.ts
+++ b/src/services/ResilientSession.ts
@@ -8,7 +8,7 @@ import {
     calculateJwkThumbprint,
     type JWTVerifyGetKey,
 } from 'jose'
-import { logAuthEvent } from './authLog'
+import { logAuthEvent, reportSessionEnded } from './authLog'
 
 /**
  * A SessionCore that treats "I could not reach the token endpoint" and
@@ -57,6 +57,18 @@ const CLOCK_TOLERANCE_SECONDS = 300
 const MAX_ATTEMPTS = 2
 
 const RETRY_BASE_MS = 800
+
+/**
+ * How long to wait before trying again after a refresh that failed transiently.
+ *
+ * Something has to own this. On a phone the renewal timer that was due while the
+ * device slept fires on the way back up, with the radio still down — the refresh
+ * fails, and unless the session asks for another go, nothing does: the app is
+ * still "logged in", so the recovery backoff in SolidPodContext (which only
+ * covers a session that is not active) never engages. The token then lapses in
+ * silence and the grant is left to rot until the provider gives up on it.
+ */
+const TRANSIENT_RETRY_DELAYS_MS = [5_000, 15_000, 45_000, 120_000, 300_000]
 
 const REFRESH_LOCK = 'pmu-solid-token-refresh'
 
@@ -163,23 +175,32 @@ export interface ResilientSessionOptions extends Omit<SessionOptions, 'database'
      * against a local key set instead of reaching the network.
      */
     resolveJwks?: (jwksUri: string) => JWTVerifyGetKey
+    /**
+     * The backoff between retries after a transient failure. Injectable so tests
+     * can watch a session come back without waiting out five real seconds.
+     */
+    transientRetryDelaysMs?: readonly number[]
 }
 
 export class ResilientSession extends SessionCore {
     /** SessionCore keeps its database private, so we hold our own handle. */
     private readonly db: SessionIDB
     private readonly resolveJwks: (jwksUri: string) => JWTVerifyGetKey
+    private readonly transientRetryDelaysMs: readonly number[]
     private renewalTimer: ReturnType<typeof setTimeout> | undefined
+    /** Consecutive transient failures, for pacing the retry timer. */
+    private transientFailures = 0
 
     constructor(
         clientDetails: ConstructorParameters<typeof SessionCore>[0],
         database: SessionIDB,
         sessionOptions: ResilientSessionOptions,
     ) {
-        const { resolveJwks, ...coreOptions } = sessionOptions
+        const { resolveJwks, transientRetryDelaysMs, ...coreOptions } = sessionOptions
         super(clientDetails, { ...coreOptions, database })
         this.db = database
         this.resolveJwks = resolveJwks ?? jwksFor
+        this.transientRetryDelaysMs = transientRetryDelaysMs ?? TRANSIENT_RETRY_DELAYS_MS
     }
 
     /**
@@ -203,6 +224,7 @@ export class ResilientSession extends SessionCore {
             try {
                 const tokens = await withRefreshLock(() => this.refreshWithRetries())
                 await this.setTokenDetails(tokens)
+                this.transientFailures = 0
                 this.scheduleRenewal()
                 logAuthEvent('refresh.succeeded', { expiresIn: this.getExpiresIn() })
                 this.resolveRefresh?.()
@@ -215,8 +237,14 @@ export class ResilientSession extends SessionCore {
                 )
                 this.rejectRefresh?.(error instanceof Error ? error : new Error(String(error)))
                 // Only the provider disowning the grant ends the session. A transient
-                // failure leaves the stored refresh token intact for the next attempt.
-                if (ended) this.dispatchExpirationEvent()
+                // failure leaves the stored refresh token intact for the next attempt,
+                // and books that attempt rather than hoping something else will.
+                if (ended) {
+                    reportSessionEnded(error.reason)
+                    this.dispatchExpirationEvent()
+                } else {
+                    this.scheduleTransientRetry()
+                }
             } finally {
                 this.clearRefreshPromise()
                 if (wasActive !== this.isActive) this.dispatchStateChangeEvent()
@@ -291,6 +319,25 @@ export class ResilientSession extends SessionCore {
             clearTimeout(this.renewalTimer)
             this.renewalTimer = undefined
         }
+    }
+
+    /**
+     * Books another attempt after a transient failure, on a backoff that tops out
+     * at five minutes. It shares the renewal timer: whichever of the two is due
+     * first is the one worth doing, and a success re-arms the normal schedule.
+     */
+    private scheduleTransientRetry(): void {
+        this.cancelRenewal()
+
+        const delay = this.transientRetryDelaysMs[
+            Math.min(this.transientFailures, this.transientRetryDelaysMs.length - 1)
+        ]
+        this.transientFailures += 1
+
+        this.renewalTimer = setTimeout(() => {
+            logAuthEvent('refresh.retry-after-failure', { attempt: this.transientFailures })
+            void this.restore().catch(() => { /* reported by restore() */ })
+        }, delay)
     }
 
     private async refreshWithRetries() {
@@ -392,6 +439,16 @@ export class ResilientSession extends SessionCore {
         } catch (error) {
             // Signature, JWKS fetch or clock problems. Retrying is safe and often works.
             throw new TransientRefreshError(`Could not verify the new access token: ${String(error)}`)
+        }
+
+        // SessionCore answers an access token it cannot read — no `webid`, no `exp`,
+        // not a JWT at all — by calling its own logout(), which clears IndexedDB and
+        // the refresh token with it. Stop such a token here, before setTokenDetails
+        // ever sees it: a provider having a bad minute must not cost the session.
+        // Transient, because the stored refresh token is untouched and the next
+        // exchange may well come back with a usable token.
+        if (!payload.webid || !payload.exp) {
+            throw new TransientRefreshError('The new access token is missing its webid or exp claim.')
         }
 
         // These two cannot come right on a retry: the stored key or registration

--- a/src/services/appResume.test.ts
+++ b/src/services/appResume.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const mockIsNativePlatform = vi.fn(() => false)
+const mockAddListener = vi.fn()
+const mockRemove = vi.fn()
+
+vi.mock('@capacitor/core', () => ({
+    Capacitor: { isNativePlatform: () => mockIsNativePlatform() },
+}))
+
+vi.mock('@capacitor/app', () => ({
+    App: { addListener: (...args: unknown[]) => mockAddListener(...args) },
+}))
+
+const { onAppResumed } = await import('./appResume')
+
+function fireAppStateChange(isActive: boolean) {
+    const handler = mockAddListener.mock.calls.at(-1)?.[1] as (state: { isActive: boolean }) => void
+    handler({ isActive })
+}
+
+/**
+ * Coming back to the app is the moment a session most needs attention: the
+ * device has been asleep, the access token has lapsed and the renewal timer did
+ * not fire while the process was frozen.
+ *
+ * On the web `visibilitychange` says so. In the native shell it does not
+ * reliably: an Android WebView whose activity is paused and resumed may never
+ * report a visibility change, so the App plugin's own resume event is the one
+ * signal that always arrives. Miss it and the app sits on an expired token until
+ * the user touches something that happens to make a request.
+ */
+describe('onAppResumed', () => {
+    beforeEach(() => {
+        mockIsNativePlatform.mockReturnValue(false)
+        mockAddListener.mockReset()
+        mockAddListener.mockResolvedValue({ remove: mockRemove })
+        mockRemove.mockReset()
+    })
+
+    it('fires when the tab becomes visible again', () => {
+        const onResume = vi.fn()
+        onAppResumed(onResume)
+
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(onResume).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not fire when the tab is hidden', () => {
+        const onResume = vi.fn()
+        vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+        onAppResumed(onResume)
+
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(onResume).not.toHaveBeenCalled()
+    })
+
+    it('stops firing once unsubscribed', () => {
+        const onResume = vi.fn()
+        onAppResumed(onResume)()
+
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(onResume).not.toHaveBeenCalled()
+    })
+
+    it('listens for the native resume event as well, which a WebView may not report as a visibility change', async () => {
+        mockIsNativePlatform.mockReturnValue(true)
+        const onResume = vi.fn()
+        onAppResumed(onResume)
+        await vi.waitFor(() => expect(mockAddListener).toHaveBeenCalledWith('appStateChange', expect.any(Function)))
+
+        fireAppStateChange(true)
+
+        expect(onResume).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores the native event for going into the background', async () => {
+        mockIsNativePlatform.mockReturnValue(true)
+        const onResume = vi.fn()
+        onAppResumed(onResume)
+        await vi.waitFor(() => expect(mockAddListener).toHaveBeenCalled())
+
+        fireAppStateChange(false)
+
+        expect(onResume).not.toHaveBeenCalled()
+    })
+
+    it('removes the native listener when unsubscribed', async () => {
+        mockIsNativePlatform.mockReturnValue(true)
+        const unsubscribe = onAppResumed(vi.fn())
+        await vi.waitFor(() => expect(mockAddListener).toHaveBeenCalled())
+
+        unsubscribe()
+
+        await vi.waitFor(() => expect(mockRemove).toHaveBeenCalled())
+    })
+
+    it('does not subscribe to the plugin on the web', () => {
+        onAppResumed(vi.fn())
+
+        expect(mockAddListener).not.toHaveBeenCalled()
+    })
+})

--- a/src/services/appResume.ts
+++ b/src/services/appResume.ts
@@ -1,0 +1,40 @@
+import { Capacitor } from '@capacitor/core'
+import { App as CapacitorApp } from '@capacitor/app'
+
+/**
+ * Runs `handler` whenever the app comes back to the foreground.
+ *
+ * This is the moment a Solid session most needs looking at. A phone that has
+ * been asleep for an hour has a lapsed access token and a renewal timer that
+ * never fired, because the WebView's timers were frozen with the process.
+ * Something has to notice on the way back in, or the app sits on a dead token
+ * until the user happens to trigger a request.
+ *
+ * On the web `visibilitychange` is that signal. In the native shell it is not
+ * dependable: an Android WebView whose activity is paused and resumed does not
+ * always report a document visibility change, so the App plugin's own
+ * `appStateChange` is the event that actually arrives. Both are wired up, and
+ * both paths are idempotent — a session that needs no renewal is left alone —
+ * so hearing twice about one resume costs nothing.
+ */
+export function onAppResumed(handler: () => void): () => void {
+    const onVisibilityChange = () => {
+        if (document.visibilityState === 'visible') handler()
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
+    // Resolves to the plugin's handle; kept so unsubscribing can await it rather
+    // than leak a listener registered after the caller has gone away.
+    const nativeListener = Capacitor.isNativePlatform()
+        ? CapacitorApp.addListener('appStateChange', ({ isActive }) => {
+            if (isActive) handler()
+        })
+        : undefined
+
+    return () => {
+        document.removeEventListener('visibilitychange', onVisibilityChange)
+        void nativeListener?.then(listener => listener.remove()).catch(() => {
+            // Nothing to unhook — the plugin never attached.
+        })
+    }
+}

--- a/src/services/authLog.ts
+++ b/src/services/authLog.ts
@@ -1,4 +1,4 @@
-import { addBreadcrumb } from '@sentry/react'
+import { addBreadcrumb, captureMessage } from '@sentry/react'
 
 /**
  * A durable record of everything that happens to the Solid session.
@@ -75,6 +75,26 @@ export function logAuthEvent(
         if (level === 'error') console.error(line, detail ?? '')
         else if (level === 'warn') console.warn(line, detail ?? '')
         else console.log(line, detail ?? '')
+    }
+}
+
+/**
+ * Reports a session that genuinely ended, so it is visible without the device.
+ *
+ * The local log answers "why was I signed out?" only for someone holding the
+ * phone. A session ending is not an error anything throws, so nothing reached
+ * Sentry either, and the mobile app's expiries were invisible. This sends the
+ * one fact that separates a dead grant from a stale client registration — the
+ * reason — and nothing that identifies the user.
+ */
+export function reportSessionEnded(reason: string): void {
+    try {
+        captureMessage(`Solid session ended: ${reason}`, {
+            level: 'error',
+            tags: { auth_session_ended: reason },
+        })
+    } catch {
+        // Sentry not initialised (tests, local dev) — the local log is what matters.
     }
 }
 

--- a/src/services/solidClientIdentity.test.ts
+++ b/src/services/solidClientIdentity.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+    HOSTED_CLIENT_ID_URL,
+    NATIVE_REDIRECT_URI,
+    solidClientDetails,
+} from './solidClientIdentity'
+
+/**
+ * Which client the app presents itself as decides how long a session survives.
+ *
+ * A hosted Client ID Document is a permanent identity: the provider re-reads it
+ * on every grant, and the registration cannot go stale. A dynamic registration
+ * is a throwaway one, created at login and kept only for as long as the provider
+ * feels like keeping it — when it is reaped, the next refresh comes back
+ * `invalid_client`, which is terminal, and the user is signed out with a
+ * perfectly good refresh token on disk.
+ *
+ * The native shell is served from `https://localhost`, so it used to fall
+ * through to dynamic registration on every install. These pin it to the hosted
+ * document instead.
+ */
+
+describe('solidClientDetails', () => {
+    it('uses the hosted Client ID Document in the native app', () => {
+        expect(solidClientDetails({ isNativePlatform: true, origin: 'https://localhost' }))
+            .toEqual({ client_id: HOSTED_CLIENT_ID_URL })
+    })
+
+    it('uses the configured Client ID Document on the deployed site', () => {
+        expect(solidClientDetails({
+            clientIdUrl: 'https://packmeup.example.com/client-id.json',
+            isNativePlatform: false,
+            origin: 'https://packmeup.example.com',
+        })).toEqual({ client_id: 'https://packmeup.example.com/client-id.json' })
+    })
+
+    it('lets a configured document override the hosted one, so a preview build can be tested natively', () => {
+        expect(solidClientDetails({
+            clientIdUrl: 'https://preview.example.com/client-id.json',
+            isNativePlatform: true,
+            origin: 'https://localhost',
+        })).toEqual({ client_id: 'https://preview.example.com/client-id.json' })
+    })
+
+    it('registers dynamically on a web origin with no hosted document, such as a preview deploy', () => {
+        expect(solidClientDetails({ isNativePlatform: false, origin: 'https://preview.example.com' }))
+            .toEqual({ redirect_uris: ['https://preview.example.com/'], client_name: 'Pack Me Up' })
+    })
+})
+
+describe('the hosted Client ID Document', () => {
+    const document = JSON.parse(
+        readFileSync(resolve(import.meta.dirname, '../../public/client-id.json'), 'utf-8'),
+    ) as { client_id: string; redirect_uris: string[] }
+
+    it('is the document the native app claims to be', () => {
+        expect(document.client_id).toBe(HOSTED_CLIENT_ID_URL)
+    })
+
+    it('lists the redirect URI the native shell sends', () => {
+        // The provider rejects the whole login when the redirect URI it receives
+        // is not in this list, and the native shell can only ever send its own
+        // loopback origin. Drop this entry and the mobile app cannot log in at all.
+        expect(document.redirect_uris).toContain(NATIVE_REDIRECT_URI)
+    })
+})

--- a/src/services/solidClientIdentity.ts
+++ b/src/services/solidClientIdentity.ts
@@ -1,0 +1,68 @@
+/**
+ * Which OIDC client this app presents itself as.
+ *
+ * Solid-OIDC offers two ways to be a client, and they age very differently:
+ *
+ * - A **Client ID Document** hosted at an https URL. The provider fetches it on
+ *   every grant, so the registration is as permanent as the file. Nothing about
+ *   it can lapse.
+ * - A **dynamic registration**, created at login. The provider hands back a
+ *   client id it owns and may reclaim — Inrupt's ESS expires them, and a
+ *   Community Solid Server drops them whenever its registration storage is
+ *   cleared. When that happens the next refresh comes back `invalid_client`.
+ *   That is terminal by definition (the app is no longer a client the provider
+ *   knows), so the user is signed out with a perfectly good refresh token still
+ *   on disk, and no amount of retrying helps.
+ *
+ * The native shell is served from `https://localhost` by Capacitor, so it never
+ * matched the hosted document's redirect URI and fell through to dynamic
+ * registration on every install — which is why phones lost their session on a
+ * schedule the web app never saw. `public/client-id.json` now lists the
+ * loopback redirect URI, and the native app uses the hosted document like the
+ * deployed site does.
+ */
+
+/**
+ * The deployed Client ID Document.
+ *
+ * Hardcoded on purpose: the native app has no deployment origin to derive this
+ * from — `window.location.origin` inside the shell is `https://localhost`, and a
+ * provider cannot fetch a client document from a phone. `VITE_CLIENT_ID_URL`
+ * still overrides it, which is how a preview build is tested natively.
+ */
+export const HOSTED_CLIENT_ID_URL = 'https://packmeup.tim-gent.com/client-id.json'
+
+/**
+ * The redirect URI the native shell sends. Capacitor serves the app over its
+ * https scheme on both platforms (see `capacitor.config.ts`), so iOS and Android
+ * share one loopback origin. `public/client-id.json` must list this, or the
+ * provider refuses the login outright.
+ */
+export const NATIVE_REDIRECT_URI = 'https://localhost/'
+
+export type SolidClientDetails =
+    | { client_id: string }
+    | { redirect_uris: string[]; client_name: string }
+
+export function solidClientDetails({
+    clientIdUrl,
+    isNativePlatform,
+    origin,
+}: {
+    /** `VITE_CLIENT_ID_URL`, when the build sets one. */
+    clientIdUrl?: string
+    isNativePlatform: boolean
+    origin: string
+}): SolidClientDetails {
+    if (clientIdUrl) return { client_id: clientIdUrl }
+    if (isNativePlatform) return { client_id: HOSTED_CLIENT_ID_URL }
+
+    // A web origin with no hosted document — localhost or a preview deploy.
+    // Dynamic registration is the only option, and its fragility matters less
+    // here: these sessions are minutes old and re-logging in costs nothing.
+    //
+    // Use the SPA root so the redirect_uri in the token exchange matches what is
+    // registered. Going through pod-auth-callback.html would have the library
+    // strip the params from that URL and send the wrong redirect_uri.
+    return { redirect_uris: [origin + '/'], client_name: 'Pack Me Up' }
+}


### PR DESCRIPTION
The refresh lifecycle was fixed everywhere and Android went on losing its
session, because what was left was not in the refresh path. It was who the app
said it was.

Solid-OIDC offers two ways to be a client. A hosted Client ID Document is
permanent: the provider re-reads it on every grant, and nothing about it can
lapse. A dynamic registration is created at login and belongs to the provider,
which may reclaim it — ESS expires them, CSS loses them when its registration
storage is reset. When that happens the next refresh comes back invalid_client,
which is terminal by definition, and the user is signed out with a perfectly
good refresh token on disk.

Capacitor serves the shell from https://localhost, and client-id.json listed
only the deployed origin, so both native apps fell through to dynamic
registration on every install. The web app has never been a dynamic client in
production, which is exactly why this only ever bit the phone.

client-id.json now lists the loopback redirect URI — one entry covers Android
and iOS, since Capacitor uses its https scheme on both — and solidClientIdentity
gives the native shell the hosted document. Only an origin with no document of
its own still registers dynamically, where a lost session costs nothing.

Three smaller holes in the same story:

- A transient failure while signed in was nobody's job. ResilientSession retries
  within one restore(), SolidPodContext retries on a backoff — but only while
  the session is not active. A phone waking with the radio down is the other
  case: the refresh fails, the app is still "logged in", and nothing books
  another attempt, so the token lapses in silence and the grant ages out.
  ResilientSession now schedules its own retry, backing off to five minutes.
- visibilitychange was the only signal for a resume, and an Android WebView
  whose activity is paused and resumed does not reliably send one. The App
  plugin's appStateChange is the event that always arrives on a phone.
- SessionCore answers an access token it cannot read by calling its own
  logout(), which clears IndexedDB and the refresh token with it. Such a token
  is now refused as transient before setTokenDetails can see it.

Finally, a session ending is not an error anything throws, so nothing reached
Sentry and mobile expiries were invisible. The reason — and only the reason — is
now reported, so a dead grant can be told from a stale registration without the
device in hand.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015kTXquKjvvK7LxFUzdPVw7