### PR TITLE
Land on the suggested destination when signing in from a neutral page

### DIFF
--- a/src/components/SolidPodContext.test.tsx
+++ b/src/components/SolidPodContext.test.tsx
@@ -305,6 +305,35 @@ describe('SolidPodContext', () => {
         })
     })
 
+    // #334: "/home" is where you happened to be, not somewhere you asked to
+    // come back to. Hand those to the redirect page, which knows what this
+    // identity's pod holds and so which page to suggest.
+    it('routes a neutral stored return route through the redirect page after OAuth callback', async () => {
+        setWindowLocation('?code=abc123&state=xyz', '')
+        sessionStorage.setItem('authReturnTo', '/home')
+        mockIsActive = true
+        mockWebId = 'https://user.example.org/profile/card#me'
+
+        const replaceSpy = vi.fn()
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { ...originalLocation, search: '?code=abc123&state=xyz', hash: '', replace: replaceSpy },
+        })
+
+        render(
+            <Wrapper>
+                <Consumer />
+            </Wrapper>
+        )
+
+        await waitFor(() => {
+            expect(replaceSpy).toHaveBeenCalledWith('/#/solid-pod-handle-redirect')
+        })
+        // Left behind, it would be restored on the next load and put the user
+        // straight back on the page they signed in from.
+        expect(sessionStorage.getItem('authReturnTo')).toBeNull()
+    })
+
     it('arms a renewal timer for the life of the session, and disarms it on logout', async () => {
         // Keeping the session alive is the session object's job now: it renews on a
         // timer pegged to the token's own expiry, rather than a fixed poll that

--- a/src/components/SolidPodContext.tsx
+++ b/src/components/SolidPodContext.tsx
@@ -8,6 +8,7 @@ import { onAppResumed } from "../services/appResume";
 import { logAuthEvent } from "../services/authLog";
 import { resetPodSessionCaches } from "../services/solidPod";
 import { AUTH_RETURN_TO_KEY } from "../pages/solid-pod-handle-redirect-page";
+import { isNeutralAuthReturnRoute } from "../pages/postLoginDestination";
 import { AppSession } from "../types/AppSession";
 import { forgetSignedIn, rememberSignedIn, rememberedWebId } from "../services/rememberedSession";
 
@@ -228,7 +229,18 @@ export function SolidPodProvider({ children }: { children: ReactNode }) {
           // redirect_uri registered with the IdP can be the plain SPA root ("/").
           logAuthEvent("login.completed", { webId: uvdslSession.webId });
           uvdslSession.scheduleRenewal();
-          const returnTo = sessionStorage.getItem(AUTH_RETURN_TO_KEY) || "/solid-pod-handle-redirect";
+          const storedReturnTo = sessionStorage.getItem(AUTH_RETURN_TO_KEY);
+          let returnTo = storedReturnTo ?? "";
+          if (isNeutralAuthReturnRoute(returnTo)) {
+            // Nowhere the user asked to come back to — the home page is where
+            // they happened to be when they signed in, not a destination. Hand
+            // it to the redirect page, which picks between their lists and the
+            // wizard once it knows what this identity's pod holds (#334).
+            // Clearing the key matters: the reload below re-reads it, and a
+            // leftover "/home" would put them straight back where they started.
+            sessionStorage.removeItem(AUTH_RETURN_TO_KEY);
+            returnTo = "/solid-pod-handle-redirect";
+          }
           window.location.replace("/#" + returnTo);
           return;
         }

--- a/src/pages/postLoginDestination.test.ts
+++ b/src/pages/postLoginDestination.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { isNeutralAuthReturnRoute, suggestedPostLoginRoute } from './postLoginDestination'
+
+describe('isNeutralAuthReturnRoute', () => {
+    it.each([null, undefined, '', '/', '/home', '/home/', '/solid-pod-handle-redirect'])(
+        'treats %p as a neutral entry point',
+        route => {
+            expect(isNeutralAuthReturnRoute(route)).toBe(true)
+        }
+    )
+
+    it.each([
+        '/view-lists',
+        '/view-lists/abc123',
+        '/wizard',
+        '/manage-questions',
+        '/pod/https%3A%2F%2Fpod.example%2F/view-lists',
+        '/create-packing-list',
+    ])('treats %p as a route the user meant to return to', route => {
+        expect(isNeutralAuthReturnRoute(route)).toBe(false)
+    })
+
+    it('ignores a query string or nested hash when classifying', () => {
+        expect(isNeutralAuthReturnRoute('/home?utm=x')).toBe(true)
+        expect(isNeutralAuthReturnRoute('/view-lists?filter=me')).toBe(false)
+    })
+})
+
+describe('suggestedPostLoginRoute', () => {
+    it('sends someone with questions to their lists', () => {
+        expect(suggestedPostLoginRoute(true)).toBe('/view-lists')
+    })
+
+    it('sends someone with no questions to the wizard', () => {
+        expect(suggestedPostLoginRoute(false)).toBe('/wizard')
+    })
+})

--- a/src/pages/postLoginDestination.ts
+++ b/src/pages/postLoginDestination.ts
@@ -1,0 +1,41 @@
+/**
+ * Where to send someone once the OIDC round trip lands.
+ *
+ * Login returns you to where you started, and that is the point of it: someone
+ * who follows a shared list's URL and signs in to read it has to land on that
+ * list, not on their own index. But the neutral entry points carry no such
+ * intent — signing in via "Sync & Share" on the home page stored `/home` and
+ * dropped you straight back on the home page, so the suggestion the app already
+ * makes for `/` (`DefaultRedirect` in App.tsx) never got to run (#334).
+ *
+ * So the substitution is scoped to those neutral routes, and every other stored
+ * route is restored untouched.
+ */
+
+/**
+ * Routes that mean "wherever the app happened to open", not "take me back here".
+ *
+ * `/solid-pod-handle-redirect` is one of them: it is where the neutral case is
+ * sent, and it re-reads the stored route on arrival, so leaving it out would let
+ * the substitution point at itself.
+ */
+const NEUTRAL_AUTH_RETURN_ROUTES = ['', '/home', '/solid-pod-handle-redirect']
+
+export const isNeutralAuthReturnRoute = (route: string | null | undefined): boolean => {
+    if (!route) return true
+    // Compare paths only — a stored `/home?utm=x` is still the home page — and
+    // let `/` and `/home/` normalise onto the same entries as `` and `/home`.
+    const path = route.split(/[?#]/)[0].replace(/\/+$/, '')
+    return NEUTRAL_AUTH_RETURN_ROUTES.includes(path)
+}
+
+/**
+ * The suggested destination for someone arriving with no route of their own —
+ * the same rule the home page's primary CTA uses (`landing-page.tsx`).
+ *
+ * Only ask this once the question check has settled: an empty answer that the
+ * login sync has not finished contradicting sends a returning user into the
+ * wizard, which is #333.
+ */
+export const suggestedPostLoginRoute = (hasQuestions: boolean): string =>
+    hasQuestions ? '/view-lists' : '/wizard'

--- a/src/pages/solid-pod-handle-redirect-page.test.tsx
+++ b/src/pages/solid-pod-handle-redirect-page.test.tsx
@@ -9,11 +9,17 @@ vi.mock('react-router-dom', () => ({
     useNavigate: () => mockNavigate,
 }))
 
+let mockHasQuestions = { hasQuestions: true, isLoading: false }
+vi.mock('../hooks/useHasQuestions', () => ({
+    useHasQuestions: () => mockHasQuestions,
+}))
+
 describe('SolidPodHandleRedirectPage', () => {
     let originalLocation: Location
 
     beforeEach(() => {
         mockNavigate.mockClear()
+        mockHasQuestions = { hasQuestions: true, isLoading: false }
         sessionStorage.clear()
         originalLocation = window.location
     })
@@ -43,22 +49,89 @@ describe('SolidPodHandleRedirectPage', () => {
     })
 
     it('falls back to returnTo URL param when sessionStorage is empty', async () => {
-        setWindowLocation('?returnTo=%2Fview-lists')
+        setWindowLocation('?returnTo=%2Fview-lists%2Fabc123')
 
         render(<SolidPodHandleRedirectPage />)
 
         await waitFor(() => {
-            expect(mockNavigate).toHaveBeenCalledWith('/view-lists')
+            expect(mockNavigate).toHaveBeenCalledWith('/view-lists/abc123')
         })
     })
 
-    it('navigates to "/" when both sessionStorage authReturnTo and returnTo param are absent', async () => {
+    // #334: a deep link is an intent to come back; the home page is not.
+    it('restores a deep link even for someone with no questions yet', async () => {
+        mockHasQuestions = { hasQuestions: false, isLoading: false }
+        sessionStorage.setItem('authReturnTo', '/view-lists/abc123')
         setWindowLocation('')
 
         render(<SolidPodHandleRedirectPage />)
 
         await waitFor(() => {
-            expect(mockNavigate).toHaveBeenCalledWith('/')
+            expect(mockNavigate).toHaveBeenCalledWith('/view-lists/abc123')
         })
+    })
+
+    it('sends someone who signed in from the home page to their lists', async () => {
+        sessionStorage.setItem('authReturnTo', '/home')
+        setWindowLocation('')
+
+        render(<SolidPodHandleRedirectPage />)
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith('/view-lists', { replace: true })
+        })
+        expect(sessionStorage.getItem('authReturnTo')).toBeNull()
+    })
+
+    it('sends someone with no questions to the wizard rather than an empty list view', async () => {
+        mockHasQuestions = { hasQuestions: false, isLoading: false }
+        sessionStorage.setItem('authReturnTo', '/home')
+        setWindowLocation('')
+
+        render(<SolidPodHandleRedirectPage />)
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith('/wizard', { replace: true })
+        })
+    })
+
+    it('navigates to the suggested destination when no route was stored at all', async () => {
+        setWindowLocation('')
+
+        render(<SolidPodHandleRedirectPage />)
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith('/view-lists', { replace: true })
+        })
+    })
+
+    // The pod sync that supplies the question set is still running, so the
+    // answer could still change — guessing here is what sent returning users
+    // into the wizard in #333.
+    it('waits rather than guessing while the question check is still settling', async () => {
+        mockHasQuestions = { hasQuestions: false, isLoading: true }
+        sessionStorage.setItem('authReturnTo', '/home')
+        setWindowLocation('')
+
+        const { queryByText } = render(<SolidPodHandleRedirectPage />)
+
+        await waitFor(() => expect(queryByText('Logging in...')).not.toBeNull())
+        expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('navigates once the question check settles', async () => {
+        mockHasQuestions = { hasQuestions: false, isLoading: true }
+        setWindowLocation('')
+
+        const { rerender } = render(<SolidPodHandleRedirectPage />)
+        expect(mockNavigate).not.toHaveBeenCalled()
+
+        mockHasQuestions = { hasQuestions: true, isLoading: false }
+        rerender(<SolidPodHandleRedirectPage />)
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith('/view-lists', { replace: true })
+        })
+        expect(mockNavigate).toHaveBeenCalledTimes(1)
     })
 })

--- a/src/pages/solid-pod-handle-redirect-page.tsx
+++ b/src/pages/solid-pod-handle-redirect-page.tsx
@@ -1,23 +1,49 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
+import { useHasQuestions } from "../hooks/useHasQuestions";
+import { isNeutralAuthReturnRoute, suggestedPostLoginRoute } from "./postLoginDestination";
 
 export const AUTH_RETURN_TO_KEY = "authReturnTo";
 
 export const SolidPodHandleRedirectPage = () => {
     const navigate = useNavigate();
+    // Only consulted for the neutral case below, but hooks can't be conditional —
+    // and the read is local-first, so asking costs nothing when it isn't used.
+    const { hasQuestions, isLoading: isCheckingQuestions } = useHasQuestions();
+    // The neutral case waits for the question check, so this effect runs again
+    // when it settles. One navigation is all we ever want.
+    const hasNavigated = useRef(false);
 
     useEffect(() => {
+        if (hasNavigated.current) return;
+
         const storedRoute = sessionStorage.getItem(AUTH_RETURN_TO_KEY);
-        if (storedRoute) {
-            sessionStorage.removeItem(AUTH_RETURN_TO_KEY);
-            navigate(storedRoute);
+        sessionStorage.removeItem(AUTH_RETURN_TO_KEY);
+        if (!isNeutralAuthReturnRoute(storedRoute)) {
+            hasNavigated.current = true;
+            navigate(storedRoute!);
             return;
         }
 
         // Fallback: use returnTo from URL params (covers cases where sessionStorage was not set)
-        const params = new URLSearchParams(window.location.search);
-        navigate(params.get("returnTo") || "/");
-    }, [navigate]);
+        const paramRoute = new URLSearchParams(window.location.search).get("returnTo");
+        if (!isNeutralAuthReturnRoute(paramRoute)) {
+            hasNavigated.current = true;
+            navigate(paramRoute!);
+            return;
+        }
+
+        // Nothing the user asked to come back to, so make the suggestion the
+        // home page would have made (#334) — but not before the check settles,
+        // or a returning user whose questions are still arriving from the pod
+        // gets sent to the wizard (#333). The "Logging in..." screen below is
+        // what they see meanwhile.
+        if (isCheckingQuestions) return;
+        hasNavigated.current = true;
+        // Replace: this page was itself reached by a location.replace, and the
+        // back button should leave the app rather than bounce through it.
+        navigate(suggestedPostLoginRoute(hasQuestions), { replace: true });
+    }, [navigate, hasQuestions, isCheckingQuestions]);
 
     return (
         <div className="flex items-center justify-center min-h-screen">


### PR DESCRIPTION
Closes #334

## The problem

Signing in via "Sync & Share" on the home page returned you to the home page. Login stashes the current hash route in `sessionStorage` and restores it after the OIDC round trip, so `DefaultRedirect` — which already sends a signed-in user from `/` to their lists — never got to run.

## The change

Return-to-origin stays, because it is what makes a shared-list deep link work: follow someone's list URL, sign in, and you must land on that list. So the substitution is scoped to the **neutral** entry points only — `/`, `/home`, empty, and the redirect page itself.

- **`src/pages/postLoginDestination.ts`** (new) — `isNeutralAuthReturnRoute()` classifies a stored route, `suggestedPostLoginRoute()` picks `/view-lists` vs `/wizard`. Both pure, both unit-tested.
- **`src/components/SolidPodContext.tsx`** — on a completed OAuth callback, a neutral stored route is cleared and replaced with `/solid-pod-handle-redirect`. Anything else is restored exactly as before.

  Worth noting: the issue suggested doing this in `solid-pod-handle-redirect-page.tsx` alone, but in the normal flow that page never runs — the context reads the stored route and jumps straight to the hash. So the context has to route the neutral case *through* the page.
- **`src/pages/solid-pod-handle-redirect-page.tsx`** — picks the destination for the neutral case using `useHasQuestions`, the same hook the home page CTA uses. While the check is still settling it keeps showing "Logging in…" and navigates nothing, so a returning user whose question set is still arriving from the pod is never guessed into the wizard (the #333 hazard the issue warns about). It navigates with `replace`, so the back button doesn't bounce through the redirect screen.

## Testing

`npm test` — 2234 tests, all green (type check included). `npm run lint` — 0 errors.

Manually exercised end to end against a real Community Solid Server with real OIDC sign-in and real pod reads, at 1280×900 and 390×844, including a before/after against the pre-fix build. All acceptance criteria pass; no bugs found.

📋 **[Manual test report — 2026-09-04, with screenshots](https://github.com/timgent/pack-me-up/blob/agent-testing/2026-09-04-issue-334-post-login-destination/README.md)** (on the `agent-testing` branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Grbi2g16DEZoMBSNjB8J1

---
_Generated by [Claude Code](https://claude.ai/code/session_017Grbi2g16DEZoMBSNjB8J1)_