### PR TITLE
Re-check for questions when the login sync lands (#333)

### DIFF
--- a/src/hooks/useHasQuestions.test.ts
+++ b/src/hooks/useHasQuestions.test.ts
@@ -17,8 +17,22 @@ function makeDb(overrides: { getQuestionSet?: ReturnType<typeof vi.fn> } = {}) {
     }
 }
 
+function databaseContext(
+    db: ReturnType<typeof makeDb>,
+    sync: { loginSyncVersion?: number; loginSyncInProgress?: boolean } = {}
+) {
+    mockUseDatabase.mockReturnValue({
+        db: db as unknown as PackingAppDatabase,
+        loginSyncVersion: sync.loginSyncVersion ?? 0,
+        loginSyncInProgress: sync.loginSyncInProgress ?? false,
+    })
+}
+
+const aQuestion = { id: '1', text: 'Do you need a jacket?' }
+
 describe('useHasQuestions', () => {
     beforeEach(() => {
+        vi.clearAllMocks()
         vi.spyOn(console, 'error').mockImplementation(() => {})
     })
 
@@ -27,39 +41,108 @@ describe('useHasQuestions', () => {
     })
 
     it('returns false when no questions exist (not_found)', async () => {
-        const db = makeDb({ getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }) })
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        databaseContext(makeDb({ getQuestionSet: vi.fn().mockRejectedValue({ name: 'not_found' }) }))
 
         const { result } = renderHook(() => useHasQuestions())
 
-        await waitFor(() => expect(result.current).toBe(false))
+        await waitFor(() => expect(result.current.hasQuestions).toBe(false))
     })
 
     it('returns false when document exists but has no questions', async () => {
-        const db = makeDb({ getQuestionSet: vi.fn().mockResolvedValue({ questions: [] }) })
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        databaseContext(makeDb({ getQuestionSet: vi.fn().mockResolvedValue({ questions: [] }) }))
 
         const { result } = renderHook(() => useHasQuestions())
 
-        await waitFor(() => expect(result.current).toBe(false))
+        await waitFor(() => expect(result.current.hasQuestions).toBe(false))
     })
 
     it('returns true when at least one question exists', async () => {
-        const db = makeDb({ getQuestionSet: vi.fn().mockResolvedValue({ questions: [{ id: '1', text: 'Do you need a jacket?' }] }) })
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        databaseContext(makeDb({ getQuestionSet: vi.fn().mockResolvedValue({ questions: [aQuestion] }) }))
 
         const { result } = renderHook(() => useHasQuestions())
 
-        await waitFor(() => expect(result.current).toBe(true))
+        await waitFor(() => expect(result.current.hasQuestions).toBe(true))
     })
 
     it('returns false and logs error for unexpected errors', async () => {
-        const db = makeDb({ getQuestionSet: vi.fn().mockRejectedValue(new Error('unexpected')) })
-        mockUseDatabase.mockReturnValue({ db: db as unknown as PackingAppDatabase })
+        databaseContext(makeDb({ getQuestionSet: vi.fn().mockRejectedValue(new Error('unexpected')) }))
 
         const { result } = renderHook(() => useHasQuestions())
 
-        await waitFor(() => expect(result.current).toBe(false))
+        await waitFor(() => expect(result.current.hasQuestions).toBe(false))
         expect(console.error).toHaveBeenCalled()
+    })
+
+    // #333: the login sync pulls the pod's question set into the local database
+    // in the background, long after this hook first read an empty one.
+    it('re-reads when the background login sync completes', async () => {
+        const getQuestionSet = vi
+            .fn()
+            .mockResolvedValueOnce({ questions: [] })
+            .mockResolvedValue({ questions: [aQuestion] })
+        const db = makeDb({ getQuestionSet })
+        databaseContext(db, { loginSyncVersion: 0, loginSyncInProgress: true })
+
+        const { result, rerender } = renderHook(() => useHasQuestions())
+
+        await waitFor(() => expect(getQuestionSet).toHaveBeenCalledTimes(1))
+        expect(result.current.hasQuestions).toBe(false)
+
+        databaseContext(db, { loginSyncVersion: 1, loginSyncInProgress: false })
+        rerender()
+
+        await waitFor(() => expect(result.current.hasQuestions).toBe(true))
+    })
+
+    describe('isLoading', () => {
+        it('is true until the first read comes back', async () => {
+            let resolveRead: (value: { questions: typeof aQuestion[] }) => void = () => {}
+            const getQuestionSet = vi.fn().mockReturnValue(
+                new Promise<{ questions: typeof aQuestion[] }>(resolve => { resolveRead = resolve })
+            )
+            databaseContext(makeDb({ getQuestionSet }))
+
+            const { result } = renderHook(() => useHasQuestions())
+
+            expect(result.current.isLoading).toBe(true)
+
+            resolveRead({ questions: [aQuestion] })
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false))
+        })
+
+        // The answer can't be un-found, so a slow pod must not hold the CTA back.
+        it('stops loading once questions are found, even while the pod is still being read', async () => {
+            databaseContext(
+                makeDb({ getQuestionSet: vi.fn().mockResolvedValue({ questions: [aQuestion] }) }),
+                { loginSyncInProgress: true }
+            )
+
+            const { result } = renderHook(() => useHasQuestions())
+
+            await waitFor(() => expect(result.current.hasQuestions).toBe(true))
+            expect(result.current.isLoading).toBe(false)
+        })
+
+        // "Nothing here" while the pod is still being read is not an answer yet.
+        it('keeps loading when nothing was found and the pod is still being read', async () => {
+            const getQuestionSet = vi.fn().mockResolvedValue({ questions: [] })
+            databaseContext(makeDb({ getQuestionSet }), { loginSyncInProgress: true })
+
+            const { result } = renderHook(() => useHasQuestions())
+
+            await waitFor(() => expect(getQuestionSet).toHaveBeenCalledTimes(1))
+            expect(result.current.isLoading).toBe(true)
+        })
+
+        it('is false for a local-only user with no questions and no pod sync', async () => {
+            const getQuestionSet = vi.fn().mockRejectedValue({ name: 'not_found' })
+            databaseContext(makeDb({ getQuestionSet }), { loginSyncInProgress: false })
+
+            const { result } = renderHook(() => useHasQuestions())
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false))
+            expect(result.current.hasQuestions).toBe(false)
+        })
     })
 })

--- a/src/hooks/useHasQuestions.ts
+++ b/src/hooks/useHasQuestions.ts
@@ -1,19 +1,50 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useDatabase } from '../components/DatabaseContext'
+import { useLocalFirstLoad } from './useLocalFirstLoad'
 
-export const useHasQuestions = () => {
+export interface HasQuestionsState {
+    /** True once a question set with at least one question has been read. */
+    hasQuestions: boolean
+    /**
+     * True while the answer could still change: the first read hasn't come
+     * back, or it found nothing and the login sync that might supply it is
+     * still running.
+     *
+     * A caller that picks between a "you have data" and a "you're new here"
+     * treatment must render neither while this holds. Defaulting to the
+     * new-here one flashed the wizard call to action at every returning user
+     * (#333) and stuck there for anyone whose questions arrived with the pod.
+     */
+    isLoading: boolean
+}
+
+/**
+ * Whether this identity has any packing questions yet.
+ *
+ * Read through `useLocalFirstLoad`, so the device's own copy answers
+ * immediately and the read runs again if the background login sync brings a
+ * question set this device had never seen — the case that made the home page
+ * CTA stale until a full reload (#333).
+ */
+export const useHasQuestions = (): HasQuestionsState => {
     const { db } = useDatabase()
     const [hasQuestions, setHasQuestions] = useState(false)
+    const [hasRead, setHasRead] = useState(false)
 
-    useEffect(() => {
-        db.getQuestionSet()
-            .then((doc) => setHasQuestions(doc.questions.length > 0))
-            .catch((err: unknown) => {
-                const hasName = typeof err === 'object' && err !== null && 'name' in err
-                if (!hasName || (err as { name: string }).name !== 'not_found') console.error(err)
-                setHasQuestions(false)
-            })
+    const { isCheckingPod } = useLocalFirstLoad(async () => {
+        try {
+            const doc = await db.getQuestionSet()
+            setHasQuestions(doc.questions.length > 0)
+        } catch (err: unknown) {
+            const hasName = typeof err === 'object' && err !== null && 'name' in err
+            if (!hasName || (err as { name: string }).name !== 'not_found') console.error(err)
+            setHasQuestions(false)
+        } finally {
+            setHasRead(true)
+        }
     }, [db])
 
-    return hasQuestions
+    // Questions already found can't be un-found by a pod that is still
+    // answering, so only the empty result waits on the sync.
+    return { hasQuestions, isLoading: !hasRead || (!hasQuestions && isCheckingPod) }
 }

--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -25,6 +25,11 @@ const mockUseHasQuestions = vi.mocked(useHasQuestions)
 const mockUseSolidPod = vi.mocked(useSolidPod)
 const mockGetSolidProfile = vi.mocked(getSolidProfile)
 
+const hasQuestions = (value: boolean) =>
+    mockUseHasQuestions.mockReturnValue({ hasQuestions: value, isLoading: false })
+const questionCheckPending = () =>
+    mockUseHasQuestions.mockReturnValue({ hasQuestions: false, isLoading: true })
+
 describe('LandingPage', () => {
     beforeEach(() => {
         mockUseSolidPod.mockReturnValue({
@@ -38,7 +43,7 @@ describe('LandingPage', () => {
     })
 
     it('shows "Get Started with the Wizard" as primary CTA when no questions exist', () => {
-        mockUseHasQuestions.mockReturnValue(false)
+        hasQuestions(false)
 
         render(
             <MemoryRouter>
@@ -51,7 +56,7 @@ describe('LandingPage', () => {
     })
 
     it('shows "View Packing Lists" as primary CTA when questions exist', () => {
-        mockUseHasQuestions.mockReturnValue(true)
+        hasQuestions(true)
 
         render(
             <MemoryRouter>
@@ -63,8 +68,36 @@ describe('LandingPage', () => {
         expect(screen.queryByRole('link', { name: /get started with the wizard/i })).toBeNull()
     })
 
+    // #333: guessing "new user" while the pod is still being read showed the
+    // wizard CTA to people who already have questions — and stuck there.
+    it('commits to neither CTA while the question check is still resolving', () => {
+        questionCheckPending()
+
+        render(
+            <MemoryRouter>
+                <LandingPage />
+            </MemoryRouter>
+        )
+
+        expect(screen.queryByRole('link', { name: /get started with the wizard/i })).toBeNull()
+        expect(screen.queryByRole('link', { name: /view packing lists/i })).toBeNull()
+        expect(screen.getByRole('status').textContent).toMatch(/checking/i)
+    })
+
+    it('keeps the CTA slot in place while the question check is resolving', () => {
+        questionCheckPending()
+
+        render(<MemoryRouter><LandingPage /></MemoryRouter>)
+
+        const placeholder = screen.getByRole('status')
+        const howItWorks = screen.getByRole('heading', { name: /how it works/i })
+        expect(
+            placeholder.compareDocumentPosition(howItWorks) & Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy()
+    })
+
     it('does not show secondary action links when questions exist', () => {
-        mockUseHasQuestions.mockReturnValue(true)
+        hasQuestions(true)
 
         render(
             <MemoryRouter>
@@ -77,14 +110,14 @@ describe('LandingPage', () => {
     })
 
     it('leads with the travel and sharing benefit in the h1', () => {
-        mockUseHasQuestions.mockReturnValue(false)
+        hasQuestions(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         const heading = screen.getByRole('heading', { level: 1 })
         expect(heading.textContent).toMatch(/packing lists that learn how you travel/i)
     })
 
     it('does not mention Solid Pod or data ownership above the fold', () => {
-        mockUseHasQuestions.mockReturnValue(false)
+        hasQuestions(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         const heading = screen.getByRole('heading', { level: 1 })
         const hero = heading.parentElement as HTMLElement
@@ -93,13 +126,13 @@ describe('LandingPage', () => {
     })
 
     it('supports the h1 with a sharing-focused subheadline', () => {
-        mockUseHasQuestions.mockReturnValue(false)
+        hasQuestions(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         expect(screen.getByText(/share one list with your partner or the whole family/i)).toBeTruthy()
     })
 
     it('renders the primary CTA before the "How it works" section so it is above the fold', () => {
-        mockUseHasQuestions.mockReturnValue(false)
+        hasQuestions(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         const cta = screen.getByRole('link', { name: /get started with the wizard/i })
         const howItWorks = screen.getByRole('heading', { name: /how it works/i })
@@ -109,7 +142,7 @@ describe('LandingPage', () => {
     })
 
     it('renders the "View Packing Lists" CTA before the "How it works" section too', () => {
-        mockUseHasQuestions.mockReturnValue(true)
+        hasQuestions(true)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         const cta = screen.getByRole('link', { name: /view packing lists/i })
         const howItWorks = screen.getByRole('heading', { name: /how it works/i })
@@ -119,7 +152,7 @@ describe('LandingPage', () => {
     })
 
     it('frames the data-ownership section as a benefit rather than a mechanism', () => {
-        mockUseHasQuestions.mockReturnValue(false)
+        hasQuestions(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         const trustSection = screen.getByRole('heading', { name: /own your data/i })
             .closest('div') as HTMLElement
@@ -127,7 +160,7 @@ describe('LandingPage', () => {
     })
 
     it('renders the Solid Pod section after the CTA in the DOM', () => {
-        mockUseHasQuestions.mockReturnValue(false)
+        hasQuestions(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         const cta = screen.getByRole('link', { name: /get started with the wizard/i })
         const solidPodHeading = screen.getByRole('heading', { name: /own your data/i })
@@ -137,20 +170,20 @@ describe('LandingPage', () => {
     })
 
     it('does not render the Solid Pod section as a dark full-width card', () => {
-        mockUseHasQuestions.mockReturnValue(false)
+        hasQuestions(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         const solidPodHeading = screen.getByRole('heading', { name: /own your data/i })
         expect(solidPodHeading.closest('[class*="bg-primary-950"]')).toBeNull()
     })
 
     it('shows a "Get a free Solid Pod" button on the page when not logged in', () => {
-        mockUseHasQuestions.mockReturnValue(false)
+        hasQuestions(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         expect(screen.getByRole('button', { name: /get a free solid pod/i })).toBeTruthy()
     })
 
     it('opens the provider selector modal when the login button is clicked', () => {
-        mockUseHasQuestions.mockReturnValue(false)
+        hasQuestions(false)
         render(<MemoryRouter><LandingPage /></MemoryRouter>)
         const loginButton = screen.getByRole('button', { name: /get a free solid pod/i })
         fireEvent.click(loginButton)
@@ -164,7 +197,7 @@ describe('LandingPage – signed-in greeting', () => {
     const WEB_ID = 'https://user.solidpod.example/profile/card#me'
 
     beforeEach(() => {
-        mockUseHasQuestions.mockReturnValue(false)
+        hasQuestions(false)
         mockGetSolidProfile.mockResolvedValue({ name: null, photo: null })
         mockUseSolidPod.mockReturnValue({
             session: null,

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -5,23 +5,33 @@ import { useHasQuestions } from '../hooks/useHasQuestions'
 import { profileDisplayName, useSolidProfile } from '../hooks/useSolidProfile'
 import { SolidProviderSelector } from '../components/SolidProviderSelector'
 
+const CTA_CLASSES =
+    'inline-block bg-gradient-primary-button text-white px-8 py-4 rounded-2xl text-lg font-bold motion-safe:hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary'
+
 export const LandingPage = () => {
     const { isLoggedIn, isReconnecting, webId, session, login } = useSolidPod()
     const profile = useSolidProfile(webId, session)
     const [isProviderSelectorOpen, setIsProviderSelectorOpen] = useState(false)
-    const hasQuestions = useHasQuestions()
-    const primaryCta = hasQuestions ? (
-        <Link
-            to="/view-lists"
-            className="inline-block bg-gradient-primary-button text-white px-8 py-4 rounded-2xl text-lg font-bold motion-safe:hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
+    const { hasQuestions, isLoading: isCheckingQuestions } = useHasQuestions()
+    // Which CTA is right depends on data that arrives from the pod after the
+    // page has painted, so until the check settles the page says neither. It
+    // used to guess "new user", which sent a returning user to the wizard and
+    // left them there until they reloaded (#333). A placeholder of the same
+    // size keeps everything below it still while the answer lands.
+    const primaryCta = isCheckingQuestions ? (
+        <div
+            role="status"
+            aria-live="polite"
+            className={`${CTA_CLASSES} pointer-events-none opacity-60 motion-safe:animate-pulse`}
         >
+            Checking your questions...
+        </div>
+    ) : hasQuestions ? (
+        <Link to="/view-lists" className={CTA_CLASSES}>
             📋 View Packing Lists
         </Link>
     ) : (
-        <Link
-            to="/wizard"
-            className="inline-block bg-gradient-primary-button text-white px-8 py-4 rounded-2xl text-lg font-bold motion-safe:hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
-        >
+        <Link to="/wizard" className={CTA_CLASSES}>
             ✨ Get Started with the Wizard
         </Link>
     )


### PR DESCRIPTION
Closes #333

## The bug

`useHasQuestions` read PouchDB once, in an effect keyed on `[db]` alone, and started out saying `false`.

Neither half survives login. `DatabaseProvider` swaps to the pod-namespaced database and *then* pulls the pod's data in the background, so the read that decides the home page's call to action runs against a database that is still empty — and never runs again. A returning user with a pod full of questions was shown the new-user wizard CTA until they reloaded. Starting at `false` also painted that same CTA on the first frame of every visit, pod or no pod.

## The fix

`useLocalFirstLoad` already exists for exactly this shape of problem: it re-runs a read when `loginSyncVersion` changes, and reports whether an empty answer might still be about to change. So:

- `src/hooks/useHasQuestions.ts` reads through it, and returns `{ hasQuestions, isLoading }`. `isLoading` is true until the first read returns, and stays true while an empty result waits on a running login sync — but not once questions have been found, since they can't be un-found by a pod that is still answering.
- `src/pages/landing-page.tsx` renders neither CTA while that holds: a placeholder pill of the same size, `role="status"`, reading "Checking your questions...".

## Verification

`npm test` (type check + 2212 vitest tests) green; e2e suites A and E green.

Manually tested against a real Community Solid Server on a pod seeded with a question set and a list, with pod reads deliberately slowed so the post-login window is observable — desktop and mobile, light and dark, plus the local-only case and the genuinely-new-user case. The pre-fix build was driven through the same walkthrough for comparison: it still showed the wizard CTA 15 seconds after login and only corrected on reload.

📋 **[Manual test report — 2026-09-03, with screenshots](https://github.com/timgent/pack-me-up/blob/agent-testing/2026-09-03-issue-333-stale-home-cta/README.md)** (on the `agent-testing` branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YfvZUgpg1C3qr2tiGtJUS

---
_Generated by [Claude Code](https://claude.ai/code/session_012YfvZUgpg1C3qr2tiGtJUS)_