### PR TITLE
Replace decorative emoji with heroicons app-wide

### DIFF
--- a/e2e/tests/z-verify-offline-share.spec.ts
+++ b/e2e/tests/z-verify-offline-share.spec.ts
@@ -71,19 +71,19 @@ test.describe('Z – Offline list → login → share (regression for 404 fix)',
         expect(linkValue).toContain('pod=')
         console.log('Shareable link:', linkValue)
 
-        // ── 7. Close + reopen → Current access shows 🌐 row ────────────────
+        // ── 7. Close + reopen → Current access shows the public row ───────
         // Use onClose button (×) rather than Escape to ensure overlay is gone
         const closeBtn = page.getByRole('button', { name: /close/i }).or(page.locator('button[aria-label="Close"]'))
         await closeBtn.click({ timeout: 3_000 }).catch(() => page.keyboard.press('Escape'))
         // Wait for modal to be fully gone before clicking Share again
         await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5_000 })
         await chooseListAction(page, /^share$/i)
-        await expect(page.getByText('🌐 Anyone with the link')).toBeVisible({ timeout: 8_000 })
+        await expect(page.getByText('Anyone with the link')).toBeVisible({ timeout: 8_000 })
         console.log('"Anyone with the link" row visible ✓')
 
         // ── 8. Probe: revoke ────────────────────────────────────────────────
         await page.getByRole('button', { name: /revoke public access/i }).click()
-        await expect(page.getByText('🌐 Anyone with the link')).not.toBeVisible({ timeout: 8_000 })
+        await expect(page.getByText('Anyone with the link')).not.toBeVisible({ timeout: 8_000 })
         console.log('Public row gone after revoke ✓')
 
         // 404s on pack-me resources are expected: pod polling before first sync + ACL probing during grant

--- a/e2e/tests/z-verify-offline-share.spec.ts
+++ b/e2e/tests/z-verify-offline-share.spec.ts
@@ -78,12 +78,15 @@ test.describe('Z – Offline list → login → share (regression for 404 fix)',
         // Wait for modal to be fully gone before clicking Share again
         await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5_000 })
         await chooseListAction(page, /^share$/i)
-        await expect(page.getByText('Anyone with the link')).toBeVisible({ timeout: 8_000 })
+        // Scoped to the Current-access row: "Anyone with the link" is also the
+        // label of the share-mode toggle above it, which never goes away.
+        const publicAccessRow = page.getByRole('listitem').filter({ hasText: 'Anyone with the link' })
+        await expect(publicAccessRow).toBeVisible({ timeout: 8_000 })
         console.log('"Anyone with the link" row visible ✓')
 
         // ── 8. Probe: revoke ────────────────────────────────────────────────
         await page.getByRole('button', { name: /revoke public access/i }).click()
-        await expect(page.getByText('Anyone with the link')).not.toBeVisible({ timeout: 8_000 })
+        await expect(publicAccessRow).not.toBeVisible({ timeout: 8_000 })
         console.log('Public row gone after revoke ✓')
 
         // 404s on pack-me resources are expected: pod polling before first sync + ACL probing during grant

--- a/src/components/AgePromotionCard.tsx
+++ b/src/components/AgePromotionCard.tsx
@@ -1,3 +1,4 @@
+import { CakeIcon } from '@heroicons/react/24/outline'
 import { useMemo, useState } from 'react'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { AGE_RANGE_OPTIONS } from '../edit-questions/types'
@@ -133,7 +134,10 @@ export function AgePromotionCard({ questionSet, onApply, manualTransitions, onMa
     return (
         <div className="bg-violet-50 dark:bg-violet-950/40 rounded-lg border border-violet-200 dark:border-violet-800 p-4">
             <div className="flex items-start justify-between gap-4">
-                <p className="text-violet-900 dark:text-violet-200 font-medium">🎂 Time flies — {summary}! Want to update their packing items?</p>
+                <p className="flex items-start gap-2 text-violet-900 dark:text-violet-200 font-medium">
+                    <CakeIcon aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0" />
+                    <span>Time flies — {summary}! Want to update their packing items?</span>
+                </p>
                 <button
                     type="button"
                     aria-label="Dismiss age update"

--- a/src/components/CategoryItemGrid.tsx
+++ b/src/components/CategoryItemGrid.tsx
@@ -1,3 +1,4 @@
+import { ChevronDownIcon, ChevronRightIcon, UsersIcon } from '@heroicons/react/24/outline'
 /**
  * A category's items as a grid: the item down the side, the people across it,
  * a checkbox where they meet.
@@ -206,7 +207,7 @@ export function CategoryItemGrid({
     const visibleRows = foldShared ? visible.filter(row => !row.communal) : visible
 
     if (visibleRows.length === 0 && sharedRows.length === 0) {
-        return <p className="text-sm font-medium text-emerald-700 dark:text-emerald-300">Nothing left to pack 🎒</p>
+        return <p className="text-sm font-medium text-emerald-700 dark:text-emerald-300">Nothing left to pack</p>
     }
 
     // One width for every row in the card, so the chips land in the same places
@@ -372,7 +373,10 @@ export function CategoryItemGrid({
                     aria-label={`${row.label} for the whole group`}
                     className="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 dark:text-blue-400 focus:ring-blue-500"
                 />
-                <span className="whitespace-nowrap">👥 Shared</span>
+                <span className="inline-flex items-center gap-1 whitespace-nowrap">
+                    <UsersIcon aria-hidden="true" className="h-3.5 w-3.5" />
+                    Shared
+                </span>
                 {renderFlourish(item)}
             </label>
         )
@@ -439,8 +443,10 @@ export function CategoryItemGrid({
                         onClick={() => setSharedOpen(open => !open)}
                         className="flex w-full items-center gap-1.5 rounded-md px-1 py-2 text-left text-xs font-semibold text-blue-800 dark:text-blue-200 transition-colors hover:bg-blue-50 dark:hover:bg-blue-950/40"
                     >
-                        <span aria-hidden="true" className="text-gray-400 dark:text-gray-500">{sharedOpen ? '▼' : '▶'}</span>
-                        <span aria-hidden="true">👥</span>
+                        {sharedOpen
+                            ? <ChevronDownIcon aria-hidden="true" className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
+                            : <ChevronRightIcon aria-hidden="true" className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />}
+                        <UsersIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
                         Shared ({sharedRows.length})
                     </button>
                     {sharedOpen && (

--- a/src/components/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { Modal } from './Modal'
 import { Button } from './Button'
 
@@ -5,10 +6,11 @@ interface ConfirmationDialogProps {
     isOpen: boolean
     onClose: () => void
     onConfirm: () => void
-    title: string
-    message: string
-    confirmText?: string
-    cancelText?: string
+    /** Nodes rather than strings, so an icon can sit beside the words (#335). */
+    title: ReactNode
+    message: ReactNode
+    confirmText?: ReactNode
+    cancelText?: ReactNode
     confirmVariant?: 'primary' | 'secondary' | 'danger' | 'ghost'
 }
 

--- a/src/components/ItemEditorControls.tsx
+++ b/src/components/ItemEditorControls.tsx
@@ -1,3 +1,4 @@
+import { UsersIcon } from '@heroicons/react/24/outline'
 /**
  * The controls that edit one item's settings, shared by the option editor's
  * dense modal rows and by the inline editor that opens inside a read-only list.
@@ -69,7 +70,7 @@ export const PersonToggles = memo(function PersonToggles({ item, people, layout,
                     aria-pressed={isCommunal}
                     className={`inline-flex items-center justify-center h-5 rounded-full px-1 text-[10px] transition-colors mr-1 ${isCommunal ? 'bg-blue-600 text-white' : PERSON_COLOR_OFF}`}
                 >
-                    👥
+                    <UsersIcon aria-hidden="true" className="h-3.5 w-3.5" />
                 </button>
                 {people.length > 1 && people.map((person, personIdx) => {
                     const selected = item.personSelections?.[personIdx]?.selected ?? false
@@ -100,7 +101,7 @@ export const PersonToggles = memo(function PersonToggles({ item, people, layout,
                 aria-pressed={isCommunal}
                 className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-colors ${isCommunal ? 'bg-blue-600 text-white border-transparent' : 'bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500'}`}
             >
-                <span className="text-lg font-bold leading-none">👥</span>
+                <UsersIcon aria-hidden="true" className="h-5 w-5" />
                 <span className="text-[10px] font-medium leading-none truncate w-full text-center px-1">
                     Shared
                 </span>

--- a/src/components/ItemRow.tsx
+++ b/src/components/ItemRow.tsx
@@ -1,3 +1,4 @@
+import { UsersIcon } from '@heroicons/react/24/outline'
 /**
  * One item as a row: the shape every list on the questions page is made of.
  *
@@ -65,7 +66,7 @@ export const ItemRow = memo(function ItemRow({ item, people, index, isOpen, high
                     title="Shared — packed once for the whole group"
                     className="inline-flex items-center justify-center h-5 rounded-full px-1.5 text-[10px] font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 select-none shrink-0"
                 >
-                    👥
+                    <UsersIcon aria-hidden="true" className="h-3.5 w-3.5" />
                 </span>
             )}
             {item.perNight !== undefined && (

--- a/src/components/ItemRowPanel.tsx
+++ b/src/components/ItemRowPanel.tsx
@@ -1,3 +1,4 @@
+import { UsersIcon } from '@heroicons/react/24/outline'
 /**
  * "Who needs this?" — everything about one row of the category grid that isn't
  * ticking a box.
@@ -141,7 +142,7 @@ export function ItemRowPanel({
 
                 {row.communal ? (
                     <div className="flex items-center gap-2 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/40 px-3 py-2">
-                        <span aria-hidden="true">👥</span>
+                        <UsersIcon aria-hidden="true" className="h-4 w-4 shrink-0 text-blue-700 dark:text-blue-300" />
                         <span className="flex-1 text-sm font-medium text-blue-900 dark:text-blue-200">
                             Shared — packed once for the whole group
                         </span>

--- a/src/components/LoadingState.test.tsx
+++ b/src/components/LoadingState.test.tsx
@@ -15,11 +15,14 @@ describe('LoadingState', () => {
     })
 
     it('shows a packing-themed suitcase that screen readers skip', () => {
-        render(<LoadingState message="Loading backups..." />)
+        const { container } = render(<LoadingState message="Loading backups..." />)
 
-        const suitcase = screen.getByText('🧳')
-        expect(suitcase.getAttribute('aria-hidden')).toBe('true')
-        expect(suitcase.className).toContain('loading-suitcase')
+        // An icon rather than 🧳 since #335, so it takes the theme's colour —
+        // but it is still the rocking suitcase, and still skipped by readers.
+        const suitcase = container.querySelector('.loading-suitcase')
+        expect(suitcase).toBeTruthy()
+        expect(suitcase!.tagName.toLowerCase()).toBe('svg')
+        expect(suitcase!.getAttribute('aria-hidden')).toBe('true')
     })
 
     it('renders a skeleton of the content to come', () => {

--- a/src/components/LoadingState.tsx
+++ b/src/components/LoadingState.tsx
@@ -1,3 +1,5 @@
+import { BriefcaseIcon } from '@heroicons/react/24/outline'
+
 interface LoadingStateProps {
     /** What is being waited for, e.g. "Loading packing lists..." — read out to screen readers. */
     message: string;
@@ -9,12 +11,16 @@ interface LoadingStateProps {
  * The app's one waiting treatment: a suitcase rocking above a skeleton of the
  * content on its way. Sized to sit in the same space the real content will
  * take, so nothing jumps when it arrives.
+ *
+ * The suitcase is an icon rather than an emoji (#335) so it is the colour of the text
+ * beside it in both themes. `loading-suitcase` still does the rocking, and
+ * still stops under `prefers-reduced-motion`.
  */
 export function LoadingState({ message, rows = 3 }: LoadingStateProps) {
     return (
         <div role="status" aria-live="polite">
             <div className="flex flex-col items-center gap-3 py-6">
-                <span aria-hidden="true" className="loading-suitcase text-5xl leading-none">🧳</span>
+                <BriefcaseIcon aria-hidden="true" className="loading-suitcase h-12 w-12 text-primary-500 dark:text-primary-400" />
                 <p className="text-lg font-semibold text-gray-700 dark:text-gray-300">{message}</p>
             </div>
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -3,7 +3,12 @@ import { ReactNode } from 'react';
 interface ModalProps {
     isOpen: boolean;
     onClose: () => void;
-    title: string;
+    /**
+     * A node, not a string, so a header can carry an icon element beside its
+     * words. Callers used to smuggle a warning glyph into the string itself
+     * because this was the only way to get one in — see #335.
+     */
+    title: ReactNode;
     children: ReactNode;
 }
 

--- a/src/components/OfflineBanner.tsx
+++ b/src/components/OfflineBanner.tsx
@@ -1,3 +1,4 @@
+import { SignalSlashIcon } from '@heroicons/react/24/outline'
 import { useSolidPod } from './SolidPodContext'
 import { useOnlineStatus } from '../hooks/useOnlineStatus'
 
@@ -29,7 +30,7 @@ export function OfflineBanner() {
             className="bg-primary-50 dark:bg-primary-950/40 border-b border-primary-200 dark:border-primary-800 px-4 py-2.5"
         >
             <p className="text-sm text-primary-900 dark:text-primary-200 font-medium">
-                <span aria-hidden="true">📴 </span>
+                <SignalSlashIcon aria-hidden="true" className="mr-1 inline-block h-4 w-4 align-[-0.2em]" />
                 {isOnline
                     ? "Can't reach your Pod — reconnecting."
                     : "You're offline."}

--- a/src/components/PastTripsSection.tsx
+++ b/src/components/PastTripsSection.tsx
@@ -1,3 +1,4 @@
+import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
 import { useId, useState, type ReactNode } from 'react'
 
 interface PastTripsSectionProps {
@@ -34,7 +35,9 @@ export function PastTripsSection({ count, allPastFinished, children }: PastTrips
                 aria-controls={panelId}
                 className="flex items-center gap-2 w-full text-left px-4 py-3 rounded-xl border-2 border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 text-gray-600 dark:text-gray-400 hover:bg-white dark:hover:bg-gray-900 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-400 transition-colors"
             >
-                <span className="shrink-0 text-sm text-gray-400 dark:text-gray-500">{isExpanded ? '▼' : '▶'}</span>
+                {isExpanded
+                    ? <ChevronDownIcon aria-hidden="true" className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
+                    : <ChevronRightIcon aria-hidden="true" className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />}
                 <span className="text-lg font-semibold">{label} ({count})</span>
             </button>
             {/* Unmounted rather than hidden: a closed section shouldn't put its

--- a/src/components/PeopleFilterBar.tsx
+++ b/src/components/PeopleFilterBar.tsx
@@ -1,3 +1,4 @@
+import { UsersIcon } from '@heroicons/react/24/outline'
 /**
  * Who the user is packing for — the strip above the cards.
  *
@@ -266,7 +267,7 @@ export function PeopleFilterBar({
                             }`}
                         >
                             <span className="relative shrink-0">
-                                <span aria-hidden="true">👥</span>
+                                <UsersIcon aria-hidden="true" className="h-4 w-4" />
                                 {done && <DoneTick />}
                             </span>
                             <span className="hidden whitespace-nowrap sm:inline">Shared</span>

--- a/src/components/PodSyncIndicator.tsx
+++ b/src/components/PodSyncIndicator.tsx
@@ -1,3 +1,5 @@
+import { BriefcaseIcon } from '@heroicons/react/24/outline'
+
 interface PodSyncIndicatorProps {
     /**
      * What is being checked, when the page is showing one thing rather than
@@ -24,7 +26,7 @@ export function PodSyncIndicator({ subject }: PodSyncIndicatorProps) {
             aria-live="polite"
             className="mb-4 flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-400"
         >
-            <span aria-hidden="true" className="loading-suitcase text-base leading-none">🧳</span>
+            <BriefcaseIcon aria-hidden="true" className="loading-suitcase h-4 w-4 shrink-0" />
             Checking your Pod for changes{subject ? ` to ${subject}` : ''}...
         </div>
     )

--- a/src/components/SharePackingListModal.test.tsx
+++ b/src/components/SharePackingListModal.test.tsx
@@ -121,7 +121,7 @@ describe('SharePackingListModal', () => {
             mockGetCollaborators.mockResolvedValue([])
             mockIsPubliclyAccessible.mockResolvedValue(true)
             renderModal()
-            await waitFor(() => expect(screen.getByText('🌐 Anyone with the link')).toBeTruthy())
+            await waitFor(() => expect(screen.getByText('Anyone with the link')).toBeTruthy())
         })
 
         it('shows revoke button for each named collaborator', async () => {

--- a/src/components/SharePackingListModal.test.tsx
+++ b/src/components/SharePackingListModal.test.tsx
@@ -121,7 +121,11 @@ describe('SharePackingListModal', () => {
             mockGetCollaborators.mockResolvedValue([])
             mockIsPubliclyAccessible.mockResolvedValue(true)
             renderModal()
-            await waitFor(() => expect(screen.getByText('Anyone with the link')).toBeTruthy())
+            // Scoped to the row: "Anyone with the link" is also the share-mode
+            // toggle's label, so a bare text match is two elements.
+            await waitFor(() => expect(
+                screen.getAllByRole('listitem').find(li => li.textContent?.includes('Anyone with the link'))
+            ).toBeTruthy())
         })
 
         it('shows revoke button for each named collaborator', async () => {

--- a/src/components/SharePackingListModal.tsx
+++ b/src/components/SharePackingListModal.tsx
@@ -1,3 +1,4 @@
+import { GlobeAltIcon } from '@heroicons/react/24/outline'
 import { useState, useEffect } from 'react'
 import { AppSession } from '../types/AppSession'
 import {
@@ -156,7 +157,10 @@ export function SharePackingListModal({
                         <ul className="space-y-2">
                             {isPublic && (
                                 <li className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
-                                    <span className="text-sm text-gray-800 dark:text-gray-100">🌐 Anyone with the link</span>
+                                    <span className="inline-flex items-center gap-1.5 text-sm text-gray-800 dark:text-gray-100">
+                                        <GlobeAltIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
+                                        Anyone with the link
+                                    </span>
                                     <button
                                         type="button"
                                         onClick={handleRevokePublic}

--- a/src/components/SolidPodPrompt.tsx
+++ b/src/components/SolidPodPrompt.tsx
@@ -45,7 +45,7 @@ export function SolidPodPrompt({
   message,
   benefitsTitle = 'What signing in unlocks:',
   benefits = DEFAULT_BENEFITS,
-  confirmLabel = '🔒 Sync & Share',
+  confirmLabel = 'Sync & Share',
   dismissLabel = 'Maybe Later',
   onBeforeLogin,
 }: SolidPodPromptProps) {

--- a/src/components/SyncAcrossDevicesPrompt.tsx
+++ b/src/components/SyncAcrossDevicesPrompt.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { XMarkIcon } from '@heroicons/react/24/outline'
+import { DevicePhoneMobileIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { useSolidPod } from './SolidPodContext'
 import { SolidProviderSelector } from './SolidProviderSelector'
 
@@ -48,7 +48,10 @@ export function SyncAcrossDevicesPrompt() {
                 className="mb-6 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-primary-200 dark:border-primary-800 bg-primary-50/70 dark:bg-primary-950/40 px-4 py-3"
             >
                 <p className="flex-1 min-w-50 text-sm text-gray-700 dark:text-gray-300">
-                    <span className="font-bold text-primary-900 dark:text-primary-200">📱 Sync across devices</span>
+                    <span className="font-bold text-primary-900 dark:text-primary-200">
+                        <DevicePhoneMobileIcon aria-hidden="true" className="mr-1 inline-block h-4 w-4 align-[-0.2em]" />
+                        Sync across devices
+                    </span>
                     {' — '}
                     sign in to pick these lists up on your phone or laptop, and keep them safe if you clear your browser.
                 </p>

--- a/src/components/TemplateUpdatesCard.tsx
+++ b/src/components/TemplateUpdatesCard.tsx
@@ -1,3 +1,4 @@
+import { SparklesIcon } from '@heroicons/react/24/outline'
 import { useMemo, useState } from 'react'
 import { PackingListQuestionSet } from '../edit-questions/types'
 import { WIZARD_TEMPLATE_VERSION } from '../edit-questions/example-data'
@@ -79,8 +80,9 @@ export function TemplateUpdatesCard({ questionSet, onApply }: TemplateUpdatesCar
     return (
         <div className="bg-emerald-50 dark:bg-emerald-950/40 rounded-lg border border-emerald-200 dark:border-emerald-800 p-4">
             <div className="flex items-start justify-between gap-4">
-                <p className="text-emerald-900 dark:text-emerald-200 font-medium">
-                    ✨ We've added to the starter suggestions since you set up — {count} new suggestion{count === 1 ? '' : 's'} available.
+                <p className="flex items-start gap-2 text-emerald-900 dark:text-emerald-200 font-medium">
+                    <SparklesIcon aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0" />
+                    <span>We've added to the starter suggestions since you set up — {count} new suggestion{count === 1 ? '' : 's'} available.</span>
                 </p>
                 <button
                     type="button"

--- a/src/components/TripCountdownBadge.test.tsx
+++ b/src/components/TripCountdownBadge.test.tsx
@@ -68,9 +68,21 @@ describe('the trip countdown badge', () => {
         expect(badge()!.textContent).toContain('2 sleeps until Cornwall · 18 items left')
     })
 
-    it('leaves the emoji out of the accessible name so it is not read aloud', () => {
+    it('leaves the glyph out of the accessible name so it is not read aloud', () => {
         freezeClock()
         renderFor({ startDate: '2026-06-18', destination: 'Cornwall' })
         expect(badge()!.querySelector('[aria-hidden="true"]')).not.toBeNull()
+    })
+
+    // #335: an emoji is a full-colour bitmap that ignores the tone around it,
+    // and `today` is white text on accent. An icon inherits `currentColor`, so
+    // each state's glyph is whatever colour that state chose.
+    it('marks the state with an icon rather than an emoji', () => {
+        freezeClock()
+        renderFor({ startDate: '2026-06-18', destination: 'Cornwall' })
+
+        const glyph = badge()!.querySelector('[aria-hidden="true"]')!
+        expect(glyph.tagName.toLowerCase()).toBe('svg')
+        expect(badge()!.textContent).not.toMatch(/\p{Extended_Pictographic}/u)
     })
 })

--- a/src/components/TripCountdownBadge.tsx
+++ b/src/components/TripCountdownBadge.tsx
@@ -1,3 +1,4 @@
+import { BriefcaseIcon, HomeIcon, MoonIcon, SparklesIcon } from '@heroicons/react/24/outline'
 import { URGENT_SLEEPS } from '../create-packing-list/tripDetails'
 import type { TripCountdown, TripCountdownStatus } from '../create-packing-list/tripDetails'
 
@@ -20,11 +21,16 @@ const TONES: Record<TripCountdownStatus | 'urgent', string> = {
     past: 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-700',
 }
 
-const ICONS: Record<TripCountdownStatus, string> = {
-    upcoming: '🌙',
-    today: '🎉',
-    'in-progress': '🧳',
-    past: '🏡',
+/**
+ * Icons, not emoji (#335): an emoji is a full-colour bitmap that ignores the
+ * tone it is sitting in, and `today`'s badge is white-on-accent. These inherit
+ * `currentColor`, so each state's glyph is the colour its own tone chose.
+ */
+const ICONS: Record<TripCountdownStatus, typeof MoonIcon> = {
+    upcoming: MoonIcon,
+    today: SparklesIcon,
+    'in-progress': BriefcaseIcon,
+    past: HomeIcon,
 }
 
 /**
@@ -37,6 +43,7 @@ export function TripCountdownBadge({ countdown, className = '' }: TripCountdownB
 
     const urgent = countdown.status === 'upcoming' && (countdown.sleeps ?? Infinity) <= URGENT_SLEEPS
     const tone = TONES[urgent ? 'urgent' : countdown.status]
+    const Icon = ICONS[countdown.status]
 
     return (
         <span
@@ -44,7 +51,7 @@ export function TripCountdownBadge({ countdown, className = '' }: TripCountdownB
             data-countdown-status={countdown.status}
             className={`inline-flex items-center gap-1 text-sm font-semibold border px-2.5 py-1 rounded-full max-w-full ${tone} ${className}`}
         >
-            <span aria-hidden="true">{ICONS[countdown.status]}</span>
+            <Icon aria-hidden="true" className="h-4 w-4 shrink-0" />
             {countdown.label}
         </span>
     )

--- a/src/decorativeEmoji.test.ts
+++ b/src/decorativeEmoji.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+/**
+ * The guard for #335: decorative emoji stay out of the app.
+ *
+ * The complaint that started it (design feedback, 26/08/2026) was that the emoji
+ * on buttons and cards "bring a lot of colors and don't contrast very well on
+ * their backgrounds" — an emoji is a full-colour bitmap the theme cannot touch,
+ * so it looks wrong in dark mode, wrong on a gradient, and different on every
+ * platform. Icons are `currentColor`, so they are always the colour of the text
+ * they sit beside.
+ *
+ * That pass is worth nothing if the next screen quietly adds a ✨ back, and a
+ * reviewer will not spot one glyph in a diff. So this test asserts the *exact*
+ * set of emoji left in the app, file by file. It fails two ways on purpose:
+ *
+ * - a new decorative emoji anywhere → an unexpected file, or an unexpected
+ *   glyph in a listed one
+ * - a semantic emoji deleted by accident → a missing glyph
+ *
+ * If you are here because you added an emoji: it belongs in the list below only
+ * if it is the content — the thing the user is looking at — rather than an
+ * ornament on a control or a heading whose label already says the same thing.
+ * Otherwise reach for `@heroicons/react/24/outline`, `aria-hidden="true"`, and
+ * a real accessible name on the control.
+ */
+
+/** Everything a font would render as a picture rather than as text. */
+const PICTOGRAPHIC = /\p{Extended_Pictographic}/u
+
+/**
+ * The emoji that are the content, and why each file keeps them. Values are the
+ * distinct glyphs in that file, sorted by code point.
+ */
+const SEMANTIC_EMOJI: Record<string, string[]> = {
+    // Per-person avatars (#248). The emoji IS the person's identity here — it
+    // is what distinguishes Alice's row from Bob's at a glance.
+    'src/edit-questions/person-emoji.ts': [
+        '⚽', '⭐', '🌈', '🍄', '🎸', '🐈', '🐕', '🐙', '🐝', '🐢', '🐧', '🐨',
+        '🐬', '🐰', '🐳', '🐸', '🐼', '🐾', '🚀', '🦁', '🦄', '🦉', '🦊', '🦋',
+        '🦖',
+    ],
+    // 🐾 marks a pet, which is a genuinely different kind of traveller from a
+    // person; the age glyphs distinguish an adult, a child and a baby, which is
+    // what the packing questions branch on.
+    'src/edit-questions/types.ts': ['🐈', '🐕', '🐾', '👦', '👧', '👶', '🧑', '🧒'],
+    // The "Add a Pet" button, matching the 🐾 the pet then carries everywhere
+    // else. Not an ornament: it is the same mark as the thing being created.
+    'src/pages/wizard.tsx': ['🐾'],
+    // Deliberate celebration copy — a milestone message where the single emoji
+    // is the point of the message.
+    'src/pages/packing-milestones.ts': ['🌱', '💪', '🔥'],
+    'src/utils/successToastCopy.ts': ['🎉'],
+    // The all-packed banner: the one moment in the app that is *about* being
+    // colourful. Confetti falls (`celebration-emoji`) and the suitcase pops
+    // (`celebration-suitcase-pop`); both are `aria-hidden` and both are
+    // switched off under `prefers-reduced-motion` in `index.css`.
+    'src/pages/view-packing-list.tsx': ['✈️', '✨', '🌍', '🎈', '🎉', '🎊', '🧳'],
+    // Fixture data: a fully populated person carries a person emoji.
+    'src/test-utils/fullyPopulatedFixtures.ts': ['🦄'],
+}
+
+const SRC = join(import.meta.dirname, '..', 'src')
+
+function sourceFiles(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+        const path = join(dir, entry.name)
+        if (entry.isDirectory()) return sourceFiles(path)
+        if (!/\.tsx?$/.test(entry.name)) return []
+        if (/\.(test|spec)\.tsx?$/.test(entry.name)) return []
+        return [path]
+    })
+}
+
+/** Distinct pictographic characters in `content`, sorted, variation selectors kept. */
+function emojiIn(content: string): string[] {
+    const found = new Set<string>()
+    // Segment by grapheme so "✈️" (aircraft + variation selector) is counted as
+    // the one glyph a reader sees rather than as two code points.
+    for (const { segment } of new Intl.Segmenter('en', { granularity: 'grapheme' }).segment(content)) {
+        if (PICTOGRAPHIC.test(segment)) found.add(segment)
+    }
+    return [...found].sort()
+}
+
+describe('decorative emoji (#335)', () => {
+    const actual: Record<string, string[]> = {}
+    for (const file of sourceFiles(SRC)) {
+        const emoji = emojiIn(readFileSync(file, 'utf8'))
+        if (emoji.length > 0) actual[relative(join(SRC, '..'), file).split(sep).join('/')] = emoji
+    }
+
+    it('leaves emoji only where they carry meaning', () => {
+        expect(actual).toEqual(SEMANTIC_EMOJI)
+    })
+
+    it('lists every allowlisted file, so a stale entry is caught too', () => {
+        expect(Object.keys(actual).sort()).toEqual(Object.keys(SEMANTIC_EMOJI).sort())
+    })
+})

--- a/src/pages/create-packing-list.tsx
+++ b/src/pages/create-packing-list.tsx
@@ -1,3 +1,4 @@
+import { ArrowPathIcon, ClipboardDocumentListIcon, PencilSquareIcon, SparklesIcon, UsersIcon } from '@heroicons/react/24/outline'
 import { useState, useMemo, useCallback, useRef } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { Link, useNavigate } from 'react-router-dom'
@@ -192,7 +193,8 @@ function SuggestionCard({ suggestions, questionSet, onSaveToQuestionSet, onSkip,
                                                     onChange={(e) => setCommunalFlags(prev => ({ ...prev, [item.id]: e.target.checked }))}
                                                     className="h-4 w-4 text-blue-600 dark:text-blue-400 rounded focus:ring-2 focus:ring-blue-500"
                                                 />
-                                                👥 Shared
+                                                <UsersIcon aria-hidden="true" className="h-4 w-4" />
+                                                Shared
                                             </label>
                                             <div className="flex gap-2">
                                                 <Button
@@ -708,7 +710,7 @@ export function CreatePackingList() {
 
                     <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-soft border-2 border-primary-200 dark:border-primary-800 p-8">
                         <div className="text-center mb-6">
-                            <div className="text-6xl mb-4">📋</div>
+                            <ClipboardDocumentListIcon aria-hidden="true" className="mx-auto mb-4 h-14 w-14 text-primary-600 dark:text-primary-400" />
                             <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">No Questions Found</h2>
                             <p className="text-gray-600 dark:text-gray-400">
                                 Before you can create a packing list, you need to set up your packing list questions.
@@ -717,7 +719,10 @@ export function CreatePackingList() {
 
                         <div className="space-y-4 max-w-2xl mx-auto">
                             <div className="bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-primary-100 dark:to-primary-900/40 p-6 rounded-xl border-2 border-primary-200 dark:border-primary-800">
-                                <h3 className="text-lg font-bold text-primary-900 dark:text-primary-200 mb-2">✨ Quick Start with Wizard</h3>
+                                <h3 className="flex items-center gap-2 text-lg font-bold text-primary-900 dark:text-primary-200 mb-2">
+                                    <SparklesIcon aria-hidden="true" className="h-5 w-5 shrink-0" />
+                                    Quick Start with Wizard
+                                </h3>
                                 <p className="text-gray-700 dark:text-gray-300 mb-4">
                                     Answer a few simple questions and we'll generate a personalized question set for you.
                                 </p>
@@ -733,7 +738,10 @@ export function CreatePackingList() {
                                 and signing in again is not what fixes no signal. */}
                             {!isLoggedIn && !isReconnecting && (
                                 <div className="bg-gradient-to-br from-accent-50 dark:from-accent-950/40 to-accent-100 dark:to-accent-900/40 p-6 rounded-xl border-2 border-accent-200 dark:border-accent-800">
-                                    <h3 className="text-lg font-bold text-accent-900 dark:text-accent-200 mb-2">🔄 Sync Questions From Another Device</h3>
+                                    <h3 className="flex items-center gap-2 text-lg font-bold text-accent-900 dark:text-accent-200 mb-2">
+                                        <ArrowPathIcon aria-hidden="true" className="h-5 w-5 shrink-0" />
+                                        Sync Questions From Another Device
+                                    </h3>
                                     <p className="text-gray-700 dark:text-gray-300 mb-4">
                                         If you've already created questions on another device, sign in to sync them here. Signing in uses your Solid Pod.
                                     </p>
@@ -747,7 +755,10 @@ export function CreatePackingList() {
                             )}
 
                             <div className="bg-gradient-to-br from-secondary-50 dark:from-secondary-950/40 to-secondary-100 dark:to-secondary-900/40 p-6 rounded-xl border-2 border-secondary-200 dark:border-secondary-800">
-                                <h3 className="text-lg font-bold text-secondary-900 dark:text-secondary-200 mb-2">✏️ Create Manually</h3>
+                                <h3 className="flex items-center gap-2 text-lg font-bold text-secondary-900 dark:text-secondary-200 mb-2">
+                                    <PencilSquareIcon aria-hidden="true" className="h-5 w-5 shrink-0" />
+                                    Create Manually
+                                </h3>
                                 <p className="text-gray-700 dark:text-gray-300 mb-4">
                                     Prefer full control? Create your packing list questions from scratch.
                                 </p>

--- a/src/pages/foreign-packing-lists.test.tsx
+++ b/src/pages/foreign-packing-lists.test.tsx
@@ -136,7 +136,7 @@ describe('ForeignPackingListsPage trip destination and dates', () => {
         await screen.findByText(/Summer Holiday/)
         expect(screen.getByText(/Lisbon, Portugal/)).toBeTruthy()
         expect(screen.getByText(new RegExp(localDateOf(tripStart).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))).toBeTruthy()
-        expect(screen.queryByText(/📅 Created/)).toBeNull()
+        expect(screen.queryByText(/Created/)).toBeNull()
     })
 
     it('falls back to a labelled creation date when a shared list has no trip dates', async () => {
@@ -148,7 +148,7 @@ describe('ForeignPackingListsPage trip destination and dates', () => {
         renderPage()
 
         await screen.findByText(/Summer Holiday/)
-        expect(screen.getByText(/📅 Created/)).toBeTruthy()
+        expect(screen.getByText(/Created/)).toBeTruthy()
     })
 })
 

--- a/src/pages/foreign-packing-lists.tsx
+++ b/src/pages/foreign-packing-lists.tsx
@@ -1,3 +1,4 @@
+import { CalendarIcon, MapPinIcon, PlusIcon } from '@heroicons/react/24/outline'
 import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useForeignPod } from '../components/ForeignPodContext'
@@ -88,18 +89,18 @@ export function ForeignPackingListsPage() {
             >
                 <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
                     <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2 flex-wrap">
-                        ✈️ {list.name}
+                        {list.name}
                         {list.destination && !countdown && (
                             <span className="text-xs font-medium bg-white/60 dark:bg-white/10 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700 px-2 py-0.5 rounded-full">
-                                📍 {list.destination}
+                                <MapPinIcon aria-hidden="true" className="mr-1 inline-block h-3.5 w-3.5 align-[-0.15em]" />
+                                {list.destination}
                             </span>
                         )}
                         <TripCountdownBadge countdown={countdown} />
                     </h3>
-                    <span className="text-sm font-medium text-gray-600 dark:text-gray-400 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg self-start sm:self-auto">
-                        {tripDates
-                            ? `📅 ${tripDates}`
-                            : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
+                    <span className="inline-flex items-center gap-1.5 self-start text-sm font-medium text-gray-600 dark:text-gray-400 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg sm:self-auto">
+                        <CalendarIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
+                        {tripDates || `Created ${new Date(list.createdAt).toLocaleDateString()}`}
                     </span>
                 </div>
                 <div className="flex items-center gap-4">
@@ -153,10 +154,13 @@ function Header({ onCreate }: { onCreate: () => void }) {
     return (
         <div className="mb-8 flex justify-between items-start gap-4">
             <div className="mb-2">
-                <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">📦 Packing Lists</h1>
+                <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">Packing Lists</h1>
                 <p className="mt-2 text-lg text-gray-700 dark:text-gray-300 font-medium">Shared packing lists.</p>
             </div>
-            <Button variant="primary" onClick={onCreate}>➕ New List</Button>
+            <Button variant="primary" onClick={onCreate}>
+                <PlusIcon aria-hidden="true" className="h-4 w-4" />
+                New List
+            </Button>
         </div>
     )
 }

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { CheckBadgeIcon, ClipboardDocumentListIcon, PencilSquareIcon, SparklesIcon } from '@heroicons/react/24/outline'
 import { Link } from 'react-router-dom'
 import { useSolidPod } from '../components/SolidPodContext'
 import { useHasQuestions } from '../hooks/useHasQuestions'
@@ -28,11 +29,11 @@ export const LandingPage = () => {
         </div>
     ) : hasQuestions ? (
         <Link to="/view-lists" className={CTA_CLASSES}>
-            📋 View Packing Lists
+            View Packing Lists
         </Link>
     ) : (
         <Link to="/wizard" className={CTA_CLASSES}>
-            ✨ Get Started with the Wizard
+            Get Started with the Wizard
         </Link>
     )
     return (
@@ -46,7 +47,8 @@ export const LandingPage = () => {
                       * stays in the nav rather than being repeated an inch away.
                       */}
                     <p className="text-success-800 dark:text-success-200 font-semibold">
-                        🎉 Signed in as <span className="font-bold">{profileDisplayName(profile, webId)}</span>
+                        <CheckBadgeIcon aria-hidden="true" className="mr-1 inline-block h-5 w-5 align-[-0.25em]" />
+                        Signed in as <span className="font-bold">{profileDisplayName(profile, webId)}</span>
                         {/* Signed in but unreachable is still signed in (#342) —
                             the greeting stays and says which of the two it is. */}
                         {isReconnecting && (
@@ -77,7 +79,7 @@ export const LandingPage = () => {
                     <h2 className="text-center text-sm font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400 mb-6">How it works</h2>
                     <div className="grid md:grid-cols-3 gap-6">
                         <div className="bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-primary-100 dark:to-primary-900/40 p-6 rounded-2xl shadow-soft hover:shadow-glow-primary transition-all duration-300 hover:scale-105 border-2 border-primary-200 dark:border-primary-800">
-                            <div className="text-3xl mb-2">✨</div>
+                            <SparklesIcon aria-hidden="true" className="mb-2 h-8 w-8 text-primary-700 dark:text-primary-300" />
                             <h3 className="text-xl font-bold mb-3 text-primary-900 dark:text-primary-200">1. Set up in a minute</h3>
                             <p className="text-gray-700 dark:text-gray-300">
                                 One screen — tell us who you travel with, and we'll generate a starter set of packing questions for your group.
@@ -85,7 +87,7 @@ export const LandingPage = () => {
                         </div>
 
                         <div className="bg-gradient-to-br from-secondary-50 dark:from-secondary-950/40 to-secondary-100 dark:to-secondary-900/40 p-6 rounded-2xl shadow-soft hover:shadow-glow-secondary transition-all duration-300 hover:scale-105 border-2 border-secondary-200 dark:border-secondary-800">
-                            <div className="text-3xl mb-2">✏️</div>
+                            <PencilSquareIcon aria-hidden="true" className="mb-2 h-8 w-8 text-secondary-700 dark:text-secondary-300" />
                             <h3 className="text-xl font-bold mb-3 text-secondary-900 dark:text-secondary-200">2. Fine-tune your questions</h3>
                             <p className="text-gray-700 dark:text-gray-300">
                                 Add, remove, and customise questions and packing items until they perfectly match how you travel.
@@ -93,7 +95,7 @@ export const LandingPage = () => {
                         </div>
 
                         <div className="bg-gradient-to-br from-success-50 dark:from-success-950/40 to-success-100 dark:to-success-900/40 p-6 rounded-2xl shadow-soft hover:shadow-lg transition-all duration-300 hover:scale-105 border-2 border-success-200 dark:border-success-800">
-                            <div className="text-3xl mb-2">📋</div>
+                            <ClipboardDocumentListIcon aria-hidden="true" className="mb-2 h-8 w-8 text-success-700 dark:text-success-300" />
                             <h3 className="text-xl font-bold mb-3 text-success-900 dark:text-success-200">3. Pack for every trip</h3>
                             <p className="text-gray-700 dark:text-gray-300">
                                 Before each trip, answer your questions to instantly generate a personalised packing list.

--- a/src/pages/packing-lists.test.tsx
+++ b/src/pages/packing-lists.test.tsx
@@ -774,7 +774,7 @@ describe('PackingLists trip destination and dates', () => {
 
     it('shows the destination on the list card', async () => {
         renderWithList({ ...tripList, startDate: undefined, endDate: undefined })
-        expect(await screen.findByText(/📍 Lisbon, Portugal/)).toBeTruthy()
+        expect(await screen.findByText('Lisbon, Portugal')).toBeTruthy()
     })
 
     // Two lines both saying Lisbon is one line too many: once the trip has
@@ -782,7 +782,7 @@ describe('PackingLists trip destination and dates', () => {
     it('folds the destination into the countdown once the trip has dates', async () => {
         renderWithList(tripList)
         expect((await screen.findByTestId('trip-countdown')).textContent).toContain('Lisbon, Portugal')
-        expect(screen.queryByText(/📍 Lisbon, Portugal/)).toBeNull()
+        expect(screen.queryByText('Lisbon, Portugal')).toBeNull()
     })
 
     it('shows the trip dates rather than the creation date', async () => {
@@ -791,21 +791,21 @@ describe('PackingLists trip destination and dates', () => {
 
         const expected = `${localDateOf(tripStart)} – ${localDateOf(tripEnd)}`
         expect(screen.getByText(new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))).toBeTruthy()
-        expect(screen.queryByText(/📅 Created/)).toBeNull()
+        expect(screen.queryByText(/Created/)).toBeNull()
     })
 
     it('labels the date as the creation date when the list has no trip dates', async () => {
         renderWithList({ ...tripList, startDate: undefined, endDate: undefined })
         await screen.findByText(/Summer Holiday/)
 
-        expect(screen.getByText(/📅 Created/).textContent).toContain(new Date('2026-01-01T00:00:00Z').toLocaleDateString())
+        expect(screen.getByText(/Created/).textContent).toContain(new Date('2026-01-01T00:00:00Z').toLocaleDateString())
     })
 
     it('shows no destination badge when the list has none', async () => {
         renderWithList({ ...tripList, destination: undefined })
         await screen.findByText(/Summer Holiday/)
 
-        expect(screen.queryByText(/📍/)).toBeNull()
+        expect(screen.queryByText('Lisbon, Portugal')).toBeNull()
     })
 })
 

--- a/src/pages/packing-lists.tsx
+++ b/src/pages/packing-lists.tsx
@@ -1,3 +1,4 @@
+import { CalendarIcon, GlobeAltIcon, MapPinIcon, PlusIcon, UserIcon } from '@heroicons/react/24/outline'
 import { useEffect, useState } from 'react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useNavigate } from 'react-router-dom'
@@ -284,18 +285,19 @@ export function PackingLists() {
                 <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center mb-3">
                     <div className="min-w-0">
                     <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2 flex-wrap">
-                        ✈️ {list.name}
+                        {list.name}
                         {list.sharedFromPodUrl ? (
                             <span className="text-xs font-medium bg-white/60 dark:bg-white/10 text-indigo-700 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-800 px-2 py-0.5 rounded-full">
-                                👤 From {resolveOwnerDisplayName(ownerNames[list.id], list.ownerWebId, list.sharedFromPodUrl)}
+                                <UserIcon aria-hidden="true" className="mr-1 inline-block h-3.5 w-3.5 align-[-0.15em]" />
+                                From {resolveOwnerDisplayName(ownerNames[list.id], list.ownerWebId, list.sharedFromPodUrl)}
                             </span>
                         ) : (
                             <>
                                 {sharingStatus[list.id] === 'public' && (
-                                    <span className="text-xs font-medium bg-white/60 dark:bg-white/10 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded-full">🌐 Public</span>
+                                    <span className="text-xs font-medium bg-white/60 dark:bg-white/10 text-blue-700 dark:text-blue-300 inline-flex items-center gap-1 px-2 py-0.5 rounded-full"><GlobeAltIcon aria-hidden="true" className="h-3.5 w-3.5" />Public</span>
                                 )}
                                 {sharingStatus[list.id] === 'shared' && (
-                                    <span className="text-xs font-medium bg-white/60 dark:bg-white/10 text-indigo-700 dark:text-indigo-300 px-2 py-0.5 rounded-full">👤 Shared</span>
+                                    <span className="text-xs font-medium bg-white/60 dark:bg-white/10 text-indigo-700 dark:text-indigo-300 inline-flex items-center gap-1 px-2 py-0.5 rounded-full"><UserIcon aria-hidden="true" className="h-3.5 w-3.5" />Shared</span>
                                 )}
                             </>
                         )}
@@ -303,15 +305,17 @@ export function PackingLists() {
                     {/* On its own line so a long destination never
                         pushes the actions onto a second row */}
                     {list.destination && !countdown && (
-                        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 truncate">📍 {list.destination}</p>
+                        <p className="mt-1 flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
+                            <MapPinIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
+                            <span className="truncate">{list.destination}</span>
+                        </p>
                     )}
                     <TripCountdownBadge countdown={countdown} className="mt-1" />
                     </div>
                     <div data-testid="list-actions" className="flex items-center gap-2 flex-wrap">
-                        <span className="text-sm font-medium text-gray-600 dark:text-gray-400 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg">
-                            {tripDates
-                                ? `📅 ${tripDates}`
-                                : `📅 Created ${new Date(list.createdAt).toLocaleDateString()}`}
+                        <span className="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 bg-white/60 dark:bg-white/10 px-3 py-1 rounded-lg">
+                            <CalendarIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
+                            {tripDates || `Created ${new Date(list.createdAt).toLocaleDateString()}`}
                         </span>
                         <ListCardMenu
                             listName={list.name}
@@ -348,10 +352,13 @@ export function PackingLists() {
             <div className="max-w-4xl mx-auto py-8 px-4">
                 <div className="mb-8 flex justify-between items-start">
                     <div className="mb-2">
-                        <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">📦 Packing Lists</h1>
+                        <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">Packing Lists</h1>
                         <p className="mt-2 text-lg text-gray-700 dark:text-gray-300 font-medium">View all your created packing lists.</p>
                     </div>
-                    <Button variant="primary" onClick={() => navigate('/create-packing-list')}>➕ New List</Button>
+                    <Button variant="primary" onClick={() => navigate('/create-packing-list')}>
+                        <PlusIcon aria-hidden="true" className="h-4 w-4" />
+                        New List
+                    </Button>
                 </div>
                 <LoadingState message="Loading packing lists..." rows={3} />
             </div>
@@ -362,10 +369,13 @@ export function PackingLists() {
         <div className="max-w-4xl mx-auto py-8 px-4">
             <div className="mb-8 flex justify-between items-start">
                 <div className="mb-2">
-                    <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">📦 Packing Lists</h1>
+                    <h1 className="text-4xl font-bold text-primary-900 dark:text-primary-200">Packing Lists</h1>
                     <p className="mt-2 text-lg text-gray-700 dark:text-gray-300 font-medium">View all your created packing lists.</p>
                 </div>
-                <Button variant="primary" onClick={() => navigate('/create-packing-list')}>➕ New List</Button>
+                <Button variant="primary" onClick={() => navigate('/create-packing-list')}>
+                        <PlusIcon aria-hidden="true" className="h-4 w-4" />
+                        New List
+                    </Button>
             </div>
 
             {/* The lists below are the local copy; say so while the pod is still
@@ -378,7 +388,7 @@ export function PackingLists() {
             {packingLists.length === 0 ? (
                 <div className="text-center py-12 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft">
                     <p className="text-lg text-gray-800 dark:text-gray-100 font-semibold">
-                        No packing lists found. Create your first packing list to get started! 🎒
+                        No packing lists found. Create your first packing list to get started!
                     </p>
                 </div>
             ) : (
@@ -392,7 +402,7 @@ export function PackingLists() {
                     {currentLists.length === 0 && (
                         <div className="text-center py-12 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft">
                             <p className="text-lg text-gray-800 dark:text-gray-100 font-semibold">
-                                No upcoming trips. Your past trips are below — or start a new list! 🎒
+                                No upcoming trips. Your past trips are below — or start a new list!
                             </p>
                         </div>
                     )}

--- a/src/pages/questions-page.tsx
+++ b/src/pages/questions-page.tsx
@@ -1995,7 +1995,7 @@ export function QuestionsPage() {
                         data-testid="questions-empty-state"
                         className="text-center py-10 px-6 bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-accent-50 dark:to-accent-950/40 rounded-2xl border-2 border-primary-200 dark:border-primary-800 shadow-soft"
                     >
-                        <p className="text-lg font-semibold text-gray-800 dark:text-gray-100">Nothing here yet — let's fix that 🧳</p>
+                        <p className="text-lg font-semibold text-gray-800 dark:text-gray-100">Nothing here yet — let's fix that</p>
                         <p className="mx-auto mt-2 max-w-md text-sm text-gray-600 dark:text-gray-400">
                             Answer a few questions about who's travelling and we'll build your questions and packing items for you. Everything stays editable afterwards.
                         </p>

--- a/src/pages/sharing-settings.tsx
+++ b/src/pages/sharing-settings.tsx
@@ -1,3 +1,4 @@
+import { CheckCircleIcon } from '@heroicons/react/24/outline'
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useSolidPod } from '../components/SolidPodContext'
@@ -283,7 +284,7 @@ export function SharingSettingsPage() {
                 { label: 'Free', text: 'All major Pod providers are free to sign up' },
                 { label: 'You own your data', text: 'Everything stays in your personal storage' },
             ]}
-            confirmLabel="🔗 Sign in and share"
+            confirmLabel="Sign in and share"
             dismissLabel="Not now"
             onBeforeLogin={() => setPendingSignInAction({ type: 'share-full-setup' })}
         />
@@ -360,8 +361,9 @@ export function SharingSettingsPage() {
 
                 {inviteLink && (
                     <div className="mt-2 rounded-xl border-2 border-primary-200 dark:border-primary-800 bg-primary-50 dark:bg-primary-950/40 p-4 space-y-2">
-                        <p className="text-sm font-semibold text-primary-900 dark:text-primary-200">
-                            ✅ Your full setup is shared{sharedWith ? ' with ' + sharedWith : ''}
+                        <p className="flex items-center gap-1.5 text-sm font-semibold text-primary-900 dark:text-primary-200">
+                            <CheckCircleIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
+                            Your full setup is shared{sharedWith ? ' with ' + sharedWith : ''}
                         </p>
                         <p className="text-sm text-gray-700 dark:text-gray-300">
                             They now have your question set and all your packing lists. Send them this
@@ -502,13 +504,13 @@ export function SharingSettingsPage() {
                                 return (
                                     <li key={list.id} className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
                                         <div className="flex flex-col flex-1 min-w-0">
-                                            <span className="text-sm font-medium text-gray-800 dark:text-gray-100 truncate">✈️ {list.name}</span>
+                                            <span className="text-sm font-medium text-gray-800 dark:text-gray-100 truncate">{list.name}</span>
                                             <span className="text-xs text-gray-500 dark:text-gray-400">
                                                 {status === 'loading' ? 'Loading sharing info…' :
                                                     status === 'error' ? 'Could not load sharing info' :
                                                     [
-                                                        status.isPublic ? '🌐 Public' : null,
-                                                        individualCollaborators(status).length > 0 ? `👤 ${individualCollaborators(status).length} person${individualCollaborators(status).length > 1 ? 's' : ''}` : null,
+                                                        status.isPublic ? 'Public' : null,
+                                                        individualCollaborators(status).length > 0 ? `Shared with ${individualCollaborators(status).length} person${individualCollaborators(status).length > 1 ? 's' : ''}` : null,
                                                     ].filter(Boolean).join(' · ')}
                                             </span>
                                         </div>

--- a/src/pages/view-packing-list.test.tsx
+++ b/src/pages/view-packing-list.test.tsx
@@ -1004,7 +1004,7 @@ describe('packing progress bar and milestones', () => {
         toggleItems(0, 8)
 
         // The section header celebrates too, so the strip is one of several
-        await waitFor(() => expect(screen.getAllByText('🎉 All packed!').length).toBeGreaterThan(0))
+        await waitFor(() => expect(screen.getAllByText('All packed!').length).toBeGreaterThan(0))
         expect(screen.queryByTestId('progress-milestone')).toBeNull()
         expect(screen.getByTestId('packing-progress-fill').style.width).toBe('100%')
     })
@@ -1825,7 +1825,7 @@ describe('ViewPackingList shared (communal) items', () => {
         // No column belongs to it, and it comes first — the shared card's place
         // in person view, kept
         expect(camping.getAllByTestId('grid-row')[0].textContent).toContain('Tent')
-        expect(camping.getByText('👥 Shared')).toBeTruthy()
+        expect(camping.getByText('Shared')).toBeTruthy()
     })
 
     it('counts shared items in the section total', async () => {
@@ -4254,7 +4254,7 @@ describe('ViewPackingList header emphasis', () => {
         // Radix's to keep — and only if the menu is actually one.
         const menu = screen.getByRole('menu')
         await waitFor(() => expect(within(menu).getAllByRole('menuitem').map(i => i.textContent))
-            .toEqual(['🔗Share', '🔄Update from questions']))
+            .toEqual(['Share', 'Update from questions']))
     })
 
     it('adds a guest from the strip the guests are on, not from the header', async () => {

--- a/src/pages/view-packing-list.tsx
+++ b/src/pages/view-packing-list.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef } from 'react'
+import { ArrowPathIcon, CalendarIcon, ChevronDownIcon, ChevronRightIcon, LinkIcon, MapPinIcon, UserIcon } from '@heroicons/react/24/outline'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useDebouncedCallback } from 'use-debounce'
 import { PackingList, PackingListItem } from '../create-packing-list/types'
@@ -1698,7 +1699,7 @@ export function ViewPackingList() {
                     {!foreignPodUrl && (
                         <ActionMenu label="List actions">
                             <ActionMenuItem
-                                icon="🔗"
+                                icon={<LinkIcon aria-hidden="true" className="h-5 w-5" />}
                                 disabled={isLoggedIn && !ownPodUrl}
                                 onSelect={() => {
                                     if (isLoggedIn) setShareModalOpen(true)
@@ -1713,7 +1714,7 @@ export function ViewPackingList() {
                             </ActionMenuItem>
                             {hasQuestionSet && (
                                 <ActionMenuItem
-                                    icon="🔄"
+                                    icon={<ArrowPathIcon aria-hidden="true" className="h-5 w-5" />}
                                     onSelect={handleOpenQuestionUpdate}
                                 >
                                     Update from questions
@@ -1730,8 +1731,18 @@ export function ViewPackingList() {
                         {/* Countdown first: how soon the trip is is what the
                             traveller came to know; the dates back it up. */}
                         <TripCountdownBadge countdown={tripCountdown} />
-                        {packingList.destination && !tripCountdown && <span>📍 {packingList.destination}</span>}
-                        {tripDates && <span>📅 {tripDates}</span>}
+                        {packingList.destination && !tripCountdown && (
+                            <span className="inline-flex items-center gap-1">
+                                <MapPinIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
+                                {packingList.destination}
+                            </span>
+                        )}
+                        {tripDates && (
+                            <span className="inline-flex items-center gap-1">
+                                <CalendarIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
+                                {tripDates}
+                            </span>
+                        )}
                     </div>
                 )}
             </div>
@@ -1748,8 +1759,9 @@ export function ViewPackingList() {
             {/* Persistent "viewing someone else's list" indicator */}
             {foreignPodUrl && !foreignPodCtx && (
                 <div className="w-full max-w-screen-2xl mb-2 bg-indigo-50 dark:bg-indigo-950/40 border border-indigo-200 dark:border-indigo-800 rounded-xl px-4 py-3">
-                    <p className="text-sm text-indigo-800 dark:text-indigo-200 font-medium">
-                        👤 Viewing a list from <span className="font-semibold">{resolveOwnerDisplayName(ownerDisplayName, effectiveOwnerWebId, foreignPodUrl)}</span>
+                    <p className="flex items-center gap-1.5 text-sm text-indigo-800 dark:text-indigo-200 font-medium">
+                        <UserIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
+                        Viewing a list from <span className="font-semibold">{resolveOwnerDisplayName(ownerDisplayName, effectiveOwnerWebId, foreignPodUrl)}</span>
                     </p>
                 </div>
             )}
@@ -1763,7 +1775,7 @@ export function ViewPackingList() {
                             rather than squeezing everything into wrapped fragments. */}
                         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
                             <span className={`text-sm font-medium whitespace-nowrap ${allPacked ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-600 dark:text-gray-400'}`}>
-                                {allPacked ? '🎉 All packed!' : `${packedCount} / ${totalCount} packed (${percentComplete}%)`}
+                                {allPacked ? 'All packed!' : `${packedCount} / ${totalCount} packed (${percentComplete}%)`}
                             </span>
                             {/* The bar shrinks to its minimum before the encouragement
                                 gives way, and at 320px the encouragement takes a line of
@@ -1800,7 +1812,9 @@ export function ViewPackingList() {
                                         {/* Same glyph the section headers use for the same
                                             state, so the toolbar and the cards never point
                                             opposite ways at each other. */}
-                                        <span aria-hidden="true" className="text-xs text-gray-400 dark:text-gray-500">{everySectionFolded ? '▶' : '▼'}</span>
+                                        {everySectionFolded
+                                            ? <ChevronRightIcon aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" />
+                                            : <ChevronDownIcon aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" />}
                                         {/* The word "all" is what tips this row onto a second
                                             line on a phone, and the icon already says it. */}
                                         {everySectionFolded ? (isDesktop ? 'Expand all' : 'Expand') : (isDesktop ? 'Collapse all' : 'Collapse')}
@@ -1887,7 +1901,7 @@ export function ViewPackingList() {
                                             but this shouldn't pass in silence. */}
                                         {solePersonUnpacked === 0 && solePersonTotal > 0 ? (
                                             <span className="shrink-0 whitespace-nowrap rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-100 dark:bg-emerald-900/40 px-2.5 py-1 text-xs font-semibold text-emerald-700 dark:text-emerald-300">
-                                                🎉 {solePerson.name}'s bag is packed!
+                                                {solePerson.name}'s bag is packed!
                                             </span>
                                         ) : solePersonUnpacked > 0 && (
                                             <button
@@ -2057,7 +2071,9 @@ export function ViewPackingList() {
                                             onClick={() => toggleSection(sectionKey)}
                                             className="flex items-center gap-2 flex-1 min-w-0 text-left"
                                         >
-                                            <span className="shrink-0 text-sm text-gray-400 dark:text-gray-500">{isSectionCollapsed ? '▶' : '▼'}</span>
+                                            {isSectionCollapsed
+                                            ? <ChevronRightIcon aria-hidden="true" className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
+                                            : <ChevronDownIcon aria-hidden="true" className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />}
                                             <span className="text-xl font-semibold text-gray-800 dark:text-gray-100">{title}</span>
                                             {/* Never let a count break across lines — "9 /" above "9" is
                                                 a fraction the eye has to reassemble. */}
@@ -2070,7 +2086,7 @@ export function ViewPackingList() {
                                                 aria-label={`All packed for ${completeLabel}${filterQualifier}`}
                                                 className="animate-pop-in text-xs font-semibold text-emerald-700 dark:text-emerald-300 bg-emerald-100 dark:bg-emerald-900/40 border border-emerald-200 dark:border-emerald-800 rounded-full px-2 py-0.5 shrink-0"
                                             >
-                                                🎉 All packed!
+                                                All packed!
                                             </span>
                                         )}
                                         {/* Used to sit on each folded group inside a card. The
@@ -2119,7 +2135,7 @@ export function ViewPackingList() {
                                     </div>
                                     {isComplete && items.length === 0 && !isGridSection && (
                                         <p className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
-                                            Nothing left to pack 🎒
+                                            Nothing left to pack
                                         </p>
                                     )}
                                     {isGridSection && (
@@ -2248,7 +2264,7 @@ export function ViewPackingList() {
                 { label: 'Free', text: 'All major Pod providers are free to sign up' },
                 { label: 'You own your data', text: 'Your lists stay in your personal storage' },
             ]}
-            confirmLabel="🔗 Sign in to share"
+            confirmLabel="Sign in to share"
             dismissLabel="Not now"
             onBeforeLogin={() => { if (id) setPendingSignInAction({ type: 'share', listId: id }) }}
         />

--- a/src/pages/wizard.tsx
+++ b/src/pages/wizard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
+import { ArrowPathIcon, CheckCircleIcon, ExclamationTriangleIcon, UsersIcon } from '@heroicons/react/24/outline'
 import { useForm, useFieldArray } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useNavigate, Link } from 'react-router-dom'
@@ -161,8 +162,9 @@ export const Wizard = () => {
 
             {hasExistingData && (
                 <div className="mb-6 p-4 bg-warning-50 dark:bg-warning-950/40 border-2 border-warning-300 dark:border-warning-700 rounded-2xl">
-                    <p className="text-warning-900 dark:text-warning-200 font-semibold">
-                        ⚠️ You already have packing list questions set up. Completing this wizard will replace them.
+                    <p className="flex items-start gap-2 text-warning-900 dark:text-warning-200 font-semibold">
+                        <ExclamationTriangleIcon aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0" />
+                        <span>You already have packing list questions set up. Completing this wizard will replace them.</span>
                     </p>
                     <p className="text-sm text-warning-800 dark:text-warning-200 mt-1">
                         To keep your existing questions, go to{' '}
@@ -175,7 +177,10 @@ export const Wizard = () => {
                 {/* People Section */}
                 <div className="bg-white dark:bg-gray-900 p-6 rounded-2xl shadow-soft border-2 border-primary-200 dark:border-primary-800">
                     <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-2xl font-bold text-primary-900 dark:text-primary-200">👥 Who's Packing?</h2>
+                        <h2 className="flex items-center gap-2 text-2xl font-bold text-primary-900 dark:text-primary-200">
+                            <UsersIcon aria-hidden="true" className="h-6 w-6 shrink-0" />
+                            Who's Packing?
+                        </h2>
                         <span className="text-sm text-gray-600 dark:text-gray-400 font-medium">
                             {fields.length} in your group
                         </span>
@@ -341,7 +346,8 @@ export const Wizard = () => {
                         disabled={isLoading}
                         className="px-8 py-4 text-lg"
                     >
-                        {isLoading ? '🔄 Generating...' : '✅ Generate My Packing Questions'}
+                        {isLoading && <ArrowPathIcon aria-hidden="true" className="h-5 w-5 motion-safe:animate-spin" />}
+                        {isLoading ? 'Generating...' : 'Generate My Packing Questions'}
                     </Button>
                 </div>
             </form>
@@ -351,7 +357,12 @@ export const Wizard = () => {
                 isOpen={showConfirmDialog}
                 onClose={() => setShowConfirmDialog(false)}
                 onConfirm={handleConfirmOverride}
-                title="⚠️ Existing Data Found"
+                title={
+                    <span className="flex items-center gap-2">
+                        <ExclamationTriangleIcon aria-hidden="true" className="h-5 w-5 shrink-0 text-warning-600 dark:text-warning-400" />
+                        Existing Data Found
+                    </span>
+                }
                 message="You already have packing list questions set up. Generating a new set will override your current questions.
 
 Are you sure you want to continue?"
@@ -364,7 +375,7 @@ Are you sure you want to continue?"
             <Modal
                 isOpen={showSuccessModal}
                 onClose={handleDismissSuccess}
-                title="🎉 Questions Generated Successfully!"
+                title="Questions Generated Successfully!"
             >
                 <div className="space-y-6">
                     {revealSteps.length > 0 && (
@@ -374,7 +385,7 @@ Are you sure you want to continue?"
                                     key={step.personId}
                                     className="reveal-line flex gap-2 text-gray-700 dark:text-gray-300 break-words"
                                 >
-                                    <span aria-hidden="true">✨</span>
+                                    <CheckCircleIcon aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0 text-success-600 dark:text-success-400" />
                                     <span className="flex-1 min-w-0">{step.text}</span>
                                 </li>
                             ))}
@@ -409,14 +420,14 @@ Are you sure you want to continue?"
                                     onClick={() => handleSuccessAction('/create-packing-list')}
                                     className="w-full bg-gradient-primary-button text-white px-4 sm:px-6 py-4 rounded-xl font-bold text-base sm:text-lg break-words motion-safe:hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary"
                                 >
-                                    🚀 Create My First Packing List
+                                    Create My First Packing List
                                 </button>
 
                                 <button
                                     onClick={() => handleSuccessAction('/manage-questions')}
                                     className="w-full text-primary-700 dark:text-primary-300 border-2 border-primary-200 dark:border-primary-800 hover:border-primary-400 dark:hover:border-primary-600 hover:bg-primary-50 dark:hover:bg-primary-950/40 px-4 sm:px-6 py-3 rounded-xl font-semibold text-sm sm:text-base break-words transition-all duration-200"
                                 >
-                                    ✏️ Refine My Packing List Questions
+                                    Refine My Packing List Questions
                                 </button>
                             </div>
 


### PR DESCRIPTION
Design feedback on the home screen and the wizard success modal: the emoji
on buttons and cards "bring a lot of colors and don't contrast very well on
their backgrounds", and the sparkles are "barely visible". An emoji is a
full-colour bitmap the theme cannot touch, so it looks wrong in dark mode,
wrong on a gradient, and different on every platform.

That was two screens; the app had 134 emoji across 28 files. Doing one
screen at a time would leave it looking half-converted, so this is the whole
pass: 24 files, every decorative glyph either replaced with a monochrome
@heroicons/react outline icon that inherits currentColor, or dropped where
the label beside it already said the same thing.

Emoji that are the content stay: person avatars, the pet marker, milestone
copy, and the all-packed celebration banner — the one moment in the app that
is about being colourful.

The split is now enforced. `decorativeEmoji.test.ts` walks every non-test
source file and asserts the exact set of emoji left, file by file, with a
comment per entry saying why it is semantic. It fails both ways: a new
decorative emoji anywhere, or a semantic one deleted by accident.

Two smaller things fall out of it:

- `Modal`/`ConfirmationDialog` take a `ReactNode` title, because callers were
  smuggling glyphs into the title string ("⚠️ Existing Data Found") — that was
  the only way to get a mark into a header. #339 needs the same door.
- Icons are `aria-hidden`, so several controls that had an emoji as their only
  visible mark now read from a real label instead.

The rocking suitcase keeps its animation and its reduced-motion guard; only
the glyph changes.

Closes #335

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016bMZrQUShTgBpC241FsE8r