### PR TITLE
Fix shared row pill overflow on single-person lists

### DIFF
--- a/src/components/CategoryItemGrid.test.tsx
+++ b/src/components/CategoryItemGrid.test.tsx
@@ -44,6 +44,37 @@ function renderGrid(visibleColumnKeys?: ReadonlySet<string>) {
     )
 }
 
+/**
+ * A one-person list, where the chip block is at its narrowest and a shared
+ * row's pill is several times wider than the column it sits in.
+ */
+const soloPeople = [{ name: 'Alice', id: 'p1' }]
+const soloItems = [
+    item({ id: 'a1', itemText: 'Sunhat', personName: 'Alice', personId: 'p1' }),
+    item({ id: 's1', itemText: 'Tent', communal: true }),
+]
+const soloColumns = buildGridColumns(soloPeople, soloItems)
+const soloRows = buildCategoryRows(soloItems, soloColumns)
+/** One chip's 32px disc and the 12px after it. */
+const soloChipBlockWidth = 44
+
+function renderSoloGrid(visibleColumnKeys?: ReadonlySet<string>) {
+    return render(
+        <CategoryItemGrid
+            columns={soloColumns}
+            visibleColumnKeys={visibleColumnKeys}
+            rows={soloRows}
+            personIdentity={() => ({ color: PERSON_COLORS[0] })}
+            packedById={{}}
+            hidePacked={false}
+            flourish={null}
+            onToggleItem={vi.fn()}
+            registerCellRef={vi.fn()}
+            onOpenRow={vi.fn()}
+        />
+    )
+}
+
 /** The chip block and the name span of the row carrying `label`. */
 function partsOf(label: string) {
     const row = screen.getByRole('button', { name: `Edit ${label}` }).closest('[data-testid="grid-row"]')!
@@ -98,6 +129,23 @@ describe('where the chips sit', () => {
 
         expect(partsOf('Tent').chips.className).not.toContain('order-first')
         expect(partsOf('Sunhat').chips.className).not.toContain('order-first')
+    })
+
+    it('lets a shared row take the width its pill needs, on a list of one', () => {
+        // The chip block is a person's place held open, and a shared row has no
+        // person in it — pinning its pill to one person's 32px ran the pill off
+        // the side of the card on every phone-width one-person list.
+        renderSoloGrid()
+
+        const shared = partsOf('Tent').chips
+        expect(shared.style.width).toBe('')
+        expect(shared.style.minWidth).toBe(`${soloChipBlockWidth}px`)
+    })
+
+    it('still holds one person in the same place down the card', () => {
+        renderSoloGrid()
+
+        expect(partsOf('Sunhat').chips.style.width).toBe(`${soloChipBlockWidth}px`)
     })
 })
 

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -398,12 +398,21 @@ export function CategoryItemGrid({
                                 person keeps their place down the whole card
                                 however many lines the chips take — and the same
                                 side of the name on every row of every card,
-                                filtered or not. */}
+                                filtered or not.
+
+                                A shared row holds the same place open but is not
+                                bound to it: its pill is one control several times
+                                wider than a disc, and one person's 44px is
+                                narrower than the pill on every one-person list.
+                                A minimum keeps it lined up with the chips wherever
+                                there is room and lets it have the rest of the row
+                                where there isn't, instead of running off the
+                                side of the card. */}
                             <div
                                 role="group"
                                 aria-label={row.label}
                                 className="flex shrink-0 flex-wrap gap-3 py-2"
-                                style={{ width: `${chipBlockWidth}px` }}
+                                style={row.communal ? { minWidth: `${chipBlockWidth}px` } : { width: `${chipBlockWidth}px` }}
                             >
                                 {row.communal
                                     ? renderSharedChip(row)


### PR DESCRIPTION
## Summary
Fixes a layout bug where shared row pills (controls) would overflow off the side of the card on single-person lists. The chip block width (44px for one person) was too narrow to contain the pill, which is several times wider than a single person's disc.

## Changes
- **CategoryItemGrid.tsx**: Changed shared rows from fixed `width` to `minWidth` styling, allowing their pills to expand beyond the chip block width when needed while still aligning with person chips when space permits
- **CategoryItemGrid.test.tsx**: Added test fixtures (`soloPeople`, `soloItems`, `soloColumns`, `soloRows`) and helper (`renderSoloGrid`) to test single-person list layouts, plus two new test cases:
  - Verifies shared rows use `minWidth` instead of `width` on single-person lists
  - Confirms person rows still maintain fixed width to hold their place

## Implementation Details
The fix distinguishes between two row types:
- **Person rows**: Keep fixed `width` to maintain consistent column alignment throughout the card
- **Shared rows**: Use `minWidth` to allow the pill to take the space it needs while respecting the minimum width when there's room

This ensures shared items don't overflow on narrow lists while maintaining the layout integrity for person-specific items.

https://claude.ai/code/session_01DjmC4oY6u11uF7yL6oJzQD