### PR TITLE
Keep the user signed in when the Pod is out of reach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ Each serial suite that writes to a Solid pod **must use its own dedicated pod us
 
 | Suite | Pod user |
 |-------|----------|
-| E, J, Z | `testuser` |
+| E, J (read-only tests), Z | `testuser` |
+| J5 (writes a list) | `juser` |
 | F | `fuser` |
 | G | `guser` |
 | H | `huser` |
@@ -47,9 +48,18 @@ Never end a session because a request failed. `@uvdsl/solid-oidc-client-browser`
   and `public/client-id.json` must keep listing the native redirect URI or the
   mobile app cannot log in at all.
 
+A fourth rule follows from the first: **a session that cannot be reached is not a
+session that has ended.** `isReconnecting` (`SolidPodContext`) is that state, and
+while it holds, the app keeps the account on screen and opens the identity's own
+PouchDB namespace from `rememberedSession.ts` rather than the empty local one —
+otherwise being offline looks exactly like being logged out (#342).
+
 `docs/staying-signed-in.md` has the full trace of the logout bugs these rules came
-from. `SolidPodContext.resilience.test.tsx`, `ResilientSession.test.ts` and e2e suite J
-pin the behaviour; suite J in particular asserts that a 401 does *not* sign the user out.
+from, and `docs/offline.md` covers what the app does with no network.
+`SolidPodContext.resilience.test.tsx`, `SolidPodContext.offline.test.tsx`,
+`ResilientSession.test.ts` and e2e suite J pin the behaviour; suite J in particular
+asserts that a 401 does *not* sign the user out, and that a pod it cannot reach
+leaves the user signed in with their lists on screen.
 
 ## Application Capability description
 

--- a/docs/offline.md
+++ b/docs/offline.md
@@ -1,0 +1,128 @@
+# Working offline
+
+What the app does when it cannot reach the network, why being offline used to
+look like being signed out (#342), and where an honestly offline-first version
+of this app goes next.
+
+## The short version
+
+Everything the app shows is already on the device. Lists, questions, people and
+tick-boxes live in PouchDB; the pod is a copy that other devices can read.
+Losing the network therefore costs nothing but syncing — and the app's job while
+it is gone is to say so, and to keep working.
+
+What it used to do instead was show its signed-out face: "Sync & Share" in the
+nav, the marketing landing page instead of the lists, a nudge to sign in for
+cross-device sync, and — worst of all — an empty list of lists. Nothing was
+lost, but there is no way to tell that from the outside, which is why the bug
+report reads "when offline it looks like you're logged out".
+
+## Why offline looked like signed out
+
+A Solid session is only *live* once the provider has answered a refresh, and
+that answer needs the network. So on a cold start with no connection there is no
+live session — only a refresh token in IndexedDB that nothing can be done with
+yet. `isLoggedIn` was the app's single answer to "who is this?", and offline it
+said *nobody*:
+
+1. **The nav offered to sign them in.** The loudest possible "you are logged
+   out", shown to someone who never left.
+2. **`/` redirected to the landing page** rather than to their lists.
+3. **The database was the wrong one.** PouchDB is namespaced per identity, and
+   the namespace is derived from the pod URL — which is read from the WebID
+   profile, over the network. With no network there was no namespace, so the app
+   fell back to the anonymous `local` database and the user's lists were simply
+   not on screen. Alarming, and the part that makes someone re-authenticate or
+   assume their data is gone.
+4. **The sync nudge and the sign-in prompts** told them to do the one thing that
+   cannot work without a connection.
+
+None of these is a session bug. `ResilientSession` was already doing the right
+thing underneath — retrying, never discarding the refresh token (see
+[staying-signed-in.md](./staying-signed-in.md)) — the app just had no way to
+render "signed in, but out of reach".
+
+## What it does now
+
+`SolidPodContext` distinguishes three states rather than two:
+
+| | `isLoggedIn` | `isReconnecting` | `sessionExpired` |
+|---|---|---|---|
+| Live session | `true` | `false` | `false` |
+| Signed in, offline | `false` | `true` | `false` |
+| Provider ended the grant | `false` | `false` | `true` |
+| Signed out | `false` | `false` | `false` |
+
+`isReconnecting` means: a session is stored on this device and nothing has told
+us it is over. The app keeps retrying on its backoff, and in the meantime:
+
+- **The nav shows the account**, with an "Offline" badge, and no sign-in button.
+- **`OfflineBanner`** says why the pod is quiet and that changes will sync
+  later. It is deliberately not an error and not dismissible — it clears itself
+  when the session comes back, which on a passing signal drop is seconds. The
+  alarming banner, `SessionExpiredBanner`, stays reserved for a session the
+  provider has actually ended.
+- **`/` still opens on the lists**, and the lists are the user's own: the pod
+  namespace resolved during the last live session is remembered
+  (`src/services/rememberedSession.ts`), so the right database opens with no
+  network at all.
+- **Sign-in nudges stay quiet**, and Share says it needs a connection rather
+  than offering to sign them in again.
+
+Two rules hold this together:
+
+- **Only the provider may make someone signed out.** `invalid_grant`,
+  `invalid_client`, a DPoP key that no longer matches — or a deliberate logout.
+  Everything else is `isReconnecting`, however long it lasts.
+- **Nothing about the identity outlives a real sign-out.** `forgetSignedIn()`
+  runs on logout, on expiry, and when a start finds no stored session at all, so
+  a signed-out device never claims to be reconnecting.
+
+The remembered WebID and namespace are in localStorage. Neither is a credential
+— the refresh token stays in IndexedDB, owned by the auth library — and both are
+facts the device already displays.
+
+### One caveat
+
+The pod namespace can only be remembered once a live session has resolved it. A
+device that has *never* had one since this feature shipped, and then starts
+offline, falls back to a namespace derived from the WebID — the same fallback
+the online path uses when no pod URL resolves. If the pod URL would have differed,
+that device opens an empty database until it gets a connection. One start, one
+time, and it corrects itself the moment a session goes live.
+
+## Where this goes next
+
+The app is local-first in its storage and online-first in its behaviour. Closing
+that gap, roughly in the order the value arrives:
+
+1. **An outbound queue.** Pod writes are best-effort today: `saveWithSyncPrevention`
+   saves locally, then pushes, and a push that fails is simply not retried — the
+   next full sync merges by `lastModified` and catches it. That works, but it is
+   luck rather than design. A durable queue of pending writes, drained when a
+   session goes live, makes "changes will sync when you're back" a promise the
+   code keeps rather than a description of what usually happens.
+2. **Per-resource sync state, shown.** "Saved on this device" and "saved to your
+   pod" are different facts and the UI mostly conflates them. A list that has
+   local edits nobody else can see yet should say so.
+3. **An app shell that survives a cold start.** Everything above assumes the app
+   loaded. On the web, opening it with no connection still gets a browser error
+   page — a service worker (or the native shell, which already ships its assets)
+   is what makes the whole app openable offline, not just usable once open.
+4. **Offline-aware affordances everywhere.** Sharing, backups and pod deletion
+   genuinely need the network. They should say that in place, once, rather than
+   each page finding its own way to fail.
+5. **Conflict handling with a face.** Merging by `lastModified` silently picks a
+   winner per field. Two devices editing the same list offline is exactly the
+   case where a person, not a timestamp, should decide.
+
+## Where the behaviour is pinned
+
+- `SolidPodContext.offline.test.tsx` — the three states, and what moves between
+  them.
+- `DatabaseContext.test.tsx` → "signed in but offline" — the right database
+  opens with no network, and nothing is asked of the pod.
+- `Navigation.test.tsx` → "signed in but offline", `OfflineBanner.test.tsx`,
+  `SyncAcrossDevicesPrompt.test.tsx` — what the user sees.
+- e2e suite J (`J4`, `J5`) — with every request to the pod refused, the app
+  still shows the account, the banner, and the lists that were made online.

--- a/docs/staying-signed-in.md
+++ b/docs/staying-signed-in.md
@@ -188,6 +188,21 @@ and only the reason, nothing identifying — so `invalid_grant` (a dead grant) c
 be told apart from `invalid_client` (a stale registration) without the device in
 hand.
 
+### 12. Offline looked exactly like signed out
+
+Everything above is about not *losing* a session. This one is about not being
+able to *show* one. A cold start with no network cannot make a session live —
+the refresh needs the provider to answer — so `isLoggedIn` was false, and the app
+had no third state to render: it offered "Sync & Share" in the nav, opened on the
+landing page, and, because the PouchDB namespace is derived from the pod URL read
+over the network, fell back to the empty `local` database. A signed-in user with
+no signal opened the app to no lists and an invitation to sign in.
+
+The session layer was already doing the right thing underneath. What was missing
+was `isReconnecting` — signed in, stored, unreachable — and a device that
+remembers who it is signed in as between live sessions.
+[offline.md](./offline.md) has that story, and where offline-first goes next.
+
 ## What changed
 
 A `ResilientSession` subclass (`src/services/ResilientSession.ts`) keeps
@@ -223,6 +238,9 @@ A `ResilientSession` subclass (`src/services/ResilientSession.ts`) keeps
   noticed through the App plugin as well as `visibilitychange` (bug 10).
 - An access token the library cannot read is refused before it can trigger the
   library's `logout()` (bug 11).
+- A session that is stored but not live reads as *offline*, not signed out: the
+  account stays on screen, the device's own copy of the data opens, and nothing
+  asks the user to sign in again (bug 12, [offline.md](./offline.md)).
 
 ## If it ever happens again
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,6 +1,6 @@
 import { test as base, BrowserContext, Page } from '@playwright/test'
 import { CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD, SCHEMA_COMPAT_EMAIL, SCHEMA_COMPAT_PASSWORD } from '../playwright.config'
-import { accountMenu, loginToCss } from './helpers/login'
+import { loginToCss, waitForLiveSession } from './helpers/login'
 
 type MyFixtures = {
   /** A page with a fresh (empty) browser context — no auth, no local data */
@@ -38,9 +38,10 @@ export const test = base.extend<MyFixtures>({
     // The context already has a valid session from authedContext's fresh login.
     // The app will try to restore the session (prompt=none), but since the same
     // CSS process is running and consent was just given, this should succeed quickly.
-    // Wait up to 30 seconds for the account menu — the signed-in sentinel — to appear.
+    // Wait up to 30 seconds for a *live* session — the account menu alone can
+    // appear while the restore is still in flight (see waitForLiveSession).
     await page.goto('/')
-    await accountMenu(page).first().waitFor({ state: 'visible', timeout: 30_000 })
+    await waitForLiveSession(page)
     await use(page)
   },
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -14,6 +14,7 @@ import {
   FUSER_EMAIL, FUSER_PASSWORD, FUSER_POD_NAME,
   GUSER_EMAIL, GUSER_PASSWORD, GUSER_POD_NAME,
   HUSER_EMAIL, HUSER_PASSWORD, HUSER_POD_NAME,
+  JUSER_EMAIL, JUSER_PASSWORD, JUSER_POD_NAME,
   LUSER_EMAIL, LUSER_PASSWORD, LUSER_POD_NAME,
   MUSER_EMAIL, MUSER_PASSWORD, MUSER_POD_NAME,
 } from '../playwright.config'
@@ -70,6 +71,9 @@ export default async function globalSetup() {
 
   await createCssAccount(CSS_PORT, HUSER_EMAIL, HUSER_PASSWORD, HUSER_POD_NAME)
   console.log(`[setup] H-suite account created: ${HUSER_EMAIL}`)
+
+  await createCssAccount(CSS_PORT, JUSER_EMAIL, JUSER_PASSWORD, JUSER_POD_NAME)
+  console.log(`[setup] J-suite account created: ${JUSER_EMAIL}`)
 
   await createCssAccount(CSS_PORT, LUSER_EMAIL, LUSER_PASSWORD, LUSER_POD_NAME)
   console.log(`[setup] L-suite account created: ${LUSER_EMAIL}`)

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from '@playwright/test'
+import { expect, type Locator, type Page } from '@playwright/test'
 
 /**
  * The signed-in sentinel. Logout used to be a button in the nav bar and was
@@ -7,6 +7,19 @@ import type { Locator, Page } from '@playwright/test'
  */
 export function accountMenu(page: Page): Locator {
   return page.getByRole('button', { name: /account menu/i })
+}
+
+/**
+ * The *live* signed-in sentinel: the account, with no offline notice beside it.
+ *
+ * The account menu on its own stopped meaning "the pod is reachable" in #342 — a
+ * session that is stored but not yet live now shows the same account with an
+ * "Offline" badge, which is the whole point of that change. So anything that
+ * needs a working pod waits for this instead, or it races the restore.
+ */
+export async function waitForLiveSession(page: Page, timeout = 30_000): Promise<void> {
+  await accountMenu(page).first().waitFor({ state: 'visible', timeout })
+  await expect(page.getByTestId('offline-banner')).toHaveCount(0, { timeout })
 }
 
 /** Opens the account menu, so its Backups link and Logout button are reachable. */

--- a/e2e/tests/e-auth.spec.ts
+++ b/e2e/tests/e-auth.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures'
-import { accountMenu, loginToCss, logoutViaAccountMenu, openAccountMenu } from '../helpers/login'
+import { accountMenu, loginToCss, logoutViaAccountMenu, openAccountMenu, waitForLiveSession } from '../helpers/login'
 
 const CSS_ISSUER = process.env.CSS_ISSUER ?? 'http://localhost:4001'
 const TEST_EMAIL = 'test@example.com'
@@ -54,7 +54,8 @@ test.describe('E – Solid Pod Authentication', () => {
   test('E4: session restored on page reload', async ({ authedPage: page }) => {
     await expect(accountMenu(page)).toBeVisible()
     await page.reload()
-    // Session should be restored from storage
-    await expect(accountMenu(page)).toBeVisible({ timeout: 15_000 })
+    // Restored, not merely remembered: an offline start shows the account too,
+    // so this waits for the session to actually be live again (#342).
+    await waitForLiveSession(page, 15_000)
   })
 })

--- a/e2e/tests/j-session-expiry.spec.ts
+++ b/e2e/tests/j-session-expiry.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '../fixtures'
-import { accountMenu } from '../helpers/login'
+import { accountMenu, loginToCss, waitForLiveSession } from '../helpers/login'
+import { fillPersonRequiredFields } from '../helpers/wizard'
+import { JUSER_EMAIL, JUSER_PASSWORD } from '../../playwright.config'
 
 const CSS_ISSUER = process.env.CSS_ISSUER ?? 'http://localhost:4001'
 const TEST_POD_NAME = 'testuser'
@@ -29,7 +31,7 @@ test.describe('J – Session Expiry', () => {
     })
 
     await expect(expiredBanner(page)).not.toBeVisible({ timeout: 5_000 })
-    await expect(accountMenu(page).first()).toBeVisible()
+    await waitForLiveSession(page)
   })
 
   /**
@@ -72,8 +74,87 @@ test.describe('J – Session Expiry', () => {
     await page.reload()
 
     // The session comes back on its own, without the user touching anything.
-    await expect(accountMenu(page).first()).toBeVisible({ timeout: 60_000 })
+    await waitForLiveSession(page, 60_000)
     expect(failures).toBe(3)
     await expect(expiredBanner(page)).not.toBeVisible()
+  })
+
+  /**
+   * Offline is not signed out (#342).
+   *
+   * A session only becomes live once the provider answers a refresh, so a start
+   * with no network cannot have one — and the app used to answer that by showing
+   * its logged-out face: "Sync & Share" in the nav, the marketing page instead of
+   * the lists, and the pod-scoped local database swapped for the empty one. On a
+   * phone, where a cold start with no signal is routine, that is what "it logged
+   * me out again" turned out to be.
+   *
+   * Every request to the pod and its provider is refused here; the app itself is
+   * already loaded, which is exactly the shape of a phone that has lost signal.
+   */
+  test('J4: a pod that cannot be reached reads as offline, not signed out', async ({ authedPage: page }) => {
+    await page.route(
+      url => url.port === new URL(CSS_ISSUER).port,
+      route => route.abort('internetdisconnected'),
+    )
+
+    await page.reload()
+
+    // Still their account, not an invitation to sign in.
+    await expect(accountMenu(page).first()).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByRole('button', { name: 'Sync & Share' })).toHaveCount(0)
+    // Said out loud, so the quiet pod is explained rather than mysterious.
+    await expect(page.getByTestId('offline-banner')).toBeVisible()
+    await expect(expiredBanner(page)).not.toBeVisible()
+  })
+
+  /**
+   * The half of #342 that loses more than confidence: the PouchDB namespace is
+   * derived from the pod URL, which is read from the WebID profile over the
+   * network. With none, the app opened the empty `local` database and the user's
+   * lists were simply not there.
+   */
+  /**
+   * The half of #342 that loses more than confidence: the PouchDB namespace is
+   * derived from the pod URL, which is read from the WebID profile over the
+   * network. With none, the app opened the empty `local` database and the user's
+   * lists were simply not there.
+   *
+   * Its own pod user, and its own context: this is the only test in J that
+   * writes, and `testuser` is shared with suites E and Z.
+   */
+  test('J5: the lists made while online are still there when the pod is not', async ({ browser }) => {
+    const ctx = await browser.newContext()
+    const page = await ctx.newPage()
+    try {
+      await page.goto('/')
+      await loginToCss(page, CSS_ISSUER, JUSER_EMAIL, JUSER_PASSWORD)
+      await waitForLiveSession(page)
+
+      await page.goto('/#/wizard')
+      await fillPersonRequiredFields(page)
+      await page.getByRole('button', { name: /Generate My Packing Questions/i }).click()
+      try { await page.getByRole('button', { name: 'Yes, Override' }).click({ timeout: 3_000 }) } catch { /* no existing questions */ }
+      await expect(page.getByRole('heading', { name: /Questions Generated Successfully/i })).toBeVisible({ timeout: 15_000 })
+
+      const listName = `Offline Survivor ${Date.now()}`
+      await page.goto('/#/create-packing-list')
+      await page.getByLabel('Packing List Name').waitFor({ timeout: 15_000 })
+      await page.getByLabel('Packing List Name').fill(listName)
+      await page.getByRole('button', { name: 'Create Packing List' }).click()
+      await page.waitForURL(/#\/view-lists\//, { timeout: 15_000 })
+
+      // Every request to the pod and its provider refused, as for J4.
+      await page.route(
+        url => url.port === new URL(CSS_ISSUER).port,
+        route => route.abort('internetdisconnected'),
+      )
+      await page.goto('/#/view-lists')
+      await page.reload()
+
+      await expect(page.getByText(listName)).toBeVisible({ timeout: 30_000 })
+    } finally {
+      await ctx.close()
+    }
   })
 })

--- a/e2e/tests/z-verify-offline-share.spec.ts
+++ b/e2e/tests/z-verify-offline-share.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures'
-import { accountMenu, loginToCss } from '../helpers/login'
+import { loginToCss, waitForLiveSession } from '../helpers/login'
 import { fillPersonRequiredFields } from '../helpers/wizard'
 import { chooseListAction, openListActions } from '../helpers/packing-list'
 import { CSS_ISSUER, TEST_EMAIL, TEST_PASSWORD } from '../../playwright.config'
@@ -36,7 +36,7 @@ test.describe('Z – Offline list → login → share (regression for 404 fix)',
         try {
             await page.getByRole('button', { name: /use.*local/i }).click({ timeout: 3_000 })
         } catch { /* no modal */ }
-        await accountMenu(page).first().waitFor({ timeout: 15_000 })
+        await waitForLiveSession(page, 15_000)
         console.log('Logged in')
 
         // ── 3. Navigate to the list ──────────────────────────────────────────

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,6 +29,11 @@ export const HUSER_POD_NAME = 'huser'
 export const LUSER_EMAIL = 'luser@example.com'
 export const LUSER_PASSWORD = 'test1234'
 export const LUSER_POD_NAME = 'luser'
+// J's one data-writing test needs a pod nobody else touches: E, J and Z share
+// `testuser`, and a suite that writes there breaks the ones that assume it empty.
+export const JUSER_EMAIL = 'juser@example.com'
+export const JUSER_PASSWORD = 'test1234'
+export const JUSER_POD_NAME = 'juser'
 export const MUSER_EMAIL = 'muser@example.com'
 export const MUSER_PASSWORD = 'test1234'
 export const MUSER_POD_NAME = 'muser'

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -27,6 +27,10 @@ vi.mock('./components/SessionExpiredBanner', () => ({
   SessionExpiredBanner: () => null,
 }))
 
+vi.mock('./components/OfflineBanner', () => ({
+  OfflineBanner: () => null,
+}))
+
 vi.mock('./pages/landing-page', () => ({ LandingPage: () => null }))
 vi.mock('./pages/questions-page', () => ({ QuestionsPage: () => null }))
 vi.mock('./pages/create-packing-list', () => ({ CreatePackingList: () => null }))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import './App.css'
 import { Navigation } from './components/Navigation'
 import { Footer } from './components/Footer'
 import { SessionExpiredBanner } from './components/SessionExpiredBanner'
+import { OfflineBanner } from './components/OfflineBanner'
 import { ToastProvider } from './components/ToastContext'
 import { ThemeProvider } from './components/ThemeContext'
 import { LandingPage } from './pages/landing-page'
@@ -27,9 +28,12 @@ import { YourDataPage } from './pages/your-data'
 import { OpenResourcePage } from './pages/open-resource'
 
 function DefaultRedirect() {
-  const { isLoggedIn, isLoading } = useSolidPod()
+  const { isLoggedIn, isReconnecting, isLoading } = useSolidPod()
   if (isLoading) return null
-  return <Navigate to={isLoggedIn ? '/view-lists' : '/home'} replace />
+  // A signed-in user whose pod is out of reach still opens on their lists —
+  // they are on the device. Sending them to the marketing landing page instead
+  // is half of what made being offline look like being signed out (#342).
+  return <Navigate to={isLoggedIn || isReconnecting ? '/view-lists' : '/home'} replace />
 }
 
 function App() {
@@ -45,6 +49,7 @@ function App() {
               <div className="min-h-screen flex flex-col bg-gradient-to-br from-primary-50 via-white to-accent-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950">
                 <Navigation />
                 <SessionExpiredBanner />
+                <OfflineBanner />
                 <div className="flex-1 container mx-auto px-4 py-8">
                   <Routes>
                     <Route path="/" element={<DefaultRedirect />} />

--- a/src/components/DatabaseContext.test.tsx
+++ b/src/components/DatabaseContext.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import React from 'react'
 import type { AppSession as Session } from '../types/AppSession'
 import { DatabaseProvider, useDatabase } from './DatabaseContext'
+import { rememberPodNamespace, rememberedPodNamespace } from '../services/rememberedSession'
 
 // --- Mocks ---
 
@@ -86,6 +87,7 @@ describe('DatabaseContext', () => {
     mockDetectPodDataFormat.mockReset()
     mockDetectPodDataFormat.mockResolvedValue('rdf')
     mockMigrateJsonToRdf.mockReset()
+    localStorage.clear()
     mockMigrateJsonToRdf.mockResolvedValue({ questionSetMigrated: false, packingListsMigrated: 0, errors: [] })
     localStorage.clear()
   })
@@ -200,6 +202,83 @@ describe('DatabaseContext', () => {
     const podNamespaceCall = namespaceCalls.find(ns => ns !== 'local')
     expect(podNamespaceCall).toBeDefined()
     expect(podNamespaceCall).toContain('example.com')
+  })
+
+  /**
+   * Offline is not signed out (#342). The pod-scoped PouchDB namespace comes from
+   * the pod URL, which comes from the WebID profile — a network read. With no
+   * network the app used to fall back to the empty `local` database, so a
+   * signed-in user opened their app to no lists at all: the most alarming way
+   * possible to say "you look logged out".
+   */
+  describe('signed in but offline', () => {
+    const WEB_ID = 'https://example.com/profile#me'
+
+    function reconnecting() {
+      mockUseSolidPod.mockReturnValue({
+        session: null,
+        isLoggedIn: false,
+        isReconnecting: true,
+        webId: WEB_ID,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+    }
+
+    it('opens the identity\'s own database from the remembered namespace', async () => {
+      rememberPodNamespace(WEB_ID, 'example.com')
+      reconnecting()
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      expect(mockGetInstance).toHaveBeenCalledWith('example.com')
+      expect(mockGetInstance).not.toHaveBeenCalledWith('local')
+      // Nothing may be asked of the pod: there is no session to ask with.
+      expect(mockGetPrimaryPodUrl).not.toHaveBeenCalled()
+      expect(mockSyncAllDataFromPod).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the sanitized webId when no namespace was remembered', async () => {
+      reconnecting()
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => screen.getByTestId('child'))
+      const namespaces = mockGetInstance.mock.calls.map(([ns]) => ns)
+      expect(namespaces.some(ns => ns !== 'local' && ns.includes('example.com'))).toBe(true)
+    })
+
+    it('remembers the namespace a live login resolved, for the next offline start', async () => {
+      const mockSession = { info: { isLoggedIn: true, webId: WEB_ID } }
+      mockUseSolidPod.mockReturnValue({
+        session: mockSession as unknown as Session,
+        isLoggedIn: true,
+        isReconnecting: false,
+        webId: WEB_ID,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+      mockGetPrimaryPodUrl.mockResolvedValue('https://example.com/')
+
+      render(
+        <DatabaseProvider>
+          <div data-testid="child" />
+        </DatabaseProvider>
+      )
+
+      await waitFor(() => expect(rememberedPodNamespace(WEB_ID)).toBe('example.com'))
+    })
   })
 
   it('throws when useDatabase is called outside DatabaseProvider', () => {

--- a/src/components/DatabaseContext.tsx
+++ b/src/components/DatabaseContext.tsx
@@ -3,6 +3,7 @@ import { PackingAppDatabase, LOCAL_NAMESPACE } from '../services/database'
 import { useSolidPod } from './SolidPodContext'
 import { getPrimaryPodUrl, syncAllDataFromPod } from '../services/solidPod'
 import { detectPodDataFormat, migrateJsonToRdf } from '../services/rdfMigration'
+import { rememberPodNamespace, rememberedPodNamespace } from '../services/rememberedSession'
 import { ConfirmationDialog } from './ConfirmationDialog'
 
 interface DatabaseContextValue {
@@ -30,7 +31,7 @@ const DatabaseContext = createContext<DatabaseContextValue | undefined>(undefine
  * choice to copy their local data to the pod.
  */
 export function DatabaseProvider({ children }: { children: ReactNode }) {
-    const { isLoggedIn, webId, session, isLoading } = useSolidPod()
+    const { isLoggedIn, isReconnecting, webId, session, isLoading } = useSolidPod()
     const [db, setDb] = useState<PackingAppDatabase | null>(null)
     const [namespace, setNamespace] = useState<string | null>(null)
     const [isResolvingPod, setIsResolvingPod] = useState(false)
@@ -51,6 +52,21 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
         }
 
         if (!isLoggedIn || !webId) {
+            // Signed in but unable to reach the pod (#342). The namespace is
+            // normally derived from the pod URL, which is read from the WebID
+            // profile — impossible with no network — so without a remembered one
+            // the app would open the empty `local` database and the user's lists
+            // would appear to be gone. This is a read of the device's own copy;
+            // nothing is asked of the pod until a session is live again.
+            if (isReconnecting && webId) {
+                const offlineNamespace =
+                    rememberedPodNamespace(webId) ?? PackingAppDatabase.sanitizePodUrl(webId)
+                setShowMigrationPrompt(false)
+                setNamespace(offlineNamespace)
+                setDb(PackingAppDatabase.getInstance(offlineNamespace))
+                return
+            }
+
             // Not logged in — use the local namespace immediately
             syncedNamespaceRef.current = null
             setShowMigrationPrompt(false)
@@ -74,6 +90,10 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
             const resolvedNamespace = podUrl
                 ? PackingAppDatabase.sanitizePodUrl(podUrl)
                 : PackingAppDatabase.sanitizePodUrl(webId)
+
+            // Banked for the next start that has no network: working this out
+            // again needs the pod, and that is exactly what will be missing.
+            rememberPodNamespace(webId, resolvedNamespace)
 
             // Session refreshed with same identity — nothing to do.
             if (syncedNamespaceRef.current === resolvedNamespace) {
@@ -145,7 +165,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
         return () => {
             cancelled = true
         }
-    }, [isLoggedIn, webId, session, isLoading])
+    }, [isLoggedIn, isReconnecting, webId, session, isLoading])
 
     if (isLoading || isResolvingPod || !db || !namespace) {
         return null

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -40,6 +40,22 @@ function signedIn() {
     mockUseSolidPod.mockReturnValue({
         session: null,
         isLoggedIn: true,
+        isReconnecting: false,
+        sessionExpired: false,
+        clearSessionExpired: vi.fn(),
+        webId: WEB_ID,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+    })
+}
+
+/** Signed in, but the Pod is out of reach — a phone that started with no signal. */
+function reconnecting() {
+    mockUseSolidPod.mockReturnValue({
+        session: null,
+        isLoggedIn: false,
+        isReconnecting: true,
         sessionExpired: false,
         clearSessionExpired: vi.fn(),
         webId: WEB_ID,
@@ -69,6 +85,7 @@ describe('Navigation', () => {
         mockUseSolidPod.mockReturnValue({
             session: null,
             isLoggedIn: false,
+            isReconnecting: false,
             sessionExpired: false,
             clearSessionExpired: vi.fn(),
             webId: undefined,
@@ -227,6 +244,7 @@ describe('Navigation – signed-out auth control', () => {
         mockUseSolidPod.mockReturnValue({
             session: null,
             isLoggedIn: false,
+            isReconnecting: false,
             sessionExpired: false,
             clearSessionExpired: vi.fn(),
             webId: undefined,
@@ -252,5 +270,39 @@ describe('Navigation – signed-out auth control', () => {
         renderNav()
 
         expect(screen.getAllByText(/sync across devices/i).length).toBeGreaterThanOrEqual(2)
+    })
+})
+
+/**
+ * Offline is not signed out (#342). A phone that starts with no signal cannot
+ * make its session live, and the nav used to answer that by offering to sign the
+ * user in — the single loudest "you are logged out" signal in the app, shown to
+ * someone who never left.
+ */
+describe('Navigation – signed in but offline', () => {
+    beforeEach(() => {
+        reconnecting()
+    })
+
+    it('keeps showing the account rather than offering to sign in', async () => {
+        renderNav()
+
+        expect(within(navBar()).queryByRole('button', { name: 'Sync & Share' })).toBeNull()
+        expect(await within(navBar()).findByRole('button', { name: /account menu/i })).toBeTruthy()
+    })
+
+    it('says the Pod is out of reach rather than leaving it unexplained', () => {
+        renderNav()
+
+        expect(within(navBar()).getByText(/offline/i)).toBeTruthy()
+    })
+
+    it('keeps the mobile menu signed in too, with a way out', () => {
+        renderNav()
+
+        const mobile = screen.getByTestId('mobile-menu')
+        expect(within(mobile).queryByRole('button', { name: 'Sync & Share' })).toBeNull()
+        expect(within(mobile).getByText(/offline/i)).toBeTruthy()
+        expect(within(mobile).getByRole('button', { name: 'Logout' })).toBeTruthy()
     })
 })

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,10 +8,25 @@ import { ThemeToggle } from './ThemeToggle'
 import { profileDisplayName, useSolidProfile } from '../hooks/useSolidProfile'
 import type { SharedContext } from '../services/rdfSerialization'
 
+/**
+ * The one thing the nav owes a signed-in user whose Pod is unreachable: which of
+ * the two states they are in. Their name is on screen either way, so without
+ * this the only difference between "synced" and "not syncing" would be invisible.
+ */
+const OfflineBadge = () => (
+    <span
+        data-testid="nav-offline-badge"
+        className="px-2 py-0.5 rounded-full bg-white/20 text-xs font-semibold whitespace-nowrap"
+        title="You're still signed in. Your Pod is out of reach, so changes will sync when the connection is back."
+    >
+        Offline
+    </span>
+)
+
 export const Navigation = () => {
     const [isOpen, setIsOpen] = useState(false)
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
-    const { login, logout, isLoggedIn, webId, session } = useSolidPod()
+    const { login, logout, isLoggedIn, isReconnecting, webId, session } = useSolidPod()
     const { db, loginSyncVersion } = useDatabase()
     const location = useLocation()
     const navigate = useNavigate()
@@ -25,6 +40,12 @@ export const Navigation = () => {
 
     const profile = useSolidProfile(webId, session)
     const displayName = profileDisplayName(profile, webId)
+
+    // Signed in is signed in, whether or not the Pod can be reached right now.
+    // Offering "Sync & Share" to someone whose session is merely offline is what
+    // made a lost connection read as a logout (#342); the badge below says which
+    // of the two it is, so nothing is hidden — it just isn't a sign-in prompt.
+    const showsAsSignedIn = isLoggedIn || isReconnecting
 
     const podMatch = /^\/pod\/([^/]+)/.exec(location.pathname)
     const currentForeignEncoded = podMatch?.[1] ?? null
@@ -97,8 +118,9 @@ export const Navigation = () => {
                         {/* Solid Login/Logout section */}
                         <div className="hidden md:flex items-center gap-4">
                             <ThemeToggle />
-                            {isLoggedIn ? (
+                            {showsAsSignedIn ? (
                                 <div className="flex items-center gap-3">
+                                    {isReconnecting && <OfflineBadge />}
                                     {/*
                                       * The context switcher stays out here rather than
                                       * inside the account menu: whose data you are
@@ -209,7 +231,7 @@ export const Navigation = () => {
                         <ThemeToggle showLabel />
                         {/* Mobile Solid Login/Logout */}
                         <div className="border-t border-white/20 pt-2 mt-2">
-                            {isLoggedIn ? (
+                            {showsAsSignedIn ? (
                                 <>
                                     {/*
                                       * The same things the desktop account menu holds,
@@ -223,6 +245,11 @@ export const Navigation = () => {
                                         <p className="text-xs font-semibold text-white/70 uppercase tracking-wide">Signed in as</p>
                                         <p className="mt-0.5 text-xs text-white/80 break-all" title={webId}>{webId}</p>
                                     </div>
+                                    {isReconnecting && (
+                                        <div className="px-3 pb-2">
+                                            <OfflineBadge />
+                                        </div>
+                                    )}
                                     <Link
                                         to="/backups"
                                         className="block px-3 py-3 rounded-xl text-base font-semibold hover:bg-white/20 transition-all duration-200"

--- a/src/components/OfflineBanner.test.tsx
+++ b/src/components/OfflineBanner.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { OfflineBanner } from './OfflineBanner'
+
+vi.mock('./SolidPodContext', () => ({
+    useSolidPod: vi.fn(),
+}))
+
+import { useSolidPod } from './SolidPodContext'
+
+const mockUseSolidPod = vi.mocked(useSolidPod)
+
+function mockPod(overrides: { isLoggedIn?: boolean; isReconnecting?: boolean } = {}) {
+    mockUseSolidPod.mockReturnValue({
+        session: null,
+        isLoggedIn: overrides.isLoggedIn ?? false,
+        isReconnecting: overrides.isReconnecting ?? false,
+        sessionExpired: false,
+        clearSessionExpired: vi.fn(),
+        webId: undefined,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+    })
+}
+
+function setOnLine(value: boolean) {
+    Object.defineProperty(navigator, 'onLine', { value, configurable: true })
+}
+
+describe('OfflineBanner', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        setOnLine(true)
+    })
+
+    afterEach(() => {
+        setOnLine(true)
+    })
+
+    it('says nothing while the session is live', () => {
+        mockPod({ isLoggedIn: true })
+
+        const { container } = render(<OfflineBanner />)
+
+        expect(container.innerHTML).toBe('')
+    })
+
+    it('says nothing to someone who is not signed in', () => {
+        mockPod()
+
+        const { container } = render(<OfflineBanner />)
+
+        expect(container.innerHTML).toBe('')
+    })
+
+    // The whole point of #342: reassurance, not an alarm. It must say the lists
+    // are still here and that changes are not being thrown away.
+    it('reassures a signed-in user whose device is offline', () => {
+        mockPod({ isReconnecting: true })
+        setOnLine(false)
+
+        render(<OfflineBanner />)
+
+        expect(screen.getByRole('status').textContent).toMatch(/offline/i)
+        expect(screen.getByRole('status').textContent).toMatch(/sync/i)
+    })
+
+    // Online but still unable to reach the provider — a pod that is down, a
+    // captive portal. Telling this user "you're offline" would be a lie.
+    it('names the Pod, not the connection, when the device is online', () => {
+        mockPod({ isReconnecting: true })
+        setOnLine(true)
+
+        render(<OfflineBanner />)
+
+        const text = screen.getByRole('status').textContent ?? ''
+        expect(text).toMatch(/reconnecting/i)
+        expect(text).not.toMatch(/you're offline/i)
+    })
+})

--- a/src/components/OfflineBanner.tsx
+++ b/src/components/OfflineBanner.tsx
@@ -1,0 +1,43 @@
+import { useSolidPod } from './SolidPodContext'
+import { useOnlineStatus } from '../hooks/useOnlineStatus'
+
+/**
+ * What the app says while it is signed in but cannot reach the Pod.
+ *
+ * The failure mode this exists for (#342) is not a broken app — everything on
+ * screen is the device's own copy and stays editable — it is a user who cannot
+ * tell "no signal" from "signed out" and re-authenticates, or worse, assumes
+ * their lists are gone. So the banner answers both questions at once: why the
+ * Pod is quiet, and what happens to the changes they make in the meantime.
+ *
+ * Deliberately not dismissible and deliberately not an error: it clears itself
+ * the moment the session comes back, which on a passing signal drop is seconds.
+ * The alarming banner is `SessionExpiredBanner`, and that one is reserved for a
+ * session the provider has actually ended.
+ */
+export function OfflineBanner() {
+    const { isReconnecting } = useSolidPod()
+    const isOnline = useOnlineStatus()
+
+    if (!isReconnecting) return null
+
+    return (
+        <div
+            data-testid="offline-banner"
+            role="status"
+            aria-live="polite"
+            className="bg-primary-50 dark:bg-primary-950/40 border-b border-primary-200 dark:border-primary-800 px-4 py-2.5"
+        >
+            <p className="text-sm text-primary-900 dark:text-primary-200 font-medium">
+                <span aria-hidden="true">📴 </span>
+                {isOnline
+                    ? "Can't reach your Pod — reconnecting."
+                    : "You're offline."}
+                {' '}
+                <span className="font-normal text-primary-800 dark:text-primary-300">
+                    Your lists are on this device and stay editable — anything you change will sync once you're back.
+                </span>
+            </p>
+        </div>
+    )
+}

--- a/src/components/SolidPodContext.offline.test.tsx
+++ b/src/components/SolidPodContext.offline.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import React from 'react'
+import { SolidPodProvider, useSolidPod } from './SolidPodContext'
+import { SessionEndedError } from '../services/ResilientSession'
+import { ToastProvider } from './ToastContext'
+import { rememberedWebId, rememberSignedIn } from '../services/rememberedSession'
+
+/**
+ * Offline is not signed out (#342).
+ *
+ * A cold start with no network cannot make a session live: the refresh needs the
+ * provider to answer. Everything the app knew about the user would then be gone
+ * until the connection came back, and the app would show its logged-out face —
+ * on a phone, where a cold start with no signal is routine, that is what "it
+ * logged me out again" turned out to be.
+ *
+ * The rule these tests encode: while a restorable session is stored on this
+ * device, the user is signed in and merely offline. Only the provider ending the
+ * grant, or a deliberate sign-out, makes them signed out.
+ */
+
+let capturedCallbacks: {
+    onSessionStateChange?: (event?: Event) => void
+    onSessionExpiration?: (event?: Event) => void
+} = {}
+
+let mockIsActive = false
+let mockWebId: string | undefined
+let mockRestore = vi.fn()
+let mockLogout = vi.fn()
+let mockHasStoredSession = vi.fn()
+
+vi.mock('../services/ResilientSession', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../services/ResilientSession')>()
+    return {
+        ...actual,
+        ResilientSession: vi.fn().mockImplementation(function (
+            _clientDetails: unknown,
+            _database: unknown,
+            options: typeof capturedCallbacks,
+        ) {
+            capturedCallbacks = options ?? {}
+            return {
+                get isActive() { return mockIsActive },
+                get webId() { return mockWebId },
+                handleRedirectFromLogin: vi.fn().mockResolvedValue(undefined),
+                restore: (...args: unknown[]) => mockRestore(...args),
+                login: vi.fn().mockResolvedValue(undefined),
+                logout: (...args: unknown[]) => mockLogout(...args),
+                authFetch: vi.fn(),
+                hasStoredSession: (...args: unknown[]) => mockHasStoredSession(...args),
+                needsRenewal: vi.fn().mockReturnValue(false),
+                scheduleRenewal: vi.fn(),
+                cancelRenewal: vi.fn(),
+                getExpiresIn: () => 3600,
+                isExpired: () => false,
+            }
+        }),
+    }
+})
+
+vi.mock('@uvdsl/solid-oidc-client-browser', () => ({
+    SessionIDB: vi.fn().mockImplementation(function () { return {} }),
+}))
+
+const WEB_ID = 'https://user.example.org/profile/card#me'
+
+function Consumer() {
+    const { isLoggedIn, isReconnecting, sessionExpired, webId, logout } = useSolidPod()
+    return (
+        <div>
+            <span data-testid="isLoggedIn">{String(isLoggedIn)}</span>
+            <span data-testid="isReconnecting">{String(isReconnecting)}</span>
+            <span data-testid="sessionExpired">{String(sessionExpired)}</span>
+            <span data-testid="webId">{webId ?? 'none'}</span>
+            <button onClick={() => void logout()}>Log out</button>
+        </div>
+    )
+}
+
+function renderApp() {
+    return render(
+        <ToastProvider>
+            <SolidPodProvider><Consumer /></SolidPodProvider>
+        </ToastProvider>
+    )
+}
+
+function activateSession() {
+    mockIsActive = true
+    mockWebId = WEB_ID
+    capturedCallbacks.onSessionStateChange?.(
+        new CustomEvent('sessionStateChange', { detail: { isActive: true, webId: WEB_ID } })
+    )
+}
+
+const state = (id: string) => screen.getByTestId(id).textContent
+
+describe('SolidPodContext — offline is not signed out', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        vi.spyOn(console, 'warn').mockImplementation(() => {})
+        capturedCallbacks = {}
+        mockIsActive = false
+        mockWebId = undefined
+        mockRestore = vi.fn().mockResolvedValue(undefined)
+        mockLogout = vi.fn().mockResolvedValue(undefined)
+        mockHasStoredSession = vi.fn().mockResolvedValue(true)
+        sessionStorage.clear()
+        localStorage.clear()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        sessionStorage.clear()
+        localStorage.clear()
+    })
+
+    it('reports a stored session it cannot reach as reconnecting, not signed out', async () => {
+        rememberSignedIn(WEB_ID)
+        mockRestore.mockRejectedValue(new Error('Failed to fetch'))
+
+        renderApp()
+
+        await waitFor(() => expect(state('isReconnecting')).toBe('true'))
+        expect(state('isLoggedIn')).toBe('false')
+        expect(state('sessionExpired')).toBe('false')
+        // Who they are is remembered, so the app can still show whose data it holds.
+        expect(state('webId')).toBe(WEB_ID)
+    })
+
+    it('does not claim to be reconnecting when no session is stored', async () => {
+        mockHasStoredSession = vi.fn().mockResolvedValue(false)
+
+        renderApp()
+
+        await waitFor(() => expect(state('isReconnecting')).toBe('false'))
+        expect(state('webId')).toBe('none')
+    })
+
+    it('stops reconnecting, and forgets the identity, when the provider ends the session', async () => {
+        rememberSignedIn(WEB_ID)
+        mockRestore.mockRejectedValue(new SessionEndedError('invalid_grant'))
+
+        renderApp()
+
+        await waitFor(() => expect(state('sessionExpired')).toBe('false'))
+        await act(async () => {
+            capturedCallbacks.onSessionExpiration?.(new CustomEvent('sessionExpiration'))
+        })
+
+        expect(state('isReconnecting')).toBe('false')
+        expect(state('sessionExpired')).toBe('true')
+        expect(state('webId')).toBe('none')
+        expect(rememberedWebId()).toBeUndefined()
+    })
+
+    it('remembers the identity once a session goes live, and stops reconnecting', async () => {
+        mockRestore.mockRejectedValue(new Error('Failed to fetch'))
+        renderApp()
+        await waitFor(() => expect(state('isReconnecting')).toBe('true'))
+
+        await act(async () => { activateSession() })
+
+        expect(state('isLoggedIn')).toBe('true')
+        expect(state('isReconnecting')).toBe('false')
+        expect(rememberedWebId()).toBe(WEB_ID)
+    })
+
+    it('forgets the identity on a deliberate sign-out', async () => {
+        renderApp()
+        await act(async () => { activateSession() })
+        expect(rememberedWebId()).toBe(WEB_ID)
+
+        await act(async () => { screen.getByText('Log out').click() })
+
+        await waitFor(() => expect(state('isLoggedIn')).toBe('false'))
+        expect(state('isReconnecting')).toBe('false')
+        expect(rememberedWebId()).toBeUndefined()
+    })
+
+    /**
+     * The mid-session case: the access token lapses while the radio is down, so
+     * the library flips the session inactive without the provider having said
+     * anything. Nothing used to book a retry for that — the recovery backoff only
+     * covers a session that was never restored — so the app went quiet, looking
+     * signed out.
+     */
+    it('keeps trying when a live session goes inactive without the provider ending it', async () => {
+        renderApp()
+        await act(async () => { activateSession() })
+        mockRestore.mockClear()
+        mockRestore.mockRejectedValue(new Error('Failed to fetch'))
+
+        await act(async () => {
+            mockIsActive = false
+            capturedCallbacks.onSessionStateChange?.(
+                new CustomEvent('sessionStateChange', { detail: { isActive: false, webId: undefined } })
+            )
+        })
+
+        await waitFor(() => expect(state('isReconnecting')).toBe('true'))
+        expect(state('sessionExpired')).toBe('false')
+        expect(state('webId')).toBe(WEB_ID)
+        expect(mockRestore).toHaveBeenCalled()
+    })
+})

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -9,12 +9,27 @@ import { logAuthEvent } from "../services/authLog";
 import { resetPodSessionCaches } from "../services/solidPod";
 import { AUTH_RETURN_TO_KEY } from "../pages/solid-pod-handle-redirect-page";
 import { AppSession } from "../types/AppSession";
+import { forgetSignedIn, rememberSignedIn, rememberedWebId } from "../services/rememberedSession";
 
 interface SolidPodContextValue {
   session: AppSession | null;
+  /** A live session: the pod is reachable and requests to it will be authorised. */
   isLoggedIn: boolean;
+  /**
+   * Signed in, but the session is not live — the provider cannot be reached, so
+   * the stored refresh token has not been exchanged yet. Almost always: no
+   * network. The user has *not* been signed out and nothing has been lost, so
+   * the app keeps their identity and their data on screen and goes on retrying.
+   * Never true once the provider has ended the grant (see `sessionExpired`).
+   */
+  isReconnecting: boolean;
   sessionExpired: boolean;
   clearSessionExpired: () => void;
+  /**
+   * Who the user is signed in as — from the live session, or, while
+   * reconnecting, remembered from the last one. Not proof that a pod request
+   * will succeed: check `isLoggedIn` (or `session`) for that.
+   */
   webId: string | undefined;
   isLoading: boolean;
   login: (oidcIssuer: string, returnTo?: string) => Promise<void>;
@@ -35,17 +50,42 @@ const STARTUP_RESTORE_BUDGET_MS = 4_000;
 
 export function SolidPodProvider({ children }: { children: ReactNode }) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [webId, setWebId] = useState<string | undefined>(undefined);
+  const [liveWebId, setLiveWebId] = useState<string | undefined>(undefined);
   const [sessionExpired, setSessionExpired] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const intentionalLogoutRef = useRef(false);
+  // Cleared only when the session is genuinely over, so it survives the reloads
+  // and cold starts an offline device is full of.
+  const [lastWebId, setLastWebId] = useState<string | undefined>(rememberedWebId);
 
   // A session we could not restore yet but have no reason to believe is dead.
   // While this is set, the app keeps quietly trying rather than showing the user
   // a login prompt for what is usually a few seconds of bad network.
+  //
+  // The ref is what the retry logic reads (callbacks made once, at construction,
+  // cannot see React state); the state is the same fact for rendering. Set them
+  // together through `setRecovering`.
   const recoveringRef = useRef(false);
+  // Seeded from what the device remembers: a cold start with a remembered
+  // identity is reconnecting until proven otherwise, so the first paint after
+  // an offline launch shows the user signed in rather than flashing a sign-in
+  // button at them. A device with no stored session corrects this within a tick.
+  const [isReconnecting, setIsReconnecting] = useState(() => rememberedWebId() !== undefined);
   const recoveryAttemptRef = useRef(0);
   const recoveryTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const setRecovering = useCallback((recovering: boolean) => {
+    recoveringRef.current = recovering;
+    setIsReconnecting(recovering);
+  }, []);
+
+  // The provider has disowned the grant. Kept in a ref because the session
+  // callbacks are built once and cannot read state: it stops the state-change
+  // event that follows an expiry from booking a retry for a session that is over.
+  const providerEndedRef = useRef(false);
+  // `attemptRestore` is defined below and re-created as its deps change; the
+  // callbacks reach it through this so they always call the current one.
+  const attemptRestoreRef = useRef<((trigger: string) => Promise<boolean>) | undefined>(undefined);
 
   const uvdslSessionRef = useRef<ResilientSession>(null!);
   if (!uvdslSessionRef.current) {
@@ -63,20 +103,39 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
         onSessionStateChange: (e) => {
           const { isActive, webId: newWebId } = (e as CustomEvent<SessionStateChangeDetail>).detail;
           setIsLoggedIn(isActive);
-          setWebId(isActive ? newWebId : undefined);
+          setLiveWebId(isActive ? newWebId : undefined);
           if (isActive) {
             setSessionExpired(false);
-            recoveringRef.current = false;
+            providerEndedRef.current = false;
+            setRecovering(false);
             recoveryAttemptRef.current = 0;
+            if (newWebId) {
+              rememberSignedIn(newWebId);
+              setLastWebId(newWebId);
+            }
+            return;
+          }
+          // A live session went inactive without the provider saying anything —
+          // the access token lapsed while the refresh could not get through,
+          // which on a phone is just "it woke up with no signal". Nothing else
+          // covers this: the recovery backoff only watches a session that was
+          // never restored. So claim it here and keep trying.
+          if (!providerEndedRef.current && !intentionalLogoutRef.current) {
+            setRecovering(true);
+            void attemptRestoreRef.current?.("session-inactive");
           }
         },
         // ResilientSession fires this only when the provider has rejected the
         // grant — not for network trouble, which it retries on its own.
         onSessionExpiration: () => {
+          providerEndedRef.current = true;
           if (!intentionalLogoutRef.current) setSessionExpired(true);
-          recoveringRef.current = false;
+          setRecovering(false);
           setIsLoggedIn(false);
-          setWebId(undefined);
+          setLiveWebId(undefined);
+          // The session is actually over, so the device stops claiming an identity.
+          forgetSignedIn();
+          setLastWebId(undefined);
           intentionalLogoutRef.current = false;
         },
       }
@@ -84,6 +143,10 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
   }
 
   const uvdslSession = uvdslSessionRef.current;
+
+  // The live session's WebID while there is one; otherwise the remembered one,
+  // but only while we still believe that session is coming back.
+  const webId = liveWebId ?? (isReconnecting ? lastWebId : undefined);
 
   const appSession: AppSession | null = isLoggedIn
     ? { fetch: uvdslSession.authFetch.bind(uvdslSession), info: { isLoggedIn, webId } }
@@ -98,25 +161,32 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
     if (uvdslSession.isActive) return true;
     if (!(await uvdslSession.hasStoredSession())) {
       logAuthEvent("restore.no-stored-session", { trigger });
-      recoveringRef.current = false;
+      setRecovering(false);
+      // Nothing to come back to — anything remembered about the identity is
+      // stale (storage evicted, or a sign-out this tab never saw).
+      forgetSignedIn();
+      setLastWebId(undefined);
       return false;
     }
+    // A stored session that is not live is a signed-in user we cannot reach
+    // yet, from this moment rather than only once an attempt has failed.
+    setRecovering(true);
 
     try {
       logAuthEvent("restore.attempt", { trigger, attempt: recoveryAttemptRef.current + 1 });
       await uvdslSession.restore();
-      recoveringRef.current = false;
+      setRecovering(false);
       recoveryAttemptRef.current = 0;
       logAuthEvent("restore.succeeded", { trigger });
       return true;
     } catch (error) {
       if (error instanceof SessionEndedError) {
         logAuthEvent("restore.session-ended", { trigger, reason: error.reason }, "error");
-        recoveringRef.current = false;
+        setRecovering(false);
         return false;
       }
       // Still recoverable. Schedule another go.
-      recoveringRef.current = true;
+      setRecovering(true);
       const attempt = recoveryAttemptRef.current;
       recoveryAttemptRef.current = attempt + 1;
       const delay = RECOVERY_DELAYS_MS[Math.min(attempt, RECOVERY_DELAYS_MS.length - 1)];
@@ -126,7 +196,11 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
       recoveryTimerRef.current = setTimeout(() => { void attemptRestore("backoff"); }, delay);
       return false;
     }
-  }, [uvdslSession]);
+  }, [uvdslSession, setRecovering]);
+
+  // The session callbacks are built once, so they reach the current
+  // `attemptRestore` through here rather than closing over a stale one.
+  attemptRestoreRef.current = attemptRestore;
 
   useEffect(() => {
     const initializeSession = async () => {
@@ -238,7 +312,7 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
 
   const logout = async () => {
     intentionalLogoutRef.current = true;
-    recoveringRef.current = false;
+    setRecovering(false);
     clearTimeout(recoveryTimerRef.current);
     try {
       await uvdslSession.logout();
@@ -249,8 +323,12 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
     // Which pod a WebID lives in, and which of its containers exist, are facts
     // about the identity that just went away.
     resetPodSessionCaches();
+    // Nothing about the identity outlives a deliberate sign-out: the next start
+    // must show a signed-out app, not one waiting to reconnect.
+    forgetSignedIn();
+    setLastWebId(undefined);
     setIsLoggedIn(false);
-    setWebId(undefined);
+    setLiveWebId(undefined);
   };
 
   const clearSessionExpired = () => setSessionExpired(false);
@@ -258,6 +336,7 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
   const value: SolidPodContextValue = {
     session: appSession,
     isLoggedIn,
+    isReconnecting: isReconnecting && !isLoggedIn,
     sessionExpired,
     clearSessionExpired,
     webId,

--- a/src/components/SyncAcrossDevicesPrompt.test.tsx
+++ b/src/components/SyncAcrossDevicesPrompt.test.tsx
@@ -12,9 +12,10 @@ import { useSolidPod } from './SolidPodContext'
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockLogin = vi.fn()
 
-function mockPod(isLoggedIn: boolean) {
+function mockPod(isLoggedIn: boolean, isReconnecting = false) {
     mockUseSolidPod.mockReturnValue({
         isLoggedIn,
+        isReconnecting,
         session: null,
         sessionExpired: false,
         clearSessionExpired: vi.fn(),
@@ -80,5 +81,16 @@ describe('SyncAcrossDevicesPrompt', () => {
         unmount()
         const { container } = render(<SyncAcrossDevicesPrompt />)
         expect(container.firstChild).toBeNull()
+    })
+    /**
+     * Offline is not signed out (#342): nudging a signed-in user to sign in is
+     * the app telling them their session is gone when it is not.
+     */
+    it('stays quiet for a signed-in user whose Pod is out of reach', () => {
+        mockPod(false, true)
+
+        const { container } = render(<SyncAcrossDevicesPrompt />)
+
+        expect(container.innerHTML).toBe('')
     })
 })

--- a/src/components/SyncAcrossDevicesPrompt.tsx
+++ b/src/components/SyncAcrossDevicesPrompt.tsx
@@ -19,15 +19,18 @@ function wasDismissed(): boolean {
 
 /**
  * A subtle, dismissible nudge shown to logged-out users who already have
- * something worth keeping. Renders nothing once the user is logged in or has
- * dismissed it this session.
+ * something worth keeping. Renders nothing once the user is logged in (or
+ * signed in but offline) or has dismissed it this session.
  */
 export function SyncAcrossDevicesPrompt() {
-    const { isLoggedIn, login } = useSolidPod()
+    const { isLoggedIn, isReconnecting, login } = useSolidPod()
     const [isDismissed, setIsDismissed] = useState(wasDismissed)
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
 
-    if (isLoggedIn || isDismissed) return null
+    // `isReconnecting` is a signed-in user the app cannot reach the pod for
+    // (#342). Asking them to sign in would be telling them their session is
+    // gone when it is not — and signing in again is not the fix for no signal.
+    if (isLoggedIn || isReconnecting || isDismissed) return null
 
     const handleDismiss = () => {
         try {

--- a/src/hooks/useOnlineStatus.test.ts
+++ b/src/hooks/useOnlineStatus.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useOnlineStatus } from './useOnlineStatus'
+
+function setOnLine(value: boolean) {
+    Object.defineProperty(navigator, 'onLine', { value, configurable: true })
+}
+
+describe('useOnlineStatus', () => {
+    afterEach(() => {
+        setOnLine(true)
+        vi.restoreAllMocks()
+    })
+
+    it('reports the browser\'s current connectivity', () => {
+        setOnLine(false)
+
+        const { result } = renderHook(() => useOnlineStatus())
+
+        expect(result.current).toBe(false)
+    })
+
+    it('follows the connection dropping and coming back', () => {
+        setOnLine(true)
+        const { result } = renderHook(() => useOnlineStatus())
+
+        act(() => {
+            setOnLine(false)
+            window.dispatchEvent(new Event('offline'))
+        })
+        expect(result.current).toBe(false)
+
+        act(() => {
+            setOnLine(true)
+            window.dispatchEvent(new Event('online'))
+        })
+        expect(result.current).toBe(true)
+    })
+
+    // A browser that cannot say is assumed connected: guessing "offline" would
+    // put an offline notice in front of someone who is perfectly online.
+    it('assumes online where the browser does not report it', () => {
+        Object.defineProperty(navigator, 'onLine', { value: undefined, configurable: true })
+
+        const { result } = renderHook(() => useOnlineStatus())
+
+        expect(result.current).toBe(true)
+    })
+})

--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+
+function currentlyOnline(): boolean {
+    // `undefined` where the browser does not report connectivity at all.
+    return navigator.onLine ?? true
+}
+
+/**
+ * Whether the device thinks it has a connection.
+ *
+ * Only ever used to *word* things — "you're offline" versus "can't reach your
+ * Pod" — never to decide what the app will attempt. `navigator.onLine` says the
+ * device has a network interface with a route, not that anything is reachable:
+ * a captive portal, a dead Wi-Fi or a pod that is down are all "online". What
+ * the app does about a failed request is decided by the request failing.
+ */
+export function useOnlineStatus(): boolean {
+    const [isOnline, setIsOnline] = useState(currentlyOnline)
+
+    useEffect(() => {
+        const update = () => setIsOnline(currentlyOnline())
+        window.addEventListener('online', update)
+        window.addEventListener('offline', update)
+        // The listeners can have missed a change between first render and here.
+        update()
+        return () => {
+            window.removeEventListener('online', update)
+            window.removeEventListener('offline', update)
+        }
+    }, [])
+
+    return isOnline
+}

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -321,7 +321,7 @@ export function CreatePackingList() {
     const [isSuggestionDismissed, setIsSuggestionDismissed] = useState(false)
     const [isDeletionSuggestionDismissed, setIsDeletionSuggestionDismissed] = useState(false)
     const { showToast } = useToast()
-    const { isLoggedIn, login, session } = useSolidPod()
+    const { isLoggedIn, isReconnecting, login, session } = useSolidPod()
     // Their own faces, on the very first screen that names them.
     const personPhoto = usePersonPhotos(questionSet?.people ?? NO_PEOPLE, session)
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
@@ -728,7 +728,10 @@ export function CreatePackingList() {
                                 </Link>
                             </div>
 
-                            {!isLoggedIn && (
+                            {/* Not offered to a signed-in user whose pod is
+                                out of reach (#342): they have already done this,
+                                and signing in again is not what fixes no signal. */}
+                            {!isLoggedIn && !isReconnecting && (
                                 <div className="bg-gradient-to-br from-accent-50 dark:from-accent-950/40 to-accent-100 dark:to-accent-900/40 p-6 rounded-xl border-2 border-accent-200 dark:border-accent-800">
                                     <h3 className="text-lg font-bold text-accent-900 dark:text-accent-200 mb-2">🔄 Sync Questions From Another Device</h3>
                                     <p className="text-gray-700 dark:text-gray-300 mb-4">

--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -225,4 +225,22 @@ describe('LandingPage – signed-in greeting', () => {
 
         expect(screen.queryByText(/signed in as/i)).toBeNull()
     })
+
+    // Offline is not signed out (#342): the greeting stays, and says which it is.
+    it('still greets a signed-in user whose Pod is out of reach', async () => {
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            isReconnecting: true,
+            webId: WEB_ID,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+
+        renderPage()
+
+        expect(await screen.findByText(/signed in as/i)).toBeTruthy()
+        expect(screen.getByText(/offline/i)).toBeTruthy()
+    })
 })

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -6,7 +6,7 @@ import { profileDisplayName, useSolidProfile } from '../hooks/useSolidProfile'
 import { SolidProviderSelector } from '../components/SolidProviderSelector'
 
 export const LandingPage = () => {
-    const { isLoggedIn, webId, session, login } = useSolidPod()
+    const { isLoggedIn, isReconnecting, webId, session, login } = useSolidPod()
     const profile = useSolidProfile(webId, session)
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
     const hasQuestions = useHasQuestions()
@@ -27,7 +27,7 @@ export const LandingPage = () => {
     )
     return (
         <>
-            {isLoggedIn && (
+            {(isLoggedIn || isReconnecting) && (
                 <div className="mb-6 p-4 bg-gradient-to-r from-success-50 dark:from-success-950/40 to-primary-50 dark:to-primary-950/40 border-2 border-success-300 dark:border-success-700 rounded-2xl shadow-soft animate-fade-in">
                     {/*
                       * Their name, not their WebID. The nav stopped printing the
@@ -37,6 +37,13 @@ export const LandingPage = () => {
                       */}
                     <p className="text-success-800 dark:text-success-200 font-semibold">
                         🎉 Signed in as <span className="font-bold">{profileDisplayName(profile, webId)}</span>
+                        {/* Signed in but unreachable is still signed in (#342) —
+                            the greeting stays and says which of the two it is. */}
+                        {isReconnecting && (
+                            <span className="ml-2 font-normal text-success-700 dark:text-success-300">
+                                · offline, changes will sync later
+                            </span>
+                        )}
                     </p>
                 </div>
             )}

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -383,7 +383,7 @@ export function ViewPackingList() {
     const handleCheckAll = (items: PackingListItem[]) =>
         items.forEach(item => setValue(`items.${item.id}`, true))
     const isDesktop = useIsDesktop()
-    const { isLoggedIn, session } = useSolidPod()
+    const { isLoggedIn, isReconnecting, session } = useSolidPod()
     const { showToast } = useToast()
     const { db } = useDatabase()
     // Read from the question set on every visit, not copied onto the list when
@@ -1702,6 +1702,10 @@ export function ViewPackingList() {
                                 disabled={isLoggedIn && !ownPodUrl}
                                 onSelect={() => {
                                     if (isLoggedIn) setShareModalOpen(true)
+                                    // Signed in but offline (#342): the sign-in
+                                    // prompt would be a lie, and sharing is the
+                                    // one thing here that genuinely needs the pod.
+                                    else if (isReconnecting) showToast("You're offline — sharing needs a connection to your Pod.", 'error')
                                     else setSignInToSharePromptOpen(true)
                                 }}
                             >

--- a/src/services/rememberedSession.test.ts
+++ b/src/services/rememberedSession.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+    rememberedWebId,
+    rememberSignedIn,
+    forgetSignedIn,
+    rememberedPodNamespace,
+    rememberPodNamespace,
+} from './rememberedSession'
+
+const WEB_ID = 'https://user.example.org/profile/card#me'
+const OTHER_WEB_ID = 'https://other.example.org/profile/card#me'
+
+describe('rememberedSession', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        localStorage.clear()
+    })
+
+    it('remembers nothing before a session has ever been live', () => {
+        expect(rememberedWebId()).toBeUndefined()
+        expect(rememberedPodNamespace(WEB_ID)).toBeUndefined()
+    })
+
+    it('remembers the signed-in WebID across reloads', () => {
+        rememberSignedIn(WEB_ID)
+
+        expect(rememberedWebId()).toBe(WEB_ID)
+    })
+
+    it('forgets the WebID once the session is genuinely over', () => {
+        rememberSignedIn(WEB_ID)
+
+        forgetSignedIn()
+
+        expect(rememberedWebId()).toBeUndefined()
+    })
+
+    it('remembers a pod namespace per identity', () => {
+        rememberPodNamespace(WEB_ID, 'pod.example.org_alice')
+        rememberPodNamespace(OTHER_WEB_ID, 'pod.example.org_bob')
+
+        expect(rememberedPodNamespace(WEB_ID)).toBe('pod.example.org_alice')
+        expect(rememberedPodNamespace(OTHER_WEB_ID)).toBe('pod.example.org_bob')
+    })
+
+    // The namespace outlives the session on purpose: it is how the *next* offline
+    // start finds the database, and it names no secret. Only the identity is
+    // forgotten at sign-out.
+    it('keeps the namespace when the identity is forgotten', () => {
+        rememberSignedIn(WEB_ID)
+        rememberPodNamespace(WEB_ID, 'pod.example.org_alice')
+
+        forgetSignedIn()
+
+        expect(rememberedPodNamespace(WEB_ID)).toBe('pod.example.org_alice')
+    })
+
+    it('survives storage that throws instead of storing', () => {
+        vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+            throw new Error('QuotaExceededError')
+        })
+        vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+            throw new Error('SecurityError')
+        })
+
+        expect(() => rememberSignedIn(WEB_ID)).not.toThrow()
+        expect(() => rememberPodNamespace(WEB_ID, 'ns')).not.toThrow()
+        expect(rememberedWebId()).toBeUndefined()
+        expect(rememberedPodNamespace(WEB_ID)).toBeUndefined()
+    })
+})

--- a/src/services/rememberedSession.ts
+++ b/src/services/rememberedSession.ts
@@ -1,0 +1,75 @@
+/**
+ * What the device remembers about the signed-in user *between* live sessions.
+ *
+ * A Solid session only becomes live once the provider has answered a refresh —
+ * which needs the network. With no network there is nothing to answer with, so
+ * everything the app knows about who is signed in would be gone until the
+ * connection came back: the nav would offer "Sync & Share", and the pod-scoped
+ * PouchDB namespace (which is derived from the pod URL, fetched from the WebID
+ * profile) could not be worked out at all, so the user's own lists would not
+ * even be on screen. That is #342 — offline looked exactly like signed out.
+ *
+ * So two facts are kept here, in localStorage, from the last live session:
+ * the WebID, and the PouchDB namespace that identity's data lives in. Neither
+ * is a credential — the refresh token stays in IndexedDB, owned by the auth
+ * library — and both are cleared the moment the session genuinely ends, so a
+ * signed-out device remembers nothing.
+ */
+
+const WEB_ID_KEY = 'pmu-last-signed-in-webid'
+const NAMESPACE_KEY_PREFIX = 'pmu-pod-namespace-'
+
+function read(key: string): string | undefined {
+    try {
+        return localStorage.getItem(key) ?? undefined
+    } catch {
+        // Storage unavailable (private mode, blocked cookies) — the app just
+        // falls back to its logged-out face, which is what it did before.
+        return undefined
+    }
+}
+
+function write(key: string, value: string): void {
+    try {
+        localStorage.setItem(key, value)
+    } catch {
+        // Nothing to do: remembering is an optimisation, not a requirement.
+    }
+}
+
+/** The WebID of the last session that was live on this device. */
+export function rememberedWebId(): string | undefined {
+    return read(WEB_ID_KEY)
+}
+
+export function rememberSignedIn(webId: string): void {
+    write(WEB_ID_KEY, webId)
+}
+
+/**
+ * Forgets the signed-in identity. Called only when the session is actually over
+ * — a deliberate logout, or the provider rejecting the grant — never for a
+ * failure the app expects to recover from.
+ */
+export function forgetSignedIn(): void {
+    try {
+        localStorage.removeItem(WEB_ID_KEY)
+    } catch {
+        // Nothing to do.
+    }
+}
+
+/**
+ * The PouchDB namespace an identity's data lives in.
+ *
+ * Normally derived from the pod URL, which comes from the WebID profile — a
+ * network read. Remembering it is what lets an offline start open the user's
+ * own database rather than the empty `local` one.
+ */
+export function rememberedPodNamespace(webId: string): string | undefined {
+    return read(NAMESPACE_KEY_PREFIX + webId)
+}
+
+export function rememberPodNamespace(webId: string, namespace: string): void {
+    write(NAMESPACE_KEY_PREFIX + webId, namespace)
+}


### PR DESCRIPTION
A Solid session only becomes live once the provider answers a refresh, so a
cold start with no network cannot have one. `isLoggedIn` was the app's single
answer to "who is this?", and offline it said nobody: the nav offered to sign
them in, `/` opened the landing page, the sign-in nudges appeared — and,
because the PouchDB namespace is derived from the pod URL read over the
network, the app fell back to the empty `local` database and their lists were
not on screen at all. Nothing was lost, but there is no way to tell that from
the outside, which is why this reads as "it logged me out again".

`SolidPodContext` now has a third state. `isReconnecting` means a session is
stored on this device and nothing has told us it is over: the user is signed
in and merely unreachable, so the account stays in the nav behind an "Offline"
badge, a quiet banner says why the Pod is silent and that changes will sync
later, `/` still opens on the lists, and the sign-in prompts stay quiet.

`rememberedSession.ts` is what makes that possible across a reload: the WebID
and the resolved pod namespace are kept from the last live session, so the
right database opens with no network at all. Neither is a credential — the
refresh token stays in IndexedDB, owned by the auth library — and both are
forgotten the moment the session genuinely ends: a deliberate logout, the
provider rejecting the grant, or a start that finds no stored session.

Also claims the mid-session case: a live session going inactive without the
provider saying anything (the token lapsing while the radio is down) now books
its own retry, where before neither backoff covered it.

The account menu therefore no longer means "the pod is reachable", so the e2e
helper for a live session waits for the offline banner to be absent too, and
J's new list-writing test gets its own pod user rather than sharing testuser.

docs/offline.md has the whole story, including where offline-first goes next.

Closes #342

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013WZr2RLkPKVWcRtMxzJc6x