### PR TITLE
Quieten the home page so the CTA is the loudest thing on it

### DIFF
--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -277,3 +277,86 @@ describe('LandingPage – signed-in greeting', () => {
         expect(screen.getByText(/offline/i)).toBeTruthy()
     })
 })
+
+// #336: three cards, three colour families, a hover-scale on a div nobody can
+// click. The complaint was "a lot going on"; the emoji (#335) were the smaller
+// half of it. Colour marks the one primary action — surfaces stay neutral.
+describe('LandingPage – how it works section', () => {
+    beforeEach(() => {
+        mockUseSolidPod.mockReturnValue({
+            session: null,
+            isLoggedIn: false,
+            webId: undefined,
+            isLoading: false,
+            login: vi.fn(),
+            logout: vi.fn(),
+        })
+    })
+
+    const renderSteps = () => {
+        hasQuestions(false)
+        render(<MemoryRouter><LandingPage /></MemoryRouter>)
+        return screen.getAllByRole('listitem')
+    }
+
+    it('renders the three steps as one ordered sequence', () => {
+        const steps = renderSteps()
+        expect(steps).toHaveLength(3)
+        expect(steps[0].closest('ol')).toBeTruthy()
+    })
+
+    it('numbers the steps', () => {
+        const steps = renderSteps()
+        expect(steps.map(step => step.textContent)).toEqual([
+            expect.stringContaining('1'),
+            expect.stringContaining('2'),
+            expect.stringContaining('3'),
+        ])
+    })
+
+    it('gives the three step cards one shared surface treatment', () => {
+        const [first, ...rest] = renderSteps()
+        rest.forEach(step => expect(step.className).toBe(first.className))
+    })
+
+    it('does not tint the step cards by colour family', () => {
+        renderSteps().forEach(step => {
+            expect(step.className).not.toMatch(/(primary|secondary|success|accent)-\d/)
+            expect(step.className).not.toMatch(/bg-gradient/)
+        })
+    })
+
+    // A <li> is not clickable, so growth and glow on hover promise an
+    // affordance that isn't there. They were also bare `hover:` rather than
+    // the `motion-safe:` variant Button.tsx uses, so they ignored
+    // prefers-reduced-motion.
+    it('offers no hover affordance on the non-interactive cards', () => {
+        renderSteps().forEach(step => {
+            expect(step.className).not.toMatch(/hover:scale/)
+            expect(step.className).not.toMatch(/hover:shadow-glow/)
+        })
+    })
+
+    it('reworks dark mode too, rather than leaving the light surface behind', () => {
+        expect(renderSteps()[0].className).toMatch(/dark:bg-/)
+    })
+
+    // "Reserve saturated colour for the primary CTA only — it should be the
+    // single most colourful thing above the fold." In dark mode the headline
+    // was the brightest thing on screen instead.
+    it('keeps the hero headline neutral rather than tinted', () => {
+        hasQuestions(false)
+        render(<MemoryRouter><LandingPage /></MemoryRouter>)
+        const heading = screen.getByRole('heading', { level: 1 })
+        expect(heading.className).not.toMatch(/text-(primary|secondary|success|accent)-[1-5]00/)
+    })
+
+    it('leaves the primary CTA as the only gradient above the fold', () => {
+        const steps = renderSteps()
+        const cta = screen.getByRole('link', { name: /get started with the wizard/i })
+        expect(cta.className).toMatch(/bg-gradient-primary-button/)
+        steps.forEach(step => {
+            expect(step.innerHTML).not.toMatch(/bg-gradient/)
+        })
+    })
+})

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -9,6 +9,41 @@ import { SolidProviderSelector } from '../components/SolidProviderSelector'
 const CTA_CLASSES =
     'inline-block bg-gradient-primary-button text-white px-8 py-4 rounded-2xl text-lg font-bold motion-safe:hover:scale-105 transition-all duration-200 shadow-soft hover:shadow-glow-primary'
 
+/*
+ * One surface for all three steps, so they read as a single sequence rather
+ * than three unrelated features (#336). They used to carry a colour family
+ * each — primary, secondary, success — competing with the CTA's gradient and
+ * the page's own background for the same attention. Colour now marks the one
+ * primary action; everything around it is neutral, and the step number is the
+ * only accent the section gets.
+ *
+ * Shared as a constant because three hand-copied class strings are how they
+ * drifted apart in the first place.
+ */
+const CARD_CLASSES =
+    'flex flex-col gap-3 p-6 rounded-2xl bg-white/70 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 shadow-soft'
+
+const STEPS = [
+    {
+        number: 1,
+        Icon: SparklesIcon,
+        title: 'Set up in a minute',
+        body: "One screen — tell us who you travel with, and we'll generate a starter set of packing questions for your group.",
+    },
+    {
+        number: 2,
+        Icon: PencilSquareIcon,
+        title: 'Fine-tune your questions',
+        body: 'Add, remove, and customise questions and packing items until they perfectly match how you travel.',
+    },
+    {
+        number: 3,
+        Icon: ClipboardDocumentListIcon,
+        title: 'Pack for every trip',
+        body: 'Before each trip, answer your questions to instantly generate a personalised packing list.',
+    },
+]
+
 export const LandingPage = () => {
     const { isLoggedIn, isReconnecting, webId, session, login } = useSolidPod()
     const profile = useSolidProfile(webId, session)
@@ -63,7 +98,10 @@ export const LandingPage = () => {
                 {/* Hero leads with the travel benefit and keeps the primary CTA above the
                     fold — the data-ownership story lives in the trust section further down. */}
                 <div className="text-center mb-10 animate-slide-up">
-                    <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-primary-900 dark:text-primary-200 text-balance">
+                    {/* Neutral, not tinted: in dark mode `primary-200` made the headline the
+                        brightest thing on screen, ahead of the CTA it is meant to lead
+                        into (#336). */}
+                    <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-gray-900 dark:text-gray-100 text-balance">
                         Packing lists that learn how you travel
                     </h1>
                     <p className="text-lg sm:text-xl text-gray-700 dark:text-gray-300 max-w-2xl mx-auto">
@@ -77,31 +115,24 @@ export const LandingPage = () => {
 
                 <div className="mb-12">
                     <h2 className="text-center text-sm font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400 mb-6">How it works</h2>
-                    <div className="grid md:grid-cols-3 gap-6">
-                        <div className="bg-gradient-to-br from-primary-50 dark:from-primary-950/40 to-primary-100 dark:to-primary-900/40 p-6 rounded-2xl shadow-soft hover:shadow-glow-primary transition-all duration-300 hover:scale-105 border-2 border-primary-200 dark:border-primary-800">
-                            <SparklesIcon aria-hidden="true" className="mb-2 h-8 w-8 text-primary-700 dark:text-primary-300" />
-                            <h3 className="text-xl font-bold mb-3 text-primary-900 dark:text-primary-200">1. Set up in a minute</h3>
-                            <p className="text-gray-700 dark:text-gray-300">
-                                One screen — tell us who you travel with, and we'll generate a starter set of packing questions for your group.
-                            </p>
-                        </div>
-
-                        <div className="bg-gradient-to-br from-secondary-50 dark:from-secondary-950/40 to-secondary-100 dark:to-secondary-900/40 p-6 rounded-2xl shadow-soft hover:shadow-glow-secondary transition-all duration-300 hover:scale-105 border-2 border-secondary-200 dark:border-secondary-800">
-                            <PencilSquareIcon aria-hidden="true" className="mb-2 h-8 w-8 text-secondary-700 dark:text-secondary-300" />
-                            <h3 className="text-xl font-bold mb-3 text-secondary-900 dark:text-secondary-200">2. Fine-tune your questions</h3>
-                            <p className="text-gray-700 dark:text-gray-300">
-                                Add, remove, and customise questions and packing items until they perfectly match how you travel.
-                            </p>
-                        </div>
-
-                        <div className="bg-gradient-to-br from-success-50 dark:from-success-950/40 to-success-100 dark:to-success-900/40 p-6 rounded-2xl shadow-soft hover:shadow-lg transition-all duration-300 hover:scale-105 border-2 border-success-200 dark:border-success-800">
-                            <ClipboardDocumentListIcon aria-hidden="true" className="mb-2 h-8 w-8 text-success-700 dark:text-success-300" />
-                            <h3 className="text-xl font-bold mb-3 text-success-900 dark:text-success-200">3. Pack for every trip</h3>
-                            <p className="text-gray-700 dark:text-gray-300">
-                                Before each trip, answer your questions to instantly generate a personalised packing list.
-                            </p>
-                        </div>
-                    </div>
+                    {/* An ordered list, because that is what it is. No hover
+                        growth or glow: these are not clickable, and promising an
+                        affordance that isn't there was half of what made the
+                        section feel busy. */}
+                    <ol className="grid md:grid-cols-3 gap-6">
+                        {STEPS.map(({ number, Icon, title, body }) => (
+                            <li key={number} className={CARD_CLASSES}>
+                                <div className="flex items-center gap-3">
+                                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary-100 dark:bg-primary-900/50 text-primary-800 dark:text-primary-200 text-sm font-bold">
+                                        {number}
+                                    </span>
+                                    <Icon aria-hidden="true" className="h-6 w-6 text-gray-400 dark:text-gray-500" />
+                                </div>
+                                <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100">{title}</h3>
+                                <p className="text-gray-700 dark:text-gray-300">{body}</p>
+                            </li>
+                        ))}
+                    </ol>
                 </div>
 
                 <div className="mt-10 p-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-center text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
Closes #336

📋 **[Manual test report — 2026-09-05, with screenshots](https://github.com/timgent/pack-me-up/blob/agent-testing/2026-09-05-issue-336-home-page-visual-weight/README.md)** (on the `agent-testing` branch)

## The problem

The three "How it works" cards carried a colour family each — primary, secondary, success — with their own gradient, `border-2`, and hover glow. Stacked against the CTA's own gradient and the page's `from-primary-50 via-white to-accent-50` background, that made four colour stories above the fold and no clear answer to *"what should I do here"*. Removing the emoji in #335 only took away the smaller half of the complaint.

## What changed

- **One shared neutral surface** for all three steps, held in a single `CARD_CLASSES` constant — three hand-copied class strings are how they drifted apart in the first place — and rendered from one `STEPS` array instead of three near-identical blocks.
- **The step number is the only accent** the section keeps: a small circular badge in one primary tint. Headings and icons go neutral.
- **The section is an ordered list**, which is what it is. That also gives the tests a handle without a test id.
- **No hover growth or glow on the cards.** A `<div>` nobody can click was promising an affordance that wasn't there — and with a bare `hover:` rather than the `motion-safe:` variant `Button.tsx` uses, so it ignored `prefers-reduced-motion` too.
- **The hero headline goes neutral.** Not in the issue's list, but it follows from the criterion the issue does set: in dark mode `dark:text-primary-200` made the headline the brightest thing on screen, ahead of the button it exists to lead into. Easy to revert on its own if you'd rather keep the tint.

The CTA itself is untouched. It's the most prominent thing above the fold now because everything around it got quiet, not because it got louder.

Out of scope per the issue's own scope note: the cards on `packing-lists.tsx`, and the navbar (#337).

## Acceptance criteria

| Criterion | Result |
|---|---|
| Primary CTA is the most visually prominent element above the fold | ✅ the only gradient above the fold, both themes |
| The three step cards share one surface treatment | ✅ identical computed background, border and shadow |
| No hover-scale on non-interactive elements | ✅ `transform` stays `none` on hover |
| Light and dark both checked, including the `dark:` variants | ✅ |
| `landing-page.test.tsx` passes / updated | ✅ 29 tests (8 new) |

## Testing

TDD — the eight new tests in `src/pages/landing-page.test.tsx` were written first and watched fail. `npm test` is green: 2245 tests across 123 files, typecheck included. `npm run lint` reports 0 errors (11 pre-existing warnings, none in the touched files).

Manually tested in the built app (`npm run build` + `vite preview`) driven with Chromium at 1280×900 and 390×844, in light and dark, signed out and signed in against a local Community Solid Server. Computed styles were read back from the browser alongside the screenshots, so the claims about gradients, borders and hover are measured rather than eyeballed. Full write-up and screenshots in the report linked at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HidXLzFqNZnVmfwjWb6qZK